### PR TITLE
Adjust to renamed BusNotifications

### DIFF
--- a/Snippets/Snippets_6/Headers/Writers/HeaderWriterError.cs
+++ b/Snippets/Snippets_6/Headers/Writers/HeaderWriterError.cs
@@ -81,9 +81,9 @@
 
         class Mutator : IMutateIncomingTransportMessages
         {
-            public Mutator(Notifications busNotifications)
+            public Mutator(Notifications notifications)
             {
-                ErrorsNotifications errors = busNotifications.Errors;
+                ErrorsNotifications errors = notifications.Errors;
                 errors.MessageSentToErrorQueue += (sender, retry) =>
                 {
                     string headerText = HeaderWriter.ToFriendlyString<HeaderWriterError>(retry.Headers);

--- a/Snippets/Snippets_6/Notifications/EventsToObservables.cs
+++ b/Snippets/Snippets_6/Notifications/EventsToObservables.cs
@@ -1,7 +1,6 @@
-﻿using System;
-
-namespace Snippets6.BusNotifications
+﻿namespace Snippets6.Notifications
 {
+    using System;
     using System.Reactive;
     using System.Reactive.Linq;
     using NServiceBus;
@@ -10,13 +9,13 @@ namespace Snippets6.BusNotifications
 
     class EventsToObservables
     {
-        EventsToObservables(Notifications busNotifications, ILog log)
+        EventsToObservables(Notifications notifications, ILog log)
         {
             #region ConvertEventToObservable
 
             IObservable<EventPattern<FailedMessage>> failedMessages = Observable.FromEventPattern<EventHandler<FailedMessage>, FailedMessage>(
-                handler => busNotifications.Errors.MessageSentToErrorQueue += handler,
-                handler => busNotifications.Errors.MessageSentToErrorQueue -= handler);
+                handler => notifications.Errors.MessageSentToErrorQueue += handler,
+                handler => notifications.Errors.MessageSentToErrorQueue -= handler);
 
             IDisposable subscription = failedMessages
                 .Subscribe(x =>

--- a/Snippets/Snippets_6/Notifications/SubscribeToNotifications.cs
+++ b/Snippets/Snippets_6/Notifications/SubscribeToNotifications.cs
@@ -1,5 +1,5 @@
 ﻿// ReSharper disable UnusedParameter.Local
-namespace Snippets6.BusNotifications
+namespace Snippets6.Notifications
 {
     using System.Threading.Tasks;
     using NServiceBus;
@@ -11,17 +11,17 @@ namespace Snippets6.BusNotifications
     public class SubscribeToNotifications :
         IWantToRunWhenBusStartsAndStops
     {
-        Notifications busNotifications;
+        Notifications notifications;
         static ILog log = LogManager.GetLogger<SubscribeToNotifications>();
 
-        public SubscribeToNotifications(Notifications busNotifications)
+        public SubscribeToNotifications(Notifications notifications)
         {
-            this.busNotifications = busNotifications;
+            this.notifications = notifications;
         }
 
         public Task Start(IMessageSession session)
         {
-            ErrorsNotifications errors = busNotifications.Errors;
+            ErrorsNotifications errors = notifications.Errors;
             errors.MessageHasBeenSentToSecondLevelRetries += (sender, retry) => LogToConsole(retry);
             errors.MessageHasFailedAFirstLevelRetryAttempt += (sender, retry) => LogToConsole(retry);
             errors.MessageSentToErrorQueue += (sender, retry) => LogToConsole(retry);

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -288,8 +288,8 @@
     <Compile Include="Azure\Persistence\AzureStorage\Usage.cs" />
     <Compile Include="BasicUsageOfIBus.cs" />
     <Compile Include="BestPracticesConfiguration.cs" />
-    <Compile Include="BusNotifications\SubscribeToNotifications.cs" />
-    <Compile Include="BusNotifications\EventsToObservables.cs" />
+    <Compile Include="Notifications\SubscribeToNotifications.cs" />
+    <Compile Include="Notifications\EventsToObservables.cs" />
     <Compile Include="Callback\Cancellation\Message.cs" />
     <Compile Include="Callback\Cancellation\Usage.cs" />
     <Compile Include="Callback\Enum\Handler.cs" />

--- a/nservicebus/errors/subscribing-to-error-notifications.md
+++ b/nservicebus/errors/subscribing-to-error-notifications.md
@@ -17,7 +17,7 @@ Error notifications are available for several events.
 
 This API was added in Version 5.1.
 
-These event are exposed via the `BusNotifications` class that can be injected via DI.
+These event are exposed via the `BusNotifications` (NServiceBus Version 5) or `Notifications` (NServiceBus Version 6) class. This class can be injected using the [container](/nservicebus/containers).
 
 The following example shows how to be notified every time a message is sent to FLR, SLR or the error queue. While this code writes to the console any other action could be taken, for example sending an email or writing to a monitoring system.
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -436,7 +436,8 @@ snippet: 5to6CriticalError
 
 ## Notifications
 
-`BusNotifications` exposed the available notification hooks as observables implementing `IObservable`. This meant a custom `IObserver` and the use of [Reactive-Extensions](https://msdn.microsoft.com/en-au/data/gg577609.aspx) was required to use this API. In Version 6  notifications has been changed to expose regular events instead of observables for easier usage. Find out more about [subscribing to error notifications](/nservicebus/errors/subscribing-to-error-notifications.md). To continue using Reactive-Extensions the events API can be transformed into `IObservable`s like this:
+The `BusNotifications` class has been renamed to `Notifications`.
+`BusNotifications` exposed the available notification hooks as observables implementing `IObservable`. This meant a custom `IObserver` or the use of [Reactive-Extensions](https://msdn.microsoft.com/en-au/data/gg577609.aspx) was required to use this API. In Version 6 notifications have been changed to expose regular events instead of observables for easier usage. Find out more about [subscribing to error notifications](/nservicebus/errors/subscribing-to-error-notifications.md). To continue using Reactive-Extensions the events API can be transformed into `IObservable`s like this:
 
 snippet: ConvertEventToObservable
 
@@ -632,7 +633,7 @@ snippet: 5to6-MsmqSubscriptionAuthorizer
 
 ## Synchronous request-response (callbacks)
 
-The synchronous request-response feature, also known as callbacks, has been moved from the NServiceBus core to the separate Nuget package [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/). That package must be used in order to use the callback functionality in Version 6. 
+The synchronous request-response feature, also known as callbacks, has been moved from the NServiceBus core to the separate Nuget package [NServiceBus.Callbacks](https://www.nuget.org/packages/NServiceBus.Callbacks/). To use the callback functionality in Version 6, use this new package.
 
 The API was also modified. Version 6 API is asynchronous by default and allows to easily access the response message. It is no longer possible to use callbacks inside handlers or sagas, because extension methods are only available on the message session. The differences in the API are fully covered in [handling responses on the client side](/nservicebus/messaging/handling-responses-on-the-client-side.md).
 

--- a/samples/logging/notifications/Version_6/Sample/Sample.csproj
+++ b/samples/logging/notifications/Version_6/Sample/Sample.csproj
@@ -37,8 +37,9 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1705\lib\net452\NServiceBus.Core.dll</HintPath>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-unstable1725\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/samples/logging/notifications/Version_6/Sample/SubscribeToNotifications.cs
+++ b/samples/logging/notifications/Version_6/Sample/SubscribeToNotifications.cs
@@ -11,16 +11,16 @@ public class SubscribeToNotifications :
     IWantToRunWhenBusStartsAndStops
 {
     static ILog log = LogManager.GetLogger<SubscribeToNotifications>();
-    BusNotifications busNotifications;
+    Notifications notifications;
 
-    public SubscribeToNotifications(BusNotifications busNotifications)
+    public SubscribeToNotifications(Notifications notifications)
     {
-        this.busNotifications = busNotifications;
+        this.notifications = notifications;
     }
 
     public Task Start(IMessageSession session)
     {
-        ErrorsNotifications errors = busNotifications.Errors;
+        ErrorsNotifications errors = notifications.Errors;
         errors.MessageHasBeenSentToSecondLevelRetries += (sender, retry) => Log(retry);
         errors.MessageHasFailedAFirstLevelRetryAttempt += (sender, retry) => Log(retry);
         errors.MessageSentToErrorQueue += (sender, retry) => Log(retry);

--- a/samples/logging/notifications/Version_6/Sample/packages.config
+++ b/samples/logging/notifications/Version_6/Sample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-unstable1705" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1725" targetFramework="net452" />
 </packages>

--- a/samples/logging/notifications/sample.md
+++ b/samples/logging/notifications/sample.md
@@ -35,7 +35,7 @@ snippet: customSLR
 
 ## Plugging to the API
 
-The notifications API is exposed via the BusNotifications class that can be injected via DI.
+The notifications API is exposed via the `BusNotifications` (NServiceBus Version 5) or `Notifications` (NServiceBus Version 6) class. This class can be injected using the [container](/nservicebus/containers).
 
 snippet:subscriptions
 


### PR DESCRIPTION
Adjust docs, snippets and samples to renaming of `BusNotifications` to `Notifications`.