### PR TITLE
[WIP] Update rabbit client

### DIFF
--- a/Snippets/Rabbit/Rabbit_1/Rabbit_1.csproj
+++ b/Snippets/Rabbit/Rabbit_1/Rabbit_1.csproj
@@ -36,8 +36,8 @@
       <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.1.1.5\lib\net40\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snippets/Rabbit/Rabbit_1/packages.config
+++ b/Snippets/Rabbit/Rabbit_1/packages.config
@@ -3,5 +3,5 @@
   <package id="NServiceBus" version="4.7.12" targetFramework="net452" />
   <package id="NServiceBus.Interfaces" version="4.7.12" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="1.1.5" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/Snippets/Rabbit/Rabbit_3/Rabbit_3.csproj
+++ b/Snippets/Rabbit/Rabbit_3/Rabbit_3.csproj
@@ -29,11 +29,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.3.2.0\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.3.3.1\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snippets/Rabbit/Rabbit_3/packages.config
+++ b/Snippets/Rabbit/Rabbit_3/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="5.2.14" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="3.2.0" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="3.3.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/Snippets/Rabbit/Rabbit_4/Rabbit_4.csproj
+++ b/Snippets/Rabbit/Rabbit_4/Rabbit_4.csproj
@@ -31,8 +31,8 @@
       <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snippets/Rabbit/Rabbit_4/packages.config
+++ b/Snippets/Rabbit/Rabbit_4/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
+++ b/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
@@ -29,15 +29,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.3.1.0\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\..\..\packages\NServiceBus.RabbitMQ.3.3.1\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snippets/Rabbit/Rabbit_All/packages.config
+++ b/Snippets/Rabbit/Rabbit_All/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="5.2.14" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="3.1.0" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="3.3.1" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/NativeSender.csproj
@@ -25,8 +25,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/Program.cs
@@ -9,7 +9,7 @@ class Program
         Console.Title = "Samples.RabbitMQ.NativeIntegration.Sender";
         ConnectionFactory connectionFactory = new ConnectionFactory();
 
-        using (IConnection connection = connectionFactory.CreateConnection())
+        using (IConnection connection = connectionFactory.CreateConnection(Console.Title))
         {
             Console.WriteLine("Press enter to send a message");
             Console.WriteLine("Press any key to exit");

--- a/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/packages.config
+++ b/samples/rabbitmq/native-integration/Rabbit_3/NativeSender/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net45" />
 </packages>

--- a/samples/rabbitmq/native-integration/Rabbit_3/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_3/Receiver/Receiver.csproj
@@ -29,11 +29,11 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.5.2.14\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.3.2.0\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.3.3.1\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -47,7 +47,6 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/samples/rabbitmq/native-integration/Rabbit_3/Receiver/packages.config
+++ b/samples/rabbitmq/native-integration/Rabbit_3/Receiver/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="5.2.14" targetFramework="net45" />
-  <package id="NServiceBus.RabbitMQ" version="3.2.0" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net45" />
+  <package id="NServiceBus.RabbitMQ" version="3.3.1" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net45" />
 </packages>

--- a/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/NativeSender.csproj
@@ -26,8 +26,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/Program.cs
@@ -9,7 +9,7 @@ class Program
         Console.Title = "Samples.RabbitMQ.NativeIntegration.Sender";
         ConnectionFactory connectionFactory = new ConnectionFactory();
 
-        using (IConnection connection = connectionFactory.CreateConnection())
+        using (IConnection connection = connectionFactory.CreateConnection(Console.Title))
         {
             Console.WriteLine("Press enter to send a message");
             Console.WriteLine("Press any key to exit");

--- a/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/packages.config
+++ b/samples/rabbitmq/native-integration/Rabbit_4/NativeSender/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Receiver.csproj
@@ -33,8 +33,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -46,6 +46,7 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/app.config
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.7.0" newVersion="3.5.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.6.2.0" newVersion="3.6.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/packages.config
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>

--- a/samples/rabbitmq/simple/Rabbit_3/Sample/Sample.csproj
+++ b/samples/rabbitmq/simple/Rabbit_3/Sample/Sample.csproj
@@ -29,11 +29,11 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.5.2.14\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.3.2.0\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.3.3.1\lib\net45\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -47,7 +47,6 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/samples/rabbitmq/simple/Rabbit_3/Sample/packages.config
+++ b/samples/rabbitmq/simple/Rabbit_3/Sample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="5.2.14" targetFramework="net45" />
-  <package id="NServiceBus.RabbitMQ" version="3.2.0" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net45" />
+  <package id="NServiceBus.RabbitMQ" version="3.3.1" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net45" />
 </packages>

--- a/samples/rabbitmq/simple/Rabbit_4/Sample/Sample.csproj
+++ b/samples/rabbitmq/simple/Rabbit_4/Sample/Sample.csproj
@@ -33,8 +33,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.RabbitMQ.4.0.0-beta0003\lib\net452\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.1\lib\net45\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -46,6 +46,7 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/samples/rabbitmq/simple/Rabbit_4/Sample/app.config
+++ b/samples/rabbitmq/simple/Rabbit_4/Sample/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.7.0" newVersion="3.5.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.6.2.0" newVersion="3.6.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/rabbitmq/simple/Rabbit_4/Sample/packages.config
+++ b/samples/rabbitmq/simple/Rabbit_4/Sample/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="4.0.0-beta0003" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.1" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This updates samples and snippets to the 3.6.2 release of the RabbitMQ client and the new 3.3.1 release of the RabbitMQ transport.

I've marked this as WIP for now because there is still a change in the Rabbit_All snippets project that needs to be made. The `ErrorQueue` class is still using the deprecated `QueueingBasicConsumer` class, and I'm not immediately sure how to remove it.

https://github.com/Particular/docs.particular.net/blob/master/Snippets/Rabbit/Rabbit_All/ErrorQueue.cs#L34

This could be switched to the recommended `EventingBasicConsumer`, but then some way to wait for the event handler firing would be needed. I could use a `TaskCompletionSource` if we don't mind introducing async here.

The other thing I'm curious about is the `query` used in the `BasicConsume` call. https://github.com/Particular/docs.particular.net/blob/master/Snippets/Rabbit/Rabbit_All/ErrorQueue.cs#L35

From the usage, it seems to imply that you can use that as a filter to only return the specified message id, but I can find absolutely zero documentation around this assumption, so I'm not even sure that it works. 