### PR TITLE
Handler ordering, upgrade guide and snippets for it

### DIFF
--- a/Snippets/Snippets_6/HandlerOrdering.cs
+++ b/Snippets/Snippets_6/HandlerOrdering.cs
@@ -1,0 +1,51 @@
+﻿namespace Snippets5
+{
+    using NServiceBus;
+
+    public class HandlerOrdering
+    {
+        public void Simple()
+        {
+            #region HandlerOrderingWithCode
+
+            BusConfiguration busConfiguration = new BusConfiguration();
+
+            busConfiguration.ExecuteTheseHandlersFirst(typeof(HandlerB), typeof(HandlerA), typeof(HandlerC));
+
+            #endregion
+        }
+
+        #region HandlerOrderingWithFirst
+        public class MySpecifyingFirst : INeedInitialization
+        {
+            public void Customize(BusConfiguration configuration)
+            {
+                configuration.ExecuteTheseHandlersFirst(typeof(HandlerB));
+            }
+        }
+        #endregion
+
+        #region HandlerOrderingWithMultiple
+        public class MySpecifyingOrder : INeedInitialization
+        {
+            public void Customize(BusConfiguration configuration)
+            {
+                configuration.ExecuteTheseHandlersFirst(typeof(HandlerB), typeof(HandlerA), typeof(HandlerC));
+            }
+        }
+        #endregion
+
+        public class HandlerA
+        {
+        
+        }
+        public class HandlerB
+        {
+        
+        }
+        public class HandlerC
+        {
+        
+        }
+    }
+}

--- a/Snippets/Snippets_6/HandlerOrdering.cs
+++ b/Snippets/Snippets_6/HandlerOrdering.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5
+﻿namespace Snippets6
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Errors\ErrorQueue\ProvideConfiguration.cs" />
     <Compile Include="Errors\ErrorQueue\ConfigurationSource\ConfigurationSource.cs" />
     <Compile Include="Errors\ErrorQueue\ConfigurationSource\Usage.cs" />
+    <Compile Include="HandlerOrdering.cs" />
     <Compile Include="Headers\MyMessage.cs" />
     <Compile Include="Headers\ReadHandler.cs" />
     <Compile Include="Headers\MutateOutgoingTransportMessages.cs" />

--- a/nservicebus/handlers/handler-ordering.md
+++ b/nservicebus/handlers/handler-ordering.md
@@ -21,10 +21,12 @@ The inference here is that the remaining handlers (not specified in the order) a
 
 <!-- import HandlerOrderingWithCode -->
 
-### Specifying First with ISpecifyMessageHandlerOrdering
+If you have been using `ISpecifyMessageHandlerOrdering` in a separate assembly scanned by NServiceBus we suggest to use `INeedInitialization`
+
+#### Specifying one to run first
 
 <!-- import HandlerOrderingWithFirst -->
 
-### Specifying multiple to run ordered with ISpecifyMessageHandlerOrdering
+#### Specifying multiple to run ordered
 
 <!-- import HandlerOrderingWithMultiple -->

--- a/nservicebus/handlers/handler-ordering.md
+++ b/nservicebus/handlers/handler-ordering.md
@@ -21,8 +21,6 @@ The inference here is that the remaining handlers (not specified in the order) a
 
 <!-- import HandlerOrderingWithCode -->
 
-If you have been using `ISpecifyMessageHandlerOrdering` in a separate assembly scanned by NServiceBus we suggest to use `INeedInitialization`
-
 #### Specifying one to run first
 
 <!-- import HandlerOrderingWithFirst -->

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -99,3 +99,25 @@ NServiceBus will automatically make correlated saga properties unique without th
 ## MSMQ ReturnToSourceQueue.exe
 
 The MSMQ ReturnToSourceQueue.exe tool is now deprecated. The code for this tool has been moved to [ParticularLabs/MsmqReturnToSourceQueue](https://github.com/ParticularLabs/MsmqReturnToSourceQueue) repository. See the readme in that repository for full details.
+
+## Message handler ordering
+In Version 6 we simplified the message handler ordering APIs drastically. Previously there were multiple ways to specify the handler ordering:
+
+* Using a code only approach with `config.LoadMessageHandlers(First<H1>.Then<H2>().AndThen<H3>().AndThen<H4>())`
+* By implementing `ISpecifyMessageHandlerOrdering` and either using `order.SpecifyFirst<H1>` or `order.Specify(First<H1>.Then<H2>())`
+
+The unified approach can be accessed by using `config.ExecuteTheseHandlersFirst(params Type[] handlerTypes)` on the `BusConfiguration` instance.
+
+### With the configuration API
+
+<!-- import HandlerOrderingWithCode -->
+
+If you have been using `ISpecifyMessageHandlerOrdering` in a separate assembly scanned by NServiceBus we suggest to use `INeedInitialization`
+
+#### Specifying one to run first
+
+<!-- import HandlerOrderingWithFirst -->
+
+#### Specifying multiple to run ordered
+
+<!-- import HandlerOrderingWithMultiple -->

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -106,7 +106,7 @@ In Version 6 we simplified the message handler ordering APIs drastically. Previo
 * Using a code only approach with `config.LoadMessageHandlers(First<H1>.Then<H2>().AndThen<H3>().AndThen<H4>())`
 * By implementing `ISpecifyMessageHandlerOrdering` and either using `order.SpecifyFirst<H1>` or `order.Specify(First<H1>.Then<H2>())`
 
-The unified approach can be accessed by using `config.ExecuteTheseHandlersFirst(params Type[] handlerTypes)` on the `BusConfiguration` instance.
+The unified approach can be accessed by either using `config.ExecuteTheseHandlersFirst(params Type[] handlerTypes)` or `config.ExecuteTheseHandlersFirst(IEnumerable<Type> handlerTypes)` on the `BusConfiguration` instance.
 
 ### With the configuration API
 


### PR DESCRIPTION
- [X] Upgrade guide
- [X] Handler ordering doco

I decided for the handler ordering doco to remove the `ISpecifyMessageHandlerOrdering` interface mentioning in the title. This makes it easier to pull in the v6 snippets under the same subtitle. My suggestion is to use `INeedInitialization` in case customer relied upon assembly scanning of those definitions.

@Particular/documentation please review. PR is not merged. Build will fail.