### PR TITLE
Do not mention pulled 3.1.0 version any longer.

### DIFF
--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -94,7 +94,7 @@ DANGER: This is a potentially dangerous feature that can result in multiple inst
 
 #### Transaction recovery storage
 
-The RavenDB client requires a method of storing DTC transaction recovery information in the case of process faults. By default, NServiceBus uses `IsolatedStorageTransactionRecoveryStorage` as its transaction recovery storage. Under certain high-load situations, this has been known to result in a [TransactionAbortedException or IsolatedStorageException](https://groups.google.com/forum/#!msg/ravendb/4UHajkua5Q8/ZbsNYv6XkFoJ). If you are experiencing this issue you should change the storage to use `LocalDirectoryTransactionRecoveryStorage`.
+The RavenDB client requires a method of storing DTC transaction recovery information in the case of process faults. By default, NServiceBus uses `IsolatedStorageTransactionRecoveryStorage` as its transaction recovery storage. Under certain high-load situations, this has been known to result in a `TransactionAbortedException` or `IsolatedStorageException`. If these exceptions occur change to use [`LocalDirectoryTransactionRecoveryStorage`](http://ravendb.net/docs/search/latest/csharp?searchTerm=LocalDirectoryTransactionRecoveryStorage).
 
 The default `TransactionRecoveryStorage` can be changed as shown in the following example.
 

--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -94,19 +94,9 @@ DANGER: This is a potentially dangerous feature that can result in multiple inst
 
 #### Transaction recovery storage
 
-The RavenDB client requires a method of storing DTC transaction recovery information in the case of process faults. The handling of transaction recovery storage by NServiceBus.RavenDB differs by version.
+The RavenDB client requires a method of storing DTC transaction recovery information in the case of process faults. By default, NServiceBus uses `IsolatedStorageTransactionRecoveryStorage` as its transaction recovery storage. Under certain high-load situations, this has been known to result in a [TransactionAbortedException or IsolatedStorageException](https://groups.google.com/forum/#!msg/ravendb/4UHajkua5Q8/ZbsNYv6XkFoJ). If you are experiencing this issue you should change the storage to use `LocalDirectoryTransactionRecoveryStorage`.
 
-
-##### NServiceBus.RavenDB 3.1 to 4.x
-
-As of 3.1.0, NServiceBus uses `LocalDirectoryTransactionRecoveryStorage` with a storage location inside `%LOCALAPPDATA%`. It is not necessary to modify this default value.
-
-
-##### NServiceBus.RavenDB 3.0.x and below
-
-These versions of NServiceBus use `IsolatedStorageTransactionRecoveryStorage` as its transaction recovery storage, which has been proven to be unstable in certain situations, sometimes resulting in a [TransactionAbortedException or IsolatedStorageException](https://groups.google.com/forum/#!msg/ravendb/4UHajkua5Q8/ZbsNYv6XkFoJ).
-
-If experiencing one of these issues and an upgrade to 3.1.0 or later is not possible, the default `TransactionRecoveryStorage` can be changed as shown in the following example.
+The default `TransactionRecoveryStorage` can be changed as shown in the following example.
 
 snippet:ConfiguringTransactionRecoveryStorage
 

--- a/nservicebus/ravendb/resourcemanagerid.md
+++ b/nservicebus/ravendb/resourcemanagerid.md
@@ -6,8 +6,6 @@ redirects:
  - nservicebus/ravendb/how-to-change-resourcemanagerid
 ---
 
-WARNING: As of NServiceBus.RavenDB 3.1.0 the RavenDB ResourceManagerId is automatically set to an appropriate value, unique between all endpoints on an individual server, based on a hash of the endpoint's local address and endpoint version. It should not be necessary to manually set this value. All customers are encouraged to upgrade to at least NServiceBus.RavenDB 3.1.0 or higher. This article remains for legacy purposes only.
-
 When using RavenDB in an environment where you are relying also on distributed transactions it can happen that a commit operation fails with the following error:
 
 > "A resource manager with the same identifier is already registered with the specified transaction coordinator"


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#697

NSB.Raven 3.1.0 was pulled, this brings docs back in line with what is currently released and for the upcoming 3.0.7 hotfix.

Snippets still do not reflect V6. That is out of scope for this PR and will come later, especially considering Particular/PlatformDevelopment#686 which may change things a bit.