### PR TITLE
Setting explicit properties

### DIFF
--- a/Snippets/Snippets_3/Injection/Injection.cs
+++ b/Snippets/Snippets_3/Injection/Injection.cs
@@ -7,7 +7,7 @@
     {
         public void ConfigurePropertyInjectionForHandler(Configure configure)
         {
-            #region ConfigurePropertyInjectionForHandlerBefore
+            #region ConfigurePropertyInjectionForHandler
 
             configure.Configurer
                 .ConfigureProperty<EmailHandler>(handler => handler.SmtpAddress, "10.0.1.233")

--- a/Snippets/Snippets_4/Injection/Injection.cs
+++ b/Snippets/Snippets_4/Injection/Injection.cs
@@ -7,7 +7,7 @@
     {
         Injection(Configure configure)
         {
-            #region ConfigurePropertyInjectionForHandlerBefore
+            #region ConfigurePropertyInjectionForHandler
 
             configure.DefaultBuilder();
             configure.Configurer

--- a/Snippets/Snippets_6/Injection/Injection.cs
+++ b/Snippets/Snippets_6/Injection/Injection.cs
@@ -1,26 +1,23 @@
 ﻿namespace Snippets5.Injection
 {
     using System.Net.Mail;
+    using System.Threading.Tasks;
     using NServiceBus;
 
-    class Injection
+    public class Injection
     {
-        Injection(BusConfiguration busConfiguration)
+        public void ConfigurePropertyInjectionForHandler()
         {
+            EndpointConfiguration busConfiguration = new EndpointConfiguration();
+
             #region ConfigurePropertyInjectionForHandler 
 
             busConfiguration.RegisterComponents(c =>
-                c.ConfigureComponent<EmailHandler>(DependencyLifecycle.InstancePerUnitOfWork)
-                    .ConfigureProperty(x => x.SmtpAddress, "10.0.1.233")
-                    .ConfigureProperty(x => x.SmtpPort, 25)
-                );
-
-            #endregion
-
-            #region ConfigurePropertyInjectionForHandlerExplicit
-
-            busConfiguration.InitializeHandlerProperty<EmailHandler>("SmtpAddress", "10.0.1.233");
-            busConfiguration.InitializeHandlerProperty<EmailHandler>("SmtpPort", 25);
+                c.ConfigureComponent(builder => new EmailHandler
+                {
+                    SmtpPort = 25,
+                    SmtpAddress = "10.0.1.233"
+                }, DependencyLifecycle.InstancePerUnitOfWork));
 
             #endregion
         }
@@ -32,10 +29,12 @@
             public string SmtpAddress { get; set; }
             public int SmtpPort { get; set; }
 
-            public void Handle(EmailMessage message)
+            public Task Handle(EmailMessage message, IMessageHandlerContext context)
             {
                 SmtpClient client = new SmtpClient(SmtpAddress, SmtpPort);
                 // ...
+
+                return Task.FromResult(0);
             }
         }
 

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -381,6 +381,7 @@
     <Compile Include="Headers\Writers\HeaderWriterSend.cs" />
     <Compile Include="Headers\Writers\TransportMessageExtension.cs" />
     <Compile Include="Host\CustomizingHost.cs" />
+    <Compile Include="Injection\Injection.cs" />
     <Compile Include="Monitoring\MessageFailedHandler.cs" />
     <Compile Include="Monitoring\ServiceControlEventsConfig.cs" />
     <Compile Include="NonDurable\DefineExpress.cs" />

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -454,6 +454,7 @@
     <Compile Include="UpgradeGuides\5to6\EndpointNameRequired.cs" />
     <Compile Include="UpgradeGuides\5to6\EndpointStart.cs" />
     <Compile Include="UpgradeGuides\5to6\HandlerOrdering.cs" />
+    <Compile Include="UpgradeGuides\5to6\Injection.cs" />
     <Compile Include="UpgradeGuides\5to6\MessageContext.cs" />
     <Compile Include="UpgradeGuides\5to6\MyEvent.cs" />
     <Compile Include="Handlers\MyHandler.cs" />

--- a/Snippets/Snippets_6/UpgradeGuides/5to6/Injection.cs
+++ b/Snippets/Snippets_6/UpgradeGuides/5to6/Injection.cs
@@ -1,0 +1,45 @@
+﻿namespace Snippets6.UpgradeGuides._5to6
+{
+    using System.Net.Mail;
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    public class Injection
+    {
+        public void ExplicitProperties()
+        {
+            EndpointConfiguration busConfiguration = new EndpointConfiguration();
+
+            #region ExplicitProperties 
+
+            busConfiguration.RegisterComponents(c =>
+                c.ConfigureComponent(builder => new MyHandler
+                {
+                    MyIntProperty = 25,
+                    MyStringProperty = "Some string"
+                }, DependencyLifecycle.InstancePerUnitOfWork));
+
+            #endregion
+        }
+
+   
+        public class MyHandler : IHandleMessages<EmailMessage>
+        {
+            public string MyStringProperty { get; set; }
+            public int MyIntProperty { get; set; }
+
+            public Task Handle(EmailMessage message, IMessageHandlerContext context)
+            {
+                SmtpClient client = new SmtpClient(MyStringProperty, MyIntProperty);
+                // ...
+
+                return Task.FromResult(0);
+            }
+        }
+        public class EmailMessage
+        {
+        }
+    }
+
+  
+}

--- a/nservicebus/containers/property-injection.md
+++ b/nservicebus/containers/property-injection.md
@@ -9,7 +9,7 @@ redirects:
  - nservicebus/property-injection-in-handlers
 ---
 
-NServiceBus will automatically enable property injection known types across the supported IOC Containers. Use the lambda overload of `.ConfigureComponent` to get full control over the injected properties if needed.
+NServiceBus will automatically enable property injection known types across the supported [Containers](/nservicebus/containers). Use the `Func` overload of `.ConfigureComponent` to get full control over the injected properties if needed.
 
 A common use case it to set primitive properties on message handlers. Given then below handler:
 
@@ -23,6 +23,6 @@ snippet: ConfigurePropertyInjectionForHandler
 
 Versions 5.2 supported a new, more explicit, API that specifically targets Handlers and Sagas.
 
-NOTE: This api has been obsoleted in Version 6
+NOTE: This API has been obsoleted with error in Version 6
 
 snippet: ConfigurePropertyInjectionForHandlerExplicit

--- a/nservicebus/containers/property-injection.md
+++ b/nservicebus/containers/property-injection.md
@@ -9,21 +9,20 @@ redirects:
  - nservicebus/property-injection-in-handlers
 ---
 
-When using the NServiceBus built-in container it is possible to control property injection.
+NServiceBus will automatically enable property injection known types across the supported IOC Containers. Use the lambda overload of `.ConfigureComponent` to get full control over the injected properties if needed.
 
-So given the following class that is constructed by the container.
+A common use case it to set primitive properties on message handlers. Given then below handler:
 
 snippet: PropertyInjectionWithHandler
 
-The property inject be done with the following:
+Setting the properties would be done as follows:
 
-snippet: ConfigurePropertyInjectionForHandlerBefore
-
-At construction time both `SmtpAddress` and `SmtpPort` will be injected.
-
+snippet: ConfigurePropertyInjectionForHandler
 
 ## A Handler/Saga specific API
 
-From Versions 5.2 and above a new, more explicit, API has been introduced that specifically targets Handlers and Sagas.
+Versions 5.2 supported a new, more explicit, API that specifically targets Handlers and Sagas.
 
-snippet: ConfigurePropertyInjectionForHandler
+NOTE: This api has been obsoleted in Version 6
+
+snippet: ConfigurePropertyInjectionForHandlerExplicit

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -1,11 +1,11 @@
 ---
-title: Upgrade Version 5 to 6
-summary: Instructions on how to upgrade NServiceBus Version 5 to 6.
+title: Upgrade from Version 5 to Version 6
+summary: Instructions on how to upgrade from NServiceBus Versions 5 to 6
 tags:
  - upgrade
  - migration
 related:
-- nservicebus/upgrades/gateway-1to2
+- nservicebus/upgrades/gateway-2to3
 - nservicebus/upgrades/sqlserver-2to3
 ---
 
@@ -19,17 +19,6 @@ In Version 6 the new minimum .NET version for NServiceBus is .NET 4.5.2.
 In the interest of "smaller changes are easier to verify" it is recommended to update to .NET 4.5.2, and full migration to production, before updating to NServiceBus Version 6.
 
 
-## [Endpoint](/nservicebus/endpoints/) Name is mandatory
-
-In Versions 6 and above endpoint name is mandatory.
-
-snippet: 5to6-endpointNameRequired
-
-If the Version 5, derived endpoint name behavior, is required then use the following helper class.
-
-snippet: 5to6EndpointNameHelper
-
-
 ## IStartableBus and Bus static class are obsolete
 
 In previous versions of NServiceBus to start a new instance of an endpoint the `Bus` static class and the `IStartableBus` interface. In Version 6 these two concepts have been replaced. More information can be found in the [hosting](/nservicebus/hosting/) section of the documentation.
@@ -39,7 +28,7 @@ snippet:5to6-endpoint-start
 
 ## IBus is obsolete
 
-In previous versions of NServiceBus, to send or publish messages within a message handler or other extension interfaces, the message session (`IBus` interface in Versions 5 and below) was accessed via container injection. In Versions 6 injecting the message session is no longer required. Message handlers and other extension interfaces now provide context parameters such as `IMessageHandlerContext` or `IEndpointInstance` which give access to the same functions that used to be available via the `IBus` interface.
+In previous versions of NServiceBus, to send messages or publish messages within a message handler or other extension interfaces such as `IWantToRunWhenBusStartsAndStops`, the `IBus` interface was used via injection. In Version 6 injecting IBus, via either a property injection or a constructor injection, is no longer required. Message handlers and other extension interfaces now provide context parameters such as `IMessageHandlerContext` or `IBusSession` which give access to the same functions that used to be available via the `IBus` interface.
 
 
 ## UnicastBus made internal
@@ -107,7 +96,7 @@ snippet:5to6HandlerOrderingWithCode
 
 ### Interface Changes
 
-Both the Start and Stop method now provide access to the message session via parameters. Instead of injecting an `IBus`, use the session parameter to access the methods that `IBus` previously provided.
+Both the Start and Stop method now provide the `IBusSession` parameter. Instead of injecting an `IBus`, use the session parameter to access the methods that `IBus` previously provided.
 
 snippet:5to6-IWantToRunWhenBusStartsAndStops
 
@@ -441,13 +430,6 @@ snippet: 5to6CriticalError
 snippet: ConvertEventToObservable
 
 
-### Delayed delivery error notifications
-
-In Versions 6 and above the `TimeoutManager` does not provide any error notifications. When an error occurs during processing of a deferred message by the `TimeoutManager`, the message will be retried and possibly moved to the error queue. The user will not be notified about these events.
-
-Note that in Versions 5 and below, when the user [subscribes to error notifications ](/nservicebus/errors/subscribing-to-error-notifications.md) they receive notification in the situation described above.
-
-
 ## Transaction configuration API
 
 Version 6 provide a configuration API that is more aligned with the transaction capabilities of the transport.
@@ -632,7 +614,7 @@ snippet: 5to6-MsmqSubscriptionAuthorizer
 
 ## Synchronous request-response (callbacks)
 
-The synchronous request-response feature, also known as callbacks, has been moved from the NServiceBus core to the separate Nuget package [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/). That package must be used in order to use the callback functionality in Version 6. 
+The synchronous request-response feature, also known as callbacks, has been moved from the NServiceBus core to the separate Nuget package [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/). That package must be used in order to use the callback functionality in Version 6.
 
 The API was also modified. Version 6 API is asynchronous by default and allows to easily access the response message. It is no longer possible to use callbacks inside handlers or sagas, because extension methods are only available on the message session. The differences in the API are fully covered in [handling responses on the client side](/nservicebus/messaging/handling-responses-on-the-client-side.md).
 
@@ -645,3 +627,9 @@ In Version 6 the callback routing is based on user-provided unique endpoint inst
 snippet: 5to6-Callbacks-InstanceId
 
 NOTE: This ID needs to be stable and should never be hardcoded, e.g. it can be read from the configuration file or from the environment (e.g. role ID in Azure).
+
+## Dependency injection
+
+Explicitly setting property values via `.ConfigureProperty<T>()` and `.InitializeHandlerProperty<T>()` has been deprecated. Instead configure the properties explicitly using:
+
+snippet: 5to6-ExplicitProperties


### PR DESCRIPTION
Adjust doco and upgrade guide to mention the removal of `.ConfigureProperty` and `.InitializeHandlerProperty`