### PR TITLE
Add note about v6 not requiring unobtrusive config

### DIFF
--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -51,7 +51,7 @@ In Versions 5 and below, if [unobtrusive mode](/nservicebus/messaging/unobtrusiv
 
 snippet:SetupConventionsForUnitTests
 
-Note: With Version 6, unobtrusive message conventions configuration is no longer required.
+Note: With Version 6, unobtrusive message conventions configuration is no longer required for the NServiceBus Testing Framework.
 
 
 ### Testing interface messages

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -51,7 +51,7 @@ In Versions 5 and below, if [unobtrusive mode](/nservicebus/messaging/unobtrusiv
 
 snippet:SetupConventionsForUnitTests
 
-Note: In Versions 6 and above unobtrusive message conventions configuration is no longer required for the NServiceBus Testing Framework.
+Note: In Versions 6 and above, unobtrusive message conventions are no longer required to use the NServiceBus Testing Framework.
 
 
 ### Testing interface messages

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -51,7 +51,7 @@ In Versions 5 and below, if [unobtrusive mode](/nservicebus/messaging/unobtrusiv
 
 snippet:SetupConventionsForUnitTests
 
-Note: With Version 6, unobtrusive message conventions configuration is no longer required for the NServiceBus Testing Framework.
+Note: In Versions 6 and above unobtrusive message conventions configuration is no longer required for the NServiceBus Testing Framework.
 
 
 ### Testing interface messages

--- a/nservicebus/testing/index.md
+++ b/nservicebus/testing/index.md
@@ -51,6 +51,8 @@ In Versions 5 and below, if [unobtrusive mode](/nservicebus/messaging/unobtrusiv
 
 snippet:SetupConventionsForUnitTests
 
+Note: With Version 6, unobtrusive message conventions configuration is no longer required.
+
 
 ### Testing interface messages
 


### PR DESCRIPTION
based on the feedback gathered by @indualagarsamy:

> Regular doco for Testing wasn't clear for the Message conventions (unobtrusive) on what to do and if it has changes in v6.

Added a note stating that v6 does no longer require unobtrusive message conventions configuration for tests.