### PR TITLE
Document transaction scope wrapper UoW and MSMQ & SQL transaction scope opts

### DIFF
--- a/Snippets/Snippets_5/UpgradeGuides/5to6/Upgrade.cs
+++ b/Snippets/Snippets_5/UpgradeGuides/5to6/Upgrade.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snippets5.UpgradeGuides._5to6
 {
     using System;
+    using System.Transactions;
     using NServiceBus;
     using NServiceBus.Unicast.Transport;
 
@@ -54,6 +55,25 @@
 
             bool isTransactional = transactionSettings.IsTransactional;
 
+            #endregion
+        }
+
+        public void TransportTransactionIsolationLevelAndTimeout()
+        {
+            #region 5to6TransportTransactionScopeOptions
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.Transactions()
+                .IsolationLevel(IsolationLevel.RepeatableRead)
+                .DefaultTimeout(TimeSpan.FromSeconds(30));
+            #endregion
+        }
+
+        public void WrapHandlersExecutionInATransactionScope()
+        {
+            #region 5to6WrapHandlersExecutionInATransactionScope
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.Transactions()
+                .WrapHandlersExecutionInATransactionScope();
             #endregion
         }
     }

--- a/Snippets/Snippets_6/MsmqTransactionScope.cs
+++ b/Snippets/Snippets_6/MsmqTransactionScope.cs
@@ -1,0 +1,29 @@
+﻿namespace Snippets6
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus;
+
+    public class MsmqTransactionScope
+    {
+        public void MsmqTransactionScopeIsolationLevel()
+        {
+            #region MsmqTransactionScopeIsolationLevel
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MsmqTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(isolationLevel: IsolationLevel.RepeatableRead);
+            #endregion
+        }
+
+        public void MsmqTransactionScopeTimeout()
+        {
+            #region MsmqTransactionScopeTimeout
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MsmqTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(timeout: TimeSpan.FromSeconds(30));
+            #endregion
+        }
+    }
+}

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -91,7 +91,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NServiceBus.6.0.0-unstable1380\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\..\packages\NServiceBus.6.0.0-unstable1414\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Host, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
@@ -124,6 +124,10 @@
     </Reference>
     <Reference Include="NServiceBus.ObjectBuilder.Unity, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NServiceBus.Unity.6.3.0-unstable0015\lib\net452\NServiceBus.ObjectBuilder.Unity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Transports.SQLServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0077\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
@@ -228,10 +232,12 @@
     <Compile Include="Pipeline\Abort\Handler.cs" />
     <Compile Include="Pipeline\Abort\Behavior.cs" />
     <Compile Include="Pipeline\Abort\MyMessage.cs" />
+    <Compile Include="MsmqTransactionScope.cs" />
     <Compile Include="Pipeline\CustomForkConnector.cs" />
     <Compile Include="Pipeline\CustomStageConnector.cs" />
     <Compile Include="Pipeline\CustomStageForkConnector.cs" />
     <Compile Include="Routing\RoutingAPIs.cs" />
+    <Compile Include="TransactionScopeUnitOfWork.cs" />
     <Compile Include="Transports\QueueCreation\ConcurrentQueueCreator.cs" />
     <Compile Include="Transports\QueueCreation\SequentialQueueCreator.cs" />
     <Compile Include="Transports\QueueCreation\QueueCreation.cs" />
@@ -332,8 +338,9 @@
     <Compile Include="TimeToWaitBeforeTriggeringCriticalErrorOnTimeoutOutages.cs" />
     <Compile Include="Transports\QueueCreation\YourMessagePump.cs" />
     <Compile Include="Transports\QueueCreation\YourQueueCreator.cs" />
+    <Compile Include="Transports\SqlServer\ConfigurationSettings.cs" />
     <Compile Include="Transports\Throughput\ProvideConfiguration.cs" />
-    <Compile Include="Transactions.cs" />
+    <Compile Include="TransportTransactions.cs" />
     <Compile Include="UpgradeGuides\5to6\StartupInterface.cs" />
     <Compile Include="UpgradeGuides\5to6\UpgradeMessageHandler.cs" />
     <Compile Include="UpgradeGuides\5to6\OutgoingBehavior.cs" />

--- a/Snippets/Snippets_6/TransactionScopeUnitOfWork.cs
+++ b/Snippets/Snippets_6/TransactionScopeUnitOfWork.cs
@@ -1,0 +1,36 @@
+﻿namespace Snippets6
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus;
+
+    public class TransactionScopeUnitOfWork
+    {
+        public void UnitOfWorkWrapHandlersInATransactionScope()
+        {
+            #region UnitOfWorkWrapHandlersInATransactionScope
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UnitOfWork()
+                .WrapHandlersInATransactionScope();
+            #endregion
+        }
+
+        public void UnitOfWorkCustomTransactionIsolationLevel()
+        {
+            #region UnitOfWorkCustomTransactionIsolationLevel
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UnitOfWork()
+                .WrapHandlersInATransactionScope(isolationLevel: IsolationLevel.RepeatableRead);
+            #endregion
+        }
+
+        public void UnitOfWorkCustomTransactionTimeout()
+        {
+            #region UnitOfWorkCustomTransactionTimeout
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UnitOfWork()
+                .WrapHandlersInATransactionScope(timeout: TimeSpan.FromSeconds(30));
+            #endregion
+        }
+    }
+}

--- a/Snippets/Snippets_6/TransportTransactions.cs
+++ b/Snippets/Snippets_6/TransportTransactions.cs
@@ -8,7 +8,7 @@
     using NServiceBus.Settings;
     using NServiceBus.Transports;
 
-    public class Transactions
+    public class TransportTransactions
     {
         public void Unreliable()
         {
@@ -16,6 +16,24 @@
             BusConfiguration busConfiguration = new BusConfiguration();
             busConfiguration.UseTransport<MyTransport>()
                 .Transactions(TransportTransactionMode.None);
+            #endregion
+        }
+
+        public void TransportTransactionReceiveOnly()
+        {
+            #region TransportTransactionReceiveOnly
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MyTransport>()
+                .Transactions(TransportTransactionMode.ReceiveOnly);
+            #endregion
+        }
+
+        public void TransportTransactionAtomicSendsWithReceive()
+        {
+            #region TransportTransactionAtomicSendsWithReceive
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MyTransport>()
+                .Transactions(TransportTransactionMode.SendsAtomicWithReceive);
             #endregion
         }
 
@@ -32,17 +50,8 @@
         {
             #region TransactionsWrapHandlersExecutionInATransactionScope
             BusConfiguration busConfiguration = new BusConfiguration();
-            busConfiguration.Transactions()
-                .WrapHandlersExecutionInATransactionScope();
-            #endregion
-        }
-
-        public void CustomTransactionTimeout()
-        {
-            #region CustomTransactionTimeout
-            BusConfiguration busConfiguration = new BusConfiguration();
-            busConfiguration.Transactions()
-                .DefaultTimeout(TimeSpan.FromSeconds(30));
+            busConfiguration.UnitOfWork()
+                .WrapHandlersInATransactionScope();
             #endregion
         }
 
@@ -50,8 +59,19 @@
         {
             #region CustomTransactionIsolationLevel
             BusConfiguration busConfiguration = new BusConfiguration();
-            busConfiguration.Transactions()
-                .IsolationLevel(IsolationLevel.RepeatableRead);
+            busConfiguration.UseTransport<MyTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(isolationLevel: IsolationLevel.RepeatableRead);
+            #endregion
+        }
+
+        public void CustomTransactionTimeout()
+        {
+            #region CustomTransactionTimeout
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MyTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(timeout: TimeSpan.FromSeconds(30));
             #endregion
         }
     }
@@ -99,5 +119,13 @@
         }
 
         public override string ExampleConnectionStringForErrorMessage { get; }
+    }
+
+    internal static class MyTransportConfigurationExtensions
+    {
+        public static TransportExtensions<MyTransport> TransactionScopeOptions(this TransportExtensions<MyTransport> transportExtensions, TimeSpan? timeout = null, IsolationLevel? isolationLevel = null)
+        {
+            return transportExtensions;
+        }
     }
 }

--- a/Snippets/Snippets_6/Transports/SqlServer/ConfigurationSettings.cs
+++ b/Snippets/Snippets_6/Transports/SqlServer/ConfigurationSettings.cs
@@ -1,0 +1,30 @@
+﻿namespace Snippets6.Transports.SqlServer
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus;
+    using NServiceBus.Transports.SQLServer;
+
+    public class ConfigurationSettings
+    {
+        public void SqlServerTransactionScopeIsolationLevel()
+        {
+            #region sqlserver-config-transactionscope-isolation-level 3
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<SqlServerTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(isolationLevel: IsolationLevel.RepeatableRead);
+            #endregion
+        }
+
+        public void SqlServerTransactionScopeTimeout()
+        {
+            #region sqlserver-config-transactionscope-timeout 3
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<SqlServerTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(timeout: TimeSpan.FromSeconds(30));
+            #endregion
+        }
+    }
+}

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/Upgrade.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/Upgrade.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
     using NServiceBus;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.MessageMutator;
@@ -79,6 +80,25 @@
         
             bool isTransactional = readOnlySettings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
 
+            #endregion
+        }
+
+        public void TransportTransactionIsolationLevelAndTimeout()
+        {
+            #region 5to6TransportTransactionScopeOptions
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UseTransport<MyTransport>()
+                .Transactions(TransportTransactionMode.TransactionScope)
+                .TransactionScopeOptions(isolationLevel: IsolationLevel.RepeatableRead, timeout: TimeSpan.FromSeconds(30));
+            #endregion
+        }
+
+        public void WrapHandlersExecutionInATransactionScope()
+        {
+            #region 5to6WrapHandlersExecutionInATransactionScope
+            BusConfiguration busConfiguration = new BusConfiguration();
+            busConfiguration.UnitOfWork()
+                .WrapHandlersInATransactionScope();
             #endregion
         }
     }

--- a/Snippets/Snippets_6/app.config
+++ b/Snippets/Snippets_6/app.config
@@ -22,6 +22,10 @@
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Snippets/Snippets_6/packages.config
+++ b/Snippets/Snippets_6/packages.config
@@ -8,7 +8,7 @@
   <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
-  <package id="NServiceBus" version="6.0.0-unstable1380" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1414" targetFramework="net452" />
   <package id="NServiceBus.Autofac" version="5.1.0-unstable0003" targetFramework="net452" />
   <package id="NServiceBus.Callbacks" version="1.0.0-unstable0026" targetFramework="net452" />
   <package id="NServiceBus.CastleWindsor" version="5.1.0-unstable0000" targetFramework="net452" />
@@ -17,6 +17,7 @@
   <package id="NServiceBus.Log4Net" version="1.1.0-unstable0016" targetFramework="net452" />
   <package id="NServiceBus.NLog" version="1.2.0-unstable0007" targetFramework="net452" />
   <package id="NServiceBus.Spring" version="7.0.0-unstable0011" targetFramework="net452" />
+  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0077" targetFramework="net452" />
   <package id="NServiceBus.StructureMap" version="6.0.0-unstable0016" targetFramework="net452" />
   <package id="NServiceBus.Unity" version="6.3.0-unstable0015" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/nservicebus/messaging/transactions.md
+++ b/nservicebus/messaging/transactions.md
@@ -114,11 +114,14 @@ NOTE: This requires the selected storage to support enlisting in transaction sco
 
 WARNING: This might escalate to a distributed transaction if data in different databases are updated.
 
+WARNING: This API must not be used in combination with transports running in *transaction scope* mode. Starting from version 6, wrapping handlers in a `TransactionScope` in such a situation throws an exception.
+
 
 ## Controlling transaction scope options
 
 The following options for transaction scopes used during message processing can be configured.
 
+NOTE: Starting from version 6 isolation level and timeout for transaction scopes are also configured at the transport level.
 
 ### Isolation level
 

--- a/nservicebus/msmq/transportconfig.md
+++ b/nservicebus/msmq/transportconfig.md
@@ -53,3 +53,30 @@ WARNING: This feature was added in Version 6 and can be used to communicate with
 Often when debugging MSMQ using [native tools](viewing-message-content-in-msmq.md) it is helpful to have some custom text in the MSMQ Label. For example the message type or the message id. As of Version 6 the text used to apply to [Message.Label](https://msdn.microsoft.com/en-us/library/vstudio/system.messaging.message.label.aspx) can be controlled at configuration time using the `ApplyLabelToMessages` extension method. This method takes a delegate which will be passed the header collection and should return a string to use for the label. It will be called for all standard messages as well as Audits, Errors and all control messages. The only exception to this rule is received messages with corrupted headers. In some cases it may be useful to use the `Headers.ControlMessageHeader` key to determine if a message is a control message. These messages will be forwarded to the error queue with no label applied. The returned string can be `String.Empty` for no label and must be at most 240 characters.
 
 snippet:ApplyLabelToMessages
+
+
+## Controlling transaction scope options
+
+The following options can be configured when the MSMQ transport is working in the transaction scope mode.
+
+
+### Isolation level
+
+NServiceBus will by default use the `ReadCommitted` [isolation level](https://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel).
+
+NOTE: Version 3 and below used the default isolation level of .Net which is `Serializable`.
+
+Change the isolation level using
+
+snippet:MsmqTransactionScopeIsolationLevel
+
+
+### Transaction timeout
+
+NServiceBus will use the [default transaction timeout](https://msdn.microsoft.com/en-us/library/system.transactions.transactionmanager.defaulttimeout) of the machine the endpoint is running on.
+
+Change the transaction timeout using
+
+snippet:MsmqTransactionScopeTimeout
+
+Or via .config file using a [example DefaultSettingsSection](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection.aspx#Anchor_5).

--- a/nservicebus/pipeline/unit-of-work.md
+++ b/nservicebus/pipeline/unit-of-work.md
@@ -6,6 +6,46 @@ redirects:
 - nservicebus/unit-of-work-in-nservicebus
 ---
 
+## Using a transaction scope
+
+If your business transaction is spread across multiple handlers there is always a risk of partial updates since one handler might succeed in updating the data while other won't. To avoid this use a unit of work that wraps all handlers in a `TransactionScope` and makes sure that there are no partial updates. Use following code to enable a wrapping scope:
+
+snippet:UnitOfWorkWrapHandlersInATransactionScope
+
+NOTE: This requires the selected storage to support enlisting in transaction scopes.
+
+WARNING: This might escalate to a distributed transaction if data in different databases are updated.
+
+WARNING: This API must not be used in combination with transports running in *transaction scope* mode. Starting from version 6, wrapping handlers in a `TransactionScope` in such a situation throws an exception.
+
+
+### Controlling transaction scope options
+
+The following options for transaction scopes used to wrap all handlers can be configured.
+
+
+### Isolation level
+
+NServiceBus will by default use the `ReadCommitted` [isolation level](https://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel).
+
+Change the isolation level using
+
+snippet:UnitOfWorkCustomTransactionIsolationLevel
+
+
+### Transaction timeout
+
+NServiceBus will use the [default transaction timeout](https://msdn.microsoft.com/en-us/library/system.transactions.transactionmanager.defaulttimeout) of the machine the endpoint is running on.
+
+Change the transaction timeout using
+
+snippet:UnitOfWorkCustomTransactionTimeout
+
+Or via .config file using a [example DefaultSettingsSection](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection.aspx#Anchor_5).
+
+
+## Implementing custom units of work
+
 When using a framework like NServiceBus you usually need to create your own units of work to avoid having to repeat code in your message handlers. For example, committing NHibernate transactions, or calling `SaveChanges` on the RavenDB session.
 
 ### IManageUnitsOfWork

--- a/nservicebus/sqlserver/index.md
+++ b/nservicebus/sqlserver/index.md
@@ -59,6 +59,31 @@ snippet:sqlserver-config-transactionscope
 When in this mode, the receive operation is wrapped in a `TransactionScope` together with the message processing in the pipeline. This means that usage of any other persistent resource manager (e.g. RavenDB client, another `SqlConnection` with different connection string) will cause escalation of the transaction to full two-phase commit protocol handled via Distributed Transaction Coordinator (MS DTC).
 
 
+### Controlling transaction scope options
+
+The following transaction scope options can be configured when the SQL Server transport is working in the ambient transaction mode.
+
+
+### Isolation level
+
+NServiceBus will by default use the `ReadCommitted` [isolation level](https://msdn.microsoft.com/en-us/library/system.transactions.isolationlevel).
+
+Change the isolation level using
+
+snippet:sqlserver-config-transactionscope-isolation-level
+
+
+### Transaction timeout
+
+NServiceBus will use the [default transaction timeout](https://msdn.microsoft.com/en-us/library/system.transactions.transactionmanager.defaulttimeout) of the machine the endpoint is running on.
+
+Change the transaction timeout using
+
+snippet:sqlserver-config-transactionscope-timeout
+
+Or via .config file using a [example DefaultSettingsSection](https://msdn.microsoft.com/en-us/library/system.transactions.configuration.defaultsettingssection.aspx#Anchor_5).
+
+
 ### Native transaction
 
 The native transaction mode requires both `Transactions.Enabled` and `Transactions.SuppressDistributedTransactions` to be set to `true`. It can be selected via

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -440,6 +440,19 @@ Version 6 provide a configuration API that is more aligned with the transaction 
 * `config.Transactions().DisableDistributedTransactions()` - replaced with `.UseTransport<MyTransport>().Transactions(TransportTransactionMode.ReceiveOnly)` or if supported by the transport `.UseTransport<MyTransport>().Transactions(TransportTransactionMode.AtomicSendsWithReceive)`
 * `config.Transactions().EnableDistributedTransactions()` - is the default mode for transactions with DTC support but can be enabled explicitly using `.UseTransport<MyTransport>().Transactions(TransportTransactionMode.TransactionScope)`
 
+### Controlling transaction scope options
+
+Version 6 allows transaction scope options to be configured at the transport level. Setting isolation level and timeout can now be done with the following:
+
+snippet:5to6TransportTransactionScopeOptions
+
+
+### Wrapping handlers execution in a transaction scope
+
+Version 6 comes with a unit of work that wraps execution of handlers in a transaction scope, which can now be done with this API:
+
+snippet:5to6WrapHandlersExecutionInATransactionScope
+
 
 ### Suppressing the ambient transaction
 


### PR DESCRIPTION
First stab at documenting the transaction API cleanup.

### Still to do:
- [x] MSMQ transport transaction scope options
- [x] UoW transaction scope options
- [x] SQL transport transaction scope options (when implemented)
- [x] Upgrade guide