### PR TITLE
fixing typo

### DIFF
--- a/nservicebus/containers.md
+++ b/nservicebus/containers.md
@@ -8,7 +8,7 @@ tags:
 
 NServiceBus automatically registers all its components as well as user-implemented handlers and sagas so that all instancing modes and wiring are done correctly by default and without errors.
 
-NServiceBus has a build in container (currently an ILMerged version of Autofac) but it can be replaced by any other container.
+NServiceBus has a built-in container (currently an ILMerged version of Autofac) but it can be replaced by any other container.
 
 ## Getting other containers
 


### PR DESCRIPTION
build in -> built-in