### PR TITLE
New Persistence extensibility per storage API

### DIFF
--- a/Snippets/Snippets_3/Injection/Injection.cs
+++ b/Snippets/Snippets_3/Injection/Injection.cs
@@ -7,17 +7,16 @@
     {
         public void ConfigurePropertyInjectionForHandler()
         {
-            var configuration = new BusConfiguration();
+            #region ConfigurePropertyInjectionForHandlerBefore
 
-            #region ConfigurePropertyInjectionForHandler 5.2
-
-            configuration.InitializeHandlerProperty<EmailHandler>("SmtpAddress", "10.0.1.233");
-            configuration.InitializeHandlerProperty<EmailHandler>("SmtpPort", 25);
+            Configure.With()
+                .DefaultBuilder()
+                .Configurer
+                    .ConfigureProperty<EmailHandler>(handler => handler.SmtpAddress, "10.0.1.233")
+                    .ConfigureProperty<EmailHandler>(handler => handler.SmtpPort, 25);
 
             #endregion
         }
-
-        #region PropertyInjectionWithHandler 5.2
 
         public class EmailHandler : IHandleMessages<EmailMessage>
         {
@@ -30,8 +29,6 @@
                 // ...
             }
         }
-
-        #endregion
     }
 
     public class EmailMessage

--- a/Snippets/Snippets_3/Snippets_3.csproj
+++ b/Snippets/Snippets_3/Snippets_3.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Gateway\GatewayConfig.cs" />
     <Compile Include="HandlerOrdering.cs" />
     <Compile Include="Headers\HeaderUsage.cs" />
+    <Compile Include="Injection\Injection.cs" />
     <Compile Include="InstancePerUnitOfWorkRegistration.cs" />
     <Compile Include="Logging\Log4Net\Log4NetFiltering.cs" />
     <Compile Include="Logging\MessageToLog.cs" />

--- a/Snippets/Snippets_5/CustomConfigOverrides.cs
+++ b/Snippets/Snippets_5/CustomConfigOverrides.cs
@@ -11,7 +11,6 @@ public class CustomConfigOverrides
         configuration.AssembliesToScan(AllAssemblies.Except("NotThis.dll"));
         configuration.Conventions().DefiningEventsAs(type => type.Name.EndsWith("Event"));
         configuration.EndpointName("MyEndpointName");
-        configuration.EndpointVersion("1.2.3");
 
         #endregion
     }

--- a/Snippets/Snippets_5/Injection/Injection.cs
+++ b/Snippets/Snippets_5/Injection/Injection.cs
@@ -1,0 +1,41 @@
+﻿namespace MyServer.Injection
+{
+    using System.Net.Mail;
+    using NServiceBus;
+
+    public class Injection
+    {
+        public void ConfigurePropertyInjectionForHandler()
+        {
+            var configuration = new BusConfiguration();
+
+            #region ConfigurePropertyInjectionForHandler 5.2
+
+            configuration.InitializeHandlerProperty<EmailHandler>("SmtpAddress", "10.0.1.233");
+            configuration.InitializeHandlerProperty<EmailHandler>("SmtpPort", 25);
+
+            #endregion
+
+        }
+
+        #region PropertyInjectionWithHandler 5.2
+
+        public class EmailHandler : IHandleMessages<EmailMessage>
+        {
+            public string SmtpAddress { get; set; }
+            public int SmtpPort { get; set; }
+
+            public void Handle(EmailMessage message)
+            {
+                var client = new SmtpClient(SmtpAddress, SmtpPort);
+                // ...
+            }
+        }
+
+        #endregion
+    }
+
+    public class EmailMessage
+    {
+    }
+}

--- a/Snippets/Snippets_5/Persistence.cs
+++ b/Snippets/Snippets_5/Persistence.cs
@@ -5,6 +5,7 @@ public class Persistence
 {
     public void AllThePersistence()
     {
+#pragma warning disable 618
 
         #region ConfigurePersistence
 
@@ -32,6 +33,7 @@ public class Persistence
             .For(Storage.Sagas, Storage.Subscriptions);
 
         #endregion
+#pragma warning restore 618
     }
 
 }

--- a/Snippets/Snippets_5/Persistence/NHibernate/ConfiguringNHibernate.cs
+++ b/Snippets/Snippets_5/Persistence/NHibernate/ConfiguringNHibernate.cs
@@ -3,9 +3,11 @@ using NServiceBus.Persistence;
 
 class ConfiguringNHibernate
 {
-    public void Foo()
+    public void Version_5_0()
     {
-        #region ConfiguringNHibernate
+#pragma warning disable 618
+
+        #region ConfiguringNHibernate 5.0
 
         var config = new BusConfiguration();
 
@@ -16,6 +18,23 @@ class ConfiguringNHibernate
                 Storage.Timeouts,
                 Storage.Outbox,
                 Storage.GatewayDeduplication);
+
+        #endregion
+#pragma warning restore 618
+
+    }
+
+    public void Version_5_2()
+    {
+        #region ConfiguringNHibernate 5.2
+
+        var config = new BusConfiguration();
+
+        config.UsePersistence<NHibernatePersistence, StorageType.Sagas>();
+        config.UsePersistence<NHibernatePersistence, StorageType.Subscriptions>();
+        config.UsePersistence<NHibernatePersistence, StorageType.Timeouts>();
+        config.UsePersistence<NHibernatePersistence, StorageType.Outbox>();
+        config.UsePersistence<NHibernatePersistence, StorageType.GatewayDeduplication>();
 
         #endregion
     }

--- a/Snippets/Snippets_5/Persistence/PersistenceOrder.cs
+++ b/Snippets/Snippets_5/Persistence/PersistenceOrder.cs
@@ -3,9 +3,11 @@ using NServiceBus.Persistence;
 
 class PersistenceOrder
 {
-    void Setup()
+    void Setup_5_0()
     {
-        #region PersistenceOrder_Correct
+#pragma warning disable 618
+
+        #region PersistenceOrder_Correct 5.0
         var config = new BusConfiguration();
 
         config.UsePersistence<RavenDBPersistence>();
@@ -16,11 +18,28 @@ class PersistenceOrder
         config.UsePersistence<InMemoryPersistence>()
             .For(Storage.GatewayDeduplication);
         #endregion
+#pragma warning restore 618
     }
 
-    void Setup3()
+    void Setup_5_2()
     {
-        #region PersistenceOrder_Explicit
+        #region PersistenceOrder_Correct 5.2
+        var config = new BusConfiguration();
+
+        config.UsePersistence<RavenDBPersistence>();
+
+        config.UsePersistence<NHibernatePersistence, StorageType.Outbox>();
+
+        config.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
+
+        #endregion
+    }
+
+    void Setup3_5_0()
+    {
+#pragma warning disable 618
+
+        #region PersistenceOrder_Explicit 5.0
         var config = new BusConfiguration();
 
         config.UsePersistence<NHibernatePersistence>()
@@ -32,11 +51,30 @@ class PersistenceOrder
         config.UsePersistence<RavenDBPersistence>()
             .For(Storage.Sagas, Storage.Subscriptions, Storage.Timeouts);
         #endregion
+#pragma warning restore 618
+
     }
 
-    void Setup2()
+    void Setup3_5_2()
     {
-        #region PersistenceOrder_Incorrect
+        #region PersistenceOrder_Explicit 5.2
+        var config = new BusConfiguration();
+
+        config.UsePersistence<NHibernatePersistence, StorageType.Outbox>();
+
+        config.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
+
+        config.UsePersistence<RavenDBPersistence, StorageType.Sagas>();
+        config.UsePersistence<RavenDBPersistence, StorageType.Subscriptions>();
+        config.UsePersistence<RavenDBPersistence, StorageType.Timeouts>();
+        #endregion
+    }
+
+    void Setup2_5_0()
+    {
+#pragma warning disable 618
+
+        #region PersistenceOrder_Incorrect 5.0
         var config = new BusConfiguration();
 
         config.UsePersistence<NHibernatePersistence>()
@@ -45,6 +83,21 @@ class PersistenceOrder
         config.UsePersistence<InMemoryPersistence>()
             .For(Storage.GatewayDeduplication);
 
+        // This one will override the above settings!
+        config.UsePersistence<RavenDBPersistence>();
+        #endregion
+#pragma warning restore 618
+    }
+
+    void Setup2_5_2()
+    {
+        #region PersistenceOrder_Incorrect 5.2
+        var config = new BusConfiguration();
+
+        config.UsePersistence<NHibernatePersistence, StorageType.Outbox>();
+
+        config.UsePersistence<InMemoryPersistence, StorageType.GatewayDeduplication>();
+            
         // This one will override the above settings!
         config.UsePersistence<RavenDBPersistence>();
         #endregion

--- a/Snippets/Snippets_5/ScaleOut/individualize_queues.cs
+++ b/Snippets/Snippets_5/ScaleOut/individualize_queues.cs
@@ -1,0 +1,24 @@
+﻿namespace Snippets_5.ScaleOut
+{
+    using NServiceBus;
+
+    class individualize_queues
+    {
+        public void ConfigurePropertyInjectionForHandler()
+        {
+            var configuration = new BusConfiguration();
+
+            #region UniqueQueuePerEndpointInstance 5.2
+
+            configuration.ScaleOut().UniqueQueuePerEndpointInstance();
+
+            #endregion
+
+            #region UniqueQueuePerEndpointInstanceWithSuffix 5.2
+
+            configuration.ScaleOut().UniqueQueuePerEndpointInstance("-MyCustomSuffix");
+
+            #endregion
+        }
+    }
+}

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -325,6 +325,7 @@
     <Compile Include="RavenDB\ChangeResourceManagerID.cs" />
     <Compile Include="RavenDB\ConfiguringTransactionRecoveryStorage.cs" />
     <Compile Include="RegisterCustomSerializer.cs" />
+    <Compile Include="ScaleOut\individualize_queues.cs" />
     <Compile Include="Scanning\ScanningPublicApi.cs" />
     <Compile Include="TimeToWaitBeforeTriggeringCriticalErrorOnTimeoutOutages.cs" />
     <Compile Include="Encryption\MessageBodyEncryption.cs" />

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -312,6 +312,7 @@
     <Compile Include="HostIdentifier\HostIdFixer_5_1.cs" />
     <Compile Include="Host\AsAClientEquivalent.cs" />
     <Compile Include="Host\CustomizingHost.cs" />
+    <Compile Include="Injection\Injection.cs" />
     <Compile Include="InstancePerUnitOfWorkRegistration.cs" />
     <Compile Include="Logging\Log4Net\Log4NetFiltering.cs" />
     <Compile Include="Logging\MessageToLog.cs" />

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -98,7 +98,7 @@
     </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Ninject.3.2.3-unstable-001\lib\net45-full\Ninject.dll</HintPath>
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="Ninject.Extensions.ContextPreservation, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -126,7 +126,7 @@
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.5.1.2\lib\net45\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.5.2.0\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Distributor.MSMQ">
       <HintPath>..\packages\NServiceBus.Distributor.MSMQ.5.0.1\lib\net45\NServiceBus.Distributor.MSMQ.dll</HintPath>

--- a/Snippets/Snippets_5/packages.config
+++ b/Snippets/Snippets_5/packages.config
@@ -12,11 +12,11 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="NHibernate" version="4.0.1.4000" targetFramework="net45" />
-  <package id="Ninject" version="3.2.3-unstable-001" targetFramework="net45" />
+  <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
   <package id="Ninject.Extensions.ContextPreservation" version="3.2.0.0" targetFramework="net45" />
   <package id="Ninject.Extensions.NamedScope" version="3.2.0.0" targetFramework="net45" />
   <package id="NLog" version="3.0.0.0" targetFramework="net45" />
-  <package id="NServiceBus" version="5.1.2" targetFramework="net45" />
+  <package id="NServiceBus" version="5.2.0" targetFramework="net45" />
   <package id="NServiceBus.Autofac" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.Azure" version="6.1.3" targetFramework="net45" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="6.1.3" targetFramework="net45" />

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -29,6 +29,7 @@
         - "nservicebus/introduction-to-the-gateway"
         - "nservicebus/deploying-nservicebus-in-a-windows-failover-cluster"
         - "nservicebus/using-multiple-azure-storage-accounts-for-scaleout"
+        - "nservicebus/individualizing-queues-when-scaling-out"
     - 
       Name: "persistence-in-nservicebus"
       Title: "Persistence In NServiceBus"
@@ -156,6 +157,7 @@
         - "nservicebus/how-to-register-a-custom-serializer"
         - "nservicebus/gateway-service-point-manager"
         - "nservicebus/plugin-custom-databus"
+        - "nservicebus/property-injection-in-handlers"
 - 
   Name: "ServiceMatrix"
   Topics: 

--- a/nservicebus/index.md
+++ b/nservicebus/index.md
@@ -48,6 +48,7 @@ summary: NServiceBus Documentation Table of Contents
 - [Load Balancing with the Distributor](load-balancing-with-the-distributor.md)
 - [Introduction to the Gateway](introduction-to-the-gateway.md)
 - [Deploying NServiceBus in a Windows Fail-over Cluster](deploying-nservicebus-in-a-windows-failover-cluster.md)
+- [Individualizing endpoint queue names when Scaling-Out](individualizing-queues-when-scaling-out.md)
 
 ## Day to Day
 
@@ -147,6 +148,7 @@ summary: NServiceBus Documentation Table of Contents
 - [How to specify time to wait before raising critical exception for timeout outages](how-do-i-specify-time-to-wait-before-raising-critical-exception-for-timeout-outages.md)
 - [How to register a custom serializer](how-to-register-a-custom-serializer.md)
 - [.Net Framework version requirements](nservicebus-net-framework-version-requirements.md)
+- [Property injection in handlers](property-injection-in-handlers.md)
 
 ## Troubleshooting
 

--- a/nservicebus/individualizing-queues-when-scaling-out.md
+++ b/nservicebus/individualizing-queues-when-scaling-out.md
@@ -1,0 +1,22 @@
+---
+title: Individualizing endpoint queue names when Scaling-Out
+summary: How to enable individualizing queue names when Scaling-Out endpoints
+tags: 
+- Scale Out
+---
+
+INFO: This is relevant to versions 5.2 and above.
+
+When scaling out an endpoint you need to make sure it gets a unique input queue per instance while keeping the endpoint name the same.
+For this reason we have introduced a new API from NServiceBus v5.2 that allows you to enable queue name individualization per endpoint.
+
+<!-- import UniqueQueuePerEndpointInstance --> 
+This will tell NServiceBus to use the suffix registered by the transport or host to make sure that each instance of your endpoint will be unique. For MSMQ this is a no-op since you commonly scaled them out by running multiple instances on different machines and that will give them a unique address out of the box. Eg: `sales@server1, sales@serverN` etc.
+
+For broker transports that's no longer true, hence the need for a suffix. For on-premise operations the machine name is likely to be used and in cloud scenarios like on Azure the instance id is better suited since machines will dynamically change. 
+
+RabbitMQ example:  `sales-server1, sales-serverN` 
+Azure ServiceBus example:  `sales-1, sales-N` where N is the role instance id
+
+If you need full control over the suffix or if the transport hasn't registered a default you can control it using:
+<!-- import UniqueQueuePerEndpointInstanceWithSuffix --> 

--- a/nservicebus/property-injection-in-handlers.md
+++ b/nservicebus/property-injection-in-handlers.md
@@ -1,0 +1,22 @@
+---
+title: Property injection in handlers
+summary: How to configure property injection for handlers
+tags: 
+- Dependency Injection
+- IOC
+---
+
+INFO: This is relevant to versions 5.2 and above.
+
+In previous versions of NServiceBus, to inject property values into a handler type you could do the following:
+<!-- import ConfigurePropertyInjectionForHandlerBefore --> 
+This is no longer supported.
+
+From v5.2 and above a new and more explicit API has been introduced.
+
+### Here is how to use the new API
+Given the following handler class:
+<!-- import PropertyInjectionWithHandler --> 
+
+To inject a value into both `SmtpAddress` and `SmtpPort` you need to at configuration time call `InitializeHandlerProperty<THandler>` with the handler and values you intend to inject, here is an example:
+<!-- import ConfigurePropertyInjectionForHandler --> 


### PR DESCRIPTION
**Warning**: Merge this documentation once NServiceBus V5.2 is released.

Updated code snippets to reflect changes in Persistence extensibility per storage API (deprecation of `Storage` and introduction of `StorageType`) introduced with the [following PR](https://github.com/Particular/NServiceBus/pull/2587).

/cc @johnsimons 