### PR TITLE
corrected NHibernate link on pub/sub

### DIFF
--- a/nservicebus/messaging/publish-subscribe/index.md
+++ b/nservicebus/messaging/publish-subscribe/index.md
@@ -44,7 +44,7 @@ Available subscription persistences include
 
  * [MSMQ](/nservicebus/msmq)
  * [RavenDB](/nservicebus/ravendb)
- * [NHibernate](/nservicebus/ravendb)
+ * [NHibernate](/nservicebus/nhibernate)
  * [InMemory](/nservicebus/persistence/in-memory.md)
  * [Azure Storage](/nservicebus/azure-storage-persistence)
 


### PR DESCRIPTION
NHibernate link was pointing to "ravendb", changed it to "nhibernate"