### PR TITLE
Describing outbox ravendb and including how to configure timetokeep

### DIFF
--- a/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
+++ b/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NServiceBus;
-using NServiceBus.Configuration.AdvanceExtensibility;
 
 public class TimeToKeep
 {
@@ -9,8 +8,8 @@ public class TimeToKeep
         BusConfiguration configuration = null;
 
         #region OutboxRavendBTimeToKeep
-        configuration.GetSettings().Set("Outbox.TimeToKeepDeduplicationData", TimeSpan.FromDays(7));
-        configuration.GetSettings().Set("Outbox.FrequencyToRunDeduplicationDataCleanup", TimeSpan.FromMinutes(1));
+        configuration.SetTimeToKeepDeduplicationData(TimeSpan.FromDays(7));
+        configuration.SetFrequencyToRunDeduplicationDataCleanup(TimeSpan.FromMinutes(1));
         #endregion
     }
 }

--- a/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
+++ b/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NServiceBus;
+using NServiceBus.RavenDB.Outbox;
 
 public class TimeToKeep
 {

--- a/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
+++ b/Snippets/Snippets_5/Outbox/RavenDB/TimeToKeep.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NServiceBus;
+using NServiceBus.Configuration.AdvanceExtensibility;
+
+public class TimeToKeep
+{
+    public void Customize()
+    {
+        BusConfiguration configuration = null;
+
+        #region OutboxRavendBTimeToKeep
+        configuration.GetSettings().Set("Outbox.TimeToKeepDeduplicationData", TimeSpan.FromDays(7));
+        configuration.GetSettings().Set("Outbox.FrequencyToRunDeduplicationDataCleanup", TimeSpan.FromMinutes(1));
+        #endregion
+    }
+}

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -391,6 +391,8 @@
     <Compile Include="UnitTesting\Saga.cs" />
     <Compile Include="UnitTesting\ServiceLayer.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Outbox\RavenDB\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -186,7 +186,7 @@
     </Reference>
     <Reference Include="NServiceBus.RavenDB, Version=2.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.RavenDB.2.1.0\lib\net45\NServiceBus.RavenDB.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.RavenDB.2.2.0\lib\net45\NServiceBus.RavenDB.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Testing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Logging\NLog\NLogFiltering.cs" />
     <Compile Include="Monitoring\ServiceControlEventsConfig.cs" />
     <Compile Include="Monitoring\MessageFailedHandler.cs" />
+    <Compile Include="Outbox\RavenDB\TimeToKeep.cs" />
     <Compile Include="Persistence\Azure\AzurePersistence.cs" />
     <Compile Include="Persistence\NHibernate\ConfiguringNHibernate.cs" />
     <Compile Include="Persistence\PersistenceOrder.cs" />
@@ -391,8 +392,6 @@
     <Compile Include="UnitTesting\Saga.cs" />
     <Compile Include="UnitTesting\ServiceLayer.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Outbox\RavenDB\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Snippets/Snippets_5/packages.config
+++ b/Snippets/Snippets_5/packages.config
@@ -32,7 +32,7 @@
   <package id="NServiceBus.Ninject" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.NLog" version="1.0.0" targetFramework="net45" />
   <package id="NServiceBus.RabbitMQ" version="2.1.1" targetFramework="net45" />
-  <package id="NServiceBus.RavenDB" version="2.1.0" targetFramework="net45" />
+  <package id="NServiceBus.RavenDB" version="2.2.0" targetFramework="net45" />
   <package id="NServiceBus.Spring" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.SqlServer" version="2.1.1" targetFramework="net45" />
   <package id="NServiceBus.StructureMap" version="5.0.1" targetFramework="net45" />

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -73,5 +73,3 @@ The RavenDB implementation by default keeps deduplication records for 7 days and
 These default settings can be changed by specifying new defaults in the settings dictionary, here is how to do it:
 
 <!-- import OutboxRavendBTimeToKeep -->
-
-### Sample

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -35,28 +35,43 @@ Here is a diagram how it all works:
 
 ## Caveats
 
-- Currently only NHibernate storage has been implemented;
-- Both the business data and dedupplication data need to share the same database;
+- Both the business data and dedupplication data need to share the same database
 
-## SQL Server Transport
+## Using outbox with NHibernate persistence
+
+### SQL Server Transport
 
 SQL Server transport supports *exactly-once* message delivery without Outbox solely by means of sharing the transport connection with persistence. This mode of operation is discussed in depth in this [sample](/samples/sqltransport-nhpersistence).
 
-## What extra tables does NHibernate outbox persistence create 
+### What extra tables does NHibernate outbox persistence create 
 
 To keep track duplicate messages, the NHibernate implementation of Outbox requires the creation of two additional tables in your database, these are called `OutboxRecord` and `OutboxOperation`.
 
-## How long are the deduplication records kept
+### How long are the deduplication records kept
 
 The NHibernate implementation by default keeps deduplication records for 7 days and runs the purge every 1 minute.
 These default settings can be changed by specifying new defaults in the config file using [TimeStamp strings](https://msdn.microsoft.com/en-us/library/ee372286.aspx), here is how to do it:
 
 <!-- import OutboxNHibernateTimeToKeep -->
 
-## Sample
+### Sample
 
 The sample shows how to configure an Endpoint that uses SQL Server transport and NHibernate as it business data storage and how to access the NHIbernate `ISession` for a `Saga` and a `Handler`.
 
 ### [Outbox Sample](https://github.com/Particular/NServiceBus.NHibernate/archive/Samples.zip) 
 
 This sample shows how to enable Outbox on an endpoint and how to access the NHibernate `ISession` for a `Saga` and a `Handler`. 
+
+## Using outbox with RavenDB persistence
+### What extra documents does RavenDB outbox persistence create 
+
+To keep track duplicate messages, the RavenDB implementation of Outbox creates a special collection of documents inside your database, these are called `OutboxRecord`.
+
+### How long are the deduplication records kept
+
+The RavenDB implementation by default keeps deduplication records for 7 days and runs the purge every 1 minute.
+These default settings can be changed by specifying new defaults in the settings dictionary, here is how to do it:
+
+<!-- import OutboxRavendBTimeToKeep -->
+
+### Sample


### PR DESCRIPTION
I'm not yet sure whether we should really document the access to the `Outbox.*` settings. Really on the fence here. But I added time for completeness reasons.

Additionally I have a few questions about the current structure:

We have the outbox doco page which is describing outbox in general and then primarily NH persistence and Sql transport related things (before). Now I just added as an extension the ravendb outbox settings as well. My question is:

Should we move all persistence specific doco into a page in the corresponding persister? And if we do so also align the navigation there? For example currently the persister in the NH case is called `NHibernate persister` but in the RavenDB case simple `RavenDB`.