### PR TITLE
Some tweaks to the Move to 4.5.2 section

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -12,12 +12,11 @@ related:
 
 ## Move to .NET 4.5.2
 
-In Version 6 the new minimum .NET version for NServiceBus is .NET 4.5.2.
+The minimum .NET version for NServiceBus Version 6 is .NET 4.5.2.
 
-**This means consumers need to update all projects (that reference NServiceBus) to be .NET 4.5.2 before updating to NServiceBus Version 6.**
+**Users must update all projects (that reference NServiceBus) to .NET 4.5.2 before updating to NServiceBus Version 6.**
 
-In the interest of "smaller changes are easier to verify" it is recommended to update to .NET 4.5.2, and full migration to production, before updating to NServiceBus Version 6.
-
+In the interest of "smaller changes are easier to verify", it is recommended that you update to .NET 4.5.2 and perform a full migration to production _before_ updating to NServiceBus Version 6.
 
 ## [Endpoint](/nservicebus/endpoints/) Name is mandatory
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -16,7 +16,7 @@ The minimum .NET version for NServiceBus Version 6 is .NET 4.5.2.
 
 **Users must update all projects (that reference NServiceBus) to .NET 4.5.2 before updating to NServiceBus Version 6.**
 
-In the interest of "smaller changes are easier to verify", it is recommended that you update to .NET 4.5.2 and perform a full migration to production _before_ updating to NServiceBus Version 6.
+In the interest of "smaller changes are easier to verify", it is recommended to update to .NET 4.5.2 and perform a full migration to production _before_ updating to NServiceBus Version 6.
 
 ## [Endpoint](/nservicebus/endpoints/) Name is mandatory
 


### PR DESCRIPTION
This started with me fixing a typo in the original:

> In the interest of "smaller changes are easier to verify" it is recommended to update to .NET 4.5.2, and full migration to production, before updating to NServiceBus Version 6.

But I also felt the text in the rest of the section could be tightened up a bit.