### PR TITLE
Add Troubleshooting info on required URLACL

### DIFF
--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -95,18 +95,19 @@ NOTE: Prior to changing firewall setting to expose ServiceControl please read [S
 
 ### Unable to start Service after exposing RavenDB
 
-The `ExposeRavenDB`setting enables the embedded RavenDB Management Studio to be accessible via a web browser.
-When this setting is used in combination with a low privilege service account it can cause the service not to start.
-This is because a URLACL is required and the low priviege account does not have sufficent right to create it. 
+The `ExposeRavenDB` setting enables the embedded RavenDB Management Studio to be accessible via a web browser.
+When this setting is used in combination with a low privilege service account it can cause the service fail on startup.
+This is because a URLACL is required and the service account does not have rights to create it.
+ 
 To workaround this create the required URLACL. This can be done using the ServiceControl Management Powershell module.  
 
-NOTE: Replace the `<hostname>` and `<port>` valuse in the sample command below   with the appropriate values for your configuration
+NOTE: Replace the `<hostname>` and `<port>` valus in the sample commands below with the appropriate values from the ServiceControl configuration.
 
 ```posh
 urlacl-add -Url http://<hostname>:<port>/storage/ -Users Users
 ```
 
-If the `ExposeRavenDB` is removed from the configuration the URLACL can be cleaned up using this command
+If the `ExposeRavenDB` setting is removed or disabled in the configuration then the URLACL can be cleaned up using this command:
 
 ```posh
 urlacl-list | ? VirtualDirectory -eq storage | ? Port -eq <port> | urlacl-delete

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -92,3 +92,22 @@ The value is the size of the version store in MB.
  1. If you are having issues remotely connecting to ServiceControl. Verify that firewall settings do not block access to the ServiceControl port specified in the URL.
 
 NOTE: Prior to changing firewall setting to expose ServiceControl please read [Securing ServiceControl](securing-servicecontrol.md).
+
+### Unable to start Service after exposing RavenDB
+
+The `ExposeRavenDB`setting enables the embedded RavenDB Management Studio to be accessible via a web browser.
+When this setting is used in combination with a low privilege service account it can cause the service not to start.
+This is because a URLACL is required and the low priviege account does not have sufficent right to create it. 
+To workaround this create the required URLACL. This can be done using the ServiceControl Management Powershell module.  
+
+NOTE: Replace the `<hostname>` and `<port>` valuse in the sample command below   with the appropriate values for your configuration
+
+```posh
+urlacl-add -Url http://<hostname>:<port>/storage/ -Users Users
+```
+
+If the `ExposeRavenDB` is removed from the configuration the URLACL can be cleaned up using this command
+
+```posh
+urlacl-list | ? VirtualDirectory -eq storage | ? Port -eq <port> | urlacl-delete
+``` 

--- a/servicecontrol/use-ravendb-studio.md
+++ b/servicecontrol/use-ravendb-studio.md
@@ -31,7 +31,7 @@ After restarting the ServiceControl service, you can access the RavenDB studio l
 
 NOTE: The ServiceControl embedded RavenDB studio can be accessed from localhost regardless of the hostname customization setting.
 
-### TroubleShooting
+### Troubleshooting
 
-If ServiceControl is configured to use a service account other than localsystem you may have to manually add a URLACL.
-Refer to this [TroubleShooting](troubleshooting.md##unable-to-start-service-after-exposing-ravendb) 
+If ServiceControl is configured to use a service account other than `localsystem` you may have to manually add a URLACL.
+Refer to [TroubleShooting](troubleshooting.md#unable-to-start-service-after-exposing-ravendb) 

--- a/servicecontrol/use-ravendb-studio.md
+++ b/servicecontrol/use-ravendb-studio.md
@@ -30,3 +30,8 @@ After restarting the ServiceControl service, you can access the RavenDB studio l
     http://localhost:33333/storage
 
 NOTE: The ServiceControl embedded RavenDB studio can be accessed from localhost regardless of the hostname customization setting.
+
+### TroubleShooting
+
+If ServiceControl is configured to use a service account other than localsystem you may have to manually add a URLACL.
+Refer to this [TroubleShooting](troubleshooting.md##unable-to-start-service-after-exposing-ravendb) 

--- a/servicecontrol/use-ravendb-studio.md
+++ b/servicecontrol/use-ravendb-studio.md
@@ -31,7 +31,8 @@ After restarting the ServiceControl service, you can access the RavenDB studio l
 
 NOTE: The ServiceControl embedded RavenDB studio can be accessed from localhost regardless of the hostname customization setting.
 
+
 ### Troubleshooting
 
-If ServiceControl is configured to use a service account other than `localsystem` you may have to manually add a URLACL.
+If ServiceControl is configured to use a service account other than `localsystem` it is necessary to manually add a URLACL.
 Refer to [TroubleShooting](troubleshooting.md#unable-to-start-service-after-exposing-ravendb) 


### PR DESCRIPTION
If the service account is not a local administrator or localsystem enabling the ExposeRavenDB setting can cause the server to fail on startup. This is because A URLACL is required to allow the Raven Management Studio to be exposed on the /storage virtual directory. Raven will create this automatically if the service account has the privileges.

This PR details the worlkaround