### PR TITLE
Alternative to "NServiceBus 5" at the top of the RavenDB article

### DIFF
--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -11,12 +11,7 @@ redirects:
  - nservicebus/ravendb/connecting
 ---
 
-Uses the [RavenDB document database](http://ravendb.net/) for storage.
-
-
-## NServiceBus 5 and above
-
-RavenDB is no longer merged into the core. The RavenDB-backed persistence is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB). This allows NServiceBus and RavenDB to be upgraded independently.
+Uses the [RavenDB document database](http://ravendb.net/) for storage. Starting with NServiceBus 5, the RavenDB-backed persistence is no longer ILMerged into the Core and is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB), which allows NServiceBus and RavenDB to be upgraded independently. See below for information specifically related to NServiceBus 3 and NServiceBus 4. 
 
 
 ### Connection options for RavenDB

--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -11,7 +11,7 @@ redirects:
  - nservicebus/ravendb/connecting
 ---
 
-Uses the [RavenDB document database](http://ravendb.net/) for storage. Starting with NServiceBus 5, the RavenDB-backed persistence is no longer ILMerged into the Core and is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB), which allows NServiceBus and RavenDB to be upgraded independently. See below for information specifically related to NServiceBus 3 and NServiceBus 4. 
+Uses the [RavenDB document database](http://ravendb.net/) for storage. When using NServiceBus Versions 5 and above, the RavenDB-backed persistence is no longer ILMerged into the Core and is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB), which allows NServiceBus and RavenDB to be upgraded independently. 
 
 
 ### Connection options for RavenDB

--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -1,6 +1,6 @@
 ---
 title: RavenDB
-summary: RavenDB persister documentation
+summary: RavenDB persistence documentation
 tags:
 - RavenDB
 - Persistence
@@ -11,7 +11,9 @@ redirects:
  - nservicebus/ravendb/connecting
 ---
 
-Uses the [RavenDB document database](http://ravendb.net/) for storage. When using NServiceBus Versions 5 and above, the RavenDB-backed persistence is no longer ILMerged into the Core and is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB), which allows NServiceBus and RavenDB to be upgraded independently. 
+Uses the [RavenDB document database](http://ravendb.net/) for storage. 
+
+When using NServiceBus Versions 5 and above, the RavenDB-backed persistence is no longer ILMerged into the Core and is available as a separate [NuGet package](https://www.nuget.org/packages/NServiceBus.RavenDB), which allows NServiceBus and RavenDB to be upgraded independently. When using RavenDB persistence in NServiceBus endpoints Versions 4 and below, see the section titled [NServiceBus 3 and NServiceBus 4](/nservicebus/ravendb/#nservicebus-3-and-nservicebus-4) for more details. 
 
 
 ### Connection options for RavenDB


### PR DESCRIPTION
@SimonCropp I committed a little fix to master because you had put NServiceBus.RavenDB 5 at the top of the RavenDB article which doesn't make any sense - it actually referred to Core. There is no NSB.Raven V4 yet let alone V5. But I agree that it's confusing to have NServiceBus 5 right at the top of the Raven article. What do you think of this attempt to get rid of that confusion?