### PR TITLE
add changed timeout persistence interface in upgrade guide

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -134,7 +134,7 @@ Saga persisters (`ISagaPersister`) and finders (`IFindSagas`) introduce a new pa
 
 ### MarkAsComplete no longer virtual
 
-The `Saga` base class method `MarkAsComplete` is no longer virtual. 
+The `Saga` base class method `MarkAsComplete` is no longer virtual.
 
 
 ## Outbox
@@ -210,7 +210,7 @@ When you wanted to control the `HostInformation` you could do that over `Unicast
 
 The configuration option `DoNotRequireExplicitRouting()` has been obsoleted since transports with support for centralized pubsub will always auto subscribe all events without requiring explicit routing. Transports with message driven pubsub (like MSMQ, SqlServer and AzureStorageQueues) will not subscribe properly if there is no routing specified. If you previously used this option you can now safely remove it.
 
-AutoSubscription happens during the startup phase of the bus. Previous versions of NServiceBus did try to subscribe multiple times on a background thread until the subscription either succeeded or failed. When the subscription failed, an error entry was written to the log file. This version of NServiceBus changes that behavior for transports with message driven pub-sub. The subscription is tried asynchronously on the startup thread. In the case when a subscriber starts and the publisher has never created its queues, the subscriber endpoint will not start and the caller will receive a `QueueNotFoundException` indicating what went wrong. 
+AutoSubscription happens during the startup phase of the bus. Previous versions of NServiceBus did try to subscribe multiple times on a background thread until the subscription either succeeded or failed. When the subscription failed, an error entry was written to the log file. This version of NServiceBus changes that behavior for transports with message driven pub-sub. The subscription is tried asynchronously on the startup thread. In the case when a subscriber starts and the publisher has never created its queues, the subscriber endpoint will not start and the caller will receive a `QueueNotFoundException` indicating what went wrong.
 
 
 ## Assembly scanning
@@ -265,3 +265,7 @@ While using a suppressed transaction scope to request sends to be dispatched imm
 ## SubscriptionEventArgs has been deprecated
 
 Version 5 introduced an undocumented way to get the list of subscribers when publishing a message on the transports using [persistence based pub/sub](/nservicebus/messaging/publish-subscribe/#mechanics-persistence-based). This is no longer available; please contact us should you need this type of information in Version 6.
+
+## Timeout Persistence interfaces redesigned
+
+We redesigned the `IPersistTimeouts` interface which can be implemented to provide a customized timeout persistence option. If you are using your own timeout persister, please note that we splited the interface into `IQueryTimeouts` and `IPersistTimeouts` (while `IPersistTimeoutsV2` has been removed). For more details see [authoring a custom persistence](/nservicebus/persistence/authoring-custom.md#timeout-persister).


### PR DESCRIPTION
adding a short chapter to note users implementing their own timeout persistence that interfaces have changed and to consult the corresponding docs page which is already updated.