### PR TITLE
[WIP] upgrade 5to6 now mentions the cancellation of a pipeline in Transport seam

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -298,7 +298,7 @@ If your are using it just include [the source code](https://github.com/Particula
 
 ## Transport seam
 
-`IDispatchMessages` have been obsoleted and is replaced by `IPushMessages`. The interfaces are equivalent so if you're implementing your own transport you should be able to just implement the new interface. It's worth to add, that `PushContext` has been given a new property `PushContext.ReceiveCancellationTokenSource`, revealing the intent of cancellation for receiving the current message. Your transport implementation should act accordingly, cancelling the receive when the source's token is cancelled.
+`IDispatchMessages` have been obsoleted and is replaced by `IPushMessages`. The interfaces are equivalent so if you're implementing a transport, you should be able to just implement the new interface. `PushContext` has been given a new property `PushContext.ReceiveCancellationTokenSource`, revealing the intent of cancellation for receiving the current message. The transport implementation should act accordingly, cancelling the receive when the source's token is cancelled.
 
 
 ### Corrupted messages

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -298,7 +298,7 @@ If your are using it just include [the source code](https://github.com/Particula
 
 ## Transport seam
 
-`IDispatchMessages` have been obsoleted and is replaced by `IPushMessages`. The interfaces are equivalent so if you're implementing your own transport you should be able to just implement the new interface.
+`IDispatchMessages` have been obsoleted and is replaced by `IPushMessages`. The interfaces are equivalent so if you're implementing your own transport you should be able to just implement the new interface. It's worth to add, that `PushContext` has been given a new property `PushContext.ReceiveCancellationTokenSource`, revealing the intent of cancellation for receiving the current message. Your transport implementation should act accordingly, cancelling the receive when the source's token is cancelled.
 
 
 ### Corrupted messages


### PR DESCRIPTION
As the documentation for transports describe use cases of existing transports, I haven't put that low level implementation detail in there. 
The upgrade notes 5to6 have notes for transport implementors. I've added a paragraph about handling the receive cancellation gracefully.

Related to Particular/NServiceBus#3254