### PR TITLE
Describe that FLR settings do not apply to TimeoutManager in v6

### DIFF
--- a/nservicebus/errors/automatic-retries.md
+++ b/nservicebus/errors/automatic-retries.md
@@ -50,7 +50,7 @@ snippet:FLRConfigurationSource
 snippet:FLRConfigurationSourceUsage
 
 
-NOTE: Starting from version 6, configuration of the FLR mechanism will have no effect on how many times a deferred message is dispatched when an exception is thrown. In such a case the `TimeoutManager` will attempt the dispatch five times.
+NOTE: From Version 6, configuration of the FLR mechanism will have no effect on how many times a deferred message is dispatched when an exception is thrown. In such a case the `TimeoutManager` will attempt the dispatch five times.
 
 
 ## Second Level Retries
@@ -64,6 +64,7 @@ For example, if there is a call to an web service in your handler, but the servi
 NOTE: Retrying messages for extended periods of time would hide failures from operators preventing them from taking manual action to honor Service Level Agreements. To avoid this happening, due to miss-configured retry polices, NServiceBus will make sure that no message is retried for more than 24 hours before being sent the error queue.
 
 SLR can be configured in several ways.
+
 
 ### Configuring SLR using app.config
 

--- a/nservicebus/errors/automatic-retries.md
+++ b/nservicebus/errors/automatic-retries.md
@@ -50,6 +50,9 @@ snippet:FLRConfigurationSource
 snippet:FLRConfigurationSourceUsage
 
 
+NOTE: Starting from version 6, configuration of the FLR mechanism will have no effect on how many times a deferred message is dispatched when an exception is thrown. In such a case the `TimeoutManager` will attempt the dispatch five times.
+
+
 ## Second Level Retries
 
 SLR introduces another level of retrying mechanism for messages that fail processing. When using SLR, the message that causes the exception is, as before, instantly retried, but instead of being sent to the error queue, it is sent to a retries queue.

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -150,7 +150,7 @@ Configuration should be easy to apply to your code and easy to manipulate by han
 
 ### Automatic retries
 
-Previously configuring the number of times a message will be retried by the First Level Retries (FLR) mechanism also determined how many times the `TimeoutManager` attempted to retry dispatching a deferred message in case an exception was thrown. Starting from version 6, the `TimeoutManager` will attempt the dispatch five times (this number is not configurable anymore). Configuration of the FLR mechanism for non-deferred message dispatch has not been changed.
+Previously configuring the number of times a message will be retried by the First Level Retries (FLR) mechanism also determined how many times the `TimeoutManager` attempted to retry dispatching a deferred message in case an exception was thrown. From Version 6, the `TimeoutManager` will attempt the dispatch five times (this number is not configurable anymore). Configuration of the FLR mechanism for non-deferred message dispatch has not been changed.
 
 
 ## Sagas

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -148,6 +148,11 @@ Configuration should be easy to apply to your code and easy to manipulate by han
 `IQueryTimeouts` implements the concern of polling for timeouts outside the context of a message pipeline. `IPersistTimeouts` implements the concern of storage and removal for timeouts which is executed inside the context of a pipeline. Depending on the design of the timeout persisters, those concerns can now be implemented independently. Furthermore, `IPersistTimeouts` introduced a new parameter `TimeoutPersistenceOptions `. This parameter allows access to the pipeline context. This enables timeout persisters to manipulate everything that exists in the context during message pipeline execution.
 
 
+### Automatic retries
+
+Previously configuring the number of times a message will be retried by the First Level Retries (FLR) mechanism also determined how many times the `TimeoutManager` attempted to retry dispatching a deferred message in case an exception was thrown. Starting from version 6, the `TimeoutManager` will attempt the dispatch five times (this number is not configurable anymore). Configuration of the FLR mechanism for non-deferred message dispatch has not been changed.
+
+
 ## Sagas
 
 


### PR DESCRIPTION
As of v6, the TimeoutManager has its own fixed FLR policy.

This is doco PR for Particular/NServiceBus#3337.