### PR TITLE
Add info for message type fallback

### DIFF
--- a/nservicebus/handlers/index.md
+++ b/nservicebus/handlers/index.md
@@ -23,14 +23,16 @@ If you are using the Request-Response or Full Duplex pattern, your handler will 
 
 If you are handling a message in a publish-and-subscribe scenario, see [How to Publish/Subscribe to a Message](/nservicebus/messaging/publish-subscribe/).
 
-### Mapping to FQN with fallback to type
 
-NServiceBus will try to map incoming messages to a type using its Fully Qualified Name (FQN). This is default behavior for sharing assemblies amongst endpoints and sendonly clients. When a message cannot be mapped based on FQN, NServiceBus will try to map to just the type. The following is an example of how NServiceBus gets the type information.
+### Mapping to name
+
+NServiceBus will try to map incoming messages to a type using [Assembly Qualified Name](https://msdn.microsoft.com/en-us/library/system.type.assemblyqualifiedname.aspx). This is default behavior for sharing assemblies amongst endpoints. When a message cannot be mapped based on Assembly Qualified Name, NServiceBus will attempt to map to the [FullName](https://msdn.microsoft.com/en-us/library/system.type.fullname.aspx). The following is an example of how NServiceBus gets the type information.
 
 ```
 string fqn = message.GetType().AssemblyQualifiedName;
 string fallback = message.GetType().FullName;
 ```
+
 
 ## What happens when there are no handlers for a message?
 

--- a/nservicebus/handlers/index.md
+++ b/nservicebus/handlers/index.md
@@ -25,7 +25,12 @@ If you are handling a message in a publish-and-subscribe scenario, see [How to P
 
 ### Mapping to FQN with fallback to type
 
-NServiceBus will try to map incoming messages to a type using its Fully Qualified Name (FQN). This is default behavior for sharing assemblies amongst endpoints and sendonly clients. When a message cannot be mapped based on FQN, NServiceBus will try to map to just the type.
+NServiceBus will try to map incoming messages to a type using its Fully Qualified Name (FQN). This is default behavior for sharing assemblies amongst endpoints and sendonly clients. When a message cannot be mapped based on FQN, NServiceBus will try to map to just the type. The following is an example of how NServiceBus gets the type information.
+
+```
+string fqn = message.GetType().AssemblyQualifiedName;
+string fallback = message.GetType().FullName;
+```
 
 ## What happens when there are no handlers for a message?
 

--- a/nservicebus/handlers/index.md
+++ b/nservicebus/handlers/index.md
@@ -23,6 +23,9 @@ If you are using the Request-Response or Full Duplex pattern, your handler will 
 
 If you are handling a message in a publish-and-subscribe scenario, see [How to Publish/Subscribe to a Message](/nservicebus/messaging/publish-subscribe/).
 
+### Mapping to FQN with fallback to type
+
+NServiceBus will try to map incoming messages to a type using its Fully Qualified Name (FQN). This is default behavior for sharing assemblies amongst endpoints and sendonly clients. When a message cannot be mapped based on FQN, NServiceBus will try to map to just the type.
 
 ## What happens when there are no handlers for a message?
 


### PR DESCRIPTION
I added a single paragraph. But although it might be clear or correct what it states (I have you to verify that ;-) ) I'm not sure of readers of the document will understand.

I've thought about a code snippet of a single line, which seems ridiculous. Also because it's not NSB version related, it's .NET related.
I've also thought about putting a triple ` addition, like in the step-by-step page (http://docs.particular.net/samples/step-by-step/)
But I'm not sure if I'm allowed to use that.

So I'd like some feedback