### PR TITLE
Version 6 gateway changes

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -546,3 +546,7 @@ WARNING: External integration systems need to ensure compatibility when receivin
 ## Encryption Service
 
 It is no longer possible to access the builder to create an encryption service. If you require container access use your container directly in the factory delegate in the `RegisterEncryptionService` method.
+
+## Gateway
+
+`IForwardMessagesToSites`, `IRouteMessagesToEndpoints`, and `IRouteMessagesToSites` have been deprecated and are no longer available as extension points in the gateway. To override the default HTTP channel, register custom `IChannelSender` and `IChannelReceiver` factory methods through the new extension point `configure.Gateway().ChannelFactories()` in the `EndpointConfiguration` of an endpoint. Dependency injection is not provided for these factory methods. `IChannelSender` and `IChannelReceiver` implementations are also no longer automatically picked up by assembly scanning. 


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Gateway/pull/25

Gateway changes for V6. Obsoletes several public interfaces and introduces an explicit configurable extension point.

