### PR TITLE
Cleaned up v5 namespaces to v6

### DIFF
--- a/Snippets/Snippets_6/CustomChecks.cs
+++ b/Snippets/Snippets_6/CustomChecks.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5
+﻿namespace Snippets6
 {
     using System;
     using System.Threading.Tasks;

--- a/Snippets/Snippets_6/Encryption/Configuration/FromCode.cs
+++ b/Snippets/Snippets_6/Encryption/Configuration/FromCode.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.Configuration
+﻿namespace Snippets6.Encryption.Configuration
 {
     using System.Collections.Generic;
     using NServiceBus;

--- a/Snippets/Snippets_6/Encryption/Configuration/ProvideConfiguration.cs
+++ b/Snippets/Snippets_6/Encryption/Configuration/ProvideConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.Configuration
+﻿namespace Snippets6.Encryption.Configuration
 {
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;

--- a/Snippets/Snippets_6/Encryption/Conventions/Message.cs
+++ b/Snippets/Snippets_6/Encryption/Conventions/Message.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.Conventions
+﻿namespace Snippets6.Encryption.Conventions
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Encryption/Conventions/Usage.cs
+++ b/Snippets/Snippets_6/Encryption/Conventions/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.Conventions
+﻿namespace Snippets6.Encryption.Conventions
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Encryption/EncryptionService/EncryptionService.cs
+++ b/Snippets/Snippets_6/Encryption/EncryptionService/EncryptionService.cs
@@ -1,4 +1,4 @@
-namespace Snippets5.Encryption.EncryptionService
+namespace Snippets6.Encryption.EncryptionService
 {
     using NServiceBus;
     using NServiceBus.Encryption;

--- a/Snippets/Snippets_6/Encryption/EncryptionService/Usage.cs
+++ b/Snippets/Snippets_6/Encryption/EncryptionService/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.EncryptionService
+﻿namespace Snippets6.Encryption.EncryptionService
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Encryption/MessageBody/MessageEncryptor.cs
+++ b/Snippets/Snippets_6/Encryption/MessageBody/MessageEncryptor.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.MessageBody
+﻿namespace Snippets6.Encryption.MessageBody
 {
     using System.Linq;
     using System.Threading.Tasks;

--- a/Snippets/Snippets_6/Encryption/MessageBody/Usage.cs
+++ b/Snippets/Snippets_6/Encryption/MessageBody/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.MessageBody
+﻿namespace Snippets6.Encryption.MessageBody
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Encryption/Usage.cs
+++ b/Snippets/Snippets_6/Encryption/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption
+﻿namespace Snippets6.Encryption
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Encryption/WireEncryptedProperty/MyMessage.cs
+++ b/Snippets/Snippets_6/Encryption/WireEncryptedProperty/MyMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Encryption.WireEncryptedProperty
+﻿namespace Snippets6.Encryption.WireEncryptedProperty
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/EndpointName/EndpointConfigByNamespace.cs
+++ b/Snippets/Snippets_6/EndpointName/EndpointConfigByNamespace.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.EndpointName
+﻿namespace Snippets6.EndpointName
 {
     // startcode EndpointNameByNamespace
     namespace MyServer

--- a/Snippets/Snippets_6/EndpointName/EndpointConfigWithAttribute.cs
+++ b/Snippets/Snippets_6/EndpointName/EndpointConfigWithAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.EndpointName
+﻿namespace Snippets6.EndpointName
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/EndpointName/Usage.cs
+++ b/Snippets/Snippets_6/EndpointName/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.EndpointName
+﻿namespace Snippets6.EndpointName
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Gateway/Channels/ConfigurationSource/ConfigurationSource.cs
+++ b/Snippets/Snippets_6/Gateway/Channels/ConfigurationSource/ConfigurationSource.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway.Channels.ConfigurationSource
+﻿namespace Snippets6.Gateway.Channels.ConfigurationSource
 {
     using System.Configuration;
     using NServiceBus.Config;

--- a/Snippets/Snippets_6/Gateway/Channels/ConfigurationSource/Usage.cs
+++ b/Snippets/Snippets_6/Gateway/Channels/ConfigurationSource/Usage.cs
@@ -1,4 +1,4 @@
-namespace Snippets5.Gateway.Channels.ConfigurationSource
+namespace Snippets6.Gateway.Channels.ConfigurationSource
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Gateway/Channels/ProvideConfiguration.cs
+++ b/Snippets/Snippets_6/Gateway/Channels/ProvideConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway.Channels
+﻿namespace Snippets6.Gateway.Channels
 {
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;

--- a/Snippets/Snippets_6/Gateway/MyMessage.cs
+++ b/Snippets/Snippets_6/Gateway/MyMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway
+﻿namespace Snippets6.Gateway
 {
     public class MyMessage
     {

--- a/Snippets/Snippets_6/Gateway/Sites/ConfigurationSource/ConfigurationSource.cs
+++ b/Snippets/Snippets_6/Gateway/Sites/ConfigurationSource/ConfigurationSource.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway.Sites.ConfigurationSource
+﻿namespace Snippets6.Gateway.Sites.ConfigurationSource
 {
     using System.Configuration;
     using NServiceBus.Config;

--- a/Snippets/Snippets_6/Gateway/Sites/ConfigurationSource/Usage.cs
+++ b/Snippets/Snippets_6/Gateway/Sites/ConfigurationSource/Usage.cs
@@ -1,4 +1,4 @@
-namespace Snippets5.Gateway.Sites.ConfigurationSource
+namespace Snippets6.Gateway.Sites.ConfigurationSource
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Gateway/Sites/ProvideConfiguration.cs
+++ b/Snippets/Snippets_6/Gateway/Sites/ProvideConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway.Sites
+﻿namespace Snippets6.Gateway.Sites
 {
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;

--- a/Snippets/Snippets_6/Gateway/Usage.cs
+++ b/Snippets/Snippets_6/Gateway/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Gateway
+﻿namespace Snippets6.Gateway
 {
     using NServiceBus;
     using NServiceBus.Features;

--- a/Snippets/Snippets_6/Monitoring/MessageFailedHandler.cs
+++ b/Snippets/Snippets_6/Monitoring/MessageFailedHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Monitoring
+﻿namespace Snippets6.Monitoring
 {
     using System;
     using System.Threading.Tasks;

--- a/Snippets/Snippets_6/Outbox/RavenDB/TimeToKeep.cs
+++ b/Snippets/Snippets_6/Outbox/RavenDB/TimeToKeep.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Outbox.RavenDB
+﻿namespace Snippets6.Outbox.RavenDB
 {
     using System;
     using NServiceBus;

--- a/Snippets/Snippets_6/Outbox/Usage.cs
+++ b/Snippets/Snippets_6/Outbox/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Outbox
+﻿namespace Snippets6.Outbox
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/RavenDB/ChangeResourceManagerID.cs
+++ b/Snippets/Snippets_6/RavenDB/ChangeResourceManagerID.cs
@@ -1,5 +1,5 @@
 ﻿// ReSharper disable EmptyConstructor
-namespace Snippets5.RavenDB
+namespace Snippets6.RavenDB
 {
     class ChangeResourceManagerID
     {

--- a/Snippets/Snippets_6/RavenDB/Configure.cs
+++ b/Snippets/Snippets_6/RavenDB/Configure.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.RavenDB
+﻿namespace Snippets6.RavenDB
 {
     using System.Threading.Tasks;
     using NServiceBus;

--- a/Snippets/Snippets_6/RavenDB/ConfiguringTransactionRecoveryStorage.cs
+++ b/Snippets/Snippets_6/RavenDB/ConfiguringTransactionRecoveryStorage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.RavenDB
+﻿namespace Snippets6.RavenDB
 {
     class ConfiguringTransactionRecoveryStorage
     {

--- a/Snippets/Snippets_6/Sagas/ConfigureSagaPersistence.cs
+++ b/Snippets/Snippets_6/Sagas/ConfigureSagaPersistence.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Sagas
+﻿namespace Snippets6.Sagas
 {
     using NServiceBus;
     using NServiceBus.Persistence;

--- a/Snippets/Snippets_6/Serialization/JsonSerialization.cs
+++ b/Snippets/Snippets_6/Serialization/JsonSerialization.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Serialization
+﻿namespace Snippets6.Serialization
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Serialization/XmlSerialization.cs
+++ b/Snippets/Snippets_6/Serialization/XmlSerialization.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Serialization
+﻿namespace Snippets6.Serialization
 {
     using NServiceBus;
 

--- a/Snippets/Snippets_6/Transports/RabbitMQ_4/Usage.cs
+++ b/Snippets/Snippets_6/Transports/RabbitMQ_4/Usage.cs
@@ -1,4 +1,4 @@
-﻿namespace Snippets5.Transports.RabbitMQ
+﻿namespace Snippets6.Transports.RabbitMQ
 {
     using System;
     using global::RabbitMQ.Client;


### PR DESCRIPTION
Cleaned up usage of "namespace Snippets5" in v6 snippets. Ping @Particular/documentation 