### PR TITLE
Outbox caveat no longer applicable

### DIFF
--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -38,8 +38,7 @@ Here is a diagram how it all works:
 
 ## Caveats
 
-- Both the business data and deduplication data need to share the same database
-- If you're forwarding processed messages to other endpoints they need to use a different datastore since outbox records are keyed on the `MessageId`
+- Both the business data and deduplication data need to share the same database.
 - The Outbox is bypassed when sending messages "from outside" via the `IBus` interface (not from a message handler). The reason for this is lack of a driving force for repeated dispatching of the Outbox messages (which currently is the retry mechanism that applies only when handling messages).
 
 ## Using outbox with NHibernate persistence


### PR DESCRIPTION
This caveat never made sense. You have to have your Outbox data in the same database as your business data, but if you have multiple endpoints, you have to have it in a *separate* data store?

More to the point, this refers to the bug in NHibernate that I fixed, and to NHibernate in general, which at the time was the only Outbox storage in town. Now it makes no sense.

Related to Particular/NServiceBus.NHibernate#117

/cc @indualagarsamy @SzymonPobiega @andreasohlund @SeanFeldman @johnsimons (Participants on bug issue)