### PR TITLE
WIP - Licensing - Make 32bit and 64 bit more explicit

### DIFF
--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -37,7 +37,7 @@ These following instructions cover installing the license file without using NSe
 - Create a new Multi-String Value (`REG_MULTI_SZ`) named `License`
 - Paste the contents of the license file you received from Particular Software.
 
-If this is a 64 bit operating system and you have chosen to add the license to `HKEY_LOCAL_MACHINE` then repeat the import process for the key `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware`
+If `HKEY_LOCAL_MACHINE`is the chosen license location and the operating system is 64-bit then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
 
 (You can safely ignore any warnings regarding empty strings.)
 
@@ -55,7 +55,7 @@ Set-ItemProperty -Path HKLM:\Software\ParticularSoftware -Name License -Force -V
 
 If modifying the registry directly using Registry Editor or a PowerShell script to update the license for ServiceControl, you will need to restart the ServiceControl service, as it only checks for its license information once at startup.
 
-NOTE: On a 64 bit operating system you should do this process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
+NOTE: On a 64 bit operating system repeat the process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
 
 ### NServiceBus Version 3.3
 

--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -21,13 +21,14 @@ Using the registry to store your license information is a way that all platform 
 
 The standalone NServiceBus PowerShell Version 5.0 includes a commandlet for importing the Platform License into the `HKEY_LOCAL_MACHINE` registry. See [Managing Using PowerShell](/nservicebus/operations/management-using-powershell.md) for more details and installation instructions for the PowerShell Module.
 
-For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry. The license is stored is `HKEY_LOCAL_MACHINE\Software\ParticularSoftware\License`.
+For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry. The license is stored is `HKEY_LOCAL_MACHINE\Software\ParticularSoftware\License` and `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware`
+
+NOTE: Using the Powershell cmdlet is the preferred and simpliest method of adding the license file. 
 
 
 #### Advanced Registry Options
 
 These following instructions cover installing the license file without using NServiceBus PowerShell Module. These options give a bit more flexibility as they allow you to store the the license in `HKEY_CURRENT_USER` if you wish. If the licenses is stored in `HKEY_CURRENT_USER` it is only accessible to the current user.
-
 
 ##### Using Registry Editor
 
@@ -36,10 +37,12 @@ These following instructions cover installing the license file without using NSe
 - Create a new Multi-String Value (`REG_MULTI_SZ`) named `License`
 - Paste the contents of the license file you received from Particular Software.
 
+If this is a 64 bit operating system and you have chosen to add the license to `HKEY_LOCAL_MACHINE` then repeat the import process for the key `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware`
+
 (You can safely ignore any warnings regarding empty strings.)
 
 
-##### Using PowerShell Script
+##### Using PowerShell Script 
 
 * Open an administrative PowerShell prompt.
 * Change the current working directory to where your license.xml file is.
@@ -52,10 +55,7 @@ Set-ItemProperty -Path HKLM:\Software\ParticularSoftware -Name License -Force -V
 
 If modifying the registry directly using Registry Editor or a PowerShell script to update the license for ServiceControl, you will need to restart the ServiceControl service, as it only checks for its license information once at startup.
 
-NOTE: On a 64 bit operating system this script should not be run through the PowerShell(x86) console prompt, doing so will result in the license being imported into the 32 registry key. Please use a 64bit PowerShell session.
-
-NOTE: As of Version 4.5, both the `LicenseInstaller.exe` tool and the `install-NServiceBusLicense` PowerShell commandlet have been deprecated.
-
+NOTE: On a 64 bit operating system you should do this process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
 
 ### NServiceBus Version 3.3
 

--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -14,6 +14,8 @@ There are several ways to make sure that your NServiceBus endpoints pick up and 
 
 ## Using the Registry
 
+NOTE: Using the Powershell cmdlet is the preferred and simpliest method of adding the license file. 
+
 Using the registry to store your license information is a way that all platform tools can access this information easily. This includes NServiceBus endpoints, ServiceControl, and ServiceInsight. (ServicePulse determines licensing status by querying the ServiceControl API.) Using the registry ensures that all the platform tools can access the license status without requiring additional complexity on every deployment.
 
 
@@ -23,24 +25,9 @@ The standalone NServiceBus PowerShell Version 5.0 includes a commandlet for impo
 
 For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry. The license is stored is `HKEY_LOCAL_MACHINE\Software\ParticularSoftware\License` and `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware`
 
-NOTE: Using the Powershell cmdlet is the preferred and simpliest method of adding the license file. 
-
-
 #### Advanced Registry Options
 
 These following instructions cover installing the license file without using NServiceBus PowerShell Module. These options give a bit more flexibility as they allow you to store the the license in `HKEY_CURRENT_USER` if you wish. If the licenses is stored in `HKEY_CURRENT_USER` it is only accessible to the current user.
-
-##### Using Registry Editor
-
-- Run `regedit.exe` (usually located in `%windir%`, e.g. `C:\Windows`)
-- Go to `HKEY_LOCAL_MACHINE\Software\ParticularSoftware` or `HKEY_CURRENT_USER\Software\ParticularSoftware`
-- Create a new Multi-String Value (`REG_MULTI_SZ`) named `License`
-- Paste the contents of the license file you received from Particular Software.
-
-If `HKEY_LOCAL_MACHINE`is the chosen license location and the operating system is 64-bit then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
-
-(You can safely ignore any warnings regarding empty strings.)
-
 
 ##### Using PowerShell Script 
 
@@ -56,6 +43,17 @@ Set-ItemProperty -Path HKLM:\Software\ParticularSoftware -Name License -Force -V
 If modifying the registry directly using Registry Editor or a PowerShell script to update the license for ServiceControl, you will need to restart the ServiceControl service, as it only checks for its license information once at startup.
 
 NOTE: For 64 bit operating systems repeat the process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
+
+##### Using Registry Editor
+
+- Run `regedit.exe` (usually located in `%windir%`, e.g. `C:\Windows`)
+- Go to `HKEY_LOCAL_MACHINE\Software\ParticularSoftware` or `HKEY_CURRENT_USER\Software\ParticularSoftware`
+- Create a new Multi-String Value (`REG_MULTI_SZ`) named `License`
+- Paste the contents of the license file you received from Particular Software.
+
+If `HKEY_LOCAL_MACHINE`is the chosen license location and the operating system is 64-bit then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
+
+(You can safely ignore any warnings regarding empty strings.)
 
 ### NServiceBus Version 3.3
 

--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -14,7 +14,7 @@ There are several ways to make sure that your NServiceBus endpoints pick up and 
 
 ## Using the Registry
 
-NOTE: Using the Powershell cmdlet is the preferred and simpliest method of adding the license file. 
+NOTE: Using the PowerShell cmdlet is the preferred and simplest method of adding the license file. 
 
 Using the registry to store your license information is a way that all platform tools can access this information easily. This includes NServiceBus endpoints, ServiceControl, and ServiceInsight. (ServicePulse determines licensing status by querying the ServiceControl API.) Using the registry ensures that all the platform tools can access the license status without requiring additional complexity on every deployment.
 
@@ -56,7 +56,7 @@ NOTE: For 64 bit operating systems repeat the process in both the Powershell pro
 
 If `HKEY_LOCAL_MACHINE`is the chosen license location and the operating system is 64-bit then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
 
-(You can safely ignore any warnings regarding empty strings.)
+You can safely ignore any warnings regarding empty strings.
 
 
 ### NServiceBus Version 3.3

--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -55,7 +55,7 @@ Set-ItemProperty -Path HKLM:\Software\ParticularSoftware -Name License -Force -V
 
 If modifying the registry directly using Registry Editor or a PowerShell script to update the license for ServiceControl, you will need to restart the ServiceControl service, as it only checks for its license information once at startup.
 
-NOTE: On a 64 bit operating system repeat the process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
+NOTE: For 64 bit operating systems repeat the process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
 
 ### NServiceBus Version 3.3
 

--- a/nservicebus/licensing/license-management.md
+++ b/nservicebus/licensing/license-management.md
@@ -25,9 +25,11 @@ The standalone NServiceBus PowerShell Version 5.0 includes a commandlet for impo
 
 For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry. The license is stored is `HKEY_LOCAL_MACHINE\Software\ParticularSoftware\License` and `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware`
 
+
 #### Advanced Registry Options
 
 These following instructions cover installing the license file without using NServiceBus PowerShell Module. These options give a bit more flexibility as they allow you to store the the license in `HKEY_CURRENT_USER` if you wish. If the licenses is stored in `HKEY_CURRENT_USER` it is only accessible to the current user.
+
 
 ##### Using PowerShell Script 
 
@@ -44,6 +46,7 @@ If modifying the registry directly using Registry Editor or a PowerShell script 
 
 NOTE: For 64 bit operating systems repeat the process in both the Powershell prompt and the PowerShell(x86) console prompt.  This will ensure the license is imported into both the 32 bit and 64 bit registry keys. 
 
+
 ##### Using Registry Editor
 
 - Run `regedit.exe` (usually located in `%windir%`, e.g. `C:\Windows`)
@@ -54,6 +57,7 @@ NOTE: For 64 bit operating systems repeat the process in both the Powershell pro
 If `HKEY_LOCAL_MACHINE`is the chosen license location and the operating system is 64-bit then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
 
 (You can safely ignore any warnings regarding empty strings.)
+
 
 ### NServiceBus Version 3.3
 


### PR DESCRIPTION
We had feedback via a desk case that the licensing doc should be more explicit about importing the license into the WOW3264Node of the registry