### PR TITLE
Release policy restructured with samples

### DIFF
--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -10,6 +10,7 @@ To reduce scope and risk we have optimized to release small components with a re
 
 While this may seem to result in a large number of releases only a small fraction of these will actually affect your system.
 
+
 ### Semantic Versioning 
 
 [SemVer](http://semver.org/) is a simple set of rules and requirements that dictate how version numbers are assigned and incremented. 
@@ -31,27 +32,25 @@ While not stipulated by SemVer we've made the decision to backport important fix
 
 By "supported" we mean
 
-* all major versions released within the last 3 years
-* and any minor version released within the last year
-* unless it is the latest minor of a major release
+* All major versions released within the last 3 years
+* And any minor version released within the last year
+* Unless it is the latest minor of a major release
 
 This means that you will get critical bugfixes without the associated risk and effort of upgrading to a higher `{major}.{minor}` version.
 
-
 Some examples:
 
- - v4.0 was released on Juli 11th, 2013 and will be supported until Juli 11th 2016 but only the minor versions released of the previous year and its latest minor.
-
- - v4.6 was released on May 1th 2014 this means that its latest patch release will be supported till May 1th 2015. This means that we will not fix minor versions after May 1th 2015. You are required to update to atleast a newer minor version that is still suppported as this version will receive a patch release. 
-
+ - v4.0 was released on 2013-07-11 and will be supported until 2016 -07-11 but only the minor versions released of the previous year and its latest minor.
+ - v4.6 was released on 2014-05-01 this means that its latest patch release will be supported till 2015-05-01. This means that we will not fix minor versions after 2015-05-01. You are required to update to at least a newer minor version that is still supported as this version will receive a patch release. 
  - A newer patch release will automatically mean that the previous patch release will be obsolete. We will apply a bugfix on the latest patch release but will not officially release a patch for a obsolete patch release. In other words, we will not patch vX.Y.3 to vX.Y.3.1 when vX.Y.4 is the latest patch. We would then release vX.Y.5
-
 
 We strongly recommend you upgrade frequently enough to stay on a supported version.
 
 Please let us know if there are any bugfixes that you believe should be back-ported to your current version by emailing [support@particular.net](mailto:support@particular.net).
 
+
 ## Summary
+
 The following table summarize the risk effort and urgency for the different types of releases
 
 |  | Patch | Minor | Major |
@@ -63,18 +62,22 @@ The following table summarize the risk effort and urgency for the different type
 
 
 ### Patch
+
 Patches are released as soon as an important issue is found. Read the release notes to determine if you're affected. 
 
 NOTE: Any issue that could affect the production stability of your system will be classified as `hotfix` so please pay extra attention to those.
 
 Patch releases are 100% backwards-compatible so you should be able safely upgrade with low risk and effort. In rare cases a code change might be required in relation to the patch. Minimal testing may be required, but where possible verify that it fixes the issue in question. 
 
+
 ### Minor
+
 Minor versions contain bugfixes not critical enough to warrant a `patch` as well as some feature enhancements. 
 
 Note that these releases are 100% backwards-compatible (as stipulated by SemVer). Since adding new features requires more code to be added/changed, the risk of upgrading to a `minor` is higher compared to a `patch` release and it's likely that code changes will be needed to take advantage of them. 
 
 Since all critical issues will be back-ported, you can choose to upgrade when it's suitable for you, for example as part of releasing non-trivial updates to your own system.
+
 
 ### Major
 

--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -29,7 +29,23 @@ By following SemVer 2.0 you will be able to quickly determine the urgency, risk 
 
 While not stipulated by SemVer we've made the decision to backport important fixes to all supported versions of NServiceBus.
 
-By "supported" we mean any minor version released within the last year and all major versions released within the last 3 years. This means that you will get critical bugfixes without the associated risk and effort of upgrading to a higher `{major}.{minor}` version. 
+By "supported" we mean
+
+* all major versions released within the last 3 years
+* and any minor version released within the last year
+* unless it is the latest minor of a major release
+
+This means that you will get critical bugfixes without the associated risk and effort of upgrading to a higher `{major}.{minor}` version.
+
+
+Some examples:
+
+ - v4.0 was released on Juli 11th, 2013 and will be supported until Juli 11th 2016 but only the minor versions released of the previous year and its latest minor.
+
+ - v4.6 was released on May 1th 2014 this means that its latest patch release will be supported till May 1th 2015. This means that we will not fix minor versions after May 1th 2015. You are required to update to atleast a newer minor version that is still suppported as this version will receive a patch release. 
+
+ - A newer patch release will automatically mean that the previous patch release will be obsolete. We will apply a bugfix on the latest patch release but will not officially release a patch for a obsolete patch release. In other words, we will not patch vX.Y.3 to vX.Y.3.1 when vX.Y.4 is the latest patch. We would then release vX.Y.5
+
 
 We strongly recommend you upgrade frequently enough to stay on a supported version.
 

--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -40,7 +40,7 @@ This means that you will get critical bugfixes without the associated risk and e
 
 Some examples:
 
- - v4.0 was released on 2013-07-11 and will be supported until 2016 -07-11 but only the minor versions released of the previous year and its latest minor.
+ - v4.0 was released on 2013-07-11 and v4 will therefor be supported until 2016-07-11 but only if you're on the latest minor or a minor version released within  the last year.
  - v4.6 was released on 2014-05-01 this means that its latest patch release will be supported till 2015-05-01. This means that we will not fix minor versions after 2015-05-01. You are required to update to at least a newer minor version that is still supported as this version will receive a patch release. 
  - A newer patch release will automatically mean that the previous patch release will be obsolete. We will apply a bugfix on the latest patch release but will not officially release a patch for a obsolete patch release. In other words, we will not patch vX.Y.3 to vX.Y.3.1 when vX.Y.4 is the latest patch. We would then release vX.Y.5
 


### PR DESCRIPTION
Better information about which versions are supported to decide when backporting is required and for customers to understand if their current version is still supported to receive bug fixes.

@andreasohlund Please review, this should reflect the discussion we had on Slacks #release-policy channel.


