### PR TITLE
Updated assembly scanning docu and snippets

### DIFF
--- a/Snippets/Snippets_4/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Snippets_4/Scanning/ScanningPublicApi.cs
@@ -39,11 +39,11 @@ public class ScanningPublicApi
         #endregion
 
         #region ScanningIncludeByPattern
-        Configure.With(AllAssemblies.Matching("MyCompany.").And("SomethingElse"));
+        Configure.With(AllAssemblies.Matching("NServiceBus").And("MyCompany.").And("SomethingElse"));
         #endregion
 
         #region ScanningMixingIncludeAndExclude
-        Configure.With(AllAssemblies.Matching("MyCompany.").Except("BadAssembly.dll"));
+        Configure.With(AllAssemblies.Matching("NServiceBus").Matching("MyCompany.").Except("MyCompany.BadAssembly.dll"));
         #endregion
          
             

--- a/Snippets/Snippets_5/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Snippets_5/Scanning/ScanningPublicApi.cs
@@ -53,13 +53,13 @@ public class ScanningPublicApi
 
         #region ScanningIncludeByPattern
 
-        configuration.AssembliesToScan(AllAssemblies.Matching("MyCompany.").And("SomethingElse"));
+        configuration.AssembliesToScan(AllAssemblies.Matching("NServiceBus").And("MyCompany.").And("SomethingElse"));
 
         #endregion
 
         #region ScanningMixingIncludeAndExclude
 
-        configuration.AssembliesToScan(AllAssemblies.Matching("MyCompany.").Except("BadAssembly.dll"));
+        configuration.AssembliesToScan(AllAssemblies.Matching("NServiceBus").Matching("MyCompany.").Except("MyCompany.BadAssembly.dll"));
 
         #endregion
 

--- a/nservicebus/assembly-scanning.md
+++ b/nservicebus/assembly-scanning.md
@@ -18,6 +18,10 @@ There are some cases where you need fine grained control over which assemblies a
  
 NOTE: Extension (like NServiceBus.Distributor.MSMQ.dll or NServiceBus.RavenDB for example) are not considered core dlls and will need to be explicitly added if you customize assembly scanning.
 
+Use the `AllAssemblies` helper to easily create a list of assemblies either by creating a blacklist using the method `Except` or a whitelist by using `Matching` or a combination of both.
+
+NOTE: The `Except`, `Matching` and `And` methods behave like `string.StartsWith(string)`.
+
 ### By default all types in your bin directory are scanned if you call:
 
 <!-- import ScanningDefault -->


### PR DESCRIPTION
* Mentioning that using `AllAssembly` helper can be used to either to whitelist or blacklist assemblies and that its methods behave like `.StartsWith(string)`
* ScanningIncludeByPattern snippet now includes the pattern to include all NServiceBus assemblies.
* ScanningMixingIncludeAndExclude snippet previously didn't make any sense as the exclusion was not included in the first place. Updated to reflect a more common scenario.