### PR TITLE
Remove `.DoNotWrapHandlersInTransactionScope`

### DIFF
--- a/Snippets/Snippets_6/Transactions.cs
+++ b/Snippets/Snippets_6/Transactions.cs
@@ -29,31 +29,16 @@
             BusConfiguration busConfiguration = new BusConfiguration();
             busConfiguration.Transactions().Enable().EnableDistributedTransactions();
             #endregion
-
-            #region TransactionsDoNotWrapHandlersExecutionInATransactionScope
-            busConfiguration.Transactions().DoNotWrapHandlersExecutionInATransactionScope();
-            #endregion
         }
 
         public void TransportTransactionsWithScope()
         {
             #region TransactionsWrapHandlersExecutionInATransactionScope
             BusConfiguration busConfiguration = new BusConfiguration();
-            busConfiguration.Transactions().DisableDistributedTransactions().WrapHandlersExecutionInATransactionScope();
+            busConfiguration.Transactions().WrapHandlersExecutionInATransactionScope();
             #endregion
         }
-
-        public void Outbox()
-        {
-
-            #region TransactionsOutbox
-
-            BusConfiguration busConfiguration = new BusConfiguration();
-            busConfiguration.EnableOutbox(); //Implies .DisableDistributedTransactions().DoNotWrapHandlersExecutionInATransactionScope();
-
-            #endregion
-        }
-
+        
         public void CustomTransactionTimeout()
         {
             #region CustomTransactionTimeout

--- a/nservicebus/concept-overview.md
+++ b/nservicebus/concept-overview.md
@@ -21,7 +21,7 @@ Message types can be set either using marker interfaces `ICommand` and `IEvent` 
 
 ### Body
 
-The payload of the message is also called body. It travels between the endpoints in a serialized form (either textual or binary). 
+The payload of the message is also called body. It travels between the endpoints in a serialized form (either textual or binary).
 
 
 ### [Headers](/nservicebus/messaging/headers.md)
@@ -36,7 +36,7 @@ An Endpoint is a design-time concept that has a name and a collection of associa
 
 ### Endpoint Instance
 
-An Endpoint Instance is a run-time object that allows to interact with the bus. Endpoint Instances are able to send and receive messages. It runs associated Message Handlers and Sagas to process incoming messages. An Endpoint Instance has a single Input Queue (which can be shared with other instances of the same Endpoint in a scale-out scenario). 
+An Endpoint Instance is a run-time object that allows to interact with the bus. Endpoint Instances are able to send and receive messages. It runs associated Message Handlers and Sagas to process incoming messages. An Endpoint Instance has a single Input Queue (which can be shared with other instances of the same Endpoint in a scale-out scenario).
 
 
 ### [Hosting](/nservicebus/hosting)
@@ -56,7 +56,7 @@ Each endpoint instance is assigned a single Input Queue. This queue can be share
 
 ### [Publish Subscribe](/nservicebus/messaging/publish-subscribe)
 
-Publish Subscribe is the interaction of 
+Publish Subscribe is the interaction of
 
  * Registering interest in being notified about an event (*subscriber*).
  * That event being delivered to the endpoint that registered itself (*publisher*)
@@ -89,12 +89,12 @@ Messages that fail all retries are send to a error queue for triage for either a
 
 ### [Pipeline](/nservicebus/pipeline/)
 
-The Pipeline refers to the series of actions taken when an incoming message is processed and an outgoing message is sent. 
+The Pipeline refers to the series of actions taken when an incoming message is processed and an outgoing message is sent.
 
 
 ### [Behavior](/nservicebus/pipeline/customizing.md)
 
-A Behavior is a single step in the Pipeline. 
+A Behavior is a single step in the Pipeline.
 
 
 ### [Encryption](/nservicebus/security/encryption.md)
@@ -124,7 +124,7 @@ NServiceBus relies heavily on Containers and Dependency Injection to manage serv
 
 ### [Assembly Scanning](/nservicebus/hosting/assembly-scanning.md)
 
-NServiceBus leverages assembly scanning to implement several features. 
+NServiceBus leverages assembly scanning to implement several features.
 
 
 ### [Logging](/nservicebus/logging/)
@@ -134,9 +134,13 @@ NServiceBus has some sensible defaults for logging built in and, for more advanc
 
 ### [OutBox](/nservicebus/outbox)
 
-An alternative to Distributed Transactions to provide exactly-once message processing semantics when accessing user data store as part of message processing. 
+An alternative to Distributed Transactions to provide exactly-once message processing semantics when accessing user data store as part of message processing.
 
 
 ### [Distributor](/nservicebus/scalability-and-ha/distributor/)
 
 A load balancing tool for message distribution.
+
+### [Idempotence](http://en.wikipedia.org/wiki/Idempotence)
+
+The ability to call the same message handler more than once without causing inconsistent business results.

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -21,7 +21,7 @@ Based on transaction handling mode, NServiceBus offers three levels of guarantee
 
 ### Ambient transaction (Distributed transaction)
 
-In this mode the receive transaction is wrapped in a `TransactionScope`. All the operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole. There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
+In this mode the receive transaction is wrapped in a [`TransactionScope`](http://msdn.microsoft.com/en-us/library/system.transactions.transactionscope). All operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole. There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
 
 NOTE: This requires the selected storage to support enlisting in distributed transactions.
 

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -11,7 +11,7 @@ This article covers various levels of consistency guarantees NServiceBus provide
 
 * receiving messages
 * updating user data
-* sending out messages
+* sending messages
 
 It does not discuss the transaction isolation aspect which only applies to the process of updating the user data and does not affect the overall coordination and failure handling.
 
@@ -58,7 +58,7 @@ In this mode some (or all) handlers might get invoked multiple times and partial
 
 To handle this you must make sure that you write code that is consistent from a business perspective even though its executed more than once. In other words you must ensure that your handlers are idempotent.
 
-See the `Outbox` section below for details on how NServiceBus can handle idempotency for you at the infrastructure level.
+See the `Outbox` section below for details on how NServiceBus can handle [idempotency](/nservicebus/concept-overview#Idempotence) for you at the infrastructure level.
 
 NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending how you ordered your code. We call this ghost messages. To avoid this you need to make sure that you always perform bus operations as the last statements in your handler taking into account that there can be multiple handlers for a given message.
 
@@ -85,7 +85,7 @@ snippet:TransactionsDisable
 
 The Outbox [feature](/nservicebus/outbox) provides idempotency on the infrastructure level and allows you to run in *transport transaction* mode while still getting the same semantics as *Ambient transaction* mode.
 
-NOTE: You need to store the outbox data in the same database as your business data to achieve the idempotency mentioned above. 
+NOTE: You need to store outbox data in the same database as your business data to achieve the idempotency mentioned above.
 
 When using the outbox, the messages resulting from processing a given received message are not being sent immediately but rather and stored in the persistence database and pushed out after handling logic is done. This mechanism ensures that the handling logic can only succeed once so there is no need to design for idempotence.
 

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -61,21 +61,21 @@ NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/
 
 ### Transport transaction - Sends atomic with Receive
 
-Some transports supports enlisting outgoing operations in the current receive transaction. This prevents messages being sent to downstream endpoints during retries. Currently only the MSMQ and SQL Server transports support this type of transaction mode.
+Some transports support enlisting outgoing operations in the current receive transaction. This prevents messages being sent to downstream endpoints during retries. Currently only the MSMQ and SQL Server transports support this type of transaction mode.
 
 Use the following code to use this mode:
 
 snippet:TransactionsDisableDistributedTransactions
 #### Consistency guarantees
-This mode have the same consistency guarantees like the *Receive Only* mode mentioned above with the difference that ghost messages are prevented since all outgoing operations are atomic with the receive operation.
+This mode has the same consistency guarantees as the *Receive Only* mode mentioned above with the difference that the ghost messages are prevented since all outgoing operations are atomic with the receive operation.
 
 ### Unreliable (Transactions Disabled)
 
-In this mode the transport doesn't wrap the receive operation in any kind of transaction. Should the message fail to process it will be moved straight to the error queue. There will be no first level or second level retries since those features relies on transport level transactions.
+In this mode the transport doesn't wrap the receive operation in any kind of transaction. Should the message fail to process it will be moved straight to the error queue. There will be no first level or second level retries since those features rely on transport level transactions.
 
 WARNING: If there is a critical failure, including system or endpoint crash, the message is **permanently lost** since it's received with no transaction.
 
-NOTE: In version 5 and below, when transactions are disabled, no retries will be performed and messages will not be forwarded to the error queue in the event of any failure.
+NOTE: In version 5 and below, when transactions are disabled, no retries will be performed and messages **will not be forwarded** to the error queue in the event of any failure.
 
 snippet:TransactionsDisable
 

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -7,23 +7,73 @@ tags:
 - Retry
 ---
 
-This article covers various levels of guarantees NServiceBus provides with regards to
+This article covers various levels of consistency guarantees NServiceBus provides with regards to
 
-* coordination of receiving messages
-* updating user data 
-* sending out other messages
+* receiving messages
+* updating user data
+* sending out messages
 
 It does not discuss the transaction isolation aspect which only applies to the process of updating the user data and does not affect the overall coordination and failure handling.
 
-
 ## Transactions
 
-Based on transaction handling mode, NServiceBus offers three levels of guarantees with regards to message processing
+Based on transaction handling mode, NServiceBus offers three levels of guarantees with regards to message processing. The levels available depends on the capability of the selected transport.
 
+### Ambient transaction (Distributed transaction)
+
+In this mode the receive transaction is wrapped in a `TransactionScope`. All the operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole. There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
+
+NOTE: This requires the selected storage to support enlisting in distributed transactions.
+
+Depending on transport the transaction is escalated to a distributed one (following two-phase commit protocol) when required. For example is not required when using SQL Server transport with NHibernate persistence both targeted at the same database. Since in this case ADO.NET driver guarantees that everything happens inside a single database transaction, ACID guarantees are held for the whole processing.
+
+NOTE: MSMQ will escalate to a distributed transaction right away since it doesn't support promotable transaction enlistments.
+
+Ambient transaction mode is enabled by default for the transports that support it. It can be enabled explicitly via
+
+snippet:TransactionsEnable
+
+#### Consistency guarantees
+In this mode handlers will execute inside of the `TransactionScope` created by the transport. This means that all the data updates are executed as a whole or rolled back as a whole.
+
+Should you not want this behavior just select one of the lower transaction modes supported by the selected transport.
+
+### Transport transaction
+
+In this mode the receive operation is wrapped in a transport native transaction. This mode guarantees that the message is not permanently deleted from the incoming queue until at least one processing attempt (including storing user data and sending out messages) is finished successfully. See the [errors](/nservicebus/errors) section for more details on retries.
+
+Use the following code to request *Transport transaction* mode to be used:
+
+snippet:TransactionsDisableDistributedTransactions
+
+#### Multi queue transactions
+Some transports supports enlisting outgoing queue operations in the current receive transaction. This removes the risk of duplicate and ghost messages, see below, being emitted but you still need to make sure that your handlers are idempotent. Currently only the MSMQ and SQL Server transports support multi queue transactions.
+
+#### Consistency guarantees
+
+In this mode some (or all) handlers might get invoked multiple times and partial results might be visible:
+
+ * partial updates - where one handler succeeded updating its data but the other didn't
+ * partial sends - where some of the messages has been sent but others not
+
+To handle this you must make sure that you write code that is consistent from a business perspective even though its executed more than once. In other words you must ensure that your handlers are idempotent.
+
+See the `Outbox` section below for details on how NServiceBus can handle idempotency for you at the infrastructure level.
+
+NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending how you ordered your code. We call this ghost messages. To avoid this you need to make sure that you always perform bus operations as the last statements in your handler taking into account that there can be multiple handlers for a given message.
+
+#### Avoiding partial updates
+In this mode there is a risk for partial updates since one handler might succeed in updating business data while other won't. To avoid this you can tell NServiceBus to wrap all handlers in a `TransactionScope` that will act as a unit of work and make sure that there is no partial updates. Use following code to enable a wrapping scope:
+
+snippet:TransactionsWrapHandlersExecutionInATransactionScope
+
+NOTE: This requires storage in use has support for enlisting in transaction scopes
+
+WARNING: This might escalate to a distributed transaction if you're updating data in different databases.
 
 ### Unreliable (Transactions Disabled)
 
-In this mode the transport in use does not attempt to wrap the receive operation in any kind of transaction. 
+In this mode the transport in use does not attempt to wrap the receive operation in any kind of transaction.
 
 Once a message has been received by an Endpoint, if the message processing fails because of an exception within the message handler, it will be put into the error queue. There will be no first level or second level retries. If there is a critical failure, including system or endpoint crash, the message is **permanently lost**. It will not be retried or added to the error queue.
 
@@ -31,29 +81,21 @@ WARNING: In version 5 and below, when transactions are disabled, no retries will
 
 snippet:TransactionsDisable
 
+## Outbox
 
-### Transport transaction
+The Outbox [feature](/nservicebus/outbox) provides idempotency on the infrastructure level and allows you to run in *transport transaction* mode while still getting the same semantics as *Ambient transaction* mode.
 
-In this mode, if supported by the transport, the receive operation is wrapped in a native transaction. The same transaction is used when processing of the message results in sending out other messages. This mode guarantees that the message is not permanently deleted from the incoming queue until at least one processing attempt (including storing user data and sending out messages) is finished successfully.
+NOTE: You need to store the outbox data in the same database as your business data to achieve the idempotency mentioned above. 
 
-NOTE: In this mode messages on the wire can get duplicated at each endpoint so the handler logic has to be designed to be idempotent.
+When using the outbox, the messages resulting from processing a given received message are not being sent immediately but rather and stored in the persistence database and pushed out after handling logic is done. This mechanism ensures that the handling logic can only succeed once so there is no need to design for idempotence.
 
-snippet:TransactionsDisableDistributedTransactions
+## Controlling transaction scope options
 
+NServiceBus allows you to control the following options for transaction scopes created when processing messages.
 
-### Ambient transaction
+### Isolation level
 
-In this mode, if supported by the transport, the receive transaction is wrapped in `TransactionScope`. All the operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole. There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
-
-That **does not** mean that a distributed transaction is started right away. The transaction is only escalated to the distributed one (following two-phase commit protocol) when it is required. For example is not required when using SQL Server transport with NHibernate persistence and both in the same database. Since in this case ADO.NET driver guarantees that everything happens inside a single database transaction, ACID guarantees are held for the whole processing.
-
-Ambient transaction mode is enabled by default. It can be enabled explicitly via
-
-snippet:TransactionsEnable
-
-#### Isolation level
-
-NServiceBus will by default use the `ReadCommitted` [isolation level](https://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel). 
+NServiceBus will by default use the `ReadCommitted` [isolation level](https://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel).
 
 NOTE: Version 3 and below used the default isolation level of .Net which is `Serializable`.
 
@@ -61,7 +103,7 @@ You can change the isolation level using
 
 snippet:CustomTransactionIsolationLevel
 
-#### Transaction timeout
+### Transaction timeout
 
 NServiceBus will use the [default transaction timeout](https://msdn.microsoft.com/en-us/library/system.transactions.transactionmanager.defaulttimeout) of the machine the endpoint is running on.
 
@@ -69,32 +111,4 @@ You can change the transaction timeout using
 
 snippet:CustomTransactionTimeout
 
-Or via your *.config file see an example [here](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection%28v=vs.100%29.aspx#Anchor_5). 
-
-
-## Handlers
-
-In the ambient transaction mode NServiceBus executes all message handlers in a single `TransactionScope` in order to ensure that all the data manipulations are either executed as a whole or rolled back as a whole. This behavior can be disabled using the following
-
-<!-- import TransactionsDoNotWrapHandlersExecutionInATransactionScope --> 
-
-This results in suppressing any ambient transaction that exist. This effectively turns the *ambient transaction* mode into *transport transaction* mode with regards to handler behavior (the only difference is the type of transaction used by the transport). Some (or all) handlers might get invoked multiple times and partial results might be visible: 
-
- * partial updates (where one handler succeeded updating its data but the other didn't), 
- * partial sends (where some of the messages has been sent but others not),
- * sends without matching updates (where messages has already been sent but the update failed).
-
-
-NOTE: Starting with version 5, in the *transport transaction* and *unreliable* modes this behavior is the default. Wrapping the message handlers with `TransactionScope` has to be enabled explicitly.
-
-snippet:TransactionsWrapHandlersExecutionInATransactionScope
-
-## Outbox
-
-Outbox is a [feature](/nservicebus/outbox)  that enhances the *transport transaction* mode guarantees. 
-
-snippet:TransactionsOutbox
-
-Enabled by default only for RabbitMQ transport, requires explicit enabling when using other transports.
-
-When using the outbox, the messages resulting from processing a given received message are not being sent immediately but rather and stored in the persistence database and pushed out after handling logic is done. This mechanism ensures that the handling logic can only succeed once so there is no need to design for idempotence.
+Or via your .config file see an example [here](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection%28v=vs.100%29.aspx#Anchor_5).

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -57,7 +57,7 @@ To handle this make sure to write code that is consistent from a business perspe
 
 See the `Outbox` section below for details on how NServiceBus can handle idempotency at the infrastructure level.
 
-NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending the order of state,emts. This is called ghost messages. To avoid this make sure to perform all bus operations after any modification to business data. When reviewing the code remember that there can be multiple handlers for a given message. Details on how to enforce message handler ordering can be found [here](/nservicebus/handlers/handler-ordering).
+NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending the order of statements. This is called ghost messages. To avoid this make sure to perform all bus operations after any modification to business data. When reviewing the code remember that there can be multiple handlers for a given message. Details on how to enforce message handler ordering can be found [here](/nservicebus/handlers/handler-ordering).
 
 ### Transport transaction - Sends atomic with Receive
 

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -21,33 +21,30 @@ Based on transaction handling mode, NServiceBus offers three levels of guarantee
 
 ### Ambient transaction (Distributed transaction)
 
-In this mode the receive transaction is wrapped in a [`TransactionScope`](http://msdn.microsoft.com/en-us/library/system.transactions.transactionscope). All operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole. There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
-
-NOTE: This requires the selected storage to support enlisting in distributed transactions.
+In this mode the receive transaction is wrapped in a [`TransactionScope`](http://msdn.microsoft.com/en-us/library/system.transactions.transactionscope). All operations inside this scope, both sending messages and manipulating data, are guaranteed to be executed (eventually) as a whole or rolled back as a whole.
 
 Depending on transport the transaction is escalated to a distributed one (following two-phase commit protocol) when required. For example is not required when using SQL Server transport with NHibernate persistence both targeted at the same database. Since in this case ADO.NET driver guarantees that everything happens inside a single database transaction, ACID guarantees are held for the whole processing.
 
 NOTE: MSMQ will escalate to a distributed transaction right away since it doesn't support promotable transaction enlistments.
 
-Ambient transaction mode is enabled by default for the transports that support it. It can be enabled explicitly via
+*Ambient transaction* mode is enabled by default for the transports that support it. It can be enabled explicitly via
 
 snippet:TransactionsEnable
 
 #### Consistency guarantees
 In this mode handlers will execute inside of the `TransactionScope` created by the transport. This means that all the data updates are executed as a whole or rolled back as a whole.
 
-Should you not want this behavior just select one of the lower transaction modes supported by the selected transport.
+There is no atomicity guarantee as changes to the database might be visible *before* the messages on the queue or vice-versa. Specific configurations might provide stronger guarantees, but not weaker.
 
-### Transport transaction
+NOTE: This requires the selected storage to support participating in distributed transactions.
+
+### Transport transaction - Receive Only
 
 In this mode the receive operation is wrapped in a transport native transaction. This mode guarantees that the message is not permanently deleted from the incoming queue until at least one processing attempt (including storing user data and sending out messages) is finished successfully. See the [errors](/nservicebus/errors) section for more details on retries.
 
-Use the following code to request *Transport transaction* mode to be used:
+Use the following code to use this mode:
 
 snippet:TransactionsDisableDistributedTransactions
-
-#### Multi queue transactions
-Some transports supports enlisting outgoing queue operations in the current receive transaction. This removes the risk of duplicate and ghost messages, see below, being emitted but you still need to make sure that your handlers are idempotent. Currently only the MSMQ and SQL Server transports support multi queue transactions.
 
 #### Consistency guarantees
 
@@ -56,42 +53,52 @@ In this mode some (or all) handlers might get invoked multiple times and partial
  * partial updates - where one handler succeeded updating its data but the other didn't
  * partial sends - where some of the messages has been sent but others not
 
-To handle this you must make sure that you write code that is consistent from a business perspective even though its executed more than once. In other words you must ensure that your handlers are idempotent.
+To handle this make sure to write code that is consistent from a business perspective even though its executed more than once. In other words all handlers must be [idempotent](/nservicebus/concept-overview#Idempotence).
 
-See the `Outbox` section below for details on how NServiceBus can handle [idempotency](/nservicebus/concept-overview#Idempotence) for you at the infrastructure level.
+See the `Outbox` section below for details on how NServiceBus can handle idempotency at the infrastructure level.
 
-NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending how you ordered your code. We call this ghost messages. To avoid this you need to make sure that you always perform bus operations as the last statements in your handler taking into account that there can be multiple handlers for a given message.
+NOTE: Version 5 and below didn't have [batched dispatch](/nservicebus/messaging/batched-dispatch.md) and this meant that messages could be sent out without a matching update to business data depending the order of state,emts. This is called ghost messages. To avoid this make sure to perform all bus operations after any modification to business data. When reviewing the code remember that there can be multiple handlers for a given message. Details on how to enforce message handler ordering can be found [here](/nservicebus/handlers/handler-ordering).
 
-#### Avoiding partial updates
-In this mode there is a risk for partial updates since one handler might succeed in updating business data while other won't. To avoid this you can tell NServiceBus to wrap all handlers in a `TransactionScope` that will act as a unit of work and make sure that there is no partial updates. Use following code to enable a wrapping scope:
+### Transport transaction - Sends atomic with Receive
 
-snippet:TransactionsWrapHandlersExecutionInATransactionScope
+Some transports supports enlisting outgoing operations in the current receive transaction. This prevents messages being sent to downstream endpoints during retries. Currently only the MSMQ and SQL Server transports support this type of transaction mode.
 
-NOTE: This requires storage in use has support for enlisting in transaction scopes
+Use the following code to use this mode:
 
-WARNING: This might escalate to a distributed transaction if you're updating data in different databases.
+snippet:TransactionsDisableDistributedTransactions
+#### Consistency guarantees
+This mode have the same consistency guarantees like the *Receive Only* mode mentioned above with the difference that ghost messages are prevented since all outgoing operations are atomic with the receive operation.
 
 ### Unreliable (Transactions Disabled)
 
-In this mode the transport in use does not attempt to wrap the receive operation in any kind of transaction.
+In this mode the transport doesn't wrap the receive operation in any kind of transaction. Should the message fail to process it will be moved straight to the error queue. There will be no first level or second level retries since those features relies on transport level transactions.
 
-Once a message has been received by an Endpoint, if the message processing fails because of an exception within the message handler, it will be put into the error queue. There will be no first level or second level retries. If there is a critical failure, including system or endpoint crash, the message is **permanently lost**. It will not be retried or added to the error queue.
+WARNING: If there is a critical failure, including system or endpoint crash, the message is **permanently lost** since it's received with no transaction.
 
-WARNING: In version 5 and below, when transactions are disabled, no retries will be performed and messages will not be forwarded to the error queue in the event of any failure.
+NOTE: In version 5 and below, when transactions are disabled, no retries will be performed and messages will not be forwarded to the error queue in the event of any failure.
 
 snippet:TransactionsDisable
 
 ## Outbox
 
-The Outbox [feature](/nservicebus/outbox) provides idempotency on the infrastructure level and allows you to run in *transport transaction* mode while still getting the same semantics as *Ambient transaction* mode.
+The Outbox [feature](/nservicebus/outbox) provides idempotency at the infrastructure level and allows running in *transport transaction* mode while still getting the same semantics as *Ambient transaction* mode.
 
-NOTE: You need to store outbox data in the same database as your business data to achieve the idempotency mentioned above.
+NOTE: Outbox data needs to be stored in the same database as business data to achieve the idempotency mentioned above.
 
-When using the outbox, the messages resulting from processing a given received message are not being sent immediately but rather and stored in the persistence database and pushed out after handling logic is done. This mechanism ensures that the handling logic can only succeed once so there is no need to design for idempotence.
+When using the outbox, the messages resulting from processing a given received message are not being sent immediately but rather and stored in the persistence database and pushed out after handling logic is done. This mechanism ensures that the handling logic can only succeed once so there is no need to design for idempotency.
+
+## Avoiding partial updates
+In this mode there is a risk for partial updates since one handler might succeed in updating business data while other won't. To avoid this configure NServiceBus to wrap all handlers in a `TransactionScope` that will act as a unit of work and make sure that there is no partial updates. Use following code to enable a wrapping scope:
+
+snippet:TransactionsWrapHandlersExecutionInATransactionScope
+
+NOTE: This requires storage in use has support for enlisting in transaction scopes
+
+WARNING: This might escalate to a distributed transaction if data in different databases are updated.
 
 ## Controlling transaction scope options
 
-NServiceBus allows you to control the following options for transaction scopes created when processing messages.
+The following options for transaction scopes used during message processing can be configured.
 
 ### Isolation level
 
@@ -99,7 +106,7 @@ NServiceBus will by default use the `ReadCommitted` [isolation level](https://ms
 
 NOTE: Version 3 and below used the default isolation level of .Net which is `Serializable`.
 
-You can change the isolation level using
+Change the isolation level using
 
 snippet:CustomTransactionIsolationLevel
 
@@ -107,8 +114,8 @@ snippet:CustomTransactionIsolationLevel
 
 NServiceBus will use the [default transaction timeout](https://msdn.microsoft.com/en-us/library/system.transactions.transactionmanager.defaulttimeout) of the machine the endpoint is running on.
 
-You can change the transaction timeout using
+Change the transaction timeout using
 
 snippet:CustomTransactionTimeout
 
-Or via your .config file see an example [here](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection%28v=vs.100%29.aspx#Anchor_5).
+Or via .config file see an example [here](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection%28v=vs.100%29.aspx#Anchor_5).

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -402,7 +402,7 @@ snippet: ConvertEventToObservable
 
 ## Transaction configuration API
 
-`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance the same level of consistency.
+`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance for the same level of consistency.
 
 Should you still want to suppress the ambient transaction you can create your own behavior that wraps the pipeline in a suppressed transaction scope.
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -402,6 +402,10 @@ snippet: ConvertEventToObservable
 
 ## Transaction configuration API
 
+`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance.
+
+Should you still want to suppress the ambient transaction you can create your own behavior that wraps the pipeline in a suppressed transaction scope.
+
 ### Access to runtime settings
 
 The following properties have been obsoleted on `TransactionSettings` class.

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -402,7 +402,7 @@ snippet: ConvertEventToObservable
 
 ## Transaction configuration API
 
-`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance.
+`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance the same level of consistency.
 
 Should you still want to suppress the ambient transaction you can create your own behavior that wraps the pipeline in a suppressed transaction scope.
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -402,7 +402,9 @@ snippet: ConvertEventToObservable
 
 ## Transaction configuration API
 
-`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. If running in DTC mode with MSMQ or SQLServer you should opt out from DTC Transactions using .DisableDistributedTransactions() since it would give you better performance for the same level of consistency.
+`config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` has been removed since transaction scopes are no longer used by non DTC transports to do delayed dispatch. 
+
+If you are running with DTC enabled on MSMQ or SQLServer and were previously using `config.Transactions().DoNotWrapHandlersExecutionInATransactionScope()` to opt out of wrapping you message handlers in a transaction scope in Version 5, you can now use `config.Transactions().DisableDistributedTransactions()` and lean on the new [batched dispatch](/nservicebus/messaging/batched-dispatch.md) in Version 6 to achieve the same level of consistency and better performance.
 
 Should you still want to suppress the ambient transaction you can create your own behavior that wraps the pipeline in a suppressed transaction scope.
 


### PR DESCRIPTION
Documents the obsoletion of DoNotWrapHandlersInTransactionScope and also restructures the transaction doco