### PR TITLE
Update Rabbit V4 snippets and samples to beta3

### DIFF
--- a/Snippets/Rabbit/Rabbit_4/Rabbit_4.csproj
+++ b/Snippets/Rabbit/Rabbit_4/Rabbit_4.csproj
@@ -27,8 +27,9 @@
     <Reference Include="NServiceBus.Core">
       <HintPath>..\..\..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Transports.RabbitMQ">
-      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0001\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+    <Reference Include="NServiceBus.Transports.RabbitMQ, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>

--- a/Snippets/Rabbit/Rabbit_4/packages.config
+++ b/Snippets/Rabbit/Rabbit_4/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Receiver.csproj
@@ -29,8 +29,9 @@
     <Reference Include="NServiceBus.Core">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Transports.RabbitMQ">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0001\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+    <Reference Include="NServiceBus.Transports.RabbitMQ, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>

--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/packages.config
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/samples/rabbitmq/simple/Rabbit_4/Sample/Sample.csproj
+++ b/samples/rabbitmq/simple/Rabbit_4/Sample/Sample.csproj
@@ -29,8 +29,9 @@
     <Reference Include="NServiceBus.Core">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceBus.Transports.RabbitMQ">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0001\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+    <Reference Include="NServiceBus.Transports.RabbitMQ, Version=4.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>

--- a/samples/rabbitmq/simple/Rabbit_4/Sample/packages.config
+++ b/samples/rabbitmq/simple/Rabbit_4/Sample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Because there is an old unlisted 4.0.0 beta1 and beta2 on nuget.org already, we had to bump up to beta 3.