### PR TITLE
Upgrade guide for the azure databus split

### DIFF
--- a/nservicebus/upgrades/absdatabus-6to1.md
+++ b/nservicebus/upgrades/absdatabus-6to1.md
@@ -10,7 +10,7 @@ related:
 
 Instructions on how to move from the NServiceBus.Azure package to the NServiceBus.DataBus.AzureBlobStorage package.
 
-### `AzureDataBusPersistence` feature no longer used
+### AzureDataBusPersistence feature no longer used
 
 Instead of `.EnableFeature<AzureDataBusPersistence>()` use `.UseDataBus<AzureDataBus>()` instead.
 
@@ -18,6 +18,6 @@ Instead of `.EnableFeature<AzureDataBusPersistence>()` use `.UseDataBus<AzureDat
 
 Configuration options are now only available via the code api. See [DataBus](/nservicebus/messaging/databus.md) documentation and the [Azure DataBus sample](/samples/azure/blob-storage-databus) for more details.
 
-### `AzureDataBusDefaults` no longer provided
+### AzureDataBusDefaults no longer provided
 
 Refer to the [DataBus](/nservicebus/messaging/databus.md) documentation for details on defaults used.

--- a/nservicebus/upgrades/absdatabus-6to1.md
+++ b/nservicebus/upgrades/absdatabus-6to1.md
@@ -1,0 +1,23 @@
+---
+title: Moving to NServiceBus.DataBus.AzureBlobStorage package
+summary: Instructions on how to move from the NServiceBus.Azure package to the NServiceBus.DataBus.AzureBlobStorage package.
+tags:
+ - upgrade
+ - migration
+related:
+- nservicebus/upgrades/azure-deprecation
+---
+
+Instructions on how to move from the NServiceBus.Azure package to the NServiceBus.DataBus.AzureBlobStorage package.
+
+### `AzureDataBusPersistence` feature no longer used
+
+Instead of `.EnableFeature<AzureDataBusPersistence>()` use `.UseDataBus<AzureDataBus>()` instead.
+
+### Custom configuration section no longer provided
+
+Configuration options are now only available via the code api. See [DataBus](/nservicebus/messaging/databus.md) documentation and the [Azure DataBus sample](/samples/azure/blob-storage-databus) for more details.
+
+### `AzureDataBusDefaults` no longer provided
+
+Refer to the [DataBus](/nservicebus/messaging/databus.md) documentation for details on defaults used.

--- a/nservicebus/upgrades/azure-deprecation.md
+++ b/nservicebus/upgrades/azure-deprecation.md
@@ -1,0 +1,17 @@
+---
+title: NServiceBus.Azure package deprecated
+summary: Instructions on how to move from the NServiceBus.Azure package to the new individual packages.
+tags:
+ - upgrade
+ - migration
+related:
+- nservicebus/upgrades/5to6
+- nservicebus/upgrades/absdatabus-6to1
+---
+
+## `NServiceBus.Azure` package deprecated
+
+`NServiceBus.Azure` package is no longer provided. All functionality has been moved to individual packages as listed below.
+
+* Persistence - `NServiceBus.Persistence.AzureStorage` see the [Azure Storage Persistence upgrade guide](/nservicebus/upgrades/nservicebus/upgrades/asp-6to7.md) for more details.
+* DataBus - `NServiceBus.DataBus.AzureBlobStorage` see the [Azure Blob Storage DataBus upgrade guide](/nservicebus/upgrades/absdatabus-6to1.md) for more details.

--- a/nservicebus/upgrades/azure-deprecation.md
+++ b/nservicebus/upgrades/azure-deprecation.md
@@ -13,5 +13,5 @@ related:
 
 `NServiceBus.Azure` package is no longer provided. All functionality has been moved to individual packages as listed below.
 
-* Persistence - `NServiceBus.Persistence.AzureStorage` see the [Azure Storage Persistence upgrade guide](/nservicebus/upgrades/nservicebus/upgrades/asp-6to7.md) for more details.
+* Persistence - `NServiceBus.Persistence.AzureStorage` see the Azure Storage Persistence upgrade guide for more details.
 * DataBus - `NServiceBus.DataBus.AzureBlobStorage` see the [Azure Blob Storage DataBus upgrade guide](/nservicebus/upgrades/absdatabus-6to1.md) for more details.

--- a/nservicebus/upgrades/azure-deprecation.md
+++ b/nservicebus/upgrades/azure-deprecation.md
@@ -9,7 +9,7 @@ related:
 - nservicebus/upgrades/absdatabus-6to1
 ---
 
-## `NServiceBus.Azure` package deprecated
+## NServiceBus.Azure package deprecated
 
 `NServiceBus.Azure` package is no longer provided. All functionality has been moved to individual packages as listed below.
 


### PR DESCRIPTION
Went with a short section in the main upgrade guide and then a new page for the data bus specific details.

Depends on https://github.com/Particular/docs.particular.net/pull/1502 since I'm linking to the upgrade guide for ASP