### PR TITLE
Throughput throttling

### DIFF
--- a/Snippets/Snippets_6/Transports/Throughput/InitialThroughput.config.xml
+++ b/Snippets/Snippets_6/Transports/Throughput/InitialThroughput.config.xml
@@ -5,7 +5,6 @@
     <section name="TransportConfig"
              type="NServiceBus.Config.TransportConfig, NServiceBus.Core"/>
   </configSections>
-  <TransportConfig MaximumConcurrencyLevel="5"
-                   MaximumMessageThroughputPerSecond="10"/>
+  <TransportConfig MaximumConcurrencyLevel="5"/>
   <!--endcode -->
 </configuration>

--- a/nservicebus/operations/tuning.md
+++ b/nservicebus/operations/tuning.md
@@ -32,13 +32,15 @@ You can define a maximum value for the number of messages per second that the en
 
 NServiceBus will not enforce any throughput restrictions by default.
 
+NOTE: Throughput throttling options have been removed with NServiceBus Version 6.
+
 
 ## Configuration
 
 The default limits of an endpoint can be changed in both code and via app.config.
 
 
-### Via Code 
+### Via Code
 
 By [overriding app.config settings](/nservicebus/hosting/custom-configuration-providers.md).
 


### PR DESCRIPTION
* Remove obsolete throughput throttling configuration options for v6 snippets
* Add a note to the tuning page that this has been removed with v6

See Particular/NServiceBus#3306

Note that I created a new issue about providing some samples on how to implement custom throughput throttling here: #1086 