### PR TITLE
corrected some of the English

### DIFF
--- a/nservicebus/testing/unit-testing.md
+++ b/nservicebus/testing/unit-testing.md
@@ -25,7 +25,7 @@ The service layer in an NServiceBus application is made from message handlers. E
 
 <!-- import TestingServiceLayer --> 
 
-This test says that when a message of the type `RequestMessage` is processed by `MyHandler`, it responds with a message of the type `ResponseMessage`. Also, if the request message's String property value is "hello" than that is also the value of the String property of the response message.
+This test says that when a message of the type `RequestMessage` is processed by `MyHandler`, it responds with a message of the type `ResponseMessage`. Also, the test checks that if the request message's String property value is "hello" then that should be the value of the String property of the response message.
 
 ## Testing a Saga
 
@@ -36,7 +36,7 @@ To support testing of interface messages v5 introduces a `.WhenHandling<T>()` me
 
 ## Testing header manipulation
 
-It is the responsibility of the message handlers in the service layer is to use data from headers found in the request to make decisions, and to set headers on top of the response messages. This is how this kind of functionality can be tested:
+It is the responsibility of the message handlers in the service layer to use data from headers found in the request to make decisions, and to set headers for the response messages. This is how such functionality can be tested:
 
 
 <!-- import TestingHeaderManipulation -->


### PR DESCRIPTION
* Removed is
* Than instead of Then (typical mistake originated with the Israeli accent in English)
* Removed double use of 'this'
* Clarified some of the text