### PR TITLE
Replacing SDK reference with nuget package

### DIFF
--- a/samples/azure/shared-host/Version_7/HostCloudService/HostCloudService.ccproj
+++ b/samples/azure/shared-host/Version_7/HostCloudService/HostCloudService.ccproj
@@ -60,5 +60,6 @@
     <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.7\</CloudExtensionsDir>
   </PropertyGroup>
   <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets"  Condition="Exists('$(CloudExtensionsDir)Microsoft.WindowsAzure.targets')"/>
-  <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets" />
+  <Target Name="Build"  Condition="!Exists('$(CloudExtensionsDir)Microsoft.WindowsAzure.targets')">
+  </Target>
 </Project>

--- a/samples/azure/shared-host/Version_7/HostCloudService/HostCloudService.ccproj
+++ b/samples/azure/shared-host/Version_7/HostCloudService/HostCloudService.ccproj
@@ -59,5 +59,6 @@
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">14.0</VisualStudioVersion>
     <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.7\</CloudExtensionsDir>
   </PropertyGroup>
+  <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets"  Condition="Exists('$(CloudExtensionsDir)Microsoft.WindowsAzure.targets')"/>
   <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets" />
 </Project>

--- a/samples/azure/shared-host/Version_7/HostWorker/HostWorker.csproj
+++ b/samples/azure/shared-host/Version_7/HostWorker/HostWorker.csproj
@@ -60,7 +60,10 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Unofficial.Microsoft.WindowsAzure.Diagnostics.2.7.0.0\lib\net40\Microsoft.WindowsAzure.Diagnostics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.7.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
       <Private>True</Private>

--- a/samples/azure/shared-host/Version_7/HostWorker/packages.config
+++ b/samples/azure/shared-host/Version_7/HostWorker/packages.config
@@ -9,6 +9,7 @@
   <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
   <package id="NServiceBus.Hosting.Azure" version="7.0.0-unstable0034" targetFramework="net452" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.Diagnostics" version="2.7.0.0" targetFramework="net452" />
   <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.7.0.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net452" />
 </packages>

--- a/samples/azure/shared-host/Version_7/Receiver/Receiver.csproj
+++ b/samples/azure/shared-host/Version_7/Receiver/Receiver.csproj
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.0.0-unstable0070\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.0.0-unstable0103\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AzureStoragePersistence, Version=0.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">

--- a/samples/azure/shared-host/Version_7/Receiver/packages.config
+++ b/samples/azure/shared-host/Version_7/Receiver/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
-  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.0.0-unstable0070" targetFramework="net452" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.0.0-unstable0103" targetFramework="net452" />
   <package id="NServiceBus.AzureStoragePersistence" version="0.2.0-unstable0120" targetFramework="net452" />
   <package id="NServiceBus.Hosting.Azure" version="7.0.0-unstable0034" targetFramework="net452" />
   <package id="NServiceBus.Hosting.Azure.HostProcess" version="7.0.0-unstable0034" targetFramework="net452" />

--- a/samples/azure/shared-host/Version_7/Sender/Sender.csproj
+++ b/samples/azure/shared-host/Version_7/Sender/Sender.csproj
@@ -55,8 +55,9 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\..\..\..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -70,7 +71,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.0.0-unstable0070\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.0.0-unstable0103\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AzureStoragePersistence, Version=0.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">

--- a/samples/azure/shared-host/Version_7/Sender/packages.config
+++ b/samples/azure/shared-host/Version_7/Sender/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
@@ -8,7 +8,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
-  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.0.0-unstable0070" targetFramework="net452" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.0.0-unstable0103" targetFramework="net452" />
   <package id="NServiceBus.AzureStoragePersistence" version="0.2.0-unstable0120" targetFramework="net452" />
   <package id="NServiceBus.Hosting.Azure" version="7.0.0-unstable0034" targetFramework="net452" />
   <package id="NServiceBus.Hosting.Azure.HostProcess" version="7.0.0-unstable0034" targetFramework="net452" />


### PR DESCRIPTION
Package: Unofficial.Microsoft.WindosAzure.Diagnostics

Note: ASQ transport is currently breaking due to unimplemented interface
```
System.TypeLoadException: Method 'Initialize' in type 'NServiceBus.AzureStorageQueueTransport' from assembly 'NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c' does not have an implementation.
```

/cc @SimonCropp