### PR TITLE
NServiceBus version 4 and RavenDB 2.5

### DIFF
--- a/Content/NServiceBus/RavenDB/VersionCompatibility.md
+++ b/Content/NServiceBus/RavenDB/VersionCompatibility.md
@@ -42,6 +42,26 @@ The root underlying cause of these compatibility issue is that NServiceBus follo
 
 Version 4 of NServiceBus was shipped with version 2.0.2375 of RavenDB resource merged.
 
+### NServiceBus 4 and RavenDB 2.5
+NServiceBus Version 4 uses RavenDB.Client version 2.0 internally. Using RavenDB client 2.0 against a RavenDB Server 2.5 is not recommended. Server restarts may result in wiping out outstanding transactions potentially resulting in message loss. Therefore if using RavenDB server version 2.5, please do the following:
+
+- Install the version 1 of NServiceBus.RavenDB nuget package in your endpoint. This will ensure that RavenDB Client version 2.5 is being used instead of 2.0
+
+```
+install-package NServiceBus.RavenDB -version 1.0.1
+```
+- Then use the new initialization extension methods to properly setup persistence for RavenDB 2.5.
+
+RavenDB integration, in both the core and the externalized versions is configured using extension methods. Since these cannot be made distinct using namespace or type,  re-using the same extension method names would result in type conflicts. To avoid the conflicts the externalized version has had to slightly rename the extension points.
+
+So where you would previously do :
+
+<!-- import OldRavenDBPersistenceInitialization -->
+
+You now will use:
+
+<!-- import Version2_5RavenDBPersistenceInitialization -->
+
 ## NServiceBus 3: ILMerged into the Core 
 
 In **version 3 of NServiceBus** the default persistence was changed from NHibernate to RavenDB. The required RavenDB assemblies were [ILMerged](http://research.microsoft.com/en-us/people/mbarnett/ilmerge.aspx) into NServiceBus.Core.dll to give users a seamless OOTB experience.

--- a/Snippets/Samples_4/CustomRavenConfigForVersion2_5.cs
+++ b/Snippets/Samples_4/CustomRavenConfigForVersion2_5.cs
@@ -1,0 +1,40 @@
+﻿using NServiceBus;
+using NServiceBus.RavenDB;
+
+public class UseRavenDBVersion2PersistenceUsingCustomInitialization : IWantCustomInitialization
+{
+    public void Init()
+    {
+
+        #region OldRavenDBPersistenceInitialization
+
+        Configure.With()
+           .DefaultBuilder()
+           .RavenPersistence()
+           .RavenSagaPersister()
+           .RavenSubscriptionStorage()
+           .UseRavenTimeoutPersister()
+           .UseRavenGatewayDeduplication()
+           .UseRavenGatewayPersister();
+
+        #endregion 
+    }
+}
+
+public class UseRavenDBVersion2_5PersistenceUsingCustomInitialization : IWantCustomInitialization
+{
+    public void Init()
+    {
+        #region Version2_5RavenDBPersistenceInitialization
+
+        Configure.With()
+           .DefaultBuilder()
+           .RavenDBStorage() // Need to call this method
+           .UseRavenDBSagaStorage() // Call this method to use Raven saga storage
+           .UseRavenDBSubscriptionStorage() // Call this method to use Raven subscription storage
+           .UseRavenDBTimeoutStorage() // Call this method to use Raven timeout storage
+           .UseRavenDBGatewayDeduplicationStorage() // Call this method to use Raven deduplication storage for the Gateway
+           .UseRavenDBGatewayStorage(); // Call this method to use the  Raven Gateway storage method
+        #endregion
+    }
+}

--- a/Snippets/Samples_4/Snippets_4.csproj
+++ b/Snippets/Samples_4/Snippets_4.csproj
@@ -150,6 +150,9 @@
     <Reference Include="NServiceBus.ObjectBuilder.Unity">
       <HintPath>..\packages\NServiceBus.Unity.5.0.0\lib\net45\NServiceBus.ObjectBuilder.Unity.dll</HintPath>
     </Reference>
+    <Reference Include="NServiceBus.RavenDB">
+      <HintPath>..\packages\NServiceBus.RavenDB.1.0.1\lib\net40\NServiceBus.RavenDB.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Testing, Version=4.7.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.Testing.4.7.4\lib\net40\NServiceBus.Testing.dll</HintPath>
@@ -160,6 +163,12 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Raven.Abstractions">
+      <HintPath>..\packages\RavenDB.Client.2.5.2938\lib\net45\Raven.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Raven.Client.Lightweight">
+      <HintPath>..\packages\RavenDB.Client.2.5.2938\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    </Reference>
     <Reference Include="Spring.Core">
       <HintPath>..\packages\Spring.Core.1.3.2\lib\net40\Spring.Core.dll</HintPath>
     </Reference>
@@ -167,6 +176,7 @@
       <HintPath>..\packages\structuremap.2.6.4.1\lib\net40\StructureMap.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Services.Client" />
@@ -193,6 +203,7 @@
     <Compile Include="Conventions\UnobtrusiveConventions.cs" />
     <Compile Include="Conventions\ExpressMessages.cs" />
     <Compile Include="CustomConfigSource.cs" />
+    <Compile Include="CustomRavenConfigForVersion2_5.cs" />
     <Compile Include="DiscardingOldMessages.cs" />
     <None Include="Encryption\encryption.config">
       <SubType>Designer</SubType>

--- a/Snippets/Samples_4/app.config
+++ b/Snippets/Samples_4/app.config
@@ -18,6 +18,14 @@
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Raven.Client.Lightweight" publicKeyToken="37f41c7f99471593" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Raven.Abstractions" publicKeyToken="37f41c7f99471593" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Snippets/Samples_4/packages.config
+++ b/Snippets/Samples_4/packages.config
@@ -23,12 +23,14 @@
   <package id="NServiceBus.Interfaces" version="4.7.4" targetFramework="net45" />
   <package id="NServiceBus.NHibernate" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.Ninject" version="4.7.4" targetFramework="net45" />
+  <package id="NServiceBus.RavenDB" version="1.0.1" targetFramework="net45" />
   <package id="NServiceBus.Spring" version="4.7.4" targetFramework="net45" />
   <package id="NServiceBus.SqlServer" version="1.2.2" targetFramework="net45" />
   <package id="NServiceBus.StructureMap" version="4.6.5" targetFramework="net45" />
   <package id="NServiceBus.Testing" version="4.7.4" targetFramework="net45" />
   <package id="NServiceBus.Unity" version="5.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="RavenDB.Client" version="2.5.2938" targetFramework="net45" />
   <package id="Spring.Core" version="1.3.2" targetFramework="net45" />
   <package id="structuremap" version="2.6.4.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />


### PR DESCRIPTION
If using NServiceBus v4 endpoints and RavenDB 2.5 server is installed, then the user must install the NServiceBus.RavenDB nuget package and initialize appropriately. Added Guidance. Fixes https://github.com/Particular/docs.particular.net/issues/158
