### PR TITLE
WIP - Added Guidance for moving away from IManageMessageFailures in V6.

### DIFF
--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -431,6 +431,7 @@
     <Compile Include="Transports\SqlServer_3\ConnectionStrings.cs" />
     <Compile Include="UpgradeGuides\5to6\Callbacks.cs" />
     <Compile Include="Transports\SqlServer_3\UpgradeGuides\Transactions.cs" />
+    <Compile Include="UpgradeGuides\5to6\CustomErrorHandlingBehaviour.cs" />
     <Compile Include="UpgradeGuides\5to6\EndpointStart.cs" />
     <Compile Include="UpgradeGuides\5to6\HandlerOrdering.cs" />
     <Compile Include="UpgradeGuides\5to6\MessageContext.cs" />

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
@@ -48,12 +48,9 @@ namespace Snippets6.UpgradeGuides._5to6
     #endregion
 
     #region 5to6-registercustomerrorhandling
-    class RegisterCustomErrorHandling : INeedInitialization
+    public void Customize(EndpointConfiguration endpointConfiguration)
     {
-        public void Customize(EndpointConfiguration configuration)
-        {
-            configuration.Pipeline.Register<NewMessageProcessingPipelineStep>();
-        }
+        endpointConfiguration.Pipeline.Register<NewMessageProcessingPipelineStep>();
     }
     #endregion
 }

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
@@ -1,0 +1,59 @@
+namespace Snippets6.UpgradeGuides._5to6
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Pipeline;
+
+    #region 5to6-customerrorhandlingbehaviour
+    class CustomErrorHandlingBehaviour : Behavior<ITransportReceiveContext>
+    {
+        public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+        {
+            try
+            {
+                await next().ConfigureAwait(false);
+            }
+            catch (MessageDeserializationException)
+            {
+                Console.WriteLine("CustomFaultManager - MessageDeserializationException");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("CustomFaultManager - ProcessingAlwaysFailsForMessage");
+                // do not rethrow the message if you want to mark the message as processed.
+                // rethrow to move the message to the error queue.
+                throw;
+                // if you want to rollback the receive operation instead of mark as processed:
+                //context.AbortReceiveOperation();
+            }
+        }
+    }
+    #endregion
+
+    #region 5to6-newmessageprocessingpipelinestep
+    class NewMessageProcessingPipelineStep : RegisterStep
+    {
+        public NewMessageProcessingPipelineStep()
+            : base("CustomErrorHandlingBehaviour", typeof(CustomErrorHandlingBehaviour), "Adds custom error behavior to pipeline")
+        {
+            InsertAfter("MoveFaultsToErrorQueue");
+            // only invoke this behavior if FLR fails to handle the message
+            InsertBeforeIfExists("FirstLevelRetries");
+            // if you want to handle the message before it is moved to error queue, insert after SLR.
+            // if you want to handle the message before it is handled by SLR, insert it before SLR.
+            InsertBeforeIfExists("SecondLevelRetries");
+        }
+    }
+    #endregion
+
+    #region 5to6-registercustomerrorhandling
+    class RegisterCustomErrorHandling : INeedInitialization
+    {
+        public void Customize(EndpointConfiguration configuration)
+        {
+            configuration.Pipeline.Register<NewMessageProcessingPipelineStep>();
+        }
+    }
+    #endregion
+}

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/CustomErrorHandlingBehaviour.cs
@@ -21,11 +21,11 @@ namespace Snippets6.UpgradeGuides._5to6
             catch (Exception)
             {
                 Console.WriteLine("CustomFaultManager - ProcessingAlwaysFailsForMessage");
-                // do not rethrow the message if you want to mark the message as processed.
-                // rethrow to move the message to the error queue.
+                // To mark the message as processed DO NOT rethrow the message.
+                // Rethrow to move the message to the error queue.
                 throw;
-                // if you want to rollback the receive operation instead of mark as processed:
-                //context.AbortReceiveOperation();
+                // To rollback the receive operation instead of mark as processed:
+                // context.AbortReceiveOperation();
             }
         }
     }
@@ -38,19 +38,21 @@ namespace Snippets6.UpgradeGuides._5to6
             : base("CustomErrorHandlingBehaviour", typeof(CustomErrorHandlingBehaviour), "Adds custom error behavior to pipeline")
         {
             InsertAfter("MoveFaultsToErrorQueue");
-            // only invoke this behavior if FLR fails to handle the message
+            // Only invoke this behavior if FLR fails to handle the message
             InsertBeforeIfExists("FirstLevelRetries");
-            // if you want to handle the message before it is moved to error queue, insert after SLR.
-            // if you want to handle the message before it is handled by SLR, insert it before SLR.
+            // To handle the message before it is moved to error queue, insert after SLR.
+            // To handle the message before it is handled by SLR, insert it before SLR.
             InsertBeforeIfExists("SecondLevelRetries");
         }
     }
     #endregion
 
-    #region 5to6-registercustomerrorhandling
-    public void Customize(EndpointConfiguration endpointConfiguration)
-    {
-        endpointConfiguration.Pipeline.Register<NewMessageProcessingPipelineStep>();
+    class RegisterCustomErrorHandling : INeedInitialization {
+        public void Customize(EndpointConfiguration endpointConfiguration)
+        {
+            #region 5to6-registercustomerrorhandling
+            endpointConfiguration.Pipeline.Register<NewMessageProcessingPipelineStep>();
+            #endregion
+        }
     }
-    #endregion
 }

--- a/nservicebus/errors/managing-errors-with-the-pipeline.md
+++ b/nservicebus/errors/managing-errors-with-the-pipeline.md
@@ -1,0 +1,30 @@
+---
+title: Managing errors with the pipeline
+summary: Instructions on how to perform custom logic during FLR and SLR with the pipeline
+tags:
+ - upgrade
+ - example
+---
+
+In versions of NServiceBus lower than v6 to add logic to FLR and SLR processing NServiceBus provided the `IManageMessageFailures` interface to implement. Now developers must instead add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled. Any custom action that needs to be performed when an exception happens can be specified. 
+
+While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, please read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
+
+
+### Create a new behavior that has access to the message at the transport message context
+
+snippet: 5to6-customerrorhandlingbehaviour
+
+As illustrated in the above example, by choosing to throw in the catch block, this custom behavior can then let NServiceBus forward the message to the error queue. If that's not the desired behavior, remove the throw to let NServiceBus know that the message handling is complete.
+
+
+### Create a new message processing step in the pipeline.
+
+Specify where and how this behavior ought to be invoked. 
+
+snippet: 5to6-newmessageprocessingpipelinestep
+
+
+### Register the new step in the pipeline
+
+snippet: 5to6-registercustomerrorhandling

--- a/nservicebus/errors/managing-errors-with-the-pipeline.md
+++ b/nservicebus/errors/managing-errors-with-the-pipeline.md
@@ -1,26 +1,26 @@
 ---
 title: Managing errors with the pipeline
-summary: Instructions on how to perform custom logic during FLR and SLR with the pipeline
+summary: Instructions on how to perform logic during FLR and SLR with the pipeline
 tags:
  - upgrade
  - example
 ---
 
-In versions of NServiceBus lower than v6 to add logic to FLR and SLR processing NServiceBus provided the `IManageMessageFailures` interface to implement. Now developers must instead add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled. Any custom action that needs to be performed when an exception happens can be specified. 
+In versions of NServiceBus lower than v6 to add logic to FLR and SLR processing NServiceBus provided the `IManageMessageFailures` interface to implement. Now developers must instead add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled as well as any custom action that needs to be performed when an exception happens. 
 
-While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, please read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
+While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
 
 
 ### Create a new behavior that has access to the message at the transport message context
 
 snippet: 5to6-customerrorhandlingbehaviour
 
-As illustrated in the above example, by choosing to throw in the catch block, this custom behavior can then let NServiceBus forward the message to the error queue. If that's not the desired behavior, remove the throw to let NServiceBus know that the message handling is complete.
+As illustrated in the above example, by choosing to throw in the catch block, this behavior can then let NServiceBus forward the message to the error queue. If that's not the desired behavior, remove the throw to let NServiceBus know that the message handling is complete.
 
 
 ### Create a new message processing step in the pipeline.
 
-Specify where and how this behavior ought to be invoked. 
+Specify where and how this behavior is invoked. 
 
 snippet: 5to6-newmessageprocessingpipelinestep
 

--- a/nservicebus/errors/managing-errors-with-the-pipeline.md
+++ b/nservicebus/errors/managing-errors-with-the-pipeline.md
@@ -6,10 +6,9 @@ tags:
  - example
 ---
 
-In versions of NServiceBus lower than v6 to add logic to FLR and SLR processing NServiceBus provided the `IManageMessageFailures` interface to implement. Now developers must instead add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled as well as any custom action that needs to be performed when an exception happens. 
+In Versions 5 and below to add logic to FLR and SLR processing required implementing the `IManageMessageFailures` interface. Instead add a new behavior which is invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled as well as any custom action that needs to be performed when an exception occurs. 
 
-While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
-
+In Version 6 SLR can either be disabled or customized as necessary. See also [disabling SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
 
 ### Create a new behavior that has access to the message at the transport message context
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -606,28 +606,5 @@ NOTE: This identifier needs to be stable and should never be hardcoded, e.g. it 
 
 In Version 5, the `IManageMessageFailures` interface served as an extension point to customize the process of handling the action when a message fails the first level retries before the message is forwarded to the error queue.  
 
-Version 6 allows more control of this behavior with the [more advanced message processing pipeline](/nservicebus/pipeline/customizing-v6.md). 
- 
-To convert existing code that used `IManageMessageFailures`, add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled. Any custom action that needs to be performed when an exception happens can be specified. 
-
-While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, please read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
-
-
-### Create a new behavior that has access to the message at the transport message context
-
-snippet: 5to6-customerrorhandlingbehaviour
-
-As illustrated in the above example, by choosing to throw in the catch block, this custom behavior can then let NServiceBus forward the message to the error queue. If that's not the desired behavior, remove the throw to let NServiceBus know that the message handling is complete.  
-
-
-### Create a new message processing step in the pipeline.
-
-Specify where and how this behavior ought to be invoked. 
-
-snippet: 5to6-newmessageprocessingpipelinestep
-
-
-### Register the new step in the pipeline
-
-snippet: 5to6-registercustomerrorhandling
+Version 6 allows more control of this behavior with the [more advanced message processing pipeline](/nservicebus/pipeline/customizing-v6.md) and there is also Version 6 specific guidance for [managing errors with the pipeline](/nservicebus/errors/managing-errors-with-the-pipeline.md).
  

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -601,19 +601,33 @@ snippet: 5to6-Callbacks-InstanceId
 
 NOTE: This identifier needs to be stable and should never be hardcoded, e.g. it can be read from the configuration file or from the environment (e.g. role ID in Azure).
 
-## IManageMessageFailures obsoleted
 
-There have been changes that effect customers using custom FLR processing
+## IManageMessageFailures is now Obsolete
 
-This is how to write a behavior to perform custom error processing
+In Version 5, the `IManageMessageFailures` interface served as an extension point to customize the process of handling the action when a message fails the first level retries before the message is forwarded to the error queue.  
+
+Version 6 allows more control of this behavior with the [more advanced message processing pipeline](/nservicebus/pipeline/customizing-v6.md). 
+ 
+To convert existing code that used `IManageMessageFailures`, add a new behavior class which will be invoked during the message processing pipeline. In this behavior, both the deserialization exception and the general exception can be handled. Any custom action that needs to be performed when an exception happens can be specified. 
+
+While Version 5 did not allow an easier way to invoke both the SLR and the custom fault handling policy, in Version 6, SLR can either be disabled or customized as necessary. For more details, please read this article on how to [disable SLR](/nservicebus/errors/automatic-retries.md#second-level-retries-disabling-slr-through-code).
+
+
+### Create a new behavior that has access to the message at the transport message context
 
 snippet: 5to6-customerrorhandlingbehaviour
 
-Write a new processing pipeline step
+As illustrated in the above example, by choosing to throw in the catch block, this custom behavior can then let NServiceBus forward the message to the error queue. If that's not the desired behavior, remove the throw to let NServiceBus know that the message handling is complete.  
+
+
+### Create a new message processing step in the pipeline.
+
+Specify where and how this behavior ought to be invoked. 
 
 snippet: 5to6-newmessageprocessingpipelinestep
 
-Register the new step in the pipeline
+
+### Register the new step in the pipeline
 
 snippet: 5to6-registercustomerrorhandling
  

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -600,3 +600,20 @@ In Version 6 the callback routing is based on user-provided unique endpoint inst
 snippet: 5to6-Callbacks-InstanceId
 
 NOTE: This identifier needs to be stable and should never be hardcoded, e.g. it can be read from the configuration file or from the environment (e.g. role ID in Azure).
+
+## IManageMessageFailures obsoleted
+
+There have been changes that effect customers using custom FLR processing
+
+This is how to write a behavior to perform custom error processing
+
+snippet: 5to6-customerrorhandlingbehaviour
+
+Write a new processing pipeline step
+
+snippet: 5to6-newmessageprocessingpipelinestep
+
+Register the new step in the pipeline
+
+snippet: 5to6-registercustomerrorhandling
+ 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -601,10 +601,9 @@ snippet: 5to6-Callbacks-InstanceId
 
 NOTE: This identifier needs to be stable and should never be hardcoded, e.g. it can be read from the configuration file or from the environment (e.g. role ID in Azure).
 
-
 ## IManageMessageFailures is now Obsolete
 
-In Version 5, the `IManageMessageFailures` interface served as an extension point to customize the process of handling the action when a message fails the first level retries before the message is forwarded to the error queue.  
+In versions 5 and below, the `IManageMessageFailures` interface was the extension point to customize handling of first level retries before a message failure is forwarded to the error queue.  
 
-Version 6 allows more control of this behavior with the [more advanced message processing pipeline](/nservicebus/pipeline/customizing-v6.md) and there is also Version 6 specific guidance for [managing errors with the pipeline](/nservicebus/errors/managing-errors-with-the-pipeline.md).
+In versions 6 allows control of this behavior with the [message processing pipeline](/nservicebus/pipeline/customizing-v6.md). There is also Version 6 specific guidance for [managing errors with the pipeline](/nservicebus/errors/managing-errors-with-the-pipeline.md).
  


### PR DESCRIPTION
Relates to https://github.com/Particular/docs.particular.net/issues/1281

In version 5, in order to override the behavior of SLR and moving messages to error queue, the user can extend the IManageMessageFailures interface and do custom logic there. See v5 code. 

**Version 5 code**
```c#
public class CustomFaultManager : IManageMessageFailures, INeedInitialization
{
    public void SerializationFailedForMessage(TransportMessage message, Exception e)
    {
        Console.WriteLine("CustomFaultManager - SerializationFailedForMessage");
    }

    public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
    {
        Console.WriteLine("CustomFaultManager - ProcessingAlwaysFailsForMessage");
    }

    public void Init(Address address)
    {
        Console.WriteLine("CustomFaultManager - Init");
    }
        
    public void Customize(BusConfiguration configuration)
    {
        configuration.RegisterComponents(c => c.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.InstancePerCall));
    }
}
```

In Version 6, this is done by adding a new message processing behavior in the pipeline. 
User can control if the behavior should still invoke SLR or not, by turning off SLR or customizing it a the endpoint level. 
User can control if the message can be forwarded to the error queue or not in the behavior. 