### PR TITLE
ConfigureAwait in behaviors

### DIFF
--- a/Snippets/Snippets_4/Pipeline/SampleBehavior.cs
+++ b/Snippets/Snippets_4/Pipeline/SampleBehavior.cs
@@ -10,7 +10,11 @@
     {
         public void Invoke(HandlerInvocationContext context, Action next)
         {
+            // custom logic before calling the next step in the pipeline.
+
             next();
+
+            // custom logic after all inner steps in the pipeline completed.
         }
     }
     #endregion

--- a/Snippets/Snippets_5/Pipeline/SampleBehavior.cs
+++ b/Snippets/Snippets_5/Pipeline/SampleBehavior.cs
@@ -10,7 +10,11 @@
     {
         public void Invoke(IncomingContext context, Action next)
         {
+            // custom logic before calling the next step in the pipeline.
+
             next();
+
+            // custom logic after all inner steps in the pipeline completed.
         }
     }
 

--- a/Snippets/Snippets_6/Headers/IncomingBehavior.cs
+++ b/Snippets/Snippets_6/Headers/IncomingBehavior.cs
@@ -14,7 +14,7 @@
             Dictionary<string, string> headers = context.Message.Headers;
             string nsbVersion = headers[Headers.NServiceBusVersion];
             string customHeader = headers["MyCustomHeader"];
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
     #endregion

--- a/Snippets/Snippets_6/Headers/OutgoingBehavior.cs
+++ b/Snippets/Snippets_6/Headers/OutgoingBehavior.cs
@@ -11,7 +11,7 @@
         public override async Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
         {
             context.Headers["MyCustomHeader"] = "My custom value";
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
     #endregion

--- a/Snippets/Snippets_6/Pipeline/AbortingPipeline.cs
+++ b/Snippets/Snippets_6/Pipeline/AbortingPipeline.cs
@@ -16,7 +16,7 @@ namespace Snippets6.Pipeline
             {
                 if (ShouldPipelineContinue(context))
                 {
-                    await next();
+                    await next().ConfigureAwait(false);
                 }
                 // since next is not invoke all downstream behaviors will be skipped
             }

--- a/Snippets/Snippets_6/Pipeline/SampleBehavior.cs
+++ b/Snippets/Snippets_6/Pipeline/SampleBehavior.cs
@@ -13,7 +13,7 @@
         {
             // custom logic before calling the next step in the pipeline.
 
-            await next();
+            await next().ConfigureAwait(false);
 
             // custom logic after all inner steps in the pipeline completed.
         }

--- a/Snippets/Snippets_6/Pipeline/SharingBehaviorData.cs
+++ b/Snippets/Snippets_6/Pipeline/SharingBehaviorData.cs
@@ -15,7 +15,7 @@
             // set some shared information on the context
             context.Extensions.Set(new SharedData());
 
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
 
@@ -26,7 +26,7 @@
             // access the shared data
             SharedData data = context.Extensions.Get<SharedData>();
 
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
 

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/OutgoingBehavior.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/OutgoingBehavior.cs
@@ -11,7 +11,7 @@
         public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
         {
             context.Headers["MyCustomHeader"] = "My custom value";
-            await next();
+            await next().ConfigureAwait(false);
         }
     }
     #endregion

--- a/samples/pipeline/handler-timer/Version_6/Sample/HandlerTimerBehavior.cs
+++ b/samples/pipeline/handler-timer/Version_6/Sample/HandlerTimerBehavior.cs
@@ -15,7 +15,7 @@ class HandlerTimerBehavior : Behavior<IInvokeHandlerContext>
         var stopwatch = Stopwatch.StartNew();
         try
         {
-            await next();
+            await next().ConfigureAwait(false);
         }
         finally
         {

--- a/samples/pipeline/stream-properties/Version_6/Shared/StreamReceiveBehavior.cs
+++ b/samples/pipeline/stream-properties/Version_6/Shared/StreamReceiveBehavior.cs
@@ -56,7 +56,7 @@ class StreamReceiveBehavior : Behavior<IIncomingLogicalMessageContext>
 
         #region cleanup-after-nested-action
 
-        await next();
+        await next().ConfigureAwait(false);
         // Clean up all the temporary streams after handler processing
         // via the "next()" delegate has occurred
         foreach (FileStream fileStream in streamsToCleanUp)

--- a/samples/pipeline/stream-properties/Version_6/Shared/StreamSendBehavior.cs
+++ b/samples/pipeline/stream-properties/Version_6/Shared/StreamSendBehavior.cs
@@ -47,7 +47,7 @@ class StreamSendBehavior : Behavior<IOutgoingLogicalMessageContext>
 
             using (FileStream target = File.OpenWrite(filePath))
             {
-                sourceStream.CopyTo(target);
+                await sourceStream.CopyToAsync(target).ConfigureAwait(false);
             }
 
             //Reset the property to null so no other serializer attempts to use the property
@@ -61,7 +61,7 @@ class StreamSendBehavior : Behavior<IOutgoingLogicalMessageContext>
             context.Headers["NServiceBus.PropertyStream." + headerKey] = fileKey;
         }
 
-        await next();
+        await next().ConfigureAwait(false);
         #endregion
     }
     #region generate-key-for-stream


### PR DESCRIPTION
@Particular/documentation This PR adds `ConfigureAwait(false)` to the behaviors. Inside the pipeline it matters.

I know this is a slight contradiction to http://docs.particular.net/samples/#technology-choices-async-await

I also aligned Snippet 4 and Snippet 4 behavior comment to Snippets 6 behavior

