### PR TITLE
Obsoletng QueueName and QueuePerInstance from Azure transports in favour on core settings

### DIFF
--- a/nservicebus/azure/azure-servicebus-transport.md
+++ b/nservicebus/azure/azure-servicebus-transport.md
@@ -59,7 +59,6 @@ If you need fine grained control on how the Azure Service Bus transport behaves,
 Using this configuration setting you can change the following values. NOTE: Most of these values are applied when a queue or topic is created and cannot be changed afterwards).
 
 - `ConnectionString`: Overrides the default "NServiceBus/Transport" connectionstring value.
-- `QueueName`: Allows you to specify the queue name. If not set, NServiceBus creates a queue name for you based on the endpoint naming convention.
 - `ConnectivityMode`: Allows you to switch between HTTP and TCP based communication. Defaults to TCP. Very useful when behind a firewall.
 - `ServerWaitTime`: The transport uses longpolling to communicate with the Azure Service Bus entities. This value specifies the amount of time, in seconds, the longpoll can take. Defaults to 300 seconds. 
 - `BackoffTimeInSeconds`: The transport will back off linearly when no messages can be found on the queue to save some money on the transaction operations. This value specifies how fast it will back off. Defaults to 10 seconds.
@@ -74,7 +73,8 @@ Using this configuration setting you can change the following values. NOTE: Most
 - `DefaultMessageTimeToLive`: Specifies the time that a message can stay in the queue without being delivered. Defaults to int64.MaxValue, which is roughly 10.000 days.
 - `EnableDeadLetteringOnMessageExpiration`: Specifies whether messages should be moved to a dead letter queue upon expiration. Defaults to false (TTL is so large it wouldn't matter anyway). This assumes there have been no attempts to deliver. Errors on delivery will still put the message on the dead letter queue.
 - `EnableDeadLetteringOnFilterEvaluationExceptions`: Specifies whether messages should be moved to a dead letter queue upon filter evaluation exceptions. Defaults to false.
-- `QueuePerInstance`: Tells NServiceBus to create a separate queue for every instance of the endpoint hosted. This is useful in pub/sub scenarios where you want a message to arrive for every instance of the endpoint, i.e., in a webfarm that has a local cache on every machine. Defaults to false.
+
+NOTE: `QueueName` and `QueuePerInstance` are obsoleted. Instead, use bus configuration object to specify endpoint name and scale-out option.
 
 ## Sample
 

--- a/nservicebus/azure/azure-storage-queues-transport.md
+++ b/nservicebus/azure/azure-storage-queues-transport.md
@@ -63,15 +63,13 @@ If you need more fine grained control on how the azure storage queue transport b
 Using this configuration setting you can change the following values.
 
 - `ConnectionString`: Overrides the default "NServiceBus/Transport" value and defaults to "UseDevelopmentStorage=true" if not set. Best to set this value when specifying the configuration setting to prevent surprises.
-- `QueueName`: Allows you to specify the queue name, if not set NServiceBus will create a queue name for you based on the endpoint naming convention.
 - `PeekInterval`: Represents the amount of time that the transport waits before polling the queue in milliseconds, defaults to 50 ms.
 - `MaximumWaitTimeWhenIdle`: The transport will back of linearly when no messages can be found on the queue to save some money on the transaction operations, but it will never wait longer than the value specified here, also in milliseconds and defaults to 1000 (1 second)
 - `PurgeOnStartup`: Instructs the transport to remove any existing messages from the queue on startup, defaults to false.
 - `MessageInvisibleTime`: The peek lock system, supported by azure storage queues relies on a period of time that a message becomes locked/invisible after being read. If the processing unit fails to delete the message by the specified time it will reappear on the queue so that another process can retry. This value is defined in milliseconds and defaults to 30000 (30 seconds).
 - `BatchSize`: The number of messages that the transport tries to pull at once from the storage queue. Defaults to 10. Depending on the load you expect, I would vary this value between 1 and 1000 (which is the limit)
-- `QueuePerInstance`: Tells nservicebus to create a separate queue for every instance of the endpoint hosted. This is useful in pub sub scenario's where you want a message to arrive at every instance of the endpoint, f.e. in a webfarm that has local cache on every machine. Defaults to false.
 
-```
+NOTE: `QueueName` and `QueuePerInstance` are obsoleted. Instead, use bus configuration object to specify endpoint name and scale-out option.
 
 ## Sample
 


### PR DESCRIPTION
Based on https://github.com/Particular/Requirements/issues/245 

**Attention**: should be merged when PR for ASB https://github.com/Particular/NServiceBus.AzureServiceBus/pull/27 and PR for ASQ https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/9 are accepted and released.