### PR TITLE
Mentioning Conventions can no longer be injected

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -18,6 +18,7 @@
       Url: "nservicebus/messaging"
       Articles:
         - "nservicebus/messaging/messages-events-commands"
+        - "nservicebus/messaging/conventions"
         - "nservicebus/messaging/databus"
         - "nservicebus/messaging/custom-databus"
         - "nservicebus/messaging/discard-old-messages"

--- a/nservicebus/handlers/index.md
+++ b/nservicebus/handlers/index.md
@@ -12,7 +12,7 @@ snippet:CreatingMessageHandler
 
 To handle messages of all types:
 
- 1. Set up the [message convention](/nservicebus/messaging/messages-events-commands.md) to designate which classes are messages. This example uses a namespace match.
+ 1. Set up the [message convention](/nservicebus/messaging/conventions.md) to designate which classes are messages. This example uses a namespace match.
  1. Create a handler of type `Object`. This handler will be executed for all messages that are delivered to the queue for this endpoint.
 
 Since this class is setup to handle type `Object`, every message arriving in the queue will trigger it.

--- a/nservicebus/messaging/conventions.md
+++ b/nservicebus/messaging/conventions.md
@@ -1,0 +1,27 @@
+---
+title: Conventions
+summary: Custom conventions for defining how certain things are detected.
+tags:
+- Unobtrusive
+- Conventions
+related:
+ - nservicebus/messaging/messages-events-commands
+ - nservicebus/messaging/unobtrusive-mode
+---
+
+A *convention* is a way of defining what a certain type is instead of using a marker interface or an attribute.
+
+Currently conventions exist to identify:
+
+ * [Commands](/nservicebus/messaging/messages-events-commands.md)
+ * [Events](/nservicebus/messaging/messages-events-commands.md)
+ * [Messages](/nservicebus/messaging/messages-events-commands.md)
+ * [Encryption](/nservicebus/security/encryption.md)
+ * [DataBus](/nservicebus/messaging/databus.md)
+ * [Express messages](/nservicebus/messaging/non-durable-messaging.md)
+ * [TimeToBeReceived](/nservicebus/messaging/discard-old-messages.md)
+
+When Conventions are combined with avoiding an reference to any NServiceBus assemblies this is referred to as [Unobtrusive Mode](unobtrusive-mode.md). This makes it also ideal to use in cross platform environments. Messages can be defined in a *Portable Class Library* (PCL) and shared across multiple platform even though not all platforms use NServiceBus for message processing.
+
+
+snippet: MessageConventions

--- a/nservicebus/messaging/headers.md
+++ b/nservicebus/messaging/headers.md
@@ -295,7 +295,7 @@ snippet: HeaderWriterDataBusProperty_Body
 
 ### When using Convention
 
-When using a [Conventions](/nservicebus/messaging/messages-events-commands.md#defining-messages-conventions) there is no way to store a correlation value inside the serialized property. Instead each property has a matching header with the property name used as the header suffix. That header then provides the path suffix of where that binary data is stored on disk on the file system.
+When using a [Conventions](/nservicebus/messaging/conventions.md) there is no way to store a correlation value inside the serialized property. Instead each property has a matching header with the property name used as the header suffix. That header then provides the path suffix of where that binary data is stored on disk on the file system.
 
 
 #### Example Headers

--- a/nservicebus/messaging/memory-transport.md
+++ b/nservicebus/messaging/memory-transport.md
@@ -143,7 +143,7 @@ Examples:
 
 ## NServiceBus eventing style
 
-NServiceBus uses IoC heavily. When the endpoints start, NServiceBus scans the assemblies in the directory. It finds event, command, and message types, either the [marker interfaces or conventions](/nservicebus/messaging/messages-events-commands.md). It also scans the assemblies to identify the types that implement the handlers for event types that implement `IHandleMessages<T>`, and registers them in the container. Read more about [NServiceBus and its use of containers](/nservicebus/containers/).
+NServiceBus uses IoC heavily. When the endpoints start, NServiceBus scans the assemblies in the directory. It finds event, command, and message types, either the [marker interfaces](/nservicebus/messaging/messages-events-commands.md) or [conventions](/nservicebus/messaging/conventions.md). It also scans the assemblies to identify the types that implement the handlers for event types that implement `IHandleMessages<T>`, and registers them in the container. Read more about [NServiceBus and its use of containers](/nservicebus/containers/).
 
 When an event is raised, the bus invokes the `Handle` method on all the registered handlers for that event. For subscribers, this offers a consistent way of subscribing to the event, regardless of how these events are published (in-memory or durable).
 

--- a/nservicebus/messaging/message-owner.md
+++ b/nservicebus/messaging/message-owner.md
@@ -102,7 +102,7 @@ To register a specific type in an assembly:
 
 ## Conventions
 
-Note that any types resolved as message from the above process are then further filtered by passing them through the [Message conventions](/nservicebus/messaging/messages-events-commands.md#defining-messages-conventions).
+Note that any types resolved as message from the above process are then further filtered by passing them through the [Message conventions](/nservicebus/messaging/conventions.md).
 
 
 ## Configuring Endpoint Mapping

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -2,18 +2,20 @@
 title: Messages, Events and Commands
 summary: What are Messages, Events and Commands and how to define them.
 tags:
-- Unobtrusive
+ - Unobtrusive
+ - Conventions
+related:
+ - nservicebus/messaging/conventions
+ - nservicebus/messaging/unobtrusive-mode
 redirects:
-- nservicebus/introducing-ievent-and-icommand
-- nservicebus/messaging/introducing-ievent-and-icommand
-- nservicebus/how-do-i-define-a-message
-- nservicebus/define-a-message
-- nservicebus/messaging/how-do-i-define-a-message
-- nservicebus/definingmessagesas-and-definingeventsas-when-starting-endpoint
-- nservicebus/messaging/definingmessagesas-and-definingeventsas
-- nservicebus/how-do-i-centralize-all-unobtrusive-declarations
-- nservicebus/invalidoperationexception-in-unobtrusive-mode
-- nservicebus/messaging/invalidoperationexception-in-unobtrusive-mode
+ - nservicebus/introducing-ievent-and-icommand
+ - nservicebus/messaging/introducing-ievent-and-icommand
+ - nservicebus/how-do-i-define-a-message
+ - nservicebus/define-a-message
+ - nservicebus/messaging/how-do-i-define-a-message
+ - nservicebus/definingmessagesas-and-definingeventsas-when-starting-endpoint
+ - nservicebus/messaging/definingmessagesas-and-definingeventsas
+ - nservicebus/messaging/invalidoperationexception-in-unobtrusive-mode
 ---
 
 A *Message* is the unit of communication for NServiceBus. There are two sub-types of messages that capture more of the intent and help NServiceBus enforce messaging best practices. This enforcement is enabled by default unless disabled in [configuration](best-practice-enforcement.md).
@@ -75,20 +77,3 @@ public class MyEvent : IEvent { }
 
 public interface MyEvent : IEvent { }
 ```
-
-
-### Conventions
-
-A *message convention* is a way of defining what a certain type is instead of using a marker interface or an attribute.
-
-We currently have conventions that can identity:
-
- * Commands
- * Events
- * Messages
- * [Encryption](/nservicebus/security/encryption.md)
- * [DataBus](/nservicebus/messaging/databus.md)
- * [Express messages](/nservicebus/messaging/non-durable-messaging.md)
- * [TimeToBeReceived](/nservicebus/messaging/discard-old-messages.md)
-
-When Message Conventions are combined with avoiding an reference to any NServiceBus assemblies this is referred to as [Unobtrusive Mode](unobtrusive-mode.md). This makes it also ideal to use in cross platform environments. Messages can be defined in a *Portable Class Library* (PCL) and shared across multiple platform even though not all platforms use NServiceBus for message processing.

--- a/nservicebus/messaging/unobtrusive-mode.md
+++ b/nservicebus/messaging/unobtrusive-mode.md
@@ -1,9 +1,15 @@
 ---
 title: Unobtrusive Mode Messages
 summary: You do not need to reference any NServiceBus assemblies from your own message assemblies.
-tags: []
+tags: 
+- Conventions
+related:
+ - nservicebus/messaging/messages-events-commands
+ - nservicebus/messaging/conventions
 redirects:
 - nservicebus/unobtrusive-mode-messages
+- nservicebus/how-do-i-centralize-all-unobtrusive-declarations
+- nservicebus/invalidoperationexception-in-unobtrusive-mode
 ---
 
 When using NServiceBus you define your message contracts using plain classes or interfaces. For NServiceBus to find those classes when scanning your assemblies you need to mark them with the special `IMessage` interface, which essentially says, "Hey, this is a message definition, please use it." This might seem like a small thing but now you're coupling your message contracts to a NServiceBus assembly since you need to reference the NServiceBus.dll to get access to the interface.
@@ -23,8 +29,6 @@ There are a couple of ways you can solve this.
 
 ## Unobtrusive mode
 
-NServiceBus allows you to define your own [message conventions](messages-events-commands.md) instead of using the `IMessage`, `ICommand` or `IEvent` interfaces and attributes like `TimeToBeReceivedAttribute` and `ExpressAttribute`. NServiceBus also supports conventions for encrypted properties, express messages, databus properties and time to be received. So with these conventions combined you can avoid referencing NServiceBus in your messages assembly.
-
-snippet: MessageConventions
+NServiceBus allows you to define your own [message conventions](conventions.md) instead of using the `IMessage`, `ICommand` or `IEvent` interfaces and attributes like `TimeToBeReceivedAttribute` and `ExpressAttribute`. NServiceBus also supports conventions for encrypted properties, express messages, databus properties and time to be received. So with these conventions combined you can avoid referencing NServiceBus in your messages assembly.
 
 Note: It is important to note that in .NET namespace is optional and hence can be null. So if any conventions do partial string checks, for example using `EndsWith` or `StartsWith`, then a null check should be used. So include `.Namespace != null` at the start of the convention. Otherwise a null reference exception will occur during the type scanning.

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -601,6 +601,8 @@ snippet: 5to6delayed-delivery
 ## Serializers
 
 The BSON serializer build into the core has been removed. Use the [Newtonsoft serializer](/nservicebus/serialization/newtonsoft.md) as a replacement. Also see the [Newtonsoft BSON sample](/samples/serializers/newtonsoft-bson/).
+
+
 ## Conventions
 
-`Conventions` can no longer be injected. Conventions need to be retrieved with `Settings.Get<Conventions>()` over `ReadOnlySettings`. 
+[Conventions](/nservicebus/messaging/conventions.md) are no longer be injected into the [Container](/nservicebus/containers/). Conventions need to be retrieved with `Settings.Get<Conventions>()` over `ReadOnlySettings`.

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -601,3 +601,6 @@ snippet: 5to6delayed-delivery
 ## Serializers
 
 The BSON serializer build into the core has been removed. Use the [Newtonsoft serializer](/nservicebus/serialization/newtonsoft.md) as a replacement. Also see the [Newtonsoft BSON sample](/samples/serializers/newtonsoft-bson/).
+## Conventions
+
+`Conventions` can no longer be injected. Conventions need to be retrieved with `Settings.Get<Conventions>()` over `ReadOnlySettings`. 


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus/pull/3461



With the above PR it is no longer possible to inject `Conventions`. This adds that fact to the upgrade 

guide.