### PR TITLE
Upgrade dependencies in outbox nhibernate samples

### DIFF
--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/Receiver.csproj
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/Receiver.csproj
@@ -50,15 +50,16 @@
     <Reference Include="NHibernate">
       <HintPath>..\..\..\..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.NHibernate, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.6.3.0-unstable0055\lib\net452\NServiceBus.NHibernate.dll</HintPath>
+    <Reference Include="NServiceBus.NHibernate, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.7.0.0-unstable0068\lib\net452\NServiceBus.NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0104\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0118\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Receiver/packages.config
@@ -3,7 +3,7 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
-  <package id="NServiceBus.NHibernate" version="6.3.0-unstable0055" targetFramework="net452" />
-  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0104" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
+  <package id="NServiceBus.NHibernate" version="7.0.0-unstable0068" targetFramework="net452" />
+  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0118" targetFramework="net452" />
 </packages>

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Sender/Sender.csproj
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Sender/Sender.csproj
@@ -44,15 +44,16 @@
     <Reference Include="NHibernate">
       <HintPath>..\..\..\..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.NHibernate, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.6.3.0-unstable0055\lib\net452\NServiceBus.NHibernate.dll</HintPath>
+    <Reference Include="NServiceBus.NHibernate, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.7.0.0-unstable0068\lib\net452\NServiceBus.NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0104\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0118\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Sender/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Sender/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
-  <package id="NServiceBus.NHibernate" version="6.3.0-unstable0055" targetFramework="net452" />
-  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0104" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
+  <package id="NServiceBus.NHibernate" version="7.0.0-unstable0068" targetFramework="net452" />
+  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0118" targetFramework="net452" />
 </packages>

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Shared/Shared.csproj
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Shared/Shared.csproj
@@ -35,8 +35,9 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Shared/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence-ef/Version_3/Shared/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
 </packages>

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Receiver/Receiver.csproj
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Receiver/Receiver.csproj
@@ -43,15 +43,16 @@
     <Reference Include="NHibernate">
       <HintPath>..\..\..\..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.NHibernate, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.6.3.0-unstable0055\lib\net452\NServiceBus.NHibernate.dll</HintPath>
+    <Reference Include="NServiceBus.NHibernate, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.7.0.0-unstable0068\lib\net452\NServiceBus.NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0104\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0118\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Receiver/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Receiver/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
-  <package id="NServiceBus.NHibernate" version="6.3.0-unstable0055" targetFramework="net452" />
-  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0104" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
+  <package id="NServiceBus.NHibernate" version="7.0.0-unstable0068" targetFramework="net452" />
+  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0118" targetFramework="net452" />
 </packages>

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Sender/Sender.csproj
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Sender/Sender.csproj
@@ -43,15 +43,16 @@
     <Reference Include="NHibernate">
       <HintPath>..\..\..\..\..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.NHibernate, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.6.3.0-unstable0055\lib\net452\NServiceBus.NHibernate.dll</HintPath>
+    <Reference Include="NServiceBus.NHibernate, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.7.0.0-unstable0068\lib\net452\NServiceBus.NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0104\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.SqlServer.3.0.0-unstable0118\lib\net452\NServiceBus.Transports.SQLServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Sender/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Sender/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
-  <package id="NServiceBus.NHibernate" version="6.3.0-unstable0055" targetFramework="net452" />
-  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0104" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
+  <package id="NServiceBus.NHibernate" version="7.0.0-unstable0068" targetFramework="net452" />
+  <package id="NServiceBus.SqlServer" version="3.0.0-unstable0118" targetFramework="net452" />
 </packages>

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Shared/Shared.csproj
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Shared/Shared.csproj
@@ -35,8 +35,9 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1616\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1685\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/samples/outbox/sqltransport-nhpersistence/Version_3/Shared/packages.config
+++ b/samples/outbox/sqltransport-nhpersistence/Version_3/Shared/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-unstable1616" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1685" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Related to the timeouts bug raised here https://github.com/Particular/NServiceBus/issues/3499.
After upgrade the bug is fixed.