### PR TITLE
Describe /scannedAssemblies switch of NServiceBus.Host

### DIFF
--- a/nservicebus/hosting/assembly-scanning.md
+++ b/nservicebus/hosting/assembly-scanning.md
@@ -19,7 +19,7 @@ snippet:ScanningConfigurationInNSBHost
 
 NOTE: During the scanning process, the core dlls for NServiceBus namely `NServiceBus.Core.dll`, `NServiceBus.dll` (in versions prior to Version 5) and if in use `NServiceBus.Host.exe` are automatically included since the endpoint needs them to function properly.
 
-NServiceBus.Host can also control assembly scanning using [command line switches](nservicebus-host/#controlling-assembly-scanning-using-the-command-line).
+When the endpoint is hosted using NServiceBus.Host, [command line switches](nservicebus-host/#controlling-assembly-scanning-using-the-command-line) can be used to control assembly scanning.
 
 ## Controlling the assemblies to scan
 

--- a/nservicebus/hosting/assembly-scanning.md
+++ b/nservicebus/hosting/assembly-scanning.md
@@ -19,6 +19,7 @@ snippet:ScanningConfigurationInNSBHost
 
 NOTE: During the scanning process, the core dlls for NServiceBus namely `NServiceBus.Core.dll`, `NServiceBus.dll` (in versions prior to Version 5) and if in use `NServiceBus.Host.exe` are automatically included since the endpoint needs them to function properly.
 
+NServiceBus.Host can also control assembly scanning using [command line switches](nservicebus-host/#controlling-assembly-scanning-using-the-command-line).
 
 ## Controlling the assemblies to scan
 

--- a/nservicebus/hosting/assembly-scanning.md
+++ b/nservicebus/hosting/assembly-scanning.md
@@ -19,7 +19,6 @@ snippet:ScanningConfigurationInNSBHost
 
 NOTE: During the scanning process, the core dlls for NServiceBus namely `NServiceBus.Core.dll`, `NServiceBus.dll` (in versions prior to Version 5) and if in use `NServiceBus.Host.exe` are automatically included since the endpoint needs them to function properly.
 
-When the endpoint is hosted using NServiceBus.Host, [command line switches](nservicebus-host/#controlling-assembly-scanning-using-the-command-line) can be used to control assembly scanning.
 
 ## Controlling the assemblies to scan
 

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -25,6 +25,15 @@ If you want to avoid the scanning process you can explicitly configure the type 
 snippet:ExplicitHostConfigType
 
 
+### Controlling assembly scanning using the command line
+
+A list of assemblies to scan can also be controlled using the `/scannedAssemblies` switch. If this option is used, the `NServiceBus.Host.exe` loads only assemblies (with references) that have been explicitly listed on the command line. Each assembly must be added using a separate switch:
+
+`NServiceBus.Host.exe /scannedAssemblies:"NServiceBus.Host" /scannedAssemblies:"MyMessages" /scannedAssemblies:"MyEndpoint"`
+
+NOTE: The `NServiceBus.Host` assembly must be listed explicitly. In this case `NServiceBus.Core` is loaded as a reference and need not be specified separately.
+
+
 ## Application Domains
 
 The `NServiceBus.Host.exe` creates a separate *service* [Application Domain](https://msdn.microsoft.com/en-us/library/2bh4z9hs.aspx) to run NServiceBus and the user code. The new domain is assigned a configuration file named after the dll that contains the class implementing `IConfigureThisEndpoint`. All the configuration should be done in that file (as opposed to `NServiceBus.Host.exe.config`). In most cases that means just adding the `app.config` file to the project and letting MSBuild take care of renaming it while moving to the `bin` folder.

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -31,7 +31,7 @@ A list of assemblies to scan can also be controlled using the `/scannedAssemblie
 
 `NServiceBus.Host.exe /scannedAssemblies:"NServiceBus.Host" /scannedAssemblies:"MyMessages" /scannedAssemblies:"MyEndpoint"`
 
-NOTE: Each assembly is loaded using a call to [`Assembly.Load`](https://msdn.microsoft.com/en-us/library/ky3942xh.aspx) method. This means that the host will load each assembly and all assemblies it depends on.
+The host loads the assemblies by invoking [`Assembly.Load`](https://msdn.microsoft.com/en-us/library/ky3942xh.aspx) method. This approach ensures that the specified assembly and all its dependent assemblies will also be loaded.
 
 NOTE: It is mandatory to include `NServiceBus.Host` in the `/scannedAssemblies` list as shown in the example above. As `NServiceBus.Host` references `NServiceBus.Core`, the latter can be safely omitted from the list.
 

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -31,7 +31,7 @@ A list of assemblies to scan can also be controlled using the `/scannedAssemblie
 
 `NServiceBus.Host.exe /scannedAssemblies:"NServiceBus.Host" /scannedAssemblies:"MyMessages" /scannedAssemblies:"MyEndpoint"`
 
-NOTE: Each assembly is loaded using a call to `Assembly.Load` method. This means that the host will load each assembly and all assemblies it depends on.
+NOTE: Each assembly is loaded using a call to [`Assembly.Load`](https://msdn.microsoft.com/en-us/library/ky3942xh.aspx) method. This means that the host will load each assembly and all assemblies it depends on.
 
 NOTE: It is mandatory to include `NServiceBus.Host` in the `/scannedAssemblies` list as shown in the example above. As `NServiceBus.Host` references `NServiceBus.Core`, the latter can be safely omitted from the list.
 

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -27,11 +27,13 @@ snippet:ExplicitHostConfigType
 
 ### Controlling assembly scanning using the command line
 
-A list of assemblies to scan can also be controlled using the `/scannedAssemblies` switch. If this option is used, the `NServiceBus.Host.exe` loads only assemblies (with references) that have been explicitly listed on the command line. Each assembly must be added using a separate switch:
+A list of assemblies to scan can also be controlled using the `/scannedAssemblies` switch. If this option is used, the `NServiceBus.Host.exe` loads only assemblies that have been explicitly listed on the command line. Each assembly must be added using a separate switch:
 
 `NServiceBus.Host.exe /scannedAssemblies:"NServiceBus.Host" /scannedAssemblies:"MyMessages" /scannedAssemblies:"MyEndpoint"`
 
-NOTE: The `NServiceBus.Host` assembly must be listed explicitly. In this case `NServiceBus.Core` is loaded as a reference and need not be specified separately.
+NOTE: Each assembly is loaded using a call to `Assembly.Load` method. This means that the host will load each assembly and all assemblies it depends on.
+
+NOTE: It is mandatory to include `NServiceBus.Host` in the `/scannedAssemblies` list as shown in the example above. As `NServiceBus.Host` references `NServiceBus.Core`, the latter can be safely omitted from the list.
 
 
 ## Application Domains


### PR DESCRIPTION
When answering a [StackOverflow question](http://stackoverflow.com/questions/35871942/nservicebus-scanning-all-assemblies) it turned out that the `/scannedAssemblies` switch of `NServiceBus.Host.exe` is undocumented.

@Particular/nservicebus-maintainers @Particular/docs-maintainers Please review this for correctness. Knowledge I describe here was gathered by code spelunking and experimentation.