### PR TITLE
Allow multiple endpoints in the schema

### DIFF
--- a/Snippets/Core/Core_6/Routing/RoutingFile.xsd
+++ b/Snippets/Core/Core_6/Routing/RoutingFile.xsd
@@ -2,7 +2,7 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="endpoints">
     <xs:complexType>
-      <xs:sequence>
+      <xs:sequence maxOccurs="unbounded">
         <xs:element name="endpoint">
           <xs:complexType>
             <xs:sequence>


### PR DESCRIPTION
Testing the xml schema showed that theres a missing maxOccurs schema constraint which is required if you want to declare multiple endpoints, otherwise schema validation fails.

/cc @SzymonPobiega 