### PR TITLE
Update outbox doco

### DIFF
--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -43,7 +43,15 @@ Here is a diagram illustrating how it works:
 
 ### SQL Server Transport
 
-SQL Server transport supports *exactly-once* message delivery without Outbox solely by means of sharing the transport connection with persistence. This mode of operation is discussed in depth in this [sample](/samples/sqltransport-nhpersistence).
+SQL Server transport in combination with NHibernate persistence can support *exactly-once* message delivery in two ways:
+- by sharing the database connection, which is enlisted in TransactionScope;
+- by using Outbox.
+
+If Outbox is enabled the messages are stored in the same physical store as saga and user data. The messages are dispatched only after the processing is finished. When NHibernate persistence detects that Outbox is enabled and used together with SQLServer transport, then it automatically stops reusing the transport connection and transaction. All the data access is done within the Outbox ambient transaction. 
+
+From the perspective of a particular endpoint this is *exactly-once* processing because of the deduplication that happens on the incoming queue. From a global point of view this is *at-least-once* since on the wire messages can get duplicated.
+ 
+The latter is discussed in depth in the [Outbox - SQL Transport and NHibernate](/samples/sqltransport-nhpersistence) sample.
 
 ### What extra tables does NHibernate Outbox persistence create
 

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -14,67 +14,61 @@ NServiceBus Version 5 adds the option of running endpoints with similar reliabil
 
 ## Enabling the outbox
 
-In order to enable the Outbox:
+In order to enable the Outbox for RabbitMQ transport:
 
 snippet: OutboxEnablineInCode
 
-This is enough for the RabbitMQ transport. For SQL Server and MSMQ transports, to enable the outbox users need to also explicitly set the following configuration settings when configuring the endpoint:
+In order to enable the Outbox for SQL Server and MSMQ transports, you additionally need:
 
 snippet: OutboxEnablingInAppConfig
 
-NOTE: It may seem extreme to require double opt-in configuration of the Outbox for all other transports, but this is because we want users to be very aware that this new feature should not be used with existing endpoints that currently use DTC, unless those endpoints are [idempotent](https://en.wikipedia.org/wiki/Idempotence). Otherwise, problems could arise from double-processing messages sent (via an at-least-once guarantee) more than once.
+NOTE: The double opt-in configuration for transports supporting DTC was introduced to make sure that Outbox is not used in combination with DTC accidentally. The Outbox can be used with DTC only if **all endpoints are [idempotent](https://en.wikipedia.org/wiki/Idempotence)**. Otherwise, problems could arise from double-processing messages sent more than once (because of at-least-once guarantee).
 
-
-## How does it work
+## How it works
 
 These feature has been implemented using both the [Outbox pattern](http://gistlabs.com/2014/05/the-outbox/) and the [Deduplication pattern](https://en.wikipedia.org/wiki/Data_deduplication#In-line_deduplication).
 
-As a message is dequeued we check to see if we have previously processed it. If so, we then deliver any messages in the outbox for that message but do not invoke message-processing logic again. If the message wasn't previously processed, then we invoke the regular handler logic, storing all outgoing message in a durable storage in the same transaction as the users own database changes. Finally we send out all outgoing messages and update the deduplication storage.
+When a message is dequeued we check if we have processed it already. If so, we then deliver any messages in the outbox for that message but do not invoke message-processing logic again. If the message hasn't been processed, then we invoke the regular handler logic, storing all outgoing message in a durable storage in the same transaction as the users own database changes. Finally we send out all outgoing messages and update the deduplication storage.
 
-Here is a diagram how it all works:
+Here is a diagram illustrating how it works:
 
 ![No DTC Diagram](outbox.png)
-
 
 ## Caveats
 
 - Both the business data and deduplication data need to share the same database.
-- The Outbox is bypassed when a message is sent outside of an NServiceBus message handler. The reason for this is lack of a driving force for repeated dispatching of the Outbox messages (which currently is the retry mechanism that applies only when handling messages).
+- The Outbox is bypassed when a message is sent outside of an NServiceBus message handler. This is because there is no mechanism for repeated dispatching of the Outbox messages other than the standard retry logic, which won't be triggered in this case.
 
-## Using outbox with NHibernate persistence
-
+## Using Outbox with NHibernate persistence
 
 ### SQL Server Transport
 
 SQL Server transport supports *exactly-once* message delivery without Outbox solely by means of sharing the transport connection with persistence. This mode of operation is discussed in depth in this [sample](/samples/sqltransport-nhpersistence).
 
+### What extra tables does NHibernate Outbox persistence create
 
-### What extra tables does NHibernate outbox persistence create
-
-To keep track duplicate messages, the NHibernate implementation of Outbox requires the creation of two additional tables in your database, these are called `OutboxRecord` and `OutboxOperation`.
-
+To keep track of duplicate messages, the NHibernate implementation of Outbox requires the creation of two additional tables in the database: `OutboxRecord` and `OutboxOperation`.
 
 ### How long are the deduplication records kept
 
 The NHibernate implementation by default keeps deduplication records for 7 days and runs the purge every 1 minute.
 
-These default settings can be changed by specifying new defaults in the config file using [TimeStamp strings](https://msdn.microsoft.com/en-us/library/ee372286.aspx), here is how to do it:
+These default settings can be changed by specifying new defaults in the config file using [TimeStamp strings](https://msdn.microsoft.com/en-us/library/ee372286.aspx):
 
 snippet:OutboxNHibernateTimeToKeep
 
 
-## Using outbox with RavenDB persistence
+## Using Outbox with RavenDB persistence
 
 
 ### What extra documents does RavenDB outbox persistence create
 
-To keep track duplicate messages, the RavenDB implementation of Outbox creates a special collection of documents inside your database, these are called `OutboxRecord`.
-
+To keep track of duplicate messages, the RavenDB implementation of Outbox creates a special collection of documents inside your database called `OutboxRecord`.
 
 ### How long are the deduplication records kept
 
 The RavenDB implementation by default keeps deduplication records for 7 days and runs the purge every 1 minute.
 
-These default settings can be changed by specifying new defaults in the settings dictionary, here is how to do it:
+These default settings can be changed by specifying new defaults in the settings dictionary:
 
 snippet:OutboxRavendBTimeToKeep


### PR DESCRIPTION
As discussed [here](https://github.com/Particular/docs.particular.net/pull/1174#discussion-diff-52883776R55) that is to include info removed from SQL Server transport doco.

Plus clean up and clarify a few points.