### PR TITLE
Clarification about heartbeat interval and grace period settings

### DIFF
--- a/servicecontrol/creating-config-file.md
+++ b/servicecontrol/creating-config-file.md
@@ -140,6 +140,8 @@ Default: `00:00:40` (40 secs)
 
 When configuring heartbeat grace period, make sure it is synchronized with heartbeat interval defined by plugin or overwritten by [`heartbeat/interval`](/servicecontrol/plugins/heartbeat.md#configuration-heartbeat-interval) setting.
 
+Note: When monitoring multiple endpoints, ensure that heartbeat grace period is larger than any individual heartbeat interval set by the endpoints.
+
 
 #### ServiceControl/MaximumMessageThroughputPerSecond 
 

--- a/servicecontrol/creating-config-file.md
+++ b/servicecontrol/creating-config-file.md
@@ -138,7 +138,7 @@ Type: timespan
 
 Default: `00:00:40` (40 secs)
 
-When configuring heartbeat grace period, make sure it is synchronized with heartbeat interval defined by plugin or overwritten by [`heartbeat/interval`](/servicecontrol/plugins/heartbeat.md#configuration-heartbeat-interval) setting.
+When configuring heartbeat grace period, make sure it is greater than heartbeat interval defined by plugin or overwritten by [`heartbeat/interval`](/servicecontrol/plugins/heartbeat.md#configuration-heartbeat-interval) setting.
 
 Note: When monitoring multiple endpoints, ensure that heartbeat grace period is larger than any individual heartbeat interval set by the endpoints.
 

--- a/servicecontrol/creating-config-file.md
+++ b/servicecontrol/creating-config-file.md
@@ -132,11 +132,13 @@ Default: `empty`
 
 #### ServiceControl/HeartbeatGracePeriod
 
-The period that defines whether an endpoint is considered alive or not. 
+The period that defines whether an endpoint is considered alive or not since the last received heartbeat. 
 
 Type: timespan
 
 Default: `00:00:40` (40 secs)
+
+When configuring heartbeat grace period, make sure it is synchronized with heartbeat interval defined by plugin or overwritten by [`heartbeat/interval`](/servicecontrol/plugins/heartbeat.md#configuration-heartbeat-interval) setting.
 
 
 #### ServiceControl/MaximumMessageThroughputPerSecond 

--- a/servicecontrol/plugins/heartbeat.md
+++ b/servicecontrol/plugins/heartbeat.md
@@ -49,4 +49,6 @@ ServiceControl heartbeats are sent, by the plugin, at a predefined interval of 1
 
 Where the value is convertible to a `TimeSpan` value. In the above sample you are setting the endpoint heartbeat interval to 40 seconds.
 
+When configuring heartbeat interval, make sure it is synchronized with Service Control setting [`HeartbeatGracePeriod`](/servicecontrol/creating-config-file.md#configuration-options-servicecontrol-heartbeatgraceperiod).
+
 Note: To enable the change the endpoint needs to be restarted.

--- a/servicecontrol/plugins/heartbeat.md
+++ b/servicecontrol/plugins/heartbeat.md
@@ -49,6 +49,6 @@ ServiceControl heartbeats are sent, by the plugin, at a predefined interval of 1
 
 Where the value is convertible to a `TimeSpan` value. In the above sample you are setting the endpoint heartbeat interval to 40 seconds.
 
-When configuring heartbeat interval, make sure it is synchronized with Service Control setting [`HeartbeatGracePeriod`](/servicecontrol/creating-config-file.md#configuration-options-servicecontrol-heartbeatgraceperiod).
+When configuring heartbeat interval, make sure Service Control setting [`HeartbeatGracePeriod`](/servicecontrol/creating-config-file.md#configuration-options-servicecontrol-heartbeatgraceperiod) is greater than the heartbeat interval.
 
 Note: To enable the change the endpoint needs to be restarted.


### PR DESCRIPTION
There are 2 settings that can affect each other if not configured appropriately. Since settings are not in the same doco/configuration file, adding that information in doco.

1. SC `ServiceControl/HeartbeatGracePeriod`
1. Heartbeat plugin `heartbeat/interval`

@Particular/servicecontrol please review