### PR TITLE
Updating the sample and documents for ISession access in v6

### DIFF
--- a/Snippets/Snippets_6/Persistence/NHibernate/AccessingData.cs
+++ b/Snippets/Snippets_6/Persistence/NHibernate/AccessingData.cs
@@ -3,7 +3,6 @@
     using System.Threading.Tasks;
     using global::NHibernate;
     using NServiceBus;
-    using NServiceBus.Persistence;
 
     public class AccessingData
     {
@@ -28,59 +27,6 @@
                 }
             }
             #endregion
-        }
-
-        public class Directly
-        {
-            public void Config()
-            {
-                #region NHibernateAccessingDataDirectlyConfig
-
-                EndpointConfiguration endpointConfiguration = new EndpointConfiguration();
-                endpointConfiguration.UsePersistence<NHibernatePersistence>()
-                    .RegisterManagedSessionInTheContainer();
-
-                #endregion
-            }
-
-            #region NHibernateAccessingDataDirectly
-
-            public class OrderHandler : IHandleMessages<OrderMessage>
-            {
-                public Task Handle(OrderMessage message, IMessageHandlerContext context)
-                {
-                    ISession nhibernateSession = context.SynchronizedStorageSession.Session();
-                    nhibernateSession.Save(new Order());
-                    return Task.FromResult(0);
-                }
-            }
-
-            #endregion
-
-            #region CustomSessionCreation
-
-            public void Configure()
-            {
-                EndpointConfiguration endpointConfiguration = new EndpointConfiguration();
-                endpointConfiguration.UsePersistence<NHibernatePersistence>()
-                    .UseCustomSessionCreationMethod(CreateSession);
-            }
-
-            ISession CreateSession(ISessionFactory sessionFactory, string connectionString)
-            {
-                return sessionFactory.OpenSession();
-            }
-            #endregion
-
-        }
-    }
-
-    public static class FakeNHibernateSessionExtensions
-    {
-        // This is required because of ambiguous Session() extension method on NHibernate and RavenDB.
-        public static ISession Session(this SynchronizedStorageSession session)
-        {
-            return SynchronizedStorageSessionExtensions.Session(session);
         }
     }
 }

--- a/Snippets/Snippets_6/Sagas/FindSagas/NHibernateSagaFinder.cs
+++ b/Snippets/Snippets_6/Sagas/FindSagas/NHibernateSagaFinder.cs
@@ -2,10 +2,10 @@
 {
     using System.Threading.Tasks;
     using NHibernate;
+    using NServiceBus;
     using NServiceBus.Extensibility;
     using NServiceBus.Persistence;
     using NServiceBus.Sagas;
-    using Snippets6.Persistence.NHibernate;
 
     public class NHibernateSagaFinder
     {

--- a/nservicebus/nhibernate/accessing-data.md
+++ b/nservicebus/nhibernate/accessing-data.md
@@ -16,28 +16,32 @@ The second is much simpler in theory but much harder in practice. In theory all 
 
 ## Accessing data in the handler
 
-The simplest way to access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides. First, the throughput when using DTC is much smaller than without it. Second, DTC is not a trivial service to configure, not mentioning making it HA via a cluster. There is one upside though. For the application data you can use any data store that supports the DTC-coordinated transaction.
+The simplest way to access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides. First, the throughput when using DTC is much smaller than without it. Second, DTC is not a trivial service to configure, not mentioning making it Highly Available (HA) via a cluster. There is one upside though. For the application data you can use any data store that supports the DTC-coordinated transaction.
 
 NServiceBus persistence APIs offer a solution to these problems but limits the data storage choices. The NHibernate persistence allows you too 'hook-up' to the data context used by NServiceBus to ensure atomic changes.
 
 snippet:NHibernateAccessingDataViaContext
 
-As shown above, `NHibernateStorageContext` can be used directly but the following is recommended instead:
+As shown above, `NHibernateStorageContext` can be used directly to access NHibernate `ISession`. 
+
+Note that prior to Version 6 you could inject `ISession` directly into the handlers. This behavior has changed in NServiceBus v6.x as internal components of NServiceBus are no longer accessible from the IoC container. You can still use this approach on Version 5 and before:
 
 snippet:NHibernateAccessingDataDirectlyConfig
 
 snippet:NHibernateAccessingDataDirectly
 
-The first part tell NServiceBus to inject the `ISession` instance into the handlers. This way your handlers are less coupled NServiceBus APIs and won't need to change should the API change in future. This `ISession` object is fully managed by NServiceBus according to the best practices defined by NServiceBus documentation with regards to transactions.
+The first part tell NServiceBus to inject the `ISession` instance into the handlers and the second part uses standard Property Injection to access the `ISession` object.
+
+Regardless of how you access the `ISession` object, it is fully managed by NServiceBus according to the best practices defined by NServiceBus documentation with regards to transactions.
 
 
 ## Customizing the session
 
-If you need some special behavior in the `ISession` object managed by NServiceBus, you can hook-up to the session creation process by providing your own delegate.
+Prior to Version 6 you could customize how the `ISession` object is instantiated. If you needed some special behavior in the `ISession` object managed by NServiceBus, you can hook-up to the session creation process by providing your own delegate.
 
 snippet:CustomSessionCreation
 
-NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, Saga and Outbox data. It does not work for other persistence concerns such as Timeouts or Subscriptions.
+NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, Saga and Outbox data. It does not work for other persistence concerns such as Timeouts or Subscriptions. Also note that this is no longer possible in NServiceBus v6.x.
 
 
 ## Known limitations

--- a/nservicebus/nhibernate/accessing-data.md
+++ b/nservicebus/nhibernate/accessing-data.md
@@ -6,19 +6,19 @@ tags:
  - Saga
 ---
 
-Most of the time message handlers are meant to modify the internal state of you application. This usually boils down to accessing some kind of a data store. Since in NServiceBus messages are durable (unless transactions are explicitly disabled in very rare cases), there are two possible synchronization options between consuming messages and accessing the data:
+Most of the time message handlers are meant to modify the internal state of an application. This usually boils down to accessing some kind of a data store. Since in NServiceBus messages are durable (unless transactions are explicitly disabled in very rare cases), there are two possible synchronization options between consuming messages and accessing the data:
 
  * have an illusion of *exactly-once* message processing either through a distributed transaction or the [outbox](/nservicebus/outbox/)
  * implement data access code in an *idempotent* way
 
-The second is much simpler in theory but much harder in practice. In theory all you need to do is create your own connection in the handler and execute the *idempotent* data access code. The practice shows that making that code idempotent is a non-trivial task. That is why NServiceBus offers APIs that allow you to work on top of *exactly-once* processing illusion. We'll focus on these APIs.
+The second is much simpler in theory but much harder in practice. In theory all that is required is to do is create a connection in the handler and execute the *idempotent* data access code. The practice shows that making that code idempotent is a non-trivial task. That is why NServiceBus offers APIs that provide the ability to work on top of *exactly-once* processing illusion. 
 
 
 ## Accessing data in the handler
 
-The simplest way to access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides. First, the throughput when using DTC is much smaller than without it. Second, DTC is not a trivial service to configure, not mentioning making it Highly Available (HA) via a cluster. There is one upside though. For the application data you can use any data store that supports the DTC-coordinated transaction.
+The simplest way to access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides. First, the throughput when using DTC is much smaller than without it. Second, DTC is not a trivial service to configure, not mentioning making it Highly Available (HA) via a cluster. There is one upside though. For the application data use any data store that supports the DTC-coordinated transaction.
 
-NServiceBus persistence APIs offer a solution to these problems but limits the data storage choices. The NHibernate persistence allows you too 'hook-up' to the data context used by NServiceBus to ensure atomic changes.
+NServiceBus persistence APIs offer a solution to these problems but limits the data storage choices. The NHibernate persistence supports 'hooking-up' to the data context used by NServiceBus to ensure atomic changes.
 
 snippet:NHibernateAccessingDataViaContext
 
@@ -32,12 +32,12 @@ snippet:NHibernateAccessingDataDirectly
 
 The first part tell NServiceBus to inject the `ISession` instance into the handlers and the second part uses standard Property Injection to access the `ISession` object.
 
-Regardless of how you access the `ISession` object, it is fully managed by NServiceBus according to the best practices defined by NServiceBus documentation with regards to transactions.
+Regardless of how the `ISession` object is accessed, it is fully managed by NServiceBus according to the best practices defined by NServiceBus documentation with regards to transactions.
 
 
 ## Customizing the session
 
-Prior to Version 6 you could customize how the `ISession` object is instantiated. If you needed some special behavior in the `ISession` object managed by NServiceBus, you can hook-up to the session creation process by providing your own delegate.
+Versions 5 and lower supported customizing the instantiation of the `ISession`. This is done by hooking up to the creation process by providing a custom delegate:
 
 snippet:CustomSessionCreation
 

--- a/nservicebus/nhibernate/accessing-data.md
+++ b/nservicebus/nhibernate/accessing-data.md
@@ -1,49 +1,55 @@
 ---
 title: Business data using NHibernate
 summary: How to access business data in sync with message consumption and modifications to NServiceBus-controlled data.
+reviewed: 2016-03-15
 tags:
  - NHibernate
  - Saga
 ---
 
-Most of the time message handlers are meant to modify the internal state of an application. This usually boils down to accessing some kind of a data store. Since in NServiceBus messages are durable (unless transactions are explicitly disabled in very rare cases), there are two possible synchronization options between consuming messages and accessing the data:
+Regularly [handlers](/nservicebus/handlers/) are meant to modify the internal state of an application. This requires accessing some kind of a data store. Since in NServiceBus messages are durable (unless transactions are explicitly disabled in very rare cases), there are two possible synchronization options between consuming messages and accessing the data:
 
- * have an illusion of *exactly-once* message processing either through a distributed transaction or the [outbox](/nservicebus/outbox/)
- * implement data access code in an *idempotent* way
+ * Have an illusion of *exactly-once* message processing either through a distributed transaction or the [outbox](/nservicebus/outbox/).
+ * Implement data access code in an *idempotent* way.
 
-The second is much simpler in theory but much harder in practice. In theory all that is required is to do is create a connection in the handler and execute the *idempotent* data access code. The practice shows that making that code idempotent is a non-trivial task. That is why NServiceBus offers APIs that provide the ability to work on top of *exactly-once* processing illusion. 
+The second is much simpler in theory but much harder in practice. In theory all that is required is to do is create a connection in the handler and execute the *idempotent* data access code. The practice shows that making that code idempotent is a non-trivial task. That is why NServiceBus offers APIs that provide the ability to work on top of *exactly-once* processing illusion.
 
 
 ## Accessing data in the handler
 
-The simplest way to access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides. First, the throughput when using DTC is much smaller than without it. Second, DTC is not a trivial service to configure, not mentioning making it Highly Available (HA) via a cluster. There is one upside though. For the application data use any data store that supports the DTC-coordinated transaction.
+To access the data in an *exactly-once* way is to just lean on the Distributed Transaction Coordinator (DTC) to make sure all the data access, happening while handling the message, is atomic. This approach has two downsides:
 
-NServiceBus persistence APIs offer a solution to these problems but limits the data storage choices. The NHibernate persistence supports 'hooking-up' to the data context used by NServiceBus to ensure atomic changes.
+ 1. The throughput when using DTC is much smaller than without it. 
+ 1. Second, DTC is complex to configure, not mentioning making it Highly Available (HA) via a cluster. 
+ 
+The upside is that or the application data use any data store that supports the DTC-coordinated transaction.
+
+NServiceBus [persistence](/nservicebus/persistence/) offers a solution to these problems but limits the data storage choices. The NHibernate persistence supports 'hooking-up' to the data context used by NServiceBus to ensure atomic changes.
 
 snippet:NHibernateAccessingDataViaContext
 
-As shown above, `NHibernateStorageContext` can be used directly to access NHibernate `ISession`. 
+As shown above, `NHibernateStorageContext` can be used directly to access NHibernate `ISession`.
 
-Note that prior to Version 6 `ISession` could be injected directly into the handlers. This behavior has changed in NServiceBus Version 6 as internal components of NServiceBus are no longer accessible from the IoC container. This approach can still be used on Version 5 and before:
+Note that in Version 5 and below, `ISession` could be injected directly into the handlers. This behavior has changed in NServiceBus Version 6 as internal components of NServiceBus are no longer accessible from the [container](/nservicebus/containers/). This approach can still be used on Version 5 and below.
 
 snippet:NHibernateAccessingDataDirectlyConfig
 
 snippet:NHibernateAccessingDataDirectly
 
-The first part tell NServiceBus to inject the `ISession` instance into the handlers and the second part uses standard Property Injection to access the `ISession` object.
+The first part instructed NServiceBus to inject the `ISession` instance into the handlers and the second part uses constructor injection to access the `ISession` object.
 
 Regardless of how the `ISession` object is accessed, it is fully managed by NServiceBus according to the best practices defined by NServiceBus documentation with regards to transactions.
 
 
 ## Customizing the session
 
-Versions 5 and lower supported customizing the instantiation of the `ISession`. This is done by hooking up to the creation process by providing a custom delegate:
+Versions 5 and below supported customizing the instantiation of the `ISession`. This is done by hooking up to the creation process by providing a custom delegate:
 
 snippet:CustomSessionCreation
 
-NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, Saga and Outbox data. It does not work for other persistence concerns such as Timeouts or Subscriptions. Also note that this is no longer possible in NServiceBus Version 6.
+NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, [Saga](/nservicebus/sagas/) and [Outbox](/nservicebus/outbox/) data. It does not work for other persistence concerns such as [Timeouts](/nservicebus/sagas/timeouts.md) or [Subscriptions](/nservicebus/messaging/publish-subscribe/). Also note that this is no longer possible in NServiceBus Version 6 and above.
 
 
 ## Known limitations
 
-Because of the way NServiceBus opens sessions by passing an existing instance of a database connection, it is currently not possible to use NHibernate's second-level cache. Such behavior of NServiceBus is caused by still-unresolved [bug](https://nhibernate.jira.com/browse/NH-3023) in NHibernate.
+Due of the way NServiceBus opens sessions, by passing an existing instance of a database connection, it is currently not possible to use NHibernate's second-level cache. Such behavior of NServiceBus is caused by [still-unresolved bug in NHibernate](https://nhibernate.jira.com/browse/NH-3023).

--- a/nservicebus/nhibernate/accessing-data.md
+++ b/nservicebus/nhibernate/accessing-data.md
@@ -24,7 +24,7 @@ snippet:NHibernateAccessingDataViaContext
 
 As shown above, `NHibernateStorageContext` can be used directly to access NHibernate `ISession`. 
 
-Note that prior to Version 6 you could inject `ISession` directly into the handlers. This behavior has changed in NServiceBus v6.x as internal components of NServiceBus are no longer accessible from the IoC container. You can still use this approach on Version 5 and before:
+Note that prior to Version 6 `ISession` could be injected directly into the handlers. This behavior has changed in NServiceBus Version 6 as internal components of NServiceBus are no longer accessible from the IoC container. This approach can still be used on Version 5 and before:
 
 snippet:NHibernateAccessingDataDirectlyConfig
 
@@ -41,7 +41,7 @@ Prior to Version 6 you could customize how the `ISession` object is instantiated
 
 snippet:CustomSessionCreation
 
-NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, Saga and Outbox data. It does not work for other persistence concerns such as Timeouts or Subscriptions. Also note that this is no longer possible in NServiceBus v6.x.
+NOTE: Customizing the way session is opened works only for the 'shared' session that is used to access business/user, Saga and Outbox data. It does not work for other persistence concerns such as Timeouts or Subscriptions. Also note that this is no longer possible in NServiceBus Version 6.
 
 
 ## Known limitations

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/Program.cs
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/Program.cs
@@ -4,7 +4,6 @@ using NHibernate.Cfg;
 using NHibernate.Dialect;
 using NServiceBus;
 using NServiceBus.Transports.SQLServer;
-using NServiceBus.Persistence;
 
 class Program
 {
@@ -52,8 +51,7 @@ class Program
             });
 
         endpointConfiguration
-            .UsePersistence<NHibernatePersistence>()
-            .RegisterManagedSessionInTheContainer();
+            .UsePersistence<NHibernatePersistence>();
 
         endpointConfiguration.EnableOutbox();
 


### PR DESCRIPTION
This would update the documents and samples on how to access ISession in v6 (while keeping the other available approaches in v5).