### PR TITLE
clarified difference between v4 and v3 service installation

### DIFF
--- a/nservicebus/how-to-specify-your-input-queue-name.md
+++ b/nservicebus/how-to-specify-your-input-queue-name.md
@@ -33,7 +33,13 @@ NOTE: This will only work when using [NServiceBus host](the-nservicebus-host.md)
 
 ### Installation parameter 
 
-If you specify a explicit service name when installing the NServiceBus host, this is used as the endpoint name: `/serviceName:"MyEndpoint"`.
+#### NServiceBus v3
+
+If you specify a explicit service name when installing the NServiceBus host, this is used as the endpoint name: `/serviceName:"MyEndpoint"`.  
+
+#### NServiceBus v4
+
+If you specify a explicit endpoint name when installing the NServiceBus host, this is used as the endpoint name: `/endpointName:"MyEndpoint"`.  
 
 ### Command-line parameter 
 

--- a/nservicebus/how-to-specify-your-input-queue-name.md
+++ b/nservicebus/how-to-specify-your-input-queue-name.md
@@ -35,13 +35,13 @@ NOTE: This will only work when using [NServiceBus host](the-nservicebus-host.md)
 
 #### NServiceBus v3
 
-If you specify a explicit service name when installing the NServiceBus host, this is used as the endpoint name: `/serviceName:"MyEndpoint"`.  
+If you specify an explicit service name when installing the NServiceBus host, this is used as the endpoint name: `/serviceName:"MyEndpoint"`.  
 
 #### NServiceBus v4
 
-If you specify a explicit endpoint name when installing the NServiceBus host, this is used as the endpoint name: `/endpointName:"MyEndpoint"`.  
+If you specify an explicit endpoint name when installing the NServiceBus host, this is used as the endpoint name: `/endpointName:"MyEndpoint"`.  
 
 ### Command-line parameter 
 
-You can specify a endpoint name when running the NServiceBus host: `/endpointName:"MyEndpoint"`.
+You can specify an endpoint name when running the NServiceBus host: `/endpointName:"MyEndpoint"`.
 


### PR DESCRIPTION
After upgrading from v3 to v4, our service install scripts were not creating the right queue names even though we were specifying the /serviceName when doing an NServiceBus /install.  We had to add /endpointName to get it to take the right name.

I think this relates to eripe970's comment that the documentation is wrong in https://github.com/Particular/NServiceBus/issues/1816 although he explained his problem differently than mine.