### PR TITLE
The ConfigureMapping example should use the new syntax

### DIFF
--- a/Content/NServiceBus/sagas-in-nservicebus.md
+++ b/Content/NServiceBus/sagas-in-nservicebus.md
@@ -98,7 +98,7 @@ public class MySaga3 : Saga<MySagaData>,
 {
   public override void ConfigureHowToFindSaga()
   {
-    ConfigureMapping<Message2>(s => s.SomeID, m => m.SomeID);
+    ConfigureMapping<Message2>(m => m.SomeID).ToSaga(s => s.SomeID);
   }
   
   public void Handle(Message1 message)
@@ -141,7 +141,7 @@ public class MySaga4 : Saga<MySagaData>,
 {
   public override void ConfigureHowToFindSaga()
   {
-    ConfigureMapping<Message2>(s => s.SomeID, m => m.SomeID);
+    ConfigureMapping<Message2>(m => m.SomeID).ToSaga(s => s.SomeID);
   }
   
   public void Handle(Message1 message)
@@ -174,7 +174,7 @@ public class MySaga5 : Saga<MySagaData>,
 {
   public override void ConfigureHowToFindSaga()
   {
-    ConfigureMapping<Message2>(s => s.SomeID, m => m.SomeID);
+    ConfigureMapping<Message2>(m => m.SomeID).ToSaga(s => s.SomeID);
   }
   
   public void Handle(Message1 message)


### PR DESCRIPTION
The ConfigureMapping code examples used the old syntax, which gives an obsolete warning. The example should use the new syntax instead.
