### PR TITLE
Mentioning that callbacks can no longer be used in handlers or sagas.

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -231,10 +231,9 @@ The MSMQ ReturnToSourceQueue.exe tool is now deprecated. The code for this tool 
 
 ## Handling responses on the client side
 
-We've separated the callback support from the NServiceBus core. This means that you now have to explicitly install our new [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/) to get access to callback support. In contrast to previous versions this API allows you to easily access the response message and is asynchronous by default.
+We've separated the callback support from the NServiceBus core. This means that you now have to explicitly install our new [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/) to get access to callback support. In contrast to previous versions this API allows you to easily access the response message and is asynchronous by default. The extension methods provided by the new callback package are only available on the bus session, so it is no longer possible to use callbacks inside handlers or sagas.
 
 The differences in the API are fully covered in [handling responses on the client side](/nservicebus/messaging/handling-responses-on-the-client-side.md).
-
 
 ## UnicastBus made internal
 


### PR DESCRIPTION
Connects to #1083

@Particular/documentation I contemplated about mentioning the usage of callbacks inside handlers and sagas but then back tracked because I didn't want to encourage bad design choices by mentioning it. If you feel otherwise I'm happy to add it to the "Handling responses on the client side" documentation page.