### PR TITLE
Raven Func<ReadOnlySettings, IDocumentStore> options

### DIFF
--- a/Snippets/Raven/Raven_4/Configure.cs
+++ b/Snippets/Raven/Raven_4/Configure.cs
@@ -58,6 +58,40 @@
             persistence.UseDocumentStoreForSubscriptions(myDocumentStore);
             persistence.UseDocumentStoreForSagas(myDocumentStore);
             persistence.UseDocumentStoreForTimeouts(myDocumentStore);
+            persistence.UseDocumentStoreForGatewayDeduplication(myDocumentStore);
+
+            #endregion
+        }
+
+        void CreateSpecificDocumentStoreByFunc(EndpointConfiguration endpointConfiguration)
+        {
+            #region ravendb-persistence-specific-create-store-by-func
+            
+            var persistence = endpointConfiguration.UsePersistence<RavenDBPersistence>();
+            persistence.UseDocumentStoreForSubscriptions(readOnlySettings =>
+            {
+                DocumentStore myDocumentStore = new DocumentStore();
+                // configure document store properties here
+                return myDocumentStore;
+            });
+            persistence.UseDocumentStoreForSagas(readOnlySettings =>
+            {
+                DocumentStore myDocumentStore = new DocumentStore();
+                // configure document store properties here
+                return myDocumentStore;
+            });
+            persistence.UseDocumentStoreForTimeouts(readOnlySettings =>
+            {
+                DocumentStore myDocumentStore = new DocumentStore();
+                // configure document store properties here
+                return myDocumentStore;
+            });
+            persistence.UseDocumentStoreForGatewayDeduplication(readOnlySettings =>
+            {
+                DocumentStore myDocumentStore = new DocumentStore();
+                // configure document store properties here
+                return myDocumentStore;
+            });
 
             #endregion
         }
@@ -87,6 +121,21 @@
             // configure connection params (ApiKey, DatabaseName, Url) here
             var persistence = endpointConfiguration.UsePersistence<RavenDBPersistence>();
             persistence.SetDefaultDocumentStore(connectionParams);
+
+            #endregion
+        }
+
+        void CreateDocumentStoreByFunc(EndpointConfiguration endpointConfiguration)
+        {
+            #region ravendb-persistence-create-store-by-func
+
+            var persistence = endpointConfiguration.UsePersistence<RavenDBPersistence>();
+            persistence.SetDefaultDocumentStore(readOnlySettings =>
+            {
+                DocumentStore myDocumentStore = new DocumentStore();
+                // configure document store properties here
+                return myDocumentStore;
+            });
 
             #endregion
         }

--- a/Snippets/Raven/Raven_4/Raven_4.csproj
+++ b/Snippets/Raven/Raven_4/Raven_4.csproj
@@ -27,8 +27,9 @@
     <Reference Include="NServiceBus.Core">
       <HintPath>..\..\..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.RavenDB">
-      <HintPath>..\..\..\packages\NServiceBus.RavenDB.4.0.0-alpha0137\lib\net452\NServiceBus.RavenDB.dll</HintPath>
+    <Reference Include="NServiceBus.RavenDB, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NServiceBus.RavenDB.4.0.0-alpha0143\lib\net452\NServiceBus.RavenDB.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\RavenDB.Client.3.0.30115\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/Snippets/Raven/Raven_4/packages.config
+++ b/Snippets/Raven/Raven_4/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
-  <package id="NServiceBus.RavenDB" version="4.0.0-alpha0137" targetFramework="net452" />
+  <package id="NServiceBus.RavenDB" version="4.0.0-alpha0143" targetFramework="net452" />
   <package id="RavenDB.Client" version="3.0.30115" targetFramework="net452" />
 </packages>

--- a/nservicebus/ravendb/index.md
+++ b/nservicebus/ravendb/index.md
@@ -49,6 +49,15 @@ If NServiceBus needs to use the same `DocumentStore` instance used elsewhere in 
 snippet:ravendb-persistence-external-store
 
 
+#### External shared store at initialization
+
+To use an external `DocumentStore`, but defer its creation until NServiceBus initializes, a `Func<ReadOnlySettings, IDocumentStore>` can be provided which will allow the `DocumentStore` to be created with access to the `ReadOnlySettings`. This gives the ability to configure the document store based on conventions derived from endpoint data present in the settings object.
+
+*This configuration option is available only in NServiceBus.RavenDB 4.0 and above.*
+
+snippet:ravendb-persistence-create-store-by-func
+
+
 #### Store defined via a connection string for a specific persister
 
 One can configure a RavenDB connection string that is only applicable to a specific store:
@@ -61,6 +70,15 @@ snippet:specific-document-store-via-connection-string
 An externally created `DocumentStore` instance can be passed to NServiceBus for usage in a specific persister (e.g. timeouts) by using the following code:
 
 snippet:ravendb-persistence-specific-external-store
+
+
+#### External store at initialization for a specific persister
+
+A `DocumentStore` can be created when NServiceBus initializes, with access to endpoint settings found in `ReadOnlySettings`, for usage in a specific persister (e.g. timeouts) by using the following code:
+
+*This configuration option is available only in NServiceBus.RavenDB 4.0 and above.*
+
+snippet:ravendb-persistence-specific-create-store-by-func
 
 
 ### Other configuration options


### PR DESCRIPTION
Related to Particular/NServiceBus.RavenDB#214

Wasn't sure what the best way was of indicating that the new options were NSB.Raven 4.0 and above. Didn't think it merited a NOTE: and so I put a line in italics above the snippets. Of course the snippets themselves will only show the 4.0-pre version. Is that enough? Looking for guidance.

It's possible we might backport this to 3.x to better support DTC customizations, but for now, this is what is true.