### PR TITLE
Fix reference to gateway upgrade guide

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -5,7 +5,7 @@ tags:
  - upgrade
  - migration
 related:
-- nservicebus/upgrades/gateway-2to3
+- nservicebus/upgrades/gateway-1to2
 - nservicebus/upgrades/sqlserver-2to3
 ---
 


### PR DESCRIPTION
Renamed the upgrade guide file but missed reference from 5to6.md.

@Particular/docs-maintainers Please merge to make the build green again.