### PR TITLE
[WIP] Unobtrusive configuration via INeedInitialization

### DIFF
--- a/samples/unobtrusive/Version_5/Client/Program.cs
+++ b/samples/unobtrusive/Version_5/Client/Program.cs
@@ -12,8 +12,6 @@ class Program
             .BasePath(@"..\..\..\DataBusShare\");
         busConfiguration.RijndaelEncryptionService("gdDbqRpqdRbTs3mhdZh8qCaDaxJXl+e7");
 
-        busConfiguration.ApplyCustomConventions();
-
         using (IBus bus = Bus.Create(busConfiguration).Start())
         {
             CommandSender.Start(bus);

--- a/samples/unobtrusive/Version_5/Server/App.config
+++ b/samples/unobtrusive/Version_5/Server/App.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="RijndaelEncryptionServiceConfig" type="NServiceBus.Config.RijndaelEncryptionServiceConfig, NServiceBus.Core"/>
+  </configSections>
+
+  <RijndaelEncryptionServiceConfig Key="gdDbqRpqdRbTs3mhdZh8qCaDaxJXl+e7"/>
+  
+</configuration>

--- a/samples/unobtrusive/Version_5/Server/Program.cs
+++ b/samples/unobtrusive/Version_5/Server/Program.cs
@@ -12,8 +12,6 @@ class Program
             .BasePath(@"..\..\..\DataBusShare\");
         busConfiguration.RijndaelEncryptionService();
 
-        busConfiguration.ApplyCustomConventions();
-
         using (IBus bus = Bus.Create(busConfiguration).Start())
         {
             CommandSender.Start(bus);

--- a/samples/unobtrusive/Version_5/Server/Server.csproj
+++ b/samples/unobtrusive/Version_5/Server/Server.csproj
@@ -58,6 +58,7 @@
     <Compile Include="MyCommandHandler.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/unobtrusive/Version_5/Shared/ConfigureMessageConventions.cs
+++ b/samples/unobtrusive/Version_5/Shared/ConfigureMessageConventions.cs
@@ -1,0 +1,9 @@
+﻿using NServiceBus;
+
+    class ConfigureMessageConventions : INeedInitialization
+    {
+        public void Customize(BusConfiguration configuration)
+        {
+            configuration.ApplyCustomConventions();
+        }
+    }

--- a/samples/unobtrusive/Version_5/Shared/ConventionExtensions.cs
+++ b/samples/unobtrusive/Version_5/Shared/ConventionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NServiceBus;
 
-public static class ConventionExtensions
+static class ConventionExtensions
 {
     #region CustomConvention
     public static void ApplyCustomConventions(this BusConfiguration busConfiguration)

--- a/samples/unobtrusive/Version_5/Shared/Shared.csproj
+++ b/samples/unobtrusive/Version_5/Shared/Shared.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigErrorQueue.cs" />
+    <Compile Include="ConfigureMessageConventions.cs" />
     <Compile Include="ConventionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The V5 sample did not work due to a missing encryption key. So there is a fix for that.

Instead of calling the message convention extension method from the client and server projects I refactored this to a `ConfigureMessageConventions` that inherits `INeedInitialization`.

Result is cleaner bus initialization code and easier to use across more projects.

Currently only applied to the V5 project as this is a bit opinionated. If we agree that this improves the sample then I'll apply it to the other versions too.

@mauroservienti What do you think?