### PR TITLE
SQL Server transport queue schema support updates

### DIFF
--- a/Snippets/Snippets_5/Transports/SqlServer/MultiDb.config
+++ b/Snippets/Snippets_5/Transports/SqlServer/MultiDb.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <!--startcode sqlserver-multidb-current-endpoint-schema-config 2.1 -->
+  <!--startcode sqlserver-multidb-current-endpoint-schema-config 1.2.3 -->
   <connectionStrings>
     <add name="NServiceBus/Transport" 
          connectionString="Data Source=INSTANCE_NAME; Initial Catalog=some_database; Integrated Security=True; Queue Schema=nsb"/>

--- a/nservicebus/sqlserver/multiple-databases.md
+++ b/nservicebus/sqlserver/multiple-databases.md
@@ -32,6 +32,8 @@ The other parameters (database and instance name/address) can be changed in code
 
 NOTE: `Queue Schema` parameter can also be used in the connection string provided via code.
 
+NOTE: Starting with `V1.2.3` of the `SQL Server Transport` the `Queue Schema` parameter is supported only when used used in the connection string provided via code or via configuration.
+
 NOTE: Unlike in the SQL Server transport, the connection string configuration API in NServiceBus core favors code over config which means that if you configure connection string both in `app.config` and via the `ConnectionString()` method, the latter will win.
 
 ## Other endpoints

--- a/servicecontrol/multi-transport-support.md
+++ b/servicecontrol/multi-transport-support.md
@@ -18,13 +18,13 @@ NOTE: This documents assumes you had already installed ServiceControl
 First, download the NuGet package for the relevant transport including any dependencies.    
 
 * RabbitMQ: [NServiceBus.RabbitMQ v1.1.5](https://www.nuget.org/api/v2/package/NServiceBus.RabbitMQ/1.1.5) and [RabbitMQ.Client 3.3.5](https://www.nuget.org/api/v2/package/RabbitMQ.Client/3.3.5)
-* SQL Server: [NServiceBus.SqlServer v1.2.2](https://www.nuget.org/api/v2/package/NServiceBus.SqlServer/1.2.2)
+* SQL Server: [NServiceBus.SqlServer v1.2.3](https://www.nuget.org/api/v2/package/NServiceBus.SqlServer/1.2.3)
 * Azure Storage Queues: [NServiceBus.Azure.Transports.WindowsAzureStorageQueues v5.3.8](https://www.nuget.org/api/v2/package/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/5.3.8) and [WindowsAzure.Storage v3.1.0.1](https://www.nuget.org/api/v2/package/WindowsAzure.Storage/3.1.0.1)
 * Azure ServiceBus: [NServiceBus.Azure.Transports.WindowsAzureServiceBus v5.3.8](https://www.nuget.org/api/v2/package/NServiceBus.Azure.Transports.WindowsAzureServiceBus/5.3.8) and [WindowsAzure.ServiceBus v2.2](https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/2.2.0)
 
 WARNING: Only transport DLLs targetting NServiceBus V4 should be used.
 
-NOTE: If you are configuring ServiceControl for use with Azure ServiceBus and want to use a newer version that 2.2 refer to the troubleshooting section 
+NOTE: If you are configuring ServiceControl for use with Azure ServiceBus and want to use a newer version than 2.2 refer to the troubleshooting section 
 
 The NuGet packages you just downloaded are in fact zip files. Rename the nupkg files to have a zip extension, and take the dlls from the `/lib` folder and put them in the ServiceControl bin folder: (`[Program Files]\Particular Software\ServiceControl`).
 
@@ -63,11 +63,13 @@ Or for Azure Storage Queues:
 x:\Your_Installed_Path\ServiceControl.exe --install -serviceName="Particular.ServiceControl" -displayName="Particular ServiceControl" -d="ServiceControl/TransportType==NServiceBus.AzureStorageQueue, NServiceBus.Azure.Transports.WindowsAzureStorageQueues" -d="NServiceBus/Transport==DefaultEndpointsProtocol=https;AccountName=[account-name];AccountKey=[account-key];"
 ```
 
-Example, for SqlServer these settings would look like:
+Example, for SQL Server these settings would look like:
 
 ```bat
 x:\Your_Installed_Path\ServiceControl.exe --install -serviceName="Particular.ServiceControl" -displayName="Particular ServiceControl" -d="ServiceControl/TransportType==NServiceBus.SqlServer, NServiceBus.Transports.SQLServer" -d="NServiceBus/Transport==Data Source=(local);Initial Catalog=NServiceBus;Integrated Security=True"
 ```
+
+NOTE: As of `V1.2.3` the `SQL Server Transport` supports the `Queue Schema` connection string parameter, enabling ServiceControl to be used in environments where endpoints are not using the default `dbo` schema. More information: [Multi-database support](/nservicebus/sqlserver/multiple-databases.md).
 
 ### Start and Verify  
 


### PR DESCRIPTION
**DO-NOT-MERGE** until v.1.2.3 is released.

update SQL Server transport documents to reflect changes introduced in the Queue Schema feature back-ported to v1.2.3.

@SimonCropp can you please review? Can you also suggest if other documents need to be updated?

/cc @danielmarbach @adamralph 
related to https://github.com/Particular/FeatureDevelopment/issues/320