### PR TITLE
Satellite migration doco

### DIFF
--- a/Snippets/Snippets_5/Features/AdvancedSatellite.cs
+++ b/Snippets/Snippets_5/Features/AdvancedSatellite.cs
@@ -15,42 +15,46 @@
 
         public void Start()
         {
-            
+
         }
 
         public void Stop()
         {
-            
+
         }
 
         public Address InputAddress { get; private set; }
         public bool Disabled { get; private set; }
 
         #region AdvancedSatelliteReceiverCustomization
+
         public Action<TransportReceiver> GetReceiverCustomization()
         {
-            // Customize the Failure Manager. 
+            // Customize the Failure Manager.
             satelliteImportFailuresHandler = new SatelliteImportFailuresHandler();
             return receiver => { receiver.FailureManager = satelliteImportFailuresHandler; };
         }
+
         SatelliteImportFailuresHandler satelliteImportFailuresHandler;
+
         #endregion
+
+        class SatelliteImportFailuresHandler : IManageMessageFailures
+        {
+            public void SerializationFailedForMessage(TransportMessage message, Exception e)
+            {
+                Console.WriteLine("Handle stuff for Serialization failure");
+            }
+
+            public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+            {
+                Console.WriteLine("Handle stuff for Processing failures");
+            }
+
+            public void Init(Address address)
+            {
+            }
+        }
     }
 
-    internal class SatelliteImportFailuresHandler : IManageMessageFailures
-    {
-        public void SerializationFailedForMessage(TransportMessage message, Exception e)
-        {
-            Console.WriteLine("Handle stuff for Serialization failure");
-        }
-
-        public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
-        {
-            Console.WriteLine("Handle stuff for Processing failures");
-        }
-
-        public void Init(Address address)
-        {
-        }
-    }
 }

--- a/Snippets/Snippets_5/Features/AdvancedSatellite.cs
+++ b/Snippets/Snippets_5/Features/AdvancedSatellite.cs
@@ -1,0 +1,56 @@
+﻿namespace Snippets5.Features
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.Faults;
+    using NServiceBus.Satellites;
+    using NServiceBus.Unicast.Transport;
+
+    class AdvancedSatellite : IAdvancedSatellite
+    {
+        public bool Handle(TransportMessage message)
+        {
+            return true;
+        }
+
+        public void Start()
+        {
+            
+        }
+
+        public void Stop()
+        {
+            
+        }
+
+        public Address InputAddress { get; private set; }
+        public bool Disabled { get; private set; }
+
+        #region AdvancedSatelliteReceiverCustomization
+        public Action<TransportReceiver> GetReceiverCustomization()
+        {
+            // Customize the Failure Manager. 
+            satelliteImportFailuresHandler = new SatelliteImportFailuresHandler();
+            return receiver => { receiver.FailureManager = satelliteImportFailuresHandler; };
+        }
+        SatelliteImportFailuresHandler satelliteImportFailuresHandler;
+        #endregion
+    }
+
+    internal class SatelliteImportFailuresHandler : IManageMessageFailures
+    {
+        public void SerializationFailedForMessage(TransportMessage message, Exception e)
+        {
+            Console.WriteLine("Handle stuff for Serialization failure");
+        }
+
+        public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+        {
+            Console.WriteLine("Handle stuff for Processing failures");
+        }
+
+        public void Init(Address address)
+        {
+        }
+    }
+}

--- a/Snippets/Snippets_5/Features/SimpleSatellite.cs
+++ b/Snippets/Snippets_5/Features/SimpleSatellite.cs
@@ -15,12 +15,10 @@
 
         public void Start()
         {
-            // Any startup actions
         }
 
         public void Stop()
         {
-            // Any cleanup actions
         }
 
         #region SimpleSatelliteSetup

--- a/Snippets/Snippets_5/Features/SimpleSatellite.cs
+++ b/Snippets/Snippets_5/Features/SimpleSatellite.cs
@@ -1,0 +1,38 @@
+﻿namespace Snippets5.Features
+{
+    using NServiceBus;
+    using NServiceBus.Satellites;
+
+    public class SimpleSatellite : ISatellite
+    {
+        #region SimpleSatelliteHandleMessages
+        public bool Handle(TransportMessage message)
+        {
+            // Implementation of what should occur when the message is received
+            return true;
+        }
+        #endregion
+
+        public void Start()
+        {
+            // Any startup actions
+        }
+
+        public void Stop()
+        {
+            // Any cleanup actions
+        }
+
+        #region SimpleSatelliteSetup
+        public Address InputAddress
+        {
+            get { return Address.Parse("targetqueue"); }
+        }
+
+        public bool Disabled
+        {
+            get { return false; }
+        }
+        #endregion
+    }
+}

--- a/Snippets/Snippets_5/Snippets_5.csproj
+++ b/Snippets/Snippets_5/Snippets_5.csproj
@@ -386,6 +386,8 @@
     <Compile Include="Azure\Transports\AzureServiceBus\NamingConventionsUsage.cs" />
     <Compile Include="Azure\Transports\AzureStorageQueues\Usage.cs" />
     <Compile Include="BasicUsageOfIBus.cs" />
+    <Compile Include="Features\AdvancedSatellite.cs" />
+    <Compile Include="Features\SimpleSatellite.cs" />
     <Compile Include="Host_6\UpgradeGuides\6to7\CustomizingHost.cs" />
     <Compile Include="Notifications\SubscribeToNotifications.cs" />
     <Compile Include="Callback\Enum\Handler.cs" />

--- a/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
+++ b/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
@@ -18,11 +18,9 @@
         protected override void Setup(FeatureConfigurationContext context)
         {
             PipelineSettings satelliteMessagePipeline = context.AddSatellitePipeline("CustomSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
-
             // register the critical error
             satelliteMessagePipeline.Register("Satellite Identifier", b => new MyAdvancedSatelliteBehavior(b.Build<CriticalError>()),
                     "Description of what the advanced satellite does");
-
         }
         #endregion
     }
@@ -30,16 +28,17 @@
     #region AdvancedSatelliteBehavior
     class MyAdvancedSatelliteBehavior : PipelineTerminator<ISatelliteProcessingContext>
     {
-        CriticalError CriticalError { get; set; }
-        public MyAdvancedSatelliteBehavior(CriticalError CriticalError)
+        CriticalError criticalError;
+
+        public MyAdvancedSatelliteBehavior(CriticalError criticalError)
         {
-            this.CriticalError = CriticalError;
+            this.criticalError = criticalError;
         }
 
         protected override Task Terminate(ISatelliteProcessingContext context)
         {
             // To raise a critical error
-            CriticalError.Raise("Something bad happened - trigger critical error", new Exception("CriticalError occured!!"));
+            criticalError.Raise("Something bad happened - trigger critical error", new Exception("CriticalError occured!!"));
             return Task.FromResult(true);
         }
     }

--- a/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
+++ b/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
@@ -1,0 +1,47 @@
+﻿namespace Snippets6.Features
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Features;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Transports;
+
+    public class MyAdvancedSatelliteFeature : Feature
+    {
+        public MyAdvancedSatelliteFeature()
+        {
+            EnableByDefault();
+        }
+
+        #region AdvancedSatelliteFeatureSetup
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            PipelineSettings messageProcessorPipeline = context.AddSatellitePipeline("AdvancedSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
+            
+            // register the critical error
+            messageProcessorPipeline.Register("AdvancedSatellite", b => new MyAdvancedSatelliteBehavior(b.Build<CriticalError>()),
+                    "Description of what the advanced satellite does");
+
+        }
+        #endregion
+    }
+
+    #region AdvancedSatelliteBehavior
+    class MyAdvancedSatelliteBehavior : PipelineTerminator<ISatelliteProcessingContext>
+    {
+        CriticalError CriticalError { get; set; }
+        public MyAdvancedSatelliteBehavior(CriticalError CriticalError)
+        {
+            this.CriticalError = CriticalError;
+        }
+
+        protected override Task Terminate(ISatelliteProcessingContext context)
+        {
+            // To raise a critical error
+            CriticalError.Raise("Something bad happened - trigger critical error", new Exception("CriticalError occured!!"));
+            return Task.FromResult(true);
+        }
+    }
+    #endregion
+}

--- a/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
+++ b/Snippets/Snippets_6/Features/AdvancedSatelliteFeature.cs
@@ -17,10 +17,10 @@
         #region AdvancedSatelliteFeatureSetup
         protected override void Setup(FeatureConfigurationContext context)
         {
-            PipelineSettings messageProcessorPipeline = context.AddSatellitePipeline("AdvancedSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
-            
+            PipelineSettings satelliteMessagePipeline = context.AddSatellitePipeline("CustomSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
+
             // register the critical error
-            messageProcessorPipeline.Register("AdvancedSatellite", b => new MyAdvancedSatelliteBehavior(b.Build<CriticalError>()),
+            satelliteMessagePipeline.Register("Satellite Identifier", b => new MyAdvancedSatelliteBehavior(b.Build<CriticalError>()),
                     "Description of what the advanced satellite does");
 
         }

--- a/Snippets/Snippets_6/Features/SatelliteFeature.cs
+++ b/Snippets/Snippets_6/Features/SatelliteFeature.cs
@@ -1,0 +1,37 @@
+﻿namespace Snippets6.Features
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Features;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Transports;
+
+    public class MySatelliteFeature : Feature
+    {
+
+        public MySatelliteFeature()
+        {
+            EnableByDefault();
+        }
+
+        #region SatelliteFeatureSetup
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            PipelineSettings messageProcessorPipeline = context.AddSatellitePipeline("CustomSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
+            messageProcessorPipeline.Register("CustomSatellite", new MySatelliteBehavior(), "Description of what the satellite does");
+        }
+        #endregion
+    }
+
+    #region SatelliteBehavior
+    class MySatelliteBehavior : PipelineTerminator<ISatelliteProcessingContext>
+    {
+        protected override Task Terminate(ISatelliteProcessingContext context)
+        {
+            // Implement what this satellite needs to do once it receives a message
+            IncomingMessage message = context.Message;
+            return Task.FromResult(true);
+        }
+    }
+    #endregion
+}

--- a/Snippets/Snippets_6/Features/SatelliteFeature.cs
+++ b/Snippets/Snippets_6/Features/SatelliteFeature.cs
@@ -6,22 +6,20 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
+    #region SimpleSatelliteFeature
     public class MySatelliteFeature : Feature
     {
-
         public MySatelliteFeature()
         {
             EnableByDefault();
         }
-
-        #region SatelliteFeatureSetup
         protected override void Setup(FeatureConfigurationContext context)
         {
-            PipelineSettings messageProcessorPipeline = context.AddSatellitePipeline("CustomSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
-            messageProcessorPipeline.Register("CustomSatellite", new MySatelliteBehavior(), "Description of what the satellite does");
+            PipelineSettings satelliteMessagePipeline = context.AddSatellitePipeline("CustomSatellite", TransportTransactionMode.TransactionScope, PushRuntimeSettings.Default, "targetQueue");
+            satelliteMessagePipeline.Register("Satellite Identifier", new MySatelliteBehavior(), "Description of what the satellite does");
         }
-        #endregion
     }
+    #endregion
 
     #region SatelliteBehavior
     class MySatelliteBehavior : PipelineTerminator<ISatelliteProcessingContext>

--- a/Snippets/Snippets_6/Snippets_6.csproj
+++ b/Snippets/Snippets_6/Snippets_6.csproj
@@ -292,6 +292,8 @@
     <Compile Include="Azure\Transports\AzureStorageQueues\Usage.cs" />
     <Compile Include="BasicUsageOfIBus.cs" />
     <Compile Include="BestPracticesConfiguration.cs" />
+    <Compile Include="Features\AdvancedSatelliteFeature.cs" />
+    <Compile Include="Features\SatelliteFeature.cs" />
     <Compile Include="Host_7\UpgradeGuides\6to7\CustomizingHost.cs" />
     <Compile Include="Injection\Injection.cs" />
     <Compile Include="Lifecycle\EndpointStartAndStop.cs" />

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -7,6 +7,26 @@ related:
 redirects:
 ---
 
+
+## Versions 6 and above
+
+In Versions 6 and above, both the `ISatellite` and the `IAdvancedSatellite` interfaces are deprecated. The same functionality is available by using the message processing pipeline `Feature`.
+
+To get the same behavior as the `ISatellite` or `IAdvancedSatellite` extension, create a new pipeline feature and enable it. See also [Feature API documentation](/nservicebus/pipeline/features.md#feature-api).
+
+snippet: SimpleSatelliteFeature
+
+The call to `AddSatellitePipeline` in the `Setup` method creates a new message processing pipeline for the satellite. In this call, the queue that needs to be watched is configured. In the above example, the satellite will watch a queue named `targetqueue`.
+
+The action of what should occur when the messages arrive at the `targetqueue` is specified as a new `Behavior`. See also [Create pipeline behaviors](/nservicebus/pipeline/customizing-v6.md).
+
+The satellite behavior class should inherit from **`PipelineTerminator<ISatelliteProcessingContext>`**. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue.
+
+snippet: SatelliteBehavior
+
+The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue. If migrating from a Satellite extension from Versions 5 and below, the implementation steps that were in the `Handle` method would go into the `Terminate` method.
+
+
 ## Versions 5 and below
 
 In NServiceBus Versions 5 and below, Satellites are extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point is useful when the robustness of a separate queue is needed without having to create and setup a new endpoint and configure any message mappings.
@@ -16,11 +36,11 @@ These extensions are available as `ISatellite` and `IAdvancedSatellite` interfac
 
 ### ISatellite
 
-To use this extension, declare a class that implements the `ISatellite` interface. Specify values for the `InputAddress` and enable it as shown. The `InputAddress` is the queue that the satellite watches for messages. 
+To use this extension, declare a class that implements the `ISatellite` interface. Specify values for the `InputAddress` and enable it as shown. The `InputAddress` is the queue that the satellite watches for messages.
 
 snippet:SimpleSatelliteSetup
 
-When messages are received in the queue specified as the `InputAddress`, the satellite's `Handle` method will be invoked. 
+When messages are received in the queue specified as the `InputAddress`, the satellite's `Handle` method will be invoked.
 
 snippet:SimpleSatelliteHandleMessages
 
@@ -31,34 +51,15 @@ To use this extension, declare a class that implements the `IAdvancedSatellite` 
 
 snippet: AdvancedSatelliteReceiverCustomization
 
-In the above example, the `SatelliteImportFailuresHandler` is a custom error handling routine that implements the `IManageMessageFailures` extension. 
-
-
-## Versions 6 and above
-
-In Versions 6 and above, both the `ISatellite` and the `IAdvancedSatellite` interfaces are deprecated. The same functionality is available by using the core message processing pipeline `Feature`. 
-
-To get the same behavior as the `ISatellite` or `IAdvancedSatellite` extension, create a new pipeline feature and enable it. For more information on how to create and enable a feature, read the [Feature API documentation](/nservicebus/pipeline/features.md#feature-api).
-
-snippet: SimpleSatelliteFeature
-
-The call to `AddSatellitePipeline` in the `Setup` method creates a new message processing pipeline for the satellite. In this call, the queue that needs to be watched is configured. In the above example, the satellite will watch a queue named `targetqueue`.
-
-The action of what should occur when the messages arrive at the `targetqueue` is specified as a new `Behavior`. Read this article for more information on how to [create pipeline behaviors](/nservicebus/pipeline/customizing-v6.md).
-
-The satellite behavior class should inherit from **`PipelineTerminator<ISatelliteProcessingContext>`**. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue.
-
-snippet: SatelliteBehavior
-
-The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue. If migrating from a Satellite extension from Versions 5 and below, the implementation steps that were in the `Handle` method would go into the `Terminate` method.
+In the above example, the `SatelliteImportFailuresHandler` is a custom error handling routine that implements the `IManageMessageFailures` extension.
 
 
 ## Injecting CriticalError
 
-In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue by implementing the `GetReceiverCustomization()` method. For example, critical error processing or error handling customization, etc. However, In Versions 6 and above, the same can be achieved by the message pipeline as explained in the previous section. Additional attributes like the endpoint's `CriticalError` can be passed in as part of the pipeline's registration step. The endpoint can also be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior. 
+In Versions 6 and above, the message processing pipeline can handle more advanced scenarios. Some examples are outlined in [NServiceBus Pipeline Samples](/samples/pipeline/) for further details.
+
+In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue by implementing the `GetReceiverCustomization()` method. For example, critical error processing or error handling customization, etc. However, In Versions 6 and above, the same can be achieved by the message pipeline as explained in the previous section. Additional attributes like the endpoint's `CriticalError` can be passed in as part of the pipeline's registration step. The endpoint can also be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior.
 
 snippet: AdvancedSatelliteFeatureSetup
- 
-snippet: AdvancedSatelliteBehavior
 
-In Versions 6 and above, the message processing pipeline can handle more advanced scenarios. Some examples are outlined in [NServiceBus Pipeline Samples](/samples/pipeline/) for further details.
+snippet: AdvancedSatelliteBehavior

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -1,0 +1,50 @@
+---
+title: Migrating Satellites
+summary: Extension point for handling messages
+tags: 
+related:
+ - nservicebus/pipeline/customizing-v6
+ - nservicebus/pipeline/features
+redirects:
+---
+
+In NServiceBus Versions 5 and below, Satellites were extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point came in handy when the robustness of a separate queue was needed without having to create and setup a brand new Endpoint and configure any needed message mappings.
+
+These extensions were available via the `ISatellite` and `IAdvancedSatellite` interfaces.
+
+Starting from Versions 6 and above, these interfaces are no longer available. However, the same functionality can be achieved using the more advanced `Feature` extension. 
+
+
+## Migrating ISatellite and IAdvancedSatellite to Pipeline Features
+
+In Versions 6 and above, to get the satellite processing behavior, create a new feature. For more details, please read this article [to create a new feature and enabling it](/nservicebus/pipeline/features.md#feature-api).
+
+
+### Configuring the Satellite feature
+
+Once the feature is created, it needs to be configured using a message pipeline behavior.
+
+In the example below, the satellite input queue is called "targetqueue." 
+       
+snippet: SatelliteFeatureSetup
+
+The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. This class handles the steps of what should occur when a message arrives in the satellite queue. 
+
+snippet: SatelliteBehavior
+
+The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue. 
+
+
+## Injecting CriticalError
+
+In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue. For example, critical error processing. 
+
+The endpoint's `CriticalError` action can be passed into the Satellite Behavior.
+
+snippet: AdvancedSatelliteFeatureSetup
+
+As part of the receiving strategy, the endpoint could be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior. 
+ 
+snippet: AdvancedSatelliteBehavior
+
+The NServiceBus message processing pipeline has been enhanced to handle more advanced scenarios. For more information, please read the article on [NServiceBus Pipeline In Versions 6 and above](/nservicebus/pipeline/customizing-v6.md).

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -1,50 +1,49 @@
 ---
 title: Migrating Satellites
-summary: Extension point for handling messages
-tags: 
+summary: Extension point for handling messages 
 related:
  - nservicebus/pipeline/customizing-v6
  - nservicebus/pipeline/features
 redirects:
 ---
 
-In NServiceBus Versions 5 and below, Satellites were extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point came in handy when the robustness of a separate queue was needed without having to create and setup a brand new Endpoint and configure any needed message mappings.
+In NServiceBus Versions 5 and below, Satellites are extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point was useful when the robustness of a separate queue was needed without having to create and setup a new Endpoint and configure any message mappings.
 
-These extensions were available via the `ISatellite` and `IAdvancedSatellite` interfaces.
+In Versions this extension is available via the `ISatellite` and `IAdvancedSatellite` interfaces.
 
-Starting from Versions 6 and above, these interfaces are no longer available. However, the same functionality can be achieved using the more advanced `Feature` extension. 
+In Versions 6 and above, these interfaces are not available. However, the same functionality is avaliable via the `Feature` API.
 
 
 ## Migrating ISatellite and IAdvancedSatellite to Pipeline Features
 
-In Versions 6 and above, to get the satellite processing behavior, create a new feature. For more details, please read this article [to create a new feature and enabling it](/nservicebus/pipeline/features.md#feature-api).
+In Versions 6 and above, to get the satellite processing behavior, create a new feature. See also [Creating a new feature and enabling it](/nservicebus/pipeline/features.md#feature-api).
 
 
 ### Configuring the Satellite feature
 
 Once the feature is created, it needs to be configured using a message pipeline behavior.
 
-In the example below, the satellite input queue is called "targetqueue." 
-       
+In the example below, the satellite input queue is called "targetqueue".
+
 snippet: SatelliteFeatureSetup
 
-The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue. 
+The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue.
 
 snippet: SatelliteBehavior
 
-The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue. 
+The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue.
 
 
 ## Injecting CriticalError
 
-In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue. For example, critical error processing. 
+In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue. For example, critical error processing.
 
 The endpoint's `CriticalError` action can be passed into the Satellite Behavior.
 
 snippet: AdvancedSatelliteFeatureSetup
 
-As part of the receiving strategy, the endpoint could be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior. 
+As part of the receiving strategy, the endpoint can be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior.
  
 snippet: AdvancedSatelliteBehavior
 
-The NServiceBus message processing pipeline has been enhanced to handle more advanced scenarios. For more information, please read the article on [NServiceBus Pipeline In Versions 6 and above](/nservicebus/pipeline/customizing-v6.md).
+The NServiceBus message processing pipeline can handle more advanced scenarios. See also [NServiceBus Pipeline In Versions 6 and above](/nservicebus/pipeline/customizing-v6.md).

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -61,4 +61,4 @@ snippet: AdvancedSatelliteFeatureSetup
  
 snippet: AdvancedSatelliteBehavior
 
-In Version 6 and above, the message processing pipeline can handle more advanced scenarios. Some examples are outlined in [NServiceBus Pipeline Samples](/samples/pipeline/) for further details.
+In Versions 6 and above, the message processing pipeline can handle more advanced scenarios. Some examples are outlined in [NServiceBus Pipeline Samples](/samples/pipeline/) for further details.

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -28,7 +28,7 @@ In the example below, the satellite input queue is called "targetqueue."
        
 snippet: SatelliteFeatureSetup
 
-The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. This class handles the steps of what should occur when a message arrives in the satellite queue. 
+The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue. 
 
 snippet: SatelliteBehavior
 

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -1,10 +1,10 @@
 ---
 title: Migrating Satellites
-summary: Extension point for handling messages 
+summary: Extension point for handling messages.
+reviewed: 2016-04-11
 related:
  - nservicebus/pipeline/customizing-v6
  - nservicebus/pipeline/features
-redirects:
 ---
 
 

--- a/nservicebus/pipeline/satellites.md
+++ b/nservicebus/pipeline/satellites.md
@@ -7,43 +7,58 @@ related:
 redirects:
 ---
 
-In NServiceBus Versions 5 and below, Satellites are extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point was useful when the robustness of a separate queue was needed without having to create and setup a new Endpoint and configure any message mappings.
+## Versions 5 and below
 
-In Versions this extension is available via the `ISatellite` and `IAdvancedSatellite` interfaces.
+In NServiceBus Versions 5 and below, Satellites are extension points to handle messages that arrive in different queues other than the endpoint's main queue. This extension point is useful when the robustness of a separate queue is needed without having to create and setup a new endpoint and configure any message mappings.
 
-In Versions 6 and above, these interfaces are not available. However, the same functionality is avaliable via the `Feature` API.
-
-
-## Migrating ISatellite and IAdvancedSatellite to Pipeline Features
-
-In Versions 6 and above, to get the satellite processing behavior, create a new feature. See also [Creating a new feature and enabling it](/nservicebus/pipeline/features.md#feature-api).
+These extensions are available as `ISatellite` and `IAdvancedSatellite` interfaces.
 
 
-### Configuring the Satellite feature
+### ISatellite
 
-Once the feature is created, it needs to be configured using a message pipeline behavior.
+To use this extension, declare a class that implements the `ISatellite` interface. Specify values for the `InputAddress` and enable it as shown. The `InputAddress` is the queue that the satellite watches for messages. 
 
-In the example below, the satellite input queue is called "targetqueue".
+snippet:SimpleSatelliteSetup
 
-snippet: SatelliteFeatureSetup
+When messages are received in the queue specified as the `InputAddress`, the satellite's `Handle` method will be invoked. 
 
-The satellite behavior class should inherit from `PipelineTerminator<ISatelliteProcessingContext>`. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue.
+snippet:SimpleSatelliteHandleMessages
+
+
+### IAdvancedSatellite
+
+To use this extension, declare a class that implements the `IAdvancedSatellite` interface. The `IAdvancedSatellite` offers additional customization. For example, as part of the receiving strategy, a custom error handling routine can be specified when there is a message processing error.
+
+snippet: AdvancedSatelliteReceiverCustomization
+
+In the above example, the `SatelliteImportFailuresHandler` is a custom error handling routine that implements the `IManageMessageFailures` extension. 
+
+
+## Versions 6 and above
+
+In Versions 6 and above, both the `ISatellite` and the `IAdvancedSatellite` interfaces are deprecated. The same functionality is available by using the core message processing pipeline `Feature`. 
+
+To get the same behavior as the `ISatellite` or `IAdvancedSatellite` extension, create a new pipeline feature and enable it. For more information on how to create and enable a feature, read the [Feature API documentation](/nservicebus/pipeline/features.md#feature-api).
+
+snippet: SimpleSatelliteFeature
+
+The call to `AddSatellitePipeline` in the `Setup` method creates a new message processing pipeline for the satellite. In this call, the queue that needs to be watched is configured. In the above example, the satellite will watch a queue named `targetqueue`.
+
+The action of what should occur when the messages arrive at the `targetqueue` is specified as a new `Behavior`. Read this article for more information on how to [create pipeline behaviors](/nservicebus/pipeline/customizing-v6.md).
+
+The satellite behavior class should inherit from **`PipelineTerminator<ISatelliteProcessingContext>`**. The `ISatelliteProcessingContext` provides the Terminate method where post-processing steps are run when a message arrives in the satellite queue.
 
 snippet: SatelliteBehavior
 
-The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue.
+The `ISatelliteProcessingContext` parameter provides necessary details about the message such as the message body, headers, and other needed information about the message that arrived in the queue. If migrating from a Satellite extension from Versions 5 and below, the implementation steps that were in the `Handle` method would go into the `Terminate` method.
 
 
 ## Injecting CriticalError
 
-In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue. For example, critical error processing.
-
-The endpoint's `CriticalError` action can be passed into the Satellite Behavior.
+In Versions 5 and below, the `IAdvancedSatellite` offered additional customization when receiving messages in the satellite queue by implementing the `GetReceiverCustomization()` method. For example, critical error processing or error handling customization, etc. However, In Versions 6 and above, the same can be achieved by the message pipeline as explained in the previous section. Additional attributes like the endpoint's `CriticalError` can be passed in as part of the pipeline's registration step. The endpoint can also be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior. 
 
 snippet: AdvancedSatelliteFeatureSetup
-
-As part of the receiving strategy, the endpoint can be instructed to shutdown if a critical error occurs during the processing of a message inside the satellite behavior.
  
 snippet: AdvancedSatelliteBehavior
 
-The NServiceBus message processing pipeline can handle more advanced scenarios. See also [NServiceBus Pipeline In Versions 6 and above](/nservicebus/pipeline/customizing-v6.md).
+In Version 6 and above, the message processing pipeline can handle more advanced scenarios. Some examples are outlined in [NServiceBus Pipeline Samples](/samples/pipeline/) for further details.

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -131,7 +131,7 @@ See the upgrade guide for more details on [using the new interface](/nservicebus
 
 ## ISatellite and IAdvancedSatellite interfaces are obsolete
 
-The Satellite extension points are now obsolete. The same functionality of a satellite can be achieved by using the more advanced message processing pipeline by implementing a `Feature`. For more details, read this article on [migrating Satellites](/nservicebus/pipeline/satellites.md).
+The [Satellite extension points](/nservicebus/pipeline/satellites.md) are now obsolete. The same functionality of a satellite can be achieved by using the more advanced message processing pipeline by implementing a `Feature`.
 
 
 ## Header management
@@ -141,7 +141,7 @@ The Satellite extension points are now obsolete. The same functionality of a sat
 
 Headers are now set using the new `Send`/`Reply` or `Publish` options. `Bus.SetMessageHeader` is no longer available.
 
-See [Header Manipulation](/nservicebus/messaging/header-manipulation.md) for more information.
+See also [Header Manipulation](/nservicebus/messaging/header-manipulation.md).
 
 
 ### Setting outgoing headers for the entire endpoint

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -129,6 +129,11 @@ See the upgrade guide for more details on [using the new interface](/nservicebus
 See the upgrade guide for more details on [using the new interface](/nservicebus/upgrades/acs-host-6to7.md) provided by the host.
 
 
+## ISatellite and IAdvancedSatellite interfaces are obsolete
+
+The Satellite extension points are now obsolete. The same functionality of a satellite can be achieved by using the more advanced message processing pipeline by implementing a `Feature`. For more details, please read this article on [migrating Satellites](/nservicebus/pipeline/satellites.md).
+
+
 ## Header management
 
 


### PR DESCRIPTION
Fixes https://github.com/Particular/docs.particular.net/issues/532

Satellites are obsolete from V6.
Satellites are implemented using the pipeline Feature.