### PR TITLE
maintain original ReplyTo address

### DIFF
--- a/samples/throttling/Version_6/Sample/GitHubSearchHandler.cs
+++ b/samples/throttling/Version_6/Sample/GitHubSearchHandler.cs
@@ -1,16 +1,18 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NServiceBus;
+using NServiceBus.Logging;
 using Octokit;
 
 public class GitHubSearchHandler : IHandleMessages<SearchGitHub>
 {
-    // use anonymous access which has very strict rate limitations
+    static ILog log = LogManager.GetLogger<GitHubSearchHandler> ();
+
+    // use anonymous access which has strict rate limitations
     GitHubClient GitHubClient = new GitHubClient(new ProductHeaderValue("ThroughputThrottlingSample"));
 
     public async Task Handle(SearchGitHub message, IMessageHandlerContext context)
     {
-        Console.WriteLine($"Received search request for \"{message.SearchFor}\" on {message.RepositoryOwner}/{message.Repository}...");
+        log.Info($"Received search request for \"{message.SearchFor}\" on {message.RepositoryOwner}/{message.Repository}...");
 
         SearchCodeRequest request = new SearchCodeRequest(
             message.SearchFor,
@@ -18,6 +20,6 @@ public class GitHubSearchHandler : IHandleMessages<SearchGitHub>
             message.Repository);
         SearchCodeResult result = await GitHubClient.Search.SearchCode(request);
 
-        Console.WriteLine($"Found {result.TotalCount} results for {message.SearchFor}.");
+        log.Info($"Found {result.TotalCount} results for {message.SearchFor}.");
     }
 }

--- a/samples/throttling/Version_6/Sample/ThrottlingBehavior.cs
+++ b/samples/throttling/Version_6/Sample/ThrottlingBehavior.cs
@@ -34,8 +34,14 @@ public class ThrottlingBehavior : Behavior<IInvokeHandlerContext>
     Task DelayMessage(IInvokeHandlerContext context, DateTime deliverAt)
     {
         SendOptions sendOptions = new SendOptions();
-        sendOptions.RouteToThisEndpoint();
+
+        // delay the message to the specified delivery date
         sendOptions.DoNotDeliverBefore(deliverAt);
+        // send message to this endpoint
+        sendOptions.RouteToThisEndpoint();
+        // maintain the original ReplyTo address
+        sendOptions.RouteReplyTo(context.Headers[Headers.ReplyToAddress]);
+
         return context.Send(context.MessageBeingHandled, sendOptions);
     }
 }

--- a/samples/throttling/Version_6/Sample/ThrottlingBehavior.cs
+++ b/samples/throttling/Version_6/Sample/ThrottlingBehavior.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus;
+using NServiceBus.Logging;
 using NServiceBus.Pipeline;
 using Octokit;
 
 #region ThrottlingBehavior
 public class ThrottlingBehavior : Behavior<IInvokeHandlerContext>
 {
+    static ILog log = LogManager.GetLogger<Behavior<IInvokeHandlerContext>>();
     static DateTime? nextRateLimitReset;
 
     public override async Task Invoke(IInvokeHandlerContext context, Func<Task> next)
@@ -14,7 +16,7 @@ public class ThrottlingBehavior : Behavior<IInvokeHandlerContext>
         DateTime? rateLimitReset = nextRateLimitReset;
         if (rateLimitReset.HasValue && rateLimitReset >= DateTime.UtcNow)
         {
-            Console.WriteLine($"rate limit already exceeded. Retry after {rateLimitReset} UTC");
+            log.Info($"rate limit already exceeded. Retry after {rateLimitReset} UTC");
             await DelayMessage(context, rateLimitReset.Value).ConfigureAwait(false);
             return;
         }
@@ -26,7 +28,7 @@ public class ThrottlingBehavior : Behavior<IInvokeHandlerContext>
         catch (RateLimitExceededException ex)
         {
             DateTime? nextReset = nextRateLimitReset = ex.Reset.UtcDateTime;
-            Console.WriteLine($"rate limit exceeded. Limit resets resets at {nextReset} UTC");
+            log.Info($"rate limit exceeded. Limit resets resets at {nextReset} UTC");
             await DelayMessage(context, nextReset.Value).ConfigureAwait(false);
         }
     }
@@ -40,7 +42,11 @@ public class ThrottlingBehavior : Behavior<IInvokeHandlerContext>
         // send message to this endpoint
         sendOptions.RouteToThisEndpoint();
         // maintain the original ReplyTo address
-        sendOptions.RouteReplyTo(context.Headers[Headers.ReplyToAddress]);
+        string replyAddress;
+        if (context.Headers.TryGetValue(Headers.ReplyToAddress, out replyAddress))
+        {
+            sendOptions.RouteReplyTo(replyAddress);
+        }
 
         return context.Send(context.MessageBeingHandled, sendOptions);
     }


### PR DESCRIPTION
fixes the bug in the throttling sample where the replyto address was overridden when doing a local send. We can now maintain the original reply to address using the new `RouteReplyTo` send option.

related to https://github.com/Particular/docs.particular.net/issues/1086

@hmemcpy @SimonCropp @johnsimons 