### PR TITLE
Adding note about deprecating ConfigureTransport

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -315,6 +315,7 @@ If you are using it just include [the source code](https://github.com/Particular
 
 `IDispatchMessages` have been obsoleted and is replaced by `IPushMessages`. The interfaces are equivalent so if you're implementing a transport, you should be able to just implement the new interface. `PushContext` has been given a new property `PushContext.ReceiveCancellationTokenSource`, revealing the intent of cancellation for receiving the current message. The transport implementation should act accordingly, cancelling the receive when the source's token is cancelled.
 
+The `ConfigureTransport` class was deprecated. Custom transports are now configured using the `TransportDefinition` class, see [this sample](/samples/custom-transport) for more information.
 
 ### Corrupted messages
 


### PR DESCRIPTION
Added this in the upgrade guide. Please see #1177 if anything else should be added.