### PR TITLE
Update install-servicepulse-in-iis.md

### DIFF
--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -11,7 +11,7 @@ It is possible to manually install ServicePulse using IIS following these steps:
 
 * Extract ServicePulse files using, at a command prompt, the following command:
 ```
-ServicePulse.Host.exe` --extract--serviceControlUrl="http://localhost:8080/api" --outPath="C:\temp\SP
+ServicePulse.Host.exe --extract --serviceControlUrl="http://localhost:8080/api" --outputPath="C:\temp\SP"
 ```
 
 Note: ServicePulse.Host.exe can be found in the ServicePulse installation directory, whose default is `%programfiles(x86)%\Particular Software\ServicePulse`


### PR DESCRIPTION
Added space in between --extract and --serviceControlURL parameters.
Renamed --outPath to --outputPath
Closing quote on outPath

These changes enabled me to run it successfully to get the site output to run in IIS.