### PR TITLE
Updating unit testing snippets to v6

### DIFF
--- a/Snippets/Snippets_4/Snippets_4.csproj
+++ b/Snippets/Snippets_4/Snippets_4.csproj
@@ -436,8 +436,6 @@
     <Compile Include="Transports\RabbitMQ_1\Usage.cs" />
     <Compile Include="Transports\Throughput\ProvideConfiguration.cs" />
     <Compile Include="Transports\Throughput\Usage.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyMessage.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyService.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\RequestMessage.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\ResponseMessage.cs" />
     <Compile Include="UnitTesting\Saga\MyCommand.cs" />

--- a/Snippets/Snippets_4/UnitTesting/AdditionalServices/MyMessage.cs
+++ b/Snippets/Snippets_4/UnitTesting/AdditionalServices/MyMessage.cs
@@ -1,6 +1,0 @@
-﻿namespace Snippets4.UnitTesting.AdditionalServices
-{
-    class MyMessage
-    {
-    }
-}

--- a/Snippets/Snippets_4/UnitTesting/AdditionalServices/MyService.cs
+++ b/Snippets/Snippets_4/UnitTesting/AdditionalServices/MyService.cs
@@ -1,6 +1,0 @@
-﻿namespace Snippets4.UnitTesting.AdditionalServices
-{
-    class MyService
-    {
-    }
-}

--- a/Snippets/Snippets_4/UnitTesting/AdditionalServices/Tests.cs
+++ b/Snippets/Snippets_4/UnitTesting/AdditionalServices/Tests.cs
@@ -66,4 +66,12 @@
     }
 
     #endregion
+
+    class MyService
+    {
+    }
+
+    class MyMessage
+    {
+    }
 }

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -628,8 +628,6 @@
     <Compile Include="Transports\Throughput\ProvideConfiguration.cs" />
     <Compile Include="Transports\Throughput\Usage.cs" />
     <Compile Include="UnitTesting\AdditionalServices\Tests.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyMessage.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyService.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\Tests.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\RequestMessage.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\ResponseMessage.cs" />

--- a/Snippets/Snippets_5/UnitTesting/AdditionalServices/MyMessage.cs
+++ b/Snippets/Snippets_5/UnitTesting/AdditionalServices/MyMessage.cs
@@ -1,6 +1,0 @@
-namespace Snippets5.UnitTesting.AdditionalServices
-{
-    class MyMessage
-    {
-    }
-}

--- a/Snippets/Snippets_5/UnitTesting/AdditionalServices/MyService.cs
+++ b/Snippets/Snippets_5/UnitTesting/AdditionalServices/MyService.cs
@@ -1,6 +1,0 @@
-namespace Snippets5.UnitTesting.AdditionalServices
-{
-    class MyService
-    {
-    }
-}

--- a/Snippets/Snippets_5/UnitTesting/AdditionalServices/Tests.cs
+++ b/Snippets/Snippets_5/UnitTesting/AdditionalServices/Tests.cs
@@ -66,4 +66,12 @@
     }
 
     #endregion
+
+    class MyService
+    {
+    }
+
+    class MyMessage
+    {
+    }
 }

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -207,6 +207,10 @@
     <Reference Include="NServiceBus.RavenDB">
       <HintPath>..\..\packages\NServiceBus.RavenDB.4.0.0-unstable0102\lib\net452\NServiceBus.RavenDB.dll</HintPath>
     </Reference>
+    <Reference Include="NServiceBus.Testing, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NServiceBus.Testing.6.0.0-unstable0035\lib\net452\NServiceBus.Testing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NServiceBus.RabbitMQ.4.0.0-unstable0190\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
@@ -429,6 +433,22 @@
     <Compile Include="Transports\RabbitMQ_4\Usage.cs" />
     <Compile Include="Transports\SqlServer_3\SingleDbMultiSchema.cs" />
     <Compile Include="Transports\SqlServer_3\ConnectionStrings.cs" />
+    <Compile Include="UnitTesting\AdditionalServices\MyMessage.cs" />
+    <Compile Include="UnitTesting\AdditionalServices\MyService.cs" />
+    <Compile Include="UnitTesting\AdditionalServices\Tests.cs" />
+    <Compile Include="UnitTesting\HeaderManipulation\RequestMessage.cs" />
+    <Compile Include="UnitTesting\HeaderManipulation\ResponseMessage.cs" />
+    <Compile Include="UnitTesting\HeaderManipulation\Tests.cs" />
+    <Compile Include="UnitTesting\Saga\MyCommand.cs" />
+    <Compile Include="UnitTesting\Saga\MyEvent.cs" />
+    <Compile Include="UnitTesting\Saga\MyResponse.cs" />
+    <Compile Include="UnitTesting\Saga\MySaga.cs" />
+    <Compile Include="UnitTesting\Saga\MySagaData.cs" />
+    <Compile Include="UnitTesting\Saga\StartsSaga.cs" />
+    <Compile Include="UnitTesting\Saga\Tests.cs" />
+    <Compile Include="UnitTesting\ServiceLayer\RequestMessage.cs" />
+    <Compile Include="UnitTesting\ServiceLayer\ResponseMessage.cs" />
+    <Compile Include="UnitTesting\ServiceLayer\Tests.cs" />
     <Compile Include="UpgradeGuides\5to6\Callbacks.cs" />
     <Compile Include="Transports\SqlServer_3\UpgradeGuides\Transactions.cs" />
     <Compile Include="UpgradeGuides\5to6\EndpointStart.cs" />

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -433,8 +433,6 @@
     <Compile Include="Transports\RabbitMQ_4\Usage.cs" />
     <Compile Include="Transports\SqlServer_3\SingleDbMultiSchema.cs" />
     <Compile Include="Transports\SqlServer_3\ConnectionStrings.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyMessage.cs" />
-    <Compile Include="UnitTesting\AdditionalServices\MyService.cs" />
     <Compile Include="UnitTesting\AdditionalServices\Tests.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\RequestMessage.cs" />
     <Compile Include="UnitTesting\HeaderManipulation\ResponseMessage.cs" />

--- a/Snippets/Snippets_6/Transports/SqlServer_3/MultiSchema.config
+++ b/Snippets/Snippets_6/Transports/SqlServer_3/MultiSchema.config
@@ -5,7 +5,7 @@
     <MessageEndpointMappings>
       <add Assembly="Billing.Contract"
            Endpoint="billing@schema_name"/>
-      <add Assembly="Sales.Contract" 
+      <add Assembly="Sales.Contract"
            Endpoint="sales@another_schema_name"/>
     </MessageEndpointMappings>
   </UnicastBusConfig>

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyMessage.cs
@@ -1,0 +1,6 @@
+namespace Snippets6.UnitTesting.AdditionalServices
+{
+    class MyMessage
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyMessage.cs
@@ -1,6 +1,0 @@
-namespace Snippets6.UnitTesting.AdditionalServices
-{
-    class MyMessage
-    {
-    }
-}

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyService.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyService.cs
@@ -1,6 +1,0 @@
-namespace Snippets6.UnitTesting.AdditionalServices
-{
-    class MyService
-    {
-    }
-}

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyService.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/MyService.cs
@@ -1,0 +1,6 @@
+namespace Snippets6.UnitTesting.AdditionalServices
+{
+    class MyService
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/Tests.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/Tests.cs
@@ -1,0 +1,41 @@
+﻿namespace Snippets6.UnitTesting.AdditionalServices
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    // ReSharper disable SuggestVarOrType_Elsewhere
+
+    [Explicit]
+    #region TestingAdditionalDependencies
+    [TestFixture]
+    public class Tests
+    {
+        [Test]
+        public void RunWithDependencyInjection()
+        {
+            MyService mockService = new MyService();
+            var handler = Test.Handler(new WithDependencyInjectionHandler(mockService));
+            //Rest of test
+        }
+    }
+
+    class WithDependencyInjectionHandler : IHandleMessages<MyMessage>
+    {
+        MyService myService;
+
+        public WithDependencyInjectionHandler(MyService myService)
+        {
+            this.myService = myService;
+        }
+
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            // use myService here
+            return Task.FromResult(0);
+        }
+    }
+
+    #endregion
+}

--- a/Snippets/Snippets_6/UnitTesting/AdditionalServices/Tests.cs
+++ b/Snippets/Snippets_6/UnitTesting/AdditionalServices/Tests.cs
@@ -38,4 +38,12 @@
     }
 
     #endregion
+
+    class MyService
+    {
+    }
+
+    class MyMessage
+    {
+    }
 }

--- a/Snippets/Snippets_6/UnitTesting/HeaderManipulation/RequestMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/HeaderManipulation/RequestMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace Snippets6.UnitTesting.HeaderManipulation
+{
+    using NServiceBus;
+
+    class RequestMessage : IMessage
+    {
+        public string String { get; set; }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/HeaderManipulation/ResponseMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/HeaderManipulation/ResponseMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace Snippets6.UnitTesting.HeaderManipulation
+{
+    using NServiceBus;
+
+    class ResponseMessage : IMessage
+    {
+        public string String { get; set; }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/HeaderManipulation/Tests.cs
+++ b/Snippets/Snippets_6/UnitTesting/HeaderManipulation/Tests.cs
@@ -1,0 +1,40 @@
+﻿namespace Snippets6.UnitTesting.HeaderManipulation
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [Explicit]
+    #region TestingHeaderManipulation
+
+    [TestFixture]
+    public class Tests
+    {
+        [Test]
+        public void Run()
+        {
+            Test.Handler<MyMessageHandler>()
+                .SetIncomingHeader("MyHeaderKey", "myHeaderValue")
+                .ExpectReply<ResponseMessage>((m, replyOptions) => 
+                    replyOptions.GetHeaders()["MyHeaderKey"] == "myHeaderValue")
+                .OnMessage<RequestMessage>(m => m.String = "hello");
+        }
+    }
+
+    class MyMessageHandler : IHandleMessages<RequestMessage>
+    {
+        public async Task Handle(RequestMessage message, IMessageHandlerContext context)
+        {
+            string header = context.MessageHeaders["MyHeaderKey"];
+
+            ResponseMessage responseMessage = new ResponseMessage();
+
+            ReplyOptions options = new ReplyOptions();
+            options.SetHeader("MyHeaderKey", header);
+            await context.Reply(responseMessage, options);
+        }
+    }
+
+    #endregion
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/MyCommand.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/MyCommand.cs
@@ -1,0 +1,8 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using NServiceBus;
+
+    class MyCommand : ICommand
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/MyEvent.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/MyEvent.cs
@@ -1,0 +1,8 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using NServiceBus;
+
+    class MyEvent : IEvent
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/MyResponse.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/MyResponse.cs
@@ -1,0 +1,8 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using NServiceBus;
+
+    public class MyResponse : IMessage
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/MySaga.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/MySaga.cs
@@ -1,0 +1,30 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    public class MySaga : Saga<MySagaData>,
+        IAmStartedByMessages<StartsSaga>,
+        IHandleTimeouts<StartsSaga>
+    {
+        public async Task Handle(StartsSaga message, IMessageHandlerContext context)
+        {
+            await ReplyToOriginator(context, new MyResponse());
+            await context.Publish(new MyEvent());
+            await context.Send(new MyCommand());
+            await RequestTimeout(context, TimeSpan.FromDays(7), message);
+        }
+
+        public async Task Timeout(StartsSaga state, IMessageHandlerContext context)
+        {
+            await context.Publish<MyEvent>();
+
+            MarkAsComplete();
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+        {
+        }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/MySagaData.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/MySagaData.cs
@@ -1,0 +1,12 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using System;
+    using NServiceBus;
+
+    public class MySagaData : IContainSagaData
+    {
+        public Guid Id { get; set; }
+        public string Originator { get; set; }
+        public string OriginalMessageId { get; set; }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/StartsSaga.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/StartsSaga.cs
@@ -1,0 +1,8 @@
+namespace Snippets6.UnitTesting.Saga
+{
+    using NServiceBus;
+
+    public class StartsSaga : ICommand
+    {
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/Saga/Tests.cs
+++ b/Snippets/Snippets_6/UnitTesting/Saga/Tests.cs
@@ -1,0 +1,29 @@
+﻿namespace Snippets6.UnitTesting.Saga
+{
+    using System;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [Explicit]
+    #region TestingSaga
+
+    [TestFixture]
+    public class Tests
+    {
+        [Test]
+        public void Run()
+        {
+            Test.Saga<MySaga>()
+                    .ExpectReplyToOriginator<MyResponse>()
+                    .ExpectTimeoutToBeSetIn<StartsSaga>((state, span) => span == TimeSpan.FromDays(7))
+                    .ExpectPublish<MyEvent>()
+                    .ExpectSend<MyCommand>()
+                .When((s, context) => s.Handle(new StartsSaga(), context))
+                    .ExpectPublish<MyEvent>()
+                .WhenSagaTimesOut()
+                    .AssertSagaCompletionIs(true);
+        }
+    }
+
+    #endregion
+}

--- a/Snippets/Snippets_6/UnitTesting/ServiceLayer/RequestMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/ServiceLayer/RequestMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace Snippets6.UnitTesting.ServiceLayer
+{
+    using NServiceBus;
+
+    public class RequestMessage : IMessage
+    {
+        public string String { get; set; }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/ServiceLayer/ResponseMessage.cs
+++ b/Snippets/Snippets_6/UnitTesting/ServiceLayer/ResponseMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace Snippets6.UnitTesting.ServiceLayer
+{
+    using NServiceBus;
+
+    public class ResponseMessage : IMessage
+    {
+        public string String { get; set; }
+    }
+}

--- a/Snippets/Snippets_6/UnitTesting/ServiceLayer/Tests.cs
+++ b/Snippets/Snippets_6/UnitTesting/ServiceLayer/Tests.cs
@@ -1,0 +1,36 @@
+﻿namespace Snippets6.UnitTesting.ServiceLayer
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [Explicit]
+    #region TestingServiceLayer
+    [TestFixture]
+    public class Tests
+    {
+        [Test]
+        public void Run()
+        {
+            Test.Handler<MyHandler>()
+                .ExpectReply<ResponseMessage>(m => m.String == "hello")
+                .OnMessage<RequestMessage>(m => m.String = "hello");
+        }
+    }
+
+    public class MyHandler :
+        IHandleMessages<RequestMessage>
+    {
+        public async Task Handle(RequestMessage message, IMessageHandlerContext context)
+        {
+            ResponseMessage reply = new ResponseMessage
+            {
+                String = message.String
+            };
+            await context.Reply(reply);
+        }
+    }
+
+    #endregion
+}

--- a/Snippets/Snippets_6/packages.config
+++ b/Snippets/Snippets_6/packages.config
@@ -39,6 +39,7 @@
   <package id="NServiceBus.Spring" version="7.0.0-unstable0011" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="3.0.0-unstable0104" targetFramework="net452" />
   <package id="NServiceBus.StructureMap" version="6.0.0-unstable0016" targetFramework="net452" />
+  <package id="NServiceBus.Testing" version="6.0.0-unstable0035" targetFramework="net452" />
   <package id="NServiceBus.Unity" version="6.3.0-unstable0015" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -7,7 +7,7 @@ redirects:
  - nservicebus/testing/unit-testing
 ---
 
-Developing enterprise-scale distributed systems is hard and testing them is just as challenging a task. The architectural approach supported by NServiceBus makes these challenges more manageable. And the testing facilities provided actually make unit testing endpoints and workflows easy. You can now develop service layers and long-running processes using test-driven development.
+Developing enterprise-scale distributed systems is hard and testing them is just as challenging a task. The architectural approach supported by NServiceBus makes these challenges more manageable. The testing facilities provided make unit testing endpoints and workflows easy, allowing developing service layers and long-running processes using Test-Driven Development.
 
 
 ## Getting started
@@ -18,9 +18,11 @@ To install this package:
 ```
 Install-Package NServiceBus.Testing
 ```
-Once the package is installed you need ensure that you call `Test.Initialize()` (or any of its overloads) before executing any test method. This is **not needed **for Version 6.
+Once the package is installed, create a new test using any of the testing frameworks, such as NUnit, xUnit.net or MSBuild.
 
-NOTE: To limit the assemblies and types scanned by the test framework it is possible to use the `Initialize()` overload that accepts a delegate you can use to customize the `ConfigurationBuilder`.
+{{Note: In Versions 5 and below, `Test.Initialize()` (or any of its overloads) must be called before executing any test method.
+
+To limit the assemblies and types scanned by the test framework it is possible to use the `Initialize()` overload that accepts a delegate to customize the `ConfigurationBuilder`.}}
 
 
 ## Testing the service layer
@@ -39,7 +41,7 @@ snippet:TestingSaga
 
 ## Configuring unobtrusive message conventions
 
-Prior to Version 6, if you are using [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md) you need to configure the unit test support with those conventions as shown below.
+In Versions 5 and below, if [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md) is used, it must be configured with those conventions as shown below.
 
 snippet:SetupConventionsForUnitTests
 
@@ -66,6 +68,6 @@ snippet:TestingAdditionalDependencies
 
 ## Constructor injected bus
 
-NOTE: The `IBus` interface was deprecated in Version 6, and replaced with the contextual `IMessageHandlerContext` parameter on the `IHandleMessages<T>.Handle()` methods.
+NOTE: In Version 6, the `IBus` interface was deprecated and removed, and replaced with the contextual `IMessageHandlerContext` parameter on the `IHandleMessages<T>.Handle()` methods.
 
 snippet: ConstructorInjectedBus

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Testing NServiceBus
 summary: Develop service layers and long-running processes using test-driven development.
-tags: []
+reviewed: 2016-03-17
 redirects:
  - nservicebus/unit-testing
  - nservicebus/testing/unit-testing
@@ -15,9 +15,11 @@ Developing enterprise-scale distributed systems is hard and testing them is just
 NServiceBus ships with a stand alone testing helper NuGet package that makes testing a lot simpler.
 
 To install this package:
+
 ```
 Install-Package NServiceBus.Testing
 ```
+
 Once the package is installed, create a new test using any of the testing frameworks, such as NUnit, xUnit.net or MSBuild.
 
 {{Note: In Versions 5 and below, `Test.Initialize()` (or any of its overloads) must be called before executing any test method.
@@ -66,8 +68,9 @@ Many of the message handling classes in the service layer make use of other obje
 
 snippet:TestingAdditionalDependencies
 
+
 ## Constructor injected bus
 
-NOTE: In Version 6, the `IBus` interface was deprecated and removed, and replaced with the contextual `IMessageHandlerContext` parameter on the `IHandleMessages<T>.Handle()` methods.
+NOTE: In Versions 6 and higher, the `IBus` interface was deprecated and removed, and replaced with the contextual `IMessageHandlerContext` parameter on the `IHandleMessages<T>.Handle()` methods.
 
 snippet: ConstructorInjectedBus

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -1,5 +1,5 @@
 ---
-title: Unit Testing
+title: Testing NServiceBus
 summary: Develop service layers and long-running processes using test-driven development.
 tags: []
 redirects:
@@ -18,12 +18,12 @@ To install this package:
 ```
 Install-Package NServiceBus.Testing
 ```
-Once the package is installed you need ensure that you call `Test.Initialize()` (or any of its overloads) before executing any test method.
+Once the package is installed you need ensure that you call `Test.Initialize()` (or any of its overloads) before executing any test method. This is **not needed **for Version 6.
 
 NOTE: To limit the assemblies and types scanned by the test framework it is possible to use the `Initialize()` overload that accepts a delegate you can use to customize the `ConfigurationBuilder`.
 
 
-## Unit testing the service layer
+## Testing the service layer
 
 The service layer in an NServiceBus application is made from message handlers. Each class typically handles one specific type of message. Testing these classes usually focuses on their externally visible behavior: the types of messages they send or reply with. This is as simple to test as could be expected:
 
@@ -39,7 +39,7 @@ snippet:TestingSaga
 
 ## Configuring unobtrusive message conventions
 
-If you are using [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md) you need to configure the unit test support with those conventions as shown below.
+Prior to Version 6, if you are using [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md) you need to configure the unit test support with those conventions as shown below.
 
 snippet:SetupConventionsForUnitTests
 
@@ -65,5 +65,7 @@ Many of the message handling classes in the service layer make use of other obje
 snippet:TestingAdditionalDependencies
 
 ## Constructor injected bus
+
+NOTE: The `IBus` interface was deprecated in Version 6, and replaced with the contextual `IMessageHandlerContext` parameter on the `IHandleMessages<T>.Handle()` methods.
 
 snippet: ConstructorInjectedBus


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Testing/issues/29

This adds testing snippets, converted to v6.
Also adding a few tweaks in the testing docs (mainly, removing the word "unit" whenever possible)