### PR TITLE
Update docs to describe current behaviour - better to submit an issue to be fixed instead?

### DIFF
--- a/nservicebus/messaging/publish-subscribe/index.md
+++ b/nservicebus/messaging/publish-subscribe/index.md
@@ -153,7 +153,7 @@ Transport->Subscriber2: Send Message1
 
 ## Versioning subscriptions
 
-In NServiceBus version 3.0 and onwards subscriptions for types with the same Major version are considered compliant. This means that a subscription for MyEvent 1.1.0 will be considered valid for MyEvent 1.X.Y as well.
+In NServiceBus version 3.0 and onwards subscriptions for types with the same Major version are considered compliant. This means that a subscription for MyEvent 1.1.0 will be considered valid for MyEvent 1.X.Y as well.  Be aware that if your assembly uses a fourth build number, i.e. 1.X.Y.Z, the Z numbers must match in each assembly to be considered compliant.
 
 NOTE: Version 2.X required a perfect match. This should make it easier to upgrade your publishers without affecting the subscribers.
 


### PR DESCRIPTION
Got stuck where my assembly wasn't reliably being picked up for subscription; tracked down the issue to be an assembly with version 0.0.1.1 apparently not being considered compliant with assembly with version 0.0.128.0.  If I force the pair to be 0.0.1.0 & 0.0.128.0, or 0.0.1.1 & 0.0.128.1, then we have success.  I can work with this for now, but do you agree this is a potential issue?