### PR TITLE
Removed statement about `await Task.FromResult` from upgrade guide

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -32,9 +32,9 @@ In previous versions of NServiceBus, to send messages or publish messages within
 
 ## Message handlers
 
-The handler method on `IHandleMessages<T>` now returns a Task. In order to leverage async code, add the async keyword to your handler method and use `await` for async methods. In order to convert your synchronous code add `return Task.FromResult(0);` to the end of your handler methods.
+The handler method on `IHandleMessages<T>` now returns a Task. In order to leverage async code, add the `async` keyword to your handler method and use `await` for async methods. In order to convert your synchronous code add `return Task.FromResult(0);` to the end of your handler methods.
 
-WARNING: Do not `return null` from your message handlers. We use the task result internally and `null` will result in errors. You may mark your `Handle` methods as `async` to enforce this, which would result in `await Task.FromResult(0);`.
+WARNING: Do not `return null` from your message handlers. We use the task result internally and `null` will result in errors.
 
 snippet:5to6-messagehandler
 
@@ -574,7 +574,7 @@ It is no longer possible to access the builder to create an encryption service. 
 
 ### Extensibility
 
-`IForwardMessagesToSites`, `IRouteMessagesToEndpoints`, and `IRouteMessagesToSites` have been deprecated and are no longer available as extension points in the gateway. To override the default HTTP channel, register custom `IChannelSender` and `IChannelReceiver` factory methods through the new extension point `configure.Gateway().ChannelFactories()` in the `EndpointConfiguration` of an endpoint. Dependency injection is not provided for these factory methods. `IChannelSender` and `IChannelReceiver` implementations are also no longer automatically picked up by assembly scanning. 
+`IForwardMessagesToSites`, `IRouteMessagesToEndpoints`, and `IRouteMessagesToSites` have been deprecated and are no longer available as extension points in the gateway. To override the default HTTP channel, register custom `IChannelSender` and `IChannelReceiver` factory methods through the new extension point `configure.Gateway().ChannelFactories()` in the `EndpointConfiguration` of an endpoint. Dependency injection is not provided for these factory methods. `IChannelSender` and `IChannelReceiver` implementations are also no longer automatically picked up by assembly scanning.
 
 
 ### Concurrency config


### PR DESCRIPTION
The statement with `await Task.FromResult` was weird. Removed it for better clarity. It was also not clear to what "this" was referring to.