### PR TITLE
notifications section in v6 upgrade guide

### DIFF
--- a/Snippets/Snippets_6/BusNotifications/EventsToObservables.cs
+++ b/Snippets/Snippets_6/BusNotifications/EventsToObservables.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Snippets6.BusNotifications
+{
+    using System.Reactive;
+    using System.Reactive.Linq;
+    using NServiceBus;
+    using NServiceBus.Faults;
+
+    class EventsToObservables
+    {
+        void TransformEventToObservable()
+        {
+            BusNotifications busNotifications = new BusNotifications();
+
+            #region ConvertEventToObservable
+
+            IObservable<EventPattern<FailedMessage>> failedMessages = Observable.FromEventPattern<EventHandler<FailedMessage>, FailedMessage>(
+                handler => busNotifications.Errors.MessageSentToErrorQueue += handler, 
+                handler => busNotifications.Errors.MessageSentToErrorQueue -= handler);
+
+            IDisposable subscription = failedMessages
+                .Subscribe(x => Console.WriteLine($"Message {x.EventArgs.MessageId} moved to error queue"));
+
+            #endregion
+
+        }
+    }
+}

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -82,6 +82,22 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
@@ -97,6 +113,7 @@
     <Compile Include="BasicUsageOfIBus.cs" />
     <Compile Include="BestPracticesConfiguration.cs" />
     <Compile Include="BusNotifications\Errors.cs" />
+    <Compile Include="BusNotifications\EventsToObservables.cs" />
     <Compile Include="Conventions\Usage.cs" />
     <Compile Include="Correlation\Usage.cs" />
     <Compile Include="Correlation\MyRequest.cs" />

--- a/Snippets/Snippets_6/packages.config
+++ b/Snippets/Snippets_6/packages.config
@@ -12,4 +12,9 @@
   <package id="NServiceBus.Log4Net" version="1.1.0-unstable0016" targetFramework="net452" />
   <package id="NServiceBus.NLog" version="1.2.0-unstable0007" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
 </packages>

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -396,6 +396,6 @@ snippet: 5to6CriticalError
 
 ## Notifications
 
-`BusNotifications` exposed the available notification hooks as observables implementing `IObservable`. This forced users to implement custom `IObserver` or to use the Reactive-Extensions libraries. We changed the notifications to expose regular events instead of observables for easier usage. Find out more about [subscribing to error notifications](/nservicebus/errors/subscribing-to-error-notifications.md). In case you'd like to continue using Reactive-Extensions you can easily transform events into `IObservable`s like this:
+`BusNotifications` exposed the available notification hooks as observables implementing `IObservable`. This meant a custom `IObserver` and the use of [Reactive-Extensions](https://msdn.microsoft.com/en-au/data/gg577609.aspx) was required to use this API. In Version 6  notifications has been changed to expose regular events instead of observables for easier usage. Find out more about [subscribing to error notifications](/nservicebus/errors/subscribing-to-error-notifications.md). To continue using Reactive-Extensions the events API can be transformed into `IObservable`s like this:
 
 snippet: ConvertEventToObservable

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -172,7 +172,7 @@ The differences in the API are fully covered in [handling responses on the clien
 
 ## Message handlers
 
-The handler method on `IHandleMessages<T>` now returns a Task. In order to leverage async code, add the async keyword to your handler method and use `await` for async methods. In order to convert your synchronous code add `return Task.FromResult(0);` to the end of your handler methods. 
+The handler method on `IHandleMessages<T>` now returns a Task. In order to leverage async code, add the async keyword to your handler method and use `await` for async methods. In order to convert your synchronous code add `return Task.FromResult(0);` to the end of your handler methods.
 
 WARNING: Do not `return null` from your message handlers. We use the task result internally and `null` will result in errors. You may mark your `Handle` methods as `async` to enforce this, which would result in `await Task.FromResult(0);`.
 
@@ -392,3 +392,10 @@ In Version 5 the implementation of the interface `ICreateQueues` was called for 
 The API for defining a [Critical Error Action](/nservicebus/hosting/critical-errors.md) has been changed to be a custom delegate.
 
 snippet: 5to6CriticalError
+
+
+## Notifications
+
+`BusNotifications` exposed the available notification hooks as observables implementing `IObservable`. This forced users to implement custom `IObserver` or to use the Reactive-Extensions libraries. We changed the notifications to expose regular events instead of observables for easier usage. Find out more about [subscribing to error notifications](/nservicebus/errors/subscribing-to-error-notifications.md). In case you'd like to continue using Reactive-Extensions you can easily transform events into `IObservable`s like this:
+
+snippet: ConvertEventToObservable


### PR DESCRIPTION
sadly, the example code requires all the rx packages, should we just omit it?