### PR TITLE
Clarify when to use custom saga finder

### DIFF
--- a/nservicebus/sagas/saga-finding.md
+++ b/nservicebus/sagas/saga-finding.md
@@ -11,7 +11,7 @@ related:
 - nservicebus/sagas/concurrency
 ---
 
-As described in [Correlating messages to a saga](/nservicebus/sagas/#correlating-messages-to-a-saga), every saga definition needs to specify how the existing saga instance should be found for an incoming message. The mechanisms described in that section should be the default choice and are suitable for many real-life scenarios. However, sometimes the mapping logic is too complex and it's necessary to define a custom saga finder.
+A saga can handle multiple messages. When NServiceBus receives a message that should be handled by a saga, it uses the [configured mapping information](/nservicebus/sagas/#correlating-messages-to-a-saga) to determine the correct saga instance that should handle the incoming message. However, in some complex scenarios, one property in the message may not be sufficient to resolve a saga instance. For example, two or more properties might together identify the correct saga instance. In such cases it becomes necessary to define a custom saga finder.
 
 
 ### [NHibernate](/nservicebus/nhibernate/) Saga Finder

--- a/nservicebus/sagas/saga-finding.md
+++ b/nservicebus/sagas/saga-finding.md
@@ -11,7 +11,7 @@ related:
 - nservicebus/sagas/concurrency
 ---
 
-Sometimes a saga handles certain message types without a single simple property that can be mapped to a specific saga instance. In those cases, finer-grained control of how to find a saga instance will be required.
+As described in [Correlating messages to a saga](/nservicebus/sagas/#correlating-messages-to-a-saga), every saga definition needs to specify how the existing saga instance should be found for an incoming message. The mechanisms described in that section should be the default choice and are suitable for many real-life scenarios. However, sometimes the mapping logic is too complex and it's necessary to define a custom saga finder.
 
 
 ### [NHibernate](/nservicebus/nhibernate/) Saga Finder


### PR DESCRIPTION
Inspired by a customer that used both mechanisms at the same time, and used custom finder even though they needed only simple property mapping. The doco could be more explicit and mention the main article (so if somebody lands on the custom finder page only, they can go to the main page for full context).

@Particular/docs-maintainers please, see if that's clear enough?