### PR TITLE
Removed a duplicate item from the ServiceControl menu.

### DIFF
--- a/Content/menu.txt
+++ b/Content/menu.txt
@@ -267,7 +267,6 @@
         "Title": "Configuration",
         "Articles": [
           "ServiceControl/multi-transport-support",
-          "ServiceControl/setting-custom-hostname",
           "ServiceControl/troubleshooting",
 	  "ServiceControl/configure-ravendb-location",
 	  "ServiceControl/customize-name-and-description",


### PR DESCRIPTION
Silly one, but I removed the duplicate "setting-custom-hostname" menu item.
