### PR TITLE
[WIP] Adding IIS reverse proxy rule 

### DIFF
--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -102,7 +102,7 @@ It is also recommended that the IIS web site be configured to use SSL if an auth
 
 ### Configuring Reverse Proxy in a non-root directory
 
-Due to a bug in SignalR (as at Microsoft.AspNet.SignalR.JS version 2.2.0), usage of IIS as a reverse proxy in a virtual directory requires an additional URL Rewrite Rule on the `/api/` sub folder. This rule makes sure that SignalR uses the correct path when hosted within a virtual directory. This rule should look as follows: 
+Due to a [bug in SignalR](https://github.com/SignalR/SignalR/issues/3649) in Microsoft.AspNet.SignalR.JS version 2.2.0, usage of IIS as a reverse proxy in a virtual directory requires an additional URL Rewrite Rule on the `/api/` sub folder. This rule makes sure that SignalR uses the correct path when hosted within a virtual directory. This rule should look as follows: 
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -100,6 +100,28 @@ WARNING: The default configuration for ServiceControl only allows access to REST
 
 It is also recommended that the IIS web site be configured to use SSL if an authorization provider is used.
 
+### Configuring Reverse Proxy in a non-root directory
+
+Currently due to the fact of a bug in JQuery SignalR JS library usage of reverse proxy in a non-root directory requires additional URL Rewrite Rule on api sub folder. This rule make sure that SignalR uses correct path when being hosted in a sub directory. This newly rule should look like the following: 
+
+```xml
+</rules>
+<outboundRules>
+    <rule name="Update Url property" preCondition="JSON" enabled="true" stopProcessing="true">
+        <match filterByTags="None" pattern="\&quot;Url\&quot;:\&quot;(.+?)\&quot;" />
+        <conditions>
+            <add input="{URL}" pattern="(.*)/api/" />
+        </conditions>
+        <action type="Rewrite" value="&quot;Url&quot;:&quot;{C:1}{R:1}&quot;" />
+    </rule>
+    <preConditions>
+        <preCondition name="JSON">
+            <add input="{URL}" pattern="/api/messagestream/negotiate" />
+            <add input="{RESPONSE_CONTENT_TYPE}" pattern="application/json" />
+        </preCondition>
+    </preConditions>
+</outboundRules>
+``` 
 
 ### Limitations
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -105,22 +105,28 @@ It is also recommended that the IIS web site be configured to use SSL if an auth
 Due to a bug in SignalR (as at Microsoft.AspNet.SignalR.JS version 2.2.0), usage of IIS as a reverse proxy in a virtual directory requires an additional URL Rewrite Rule on the `/api/` sub folder. This rule makes sure that SignalR uses the correct path when hosted within a virtual directory. This rule should look as follows: 
 
 ```xml
-</rules>
-<outboundRules>
-    <rule name="Update Url property" preCondition="JSON" enabled="true" stopProcessing="true">
-        <match filterByTags="None" pattern="\&quot;Url\&quot;:\&quot;(.+?)\&quot;" />
-        <conditions>
-            <add input="{URL}" pattern="(.*)/api/" />
-        </conditions>
-        <action type="Rewrite" value="&quot;Url&quot;:&quot;{C:1}{R:1}&quot;" />
-    </rule>
-    <preConditions>
-        <preCondition name="JSON">
-            <add input="{URL}" pattern="/api/messagestream/negotiate" />
-            <add input="{RESPONSE_CONTENT_TYPE}" pattern="application/json" />
-        </preCondition>
-    </preConditions>
-</outboundRules>
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <outboundRules>
+                <rule name="Update Url property" preCondition="JSON" enabled="true" stopProcessing="true">
+                    <match filterByTags="None" pattern="\&quot;Url\&quot;:\&quot;(.+?)\&quot;" />
+                    <conditions>
+                        <add input="{URL}" pattern="(.*)/api/" />
+                    </conditions>
+                    <action type="Rewrite" value="&quot;Url&quot;:&quot;{C:1}{R:1}&quot;" />
+                </rule>
+                <preConditions>
+                    <preCondition name="JSON">
+                        <add input="{URL}" pattern="/api/messagestream/negotiate" />
+                        <add input="{RESPONSE_CONTENT_TYPE}" pattern="application/json" />
+                    </preCondition>
+                </preConditions>
+            </outboundRules>
+        </rewrite>
+    </system.webServer>
+</configuration>
 ``` 
 
 ### Limitations

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -102,7 +102,7 @@ It is also recommended that the IIS web site be configured to use SSL if an auth
 
 ### Configuring Reverse Proxy in a non-root directory
 
-Currently due to the fact of a bug in JQuery SignalR JS library usage of reverse proxy in a non-root directory requires additional URL Rewrite Rule on api sub folder. This rule make sure that SignalR uses correct path when being hosted in a sub directory. This newly rule should look like the following: 
+Due to a bug in SignalR (as at Microsoft.AspNet.SignalR.JS version 2.2.0), usage of IIS as a reverse proxy in a virtual directory requires an additional URL Rewrite Rule on the `/api/` sub folder. This rule makes sure that SignalR uses the correct path when hosted within a virtual directory. This rule should look as follows: 
 
 ```xml
 </rules>


### PR DESCRIPTION
This change in doco involves writing down a IIS Reverse Proxy rule that was created by @rlaveycal in the following [Service Pulse bug](https://github.com/Particular/ServicePulse/issues/343#issuecomment-219088021). This section will disappear when the SignalR will be fixed to properly work with reverse proxy hosting configuration.

@Particular/docs-maintainers please review. 
I have questions/doubts regarding:
 * if we should state that this configuration is due to a bug in another library. 
 * if we should describe a bit more what was the problem and what this solution actually does (however for customers that didn't encounter this error it is just not important)
 * I struggle here how to name this situation, currently I use 2 terms:
  * non-root directory
  * sub directory
To refer to the same thing. And I still have doubts if customer would understand when this section refers to them, so any suggestions would be apreciated.

Connects to: Particular/ServicePulse#343
