### PR TITLE
Standard async patterns including concurrency

### DIFF
--- a/Snippets/Common/SomeLibrary.cs
+++ b/Snippets/Common/SomeLibrary.cs
@@ -8,6 +8,10 @@ namespace Common
         {
             return Task.FromResult(0);
         }
+        public static Task AnotherAsyncMethod(params object[] data)
+        {
+            return Task.FromResult(0);
+        }
         public static void SomeMethod(params object[] data)
         {
             //no-op

--- a/Snippets/Core/Core_6/Core_6.csproj
+++ b/Snippets/Core/Core_6/Core_6.csproj
@@ -108,7 +108,9 @@
     <Compile Include="Errors\SecondLevel\SlrCodeFirstConfiguration.cs" />
     <Compile Include="Features\AdvancedSatelliteFeature.cs" />
     <Compile Include="Features\SatelliteFeature.cs" />
+    <Compile Include="Handlers\AsyncHandler.cs" />
     <Compile Include="Injection\Injection.cs" />
+    <Compile Include="Handlers\IntegrationWithNonTaskBasedAPI.cs" />
     <Compile Include="Notifications\SubscribeToNotifications.cs" />
     <Compile Include="Notifications\EventsToObservables.cs" />
     <Compile Include="Container\Custom\ContainerCustom.cs" />

--- a/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
+++ b/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
@@ -11,7 +11,6 @@
         public Task Handle(MyMessage message, IMessageHandlerContext context)
         {
             ComputeBoundComponent.BlocksForAFewMilliseconds();
-
             return Task.FromResult(0); // or Task.CompletedTask
         }
     }
@@ -80,8 +79,10 @@
     {
         public async Task Handle(MyMessage message, IMessageHandlerContext context)
         {
-            await SomeLibrary.SomeAsyncMethod(message).ConfigureAwait(false);
-            await SomeLibrary.AnotherAsyncMethod(message).ConfigureAwait(false);
+            await SomeLibrary.SomeAsyncMethod(message)
+                .ConfigureAwait(false);
+            await SomeLibrary.AnotherAsyncMethod(message)
+                .ConfigureAwait(false);
         }
     }
     #endregion
@@ -104,7 +105,8 @@
         {
             for (var i = 0; i < 100; i++)
             {
-                await context.Send(new MyMessage()).ConfigureAwait(false);
+                await context.Send(new MyMessage())
+                    .ConfigureAwait(false);
             }
         }
     }
@@ -143,7 +145,8 @@
 
                     tasks[j] = context.Send(new MyMessage(), options);
                 }
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                await Task.WhenAll(tasks)
+                    .ConfigureAwait(false);
             }
         }
     }
@@ -159,11 +162,13 @@
             var tasks = new Task[10000];
             for (var i = 0; i < 10000; i++)
             {
-                await semaphore.WaitAsync().ConfigureAwait(false);
+                await semaphore.WaitAsync()
+                    .ConfigureAwait(false);
 
                 tasks[i] = Send(context, semaphore);
             }
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks)
+                .ConfigureAwait(false);
         }
 
         static async Task Send(IMessageHandlerContext context, SemaphoreSlim semaphore)
@@ -172,7 +177,8 @@
             {
                 var options = new SendOptions();
                 options.RequireImmediateDispatch();
-                await context.Send(new MyMessage(), options).ConfigureAwait(false);
+                await context.Send(new MyMessage(), options)
+                    .ConfigureAwait(false);
             }
             finally
             {

--- a/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
+++ b/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
@@ -1,0 +1,167 @@
+﻿namespace Core6.Handlers
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Common;
+    using NServiceBus;
+
+    #region ShortComputeBoundMessageHandler
+    public class ShortComputeBoundHandler : IHandleMessages<MyMessage>
+    {
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            ComputeBoundComponent.BlocksForAFewMilliseconds();
+
+            return Task.FromResult(0); // or Task.CompletedTask
+        }
+    }
+    #endregion
+
+    #region LongComputeBoundMessageHandler
+    public class LongComputeBoundHandler : IHandleMessages<MyMessage>
+    {
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            return Task.Run(() => ComputeBoundComponent.BlocksForMoreThanHundredMilliseconds());
+        }
+    }
+    #endregion
+
+    public class ComputeBoundComponent
+    {
+        public static void BlocksForAFewMilliseconds()
+        {
+        }
+
+        public static void BlocksForMoreThanHundredMilliseconds()
+        {
+        }
+    }
+
+    #region HandlerReturnsATask
+    public class HandlerReturnsATask : IHandleMessages<MyMessage>
+    {
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            return SomeLibrary.SomeAsyncMethod(message);
+        }
+    }
+    #endregion
+
+    #region HandlerAwaitsTheTask
+    public class HandlerAwaitsTheTask : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            await SomeLibrary.SomeAsyncMethod(message);
+        }
+    }
+    #endregion
+
+    #region HandlerConfigureAwaitSpecified
+    public class HandlerConfigureAwaitSpecified : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            await SomeLibrary.SomeAsyncMethod(message).ConfigureAwait(false);
+            await SomeLibrary.AnotherAsyncMethod(message).ConfigureAwait(false);
+        }
+    }
+    #endregion
+
+    #region HandlerConfigureAwaitNotSpecified
+    public class HandlerConfigureAwaitNotSpecified : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            await SomeLibrary.SomeAsyncMethod(message);
+            await SomeLibrary.AnotherAsyncMethod(message);
+        }
+    }
+    #endregion
+
+    #region BatchedDispatchHandler
+    public class BatchedDispatchHandler : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                await context.Send(new MyMessage()).ConfigureAwait(false);
+            }
+        }
+    }
+    #endregion
+
+    #region ImmediateDispatchHandler
+    public class ImmediateDispatchHandler : IHandleMessages<MyMessage>
+    {
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            var tasks = new Task[100];
+            for (var i = 0; i < 100; i++)
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+
+                tasks[i] = context.Send(new MyMessage(), options);
+            }
+            return Task.WhenAll(tasks);
+        }
+    }
+    #endregion
+
+    #region PacketsImmediateDispatchHandler
+    public class PacketsImmediateDispatchHandler : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                var tasks = new Task[100];
+                for (var j = 0; j < 100; j++)
+                {
+                    var options = new SendOptions();
+                    options.RequireImmediateDispatch();
+
+                    tasks[j] = context.Send(new MyMessage(), options);
+                }
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+        }
+    }
+    #endregion
+
+    #region ConcurrencyLimittingImmediateDispatchHandler
+    public class LimitConcurrencyImmediateDispatchHandler : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            var semaphore = new SemaphoreSlim(100);
+
+            var tasks = new Task[10000];
+            for (var i = 0; i < 10000; i++)
+            {
+                await semaphore.WaitAsync().ConfigureAwait(false);
+
+                tasks[i] = Send(context, semaphore);
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        static async Task Send(IMessageHandlerContext context, SemaphoreSlim semaphore)
+        {
+            try
+            {
+                var options = new SendOptions();
+                options.RequireImmediateDispatch();
+                await context.Send(new MyMessage(), options).ConfigureAwait(false);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+    }
+    #endregion
+}

--- a/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
+++ b/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
@@ -48,6 +48,23 @@
     }
     #endregion
 
+    #region HandlerReturnsTwoTasks
+    public class HandlerReturnsTwoTasks : IHandleMessages<MyMessage>
+    {
+        bool someCondition = true;
+
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            if (someCondition)
+            {
+                return Task.FromResult(0); // Task.CompletedTask
+            }
+
+            return SomeLibrary.SomeAsyncMethod(message);
+        }
+    }
+    #endregion
+
     #region HandlerAwaitsTheTask
     public class HandlerAwaitsTheTask : IHandleMessages<MyMessage>
     {

--- a/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
+++ b/Snippets/Core/Core_6/Handlers/AsyncHandler.cs
@@ -42,7 +42,9 @@
     {
         public Task Handle(MyMessage message, IMessageHandlerContext context)
         {
-            return SomeLibrary.SomeAsyncMethod(message);
+            var task = SomeLibrary.SomeAsyncMethod(message);
+            //return the Task
+            return task;
         }
     }
     #endregion

--- a/Snippets/Core/Core_6/Handlers/IntegrationWithNonTaskBasedAPI.cs
+++ b/Snippets/Core/Core_6/Handlers/IntegrationWithNonTaskBasedAPI.cs
@@ -1,0 +1,67 @@
+﻿namespace Core6
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Encryption.Conventions;
+    using NServiceBus;
+
+    #region HandlerWhichIntegratesWithEvent
+    public class HandlerWhichIntegratesWithEvent : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            var cs = new CancellationTokenSource();
+            cs.CancelAfter(TimeSpan.FromSeconds(10));
+
+            var tcs = new TaskCompletionSource<object>();
+
+            using (cs.Token.Register(() => tcs.TrySetCanceled()))
+            {
+                var dependency = new DependencyWhichRaisedEvent();
+                dependency.MyEvent += (sender, args) => { tcs.TrySetResult(null); };
+
+                await tcs.Task.ConfigureAwait(false);
+            }
+        }
+    }
+    #endregion
+
+
+    public class DependencyWhichRaisedEvent
+    {
+        public event EventHandler MyEvent;
+
+        protected virtual void OnMyEvent()
+        {
+            MyEvent?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    #region HandlerWhichIntegratesWithAPM
+    public class HandlerWhichIntegratesWithAPM : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            var dependency = new DependencyWhichUsesAPM();
+            var state = new object();
+
+            var result = await Task.Factory.FromAsync((c, s) => dependency.BeginCall(c, s), dependency.EndCall, state)
+                .ConfigureAwait(false);
+        }
+    }
+    #endregion
+
+    public class DependencyWhichUsesAPM
+    {
+        public IAsyncResult BeginCall(AsyncCallback callback, object state)
+        {
+            return null;
+        }
+
+        public string EndCall(IAsyncResult callback)
+        {
+            return null;
+        }
+    }
+}

--- a/Snippets/Core/Core_6/Handlers/IntegrationWithNonTaskBasedAPI.cs
+++ b/Snippets/Core/Core_6/Handlers/IntegrationWithNonTaskBasedAPI.cs
@@ -77,9 +77,9 @@
         }
     }
 
-    #region HandlerWhichIntegratesWithRemoting
+    #region HandlerWhichIntegratesWithRemotingWithAPM
 
-    public class HandlerWhichIntegratesWithRemoting : IHandleMessages<MyMessage>
+    public class HandlerWhichIntegratesWithRemotingWithAPM : IHandleMessages<MyMessage>
     {
         public async Task Handle(MyMessage message, IMessageHandlerContext context)
         {
@@ -113,6 +113,23 @@
                 var call = (Tuple<Func<string>, AsyncClient>)rslt.AsyncState;
                 return call.Item2.Callback(rslt);
             }, Tuple.Create(remoteCall, this));
+        }
+    }
+
+    #endregion
+
+    #region HandlerWhichIntegratesWithRemotingWithTask
+
+    public class HandlerWhichIntegratesWithRemotingWithTask : IHandleMessages<MyMessage>
+    {
+        public async Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            var result = await Task.Run(() =>
+            {
+                var remoteService = new RemoteService();
+                return remoteService.TimeConsumingRemoteCall();
+
+            });
         }
     }
 

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -116,6 +116,7 @@
       Url: "nservicebus/handlers"
       Articles:
         - "nservicebus/handlers/handler-ordering"
+        - "nservicebus/handlers/async-handlers"
     -
       Title: "Sagas"
       Url: "nservicebus/sagas"

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -125,6 +125,7 @@
         - "nservicebus/sagas/saga-finding"
         - "nservicebus/sagas/saga-not-found"
         - "nservicebus/sagas/concurrency"
+        - "nservicebus/handlers/async-handlers"
         - "nservicebus/sagas/reply-replaytooriginator-differences"
         - "nservicebus/persistence"
     -

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -24,7 +24,7 @@ There are two thread pools. The worker thread pool and the IO thread pool.
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx), [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx), [`Parallel.For`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.parallel.for.aspx) schedule tasks on the worker thread pool.
 On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp-up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
-Offloading compute-bound work to the worker thread pool is a top-level concern only. Use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
+Offloading compute-bound work to the worker thread pool is a top-level concern only. Use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) is as high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
 
 #### IO-thread pool

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -8,6 +8,8 @@ redirects:
 
 ### Introduction
 
+Message handlers and Sagas will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, callling webservices and more. In other cases message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
+
 #### Threadpools
 
 There are basically two thread pools. The worker thread pool and the IO thread pool.

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -52,3 +52,13 @@ snippet: PacketsImmediateDispatchHandler
 Brain dump: You can limit concurrency
 
 snippet: ConcurrencyLimittingImmediateDispatchHandler
+
+### Integration with non-tasked based APIs
+
+#### Events
+
+snippet: HandlerWhichIntegratesWithEvent
+
+#### Asynchronous programming model pattern
+
+snippet: HandlerWhichIntegratesWithAPM

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -24,7 +24,7 @@ There are two thread pools. The worker thread pool and the IO thread pool.
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx), [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx), [`Parallel.For`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.parallel.for.aspx) schedule tasks on the worker thread pool.
 On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp-up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
-Offloading compute-bound work to the worker thread pool is a top-level concern only. Use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) is as high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
+Offloading compute-bound work to the worker thread pool is a top-level concern only. Use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) is as high up in the hierarchy as possible (eg. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
 
 #### IO-thread pool

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -68,7 +68,7 @@ snippet: HandlerReturnsATask
 
 snippet: HandlerReturnsTwoTasks
 
-### Usage of `ConfigureAwait`
+### Usage of ConfigureAwait
 
 By default when a task is awaited a mechanism called context capturing is enabled. The current context is captured and restored for the continuation that is scheduled after the precedent task was completed.
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -30,7 +30,7 @@ IO-bound work typically takes very long, and compute-bound work is comparatively
 Asynchronous code tends to use much less memory because the amount of memory saved by freeing up a thread in the worker thread pool dwarfs the amount of memory used for all the compiler-generated async structures combined.
 
 ##### Sync vs. async
-If we'd examine each request in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
+If each request is examined in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
 
 From a server perspective if asynchrony is compared to synchrony by just looking at one method or one request at a time, then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -82,18 +82,19 @@ Specify `ConfigureAwait(false)` on each awaited statement. Apply this principle 
 
 ### Concurrency
 
-Task based APIs enable to better compose asynchronous code and making concious decisions whether to execute the asynchronous code sequentially or concurrent.
+Task based APIs enable to better compose asynchronous code and making conscious decisions whether to execute the asynchronous code sequentially or concurrent.
 
 #### Small amount of concurrent message operations
 
+By default all outgoing message operations on the message handler contexts are batched (READ DOCO HERE). In summary batched means they are collected in memory and sent out when the handler is completed. So the IO-bound work happens outside the execution scope of a handler (individual transports may apply optimizations). For a small amount of outgoing message operations it makes sense, in order to reduce complexity, to sequentially await all the outgoing operations like shown below.  
+
 snippet: BatchedDispatchHandler
 
-For immediate dispatch it might make sense
+Immediate dispatch (READ DOCO HERE) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations it might make sense execute them concurrently like shown below.
 
 snippet: ImmediateDispatchHandler
 
 #### Large amount of concurrent message operations
-
 
 snippet: PacketsImmediateDispatchHandler
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -18,6 +18,12 @@ WARN: It is difficult to give generic advice how asynchronous code should be str
 
 There are two thread pools. The worker thread pool and the IO thread pool.
 
+Further reading: 
+
+ * [Thread Pools](https://msdn.microsoft.com/en-us/library/windows/desktop/ms686760.aspx)
+ * [Thread Pooling](https://msdn.microsoft.com/en-us/library/windows/desktop/ms686756.aspx)
+ * [IO Completion Ports](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198.aspx)
+
 
 #### Worker thread pool
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -18,7 +18,7 @@ There are basically two thread pools. The worker thread pool and the IO thread p
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like `Task.Run`, `Task.Factory.StartNew`, `Parallel.For` schedule tasks on the worker thread pool.
 On the other hand if we schedule Compute bound work the worker thread pool will start expanding its worker threads. Let's call this phase ramp up phase. Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
-Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in your hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
+Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
 ##### IO-thread pool
 IO-bound work is scheduled on the IO-thread pool. The IO-bound thread pool has a fixed number of worker threads (usually number of cores) which can work concurrently on thousands of IO-bound tasks. IO-bound work under Windows uses so called IO completion ports (IOCP) to get notifications when an IO-bound operation is completed. IOCP enable efficient offloading of IO-bound work from the user code to the kernel, driver and hardware without blocking the user code until the IO work is done. To achieve that the user code registeres notifications in form of a callback. The callback occors on an IO thread which is a pool thread managed by the IO system that is made available to the user code.
@@ -32,9 +32,9 @@ Asynchronous code tends to use much less memory because the amount of memory sav
 ##### Sync vs. async
 If we'd examine each request in isolation, asynchronous code would actually be sligthly slower than the synchronous version. There might be extra kernel transitions, task scheduling etc. involved. But the scalability more than makes up for it.
 
-From a server perspective if we compare asynchrony to synchrony by just looking at one method or one request at a time then synchrony might make more sense. But if you compare asynchrony to parallelism - looking at the server as a whole - then asynchrony generally wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
+From a server perspective if we compare asynchrony to synchrony by just looking at one method or one request at a time then synchrony might make more sense. But if asynchrony is compared to parallelism - looking at the server as a whole - asynchrony generally wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
 
-WARN: It is generally hard to give generic advice how you should structure your asynchronous code. It is important to understand compute-bound vs. IO-bound like summarized above. Do not copy paste the snippets blindly without further analysis if they actually provide benefit for your scenarios. Don't assume. Measure it!
+WARN: It is generally hard to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound like summarized above. Avoid to copy paste the snippets blindly without further analysis if they actually provide benefit for the involved business scenarios. Don't assume. Measure it!
 
 ### Calling short running compute-bound code
 
@@ -70,7 +70,7 @@ snippet: HandlerReturnsTwoTasks
 
 ### Usage of `ConfigureAwait`
 
-By default when you are awaiting a task a mechanism called context capturing is enabled. The current context is captured and restored for the continuation that is scheduled after the precedent task was completed.
+By default when a task is awaited a mechanism called context capturing is enabled. The current context is captured and restored for the continuation that is scheduled after the precedent task was completed.
 
 snippet: HandlerConfigureAwaitSpecified
 
@@ -78,14 +78,13 @@ In the snippet above `SomeAsyncMethod` and `AnotherAsyncMethod` are simply await
 
 snippet: HandlerConfigureAwaitNotSpecified
 
-Specify `ConfigureAwait(false)` on each awaited statement. Apply this principle to all your asynchronous code that is called from handlers and sagas.
+Specify `ConfigureAwait(false)` on each awaited statement. Apply this principle to all asynchronous code that is called from handlers and sagas.
 
 ### Concurrency
 
-#### Small amount of concurrent message operations
+Task based APIs enable to better compose asynchronous code and making concious decisions whether to execute the asynchronous code sequentially or concurrent.
 
-Brain dump:
-By default batched. Concurreny only makes sense if the outgoing pipeline is customized by user or third party and executes actual IO-bound operations inside the batched part of the outgoing pipeline. So for batched dispatch, do not use concurrent execution (the overhead would outweight the benefit):
+#### Small amount of concurrent message operations
 
 snippet: BatchedDispatchHandler
 
@@ -95,11 +94,8 @@ snippet: ImmediateDispatchHandler
 
 #### Large amount of concurrent message operations
 
-Brain dump: You can schedule packets of immediate dispatches, usually most efficient one
 
 snippet: PacketsImmediateDispatchHandler
-
-Brain dump: You can limit concurrency
 
 snippet: ConcurrencyLimittingImmediateDispatchHandler
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -48,7 +48,7 @@ Call the code directly and do not wrap it with a `Task.Run` or `Task.Factory.Sta
 
 Long running compute-bound code (more than hundred milliseconds) that is executed in a handler could be offloaded to the worker thread pool.
 
-snippet: LongComputeBoundHandler
+snippet: LongComputeBoundMessageHandler
 
 Wrap the compute-bound code in a `Task.Run` or `Task.Factory.StartNew` and `await` the result of the task.
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -8,33 +8,33 @@ redirects:
 
 ### Introduction
 
-Message handlers and Sagas will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, callling webservices and more. In other cases message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
+Message handlers and Sagas will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, calling web services and more. In other cases, message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
 
 #### Threadpools
 
-There are basically two thread pools. The worker thread pool and the IO thread pool.
+There are two thread pools. The worker thread pool and the IO thread pool.
 
 ##### Worker thread pool
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like `Task.Run`, `Task.Factory.StartNew`, `Parallel.For` schedule tasks on the worker thread pool.
-On the other hand if we schedule Compute bound work the worker thread pool will start expanding its worker threads. Let's call this phase ramp up phase. Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
+On the other hand, if we schedule Compute bound work the worker thread pool will start expanding its worker threads. Let's call this phase ramp up phase. Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
 Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
 ##### IO-thread pool
-IO-bound work is scheduled on the IO-thread pool. The IO-bound thread pool has a fixed number of worker threads (usually number of cores) which can work concurrently on thousands of IO-bound tasks. IO-bound work under Windows uses so called IO completion ports (IOCP) to get notifications when an IO-bound operation is completed. IOCP enable efficient offloading of IO-bound work from the user code to the kernel, driver and hardware without blocking the user code until the IO work is done. To achieve that the user code registeres notifications in form of a callback. The callback occors on an IO thread which is a pool thread managed by the IO system that is made available to the user code.
+IO-bound work is scheduled on the IO-thread pool. The IO-bound thread pool has a fixed number of worker threads (usually number of cores) which can work concurrently on thousands of IO-bound tasks. IO-bound work under Windows uses so-called IO completion ports (IOCP) to get notifications when an IO-bound operation is completed. IOCP enable efficient offloading of IO-bound work from the user code to the kernel, driver, and hardware without blocking the user code until the IO work is done. To achieve that the user code registers notifications in the form of a callback. The callback occurs on an IO thread which is a pool thread managed by the IO system that is made available to the user code.
 
-IO-bound work typically takes very long and compute-bound work is comparatively cheap. The IO system is optimized to keep the thread count low and schedule all callbacks, and therefore the execution of interleaved user code on that one thread. Due to those optimizations all works get serialized and there is minimal context switching as the OS scheduler owns the threads. In general asynchronous code can handle bursting traffic much better because of the "always-on" nature of the IOCP.
+IO-bound work typically takes very long, and compute-bound work is comparatively cheap. The IO system is optimized to keep the thread count low and schedule all callbacks, and therefore the execution of interleaved user code on that one thread. Due to those optimizations, all works get serialized, and there is minimal context switching as the OS scheduler owns the threads. In general asynchronous code can handle bursting traffic much better because of the "always-on" nature of the IOCP.
 
 ##### Memory and allocations
 
 Asynchronous code tends to use much less memory because the amount of memory saved by freeing up a thread in the worker thread pool dwarfs the amount of memory used for all the compiler-generated async structures combined.
 
 ##### Sync vs. async
-If we'd examine each request in isolation, asynchronous code would actually be sligthly slower than the synchronous version. There might be extra kernel transitions, task scheduling etc. involved. But the scalability more than makes up for it.
+If we'd examine each request in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
 
-From a server perspective if we compare asynchrony to synchrony by just looking at one method or one request at a time then synchrony might make more sense. But if asynchrony is compared to parallelism - looking at the server as a whole - asynchrony generally wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
+From a server perspective if we compare asynchrony to synchrony by just looking at one method or one request at a time then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
 
-WARN: It is generally hard to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound like summarized above. Avoid to copy paste the snippets blindly without further analysis if they actually provide benefit for the involved business scenarios. Don't assume. Measure it!
+WARN: It is hard to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound like summarized above. Avoid to copy paste the snippets blindly without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
 
 ### Calling short running compute-bound code
 
@@ -44,7 +44,7 @@ snippet: ShortComputeBoundMessageHandler
 
 Call the code directly and do not wrap it with a `Task.Run` or `Task.Factory.StartNew`.
 
-### Calling long running compute-bound code
+### Calling long-running compute-bound code
 
 Long running compute-bound code (more than hundred milliseconds) that is executed in a handler could be offloaded to the worker thread pool.
 
@@ -62,7 +62,7 @@ snippet: HandlerAwaitsTheTask
 
 #### Returns the task
 
-For high-troughput scenarios and if you have only one or two asynchronous exit points in the Handle method you can avoid the `async` keyword by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
+For high-throughput scenarios and if you have only one or two asynchronous exit points in the Handle method you can avoid the `async` keyword by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
 
 snippet: HandlerReturnsATask
 
@@ -86,17 +86,17 @@ Task based APIs enable to better compose asynchronous code and making conscious 
 
 #### Small amount of concurrent message operations
 
-By default all outgoing message operations on the message handler contexts are batched (READ DOCO HERE). In summary batched means they are collected in memory and sent out when the handler is completed. So the IO-bound work happens outside the execution scope of a handler (individual transports may apply optimizations). For a small amount of outgoing message operations it makes sense, in order to reduce complexity, to sequentially await all the outgoing operations like shown below.  
+By default, all outgoing message operations on the message handler contexts are batched (READ DOCO HERE). In summary batched means they are collected in memory and sent out when the handler is completed. So the IO-bound work happens outside the execution scope of a handler (individual transports may apply optimizations). For a few outgoing message operations, it makes sense, to reduce complexity, to sequentially await all the outgoing operations like shown below.  
 
 snippet: BatchedDispatchHandler
 
-Immediate dispatch (READ DOCO HERE) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations it might make sense execute them concurrently like shown below.
+Immediate dispatch (READ DOCO HERE) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations, it might make sense execute them concurrently like shown below.
 
 snippet: ImmediateDispatchHandler
 
 #### Large amount of concurrent message operations
 
-Unbounded concurrency can be problematic. For large numbers of concurrent message operations it might make sense to package multiple outgoing operations together into batches. Therefore limiting the concurrency to the size of an individual batch (divide & conquer).
+Unbounded concurrency can be problematic. For large numbers of concurrent message operations, it might make sense to package multiple outgoing operations together into batches. Therefore limiting the concurrency to the size of an individual batch (divide & conquer).
 
 snippet: PacketsImmediateDispatchHandler
 
@@ -104,7 +104,7 @@ It is also possible to limit the concurrency by using `SemaphoreSlim` like shown
 
 snippet: ConcurrencyLimittingImmediateDispatchHandler
 
-In practice packaging operations together has shown to be more effective both in regards to memory allocations and performance. The snippet is shown nonetheless for completness reasons as well as because `SemaphoreSlim` is a useful concurrency primitive for various scenarios.
+In practice packaging operations together has proved to be more effective both in regards to memory allocations and performance. The snippet is shown nonetheless for completeness reasons as well as because `SemaphoreSlim` is a useful concurrency primitive for various scenarios.
 
 ### Integration with non-tasked based APIs
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -9,6 +9,8 @@ tags:
 
 ## Introduction
 
+WARN: It is difficult to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound as summarized above. Avoid copy-pasteing snippets without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
+
 [Message handlers](/nservicebus/handlers/) and [Sagas](/nservicebus/sagas/) will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, calling web services and more. In other cases, message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
 
 
@@ -42,8 +44,6 @@ Asynchronous code tends to use much less memory because the amount of memory sav
 If each request is examined in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
 
 From a server perspective if asynchrony is compared to synchrony by just looking at one method or one request at a time, then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
-
-WARN: It is difficult to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound as summarized above. Avoid copy-pasteing snippets without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
 
 
 ## Calling short running compute-bound code

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -110,12 +110,26 @@ In practice packaging operations together has proved to be more effective both i
 
 #### Events
 
+Sometimes it is necessary to integrate existing code which fires events into an asynchronous handler. Before async/await was introduced [`ManualResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.manualresetevent.aspx) or [`AutoResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.autoresetevent.aspx) were usually used to synchronize runtime code flow. Unfortunately these synchronization primitives are of blocking nature. For asynchronous one time event synchronization the [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) comes in handy.
+
 snippet: HandlerWhichIntegratesWithEvent
 
+The above snippet shows how a task completion source can be used to asynchronously wait for an event to happen including cancellation support.
+
 #### Asynchronous programming model pattern
+
+For existing code which uses the [Asynchronous Programming Model (APM)](https://msdn.microsoft.com/en-us/library/ms228963.aspx) it is best to use [`Task.Factory.FromAsync`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.taskfactory.fromasync.asp) to wrap the `BeginOperationName` and `EndOperationName` methods with a task object.
 
 snippet: HandlerWhichIntegratesWithAPM
 
 #### Asynchronous RPC calls
 
-snippet: HandlerWhichIntegratesWithRemoting
+The Asynchronous Programming Model (APM) approach described above can be used to integration with remote procedure calls as shown in this snippet:
+
+snippet: HandlerWhichIntegratesWithRemotingWithAPM
+
+or use `Task.Run` directly in message handler:
+
+snippet: HandlerWhichIntegratesWithTask
+
+NOTE: `Task.Run` can have significantly less overhead than using a delegate with `BeginInvoke`/`EndInvoke`. By default, both APIs will use the worker thread pool as the underlying scheduling engine. Analyze and measure for the business scenarios involved.

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -16,7 +16,7 @@ There are two thread pools. The worker thread pool and the IO thread pool.
 
 ##### Worker thread pool
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like `Task.Run`, `Task.Factory.StartNew`, `Parallel.For` schedule tasks on the worker thread pool.
-On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
+On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp-up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
 Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
@@ -110,7 +110,7 @@ In practice packaging operations together has proved to be more effective both i
 
 #### Events
 
-Sometimes it is necessary to integrate existing code which fires events into an asynchronous handler. Before async/await was introduced [`ManualResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.manualresetevent.aspx) or [`AutoResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.autoresetevent.aspx) were usually used to synchronize runtime code flow. Unfortunately these synchronization primitives are of blocking nature. For asynchronous one time event synchronization the [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) comes in handy.
+Sometimes it is necessary to integrate existing code which fires events into an asynchronous handler. Before async/await was introduced [`ManualResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.manualresetevent.aspx) or [`AutoResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.autoresetevent.aspx) were usually used to synchronize runtime code flow. Unfortunately, these synchronization primitives are of blocking nature. For asynchronous one-time event synchronization the [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) comes in handy.
 
 snippet: HandlerWhichIntegratesWithEvent
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -1,0 +1,54 @@
+---
+title: Asynchronous Handlers
+summary: Shows how to deal with synchronous and asynchronous code inside asynchronous handlers
+tags:
+ - Async
+redirects:
+---
+
+### Calling short running compute-bound code
+
+snippet: ShortComputeBoundMessageHandler
+
+### Calling long running compute-bound code
+
+snippet: LongComputeBoundHandler
+
+### Return or await
+
+#### Returns the task
+
+snippet: HandlerReturnsATask
+
+#### Awaits the task
+
+snippet: HandlerAwaitsTheTask
+
+### Usage of `ConfigureAwait`
+
+snippet: HandlerConfigureAwaitSpecified
+
+snippet: HandlerConfigureAwaitNotSpecified
+
+### Concurrency
+
+#### Small amount of concurrent message operations
+
+Brain dump:
+By default batched. Concurreny only makes sense if the outgoing pipeline is customized by user or third party and executes actual IO-bound operations inside the batched part of the outgoing pipeline. So for batched dispatch, do not use concurrent execution (the overhead would outweight the benefit):
+
+snippet: BatchedDispatchHandler
+
+For immediate dispatch it might make sense
+
+snippet: ImmediateDispatchHandler
+
+#### Large amount of concurrent message operations
+
+Brain dump: You can schedule packets of immediate dispatches, usually most efficient one
+
+snippet: PacketsImmediateDispatchHandler
+
+Brain dump: You can limit concurrency
+
+snippet: ConcurrencyLimittingImmediateDispatchHandler

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -1,66 +1,80 @@
 ---
 title: Asynchronous Handlers
 summary: Shows how to deal with synchronous and asynchronous code inside asynchronous handlers
+reviewed: 2016-07-05
 tags:
  - Async
-redirects:
 ---
 
-### Introduction
 
-Message handlers and Sagas will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, calling web services and more. In other cases, message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
+## Introduction
 
-#### Threadpools
+[Message handlers](/nservicebus/handlers/) and [Sagas](/nservicebus/sagas/) will be invoked from an IO thread pool thread. Typically message handlers and sagas issue IO bound work like sending or publishing messages, storing information into databases, calling web services and more. In other cases, message handlers are used to schedule compute-bound work. To be able to write efficient message handlers and sagas it is crucial to understand the difference between compute-bound and IO bound work and the thread pools involved.
+
+
+### Threadpools
 
 There are two thread pools. The worker thread pool and the IO thread pool.
 
-##### Worker thread pool
-Parallel / Compute-bound blocking work happens on the worker thread pool. Things like `Task.Run`, `Task.Factory.StartNew`, `Parallel.For` schedule tasks on the worker thread pool.
+
+#### Worker thread pool
+
+Parallel / Compute-bound blocking work happens on the worker thread pool. Things like [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx), [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx), [`Parallel.For`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.parallel.for.aspx) schedule tasks on the worker thread pool.
 On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp-up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
-Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
+Offloading compute-bound work to the worker thread pool is a top-level concern only. Use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
-##### IO-thread pool
-IO-bound work is scheduled on the IO-thread pool. The IO-bound thread pool has a fixed number of worker threads (usually number of cores) which can work concurrently on thousands of IO-bound tasks. IO-bound work under Windows uses so-called IO completion ports (IOCP) to get notifications when an IO-bound operation is completed. IOCP enable efficient offloading of IO-bound work from the user code to the kernel, driver, and hardware without blocking the user code until the IO work is done. To achieve that the user code registers notifications in the form of a callback. The callback occurs on an IO thread which is a pool thread managed by the IO system that is made available to the user code.
+
+#### IO-thread pool
+
+IO-bound work is scheduled on the IO-thread pool. The IO-bound thread pool has a fixed number of worker threads (usually number of cores) which can work concurrently on thousands of IO-bound tasks. IO-bound work under Windows uses so-called [IO completion ports (IOCP)](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198.aspx) to get notifications when an IO-bound operation is completed. IOCP enable efficient offloading of IO-bound work from the user code to the kernel, driver, and hardware without blocking the user code until the IO work is done. To achieve that the user code registers notifications in the form of a callback. The callback occurs on an IO thread which is a pool thread managed by the IO system that is made available to the user code.
 
 IO-bound work typically takes very long, and compute-bound work is comparatively cheap. The IO system is optimized to keep the thread count low and schedule all callbacks, and therefore the execution of interleaved user code on that one thread. Due to those optimizations, all works get serialized, and there is minimal context switching as the OS scheduler owns the threads. In general asynchronous code can handle bursting traffic much better because of the "always-on" nature of the IOCP.
 
-##### Memory and allocations
+
+#### Memory and allocations
 
 Asynchronous code tends to use much less memory because the amount of memory saved by freeing up a thread in the worker thread pool dwarfs the amount of memory used for all the compiler-generated async structures combined.
 
-##### Sync vs. async
+
+#### Sync vs. async
+
 If each request is examined in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
 
 From a server perspective if asynchrony is compared to synchrony by just looking at one method or one request at a time, then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
 
-WARN: It is hard to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound like summarized above. Avoid to copy paste the snippets blindly without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
+WARN: It is difficult to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound as summarized above. Avoid copy-pasteing snippets without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
 
-### Calling short running compute-bound code
+
+## Calling short running compute-bound code
 
 Short running compute-bound code (a few milliseconds) that is executed in the handler should be executed directly on the IO-thread that is executing the handler code.
 
 snippet: ShortComputeBoundMessageHandler
 
-Call the code directly and do not wrap it with a `Task.Run` or `Task.Factory.StartNew`.
+Call the code directly and **do not** wrap it with a [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx).
 
-### Calling long-running compute-bound code
 
-Long running compute-bound code (more than hundred milliseconds) that is executed in a handler could be offloaded to the worker thread pool.
+## Calling long-running compute-bound code
+
+Long running compute-bound code (more than a hundred milliseconds) that is executed in a handler could be offloaded to the worker thread pool.
 
 snippet: LongComputeBoundMessageHandler
 
-Wrap the compute-bound code in a `Task.Run` or `Task.Factory.StartNew` and `await` the result of the task.
+Wrap the compute-bound code in a [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) or [`Task.Factory.StartNew`](https://msdn.microsoft.com/en-au/library/dd321439.aspx) and `await` the result of the task.
 
-### Return or await
 
-#### Awaits the task
+## Return or await
+
+
+### Awaits the task
 
 For the majority of cases just mark the handler's Handle method with the `async` keyword and `await` all asynchronous calls inside the method.
 
 snippet: HandlerAwaitsTheTask
 
-#### Returns the task
+
+### Returns the task
 
 For high-throughput scenarios and if there are only one or two asynchronous exit points in the Handle method the `async` keyword can be avoided completely by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
 
@@ -68,7 +82,8 @@ snippet: HandlerReturnsATask
 
 snippet: HandlerReturnsTwoTasks
 
-### Usage of ConfigureAwait
+
+## Usage of ConfigureAwait
 
 By default when a task is awaited a mechanism called context capturing is enabled. The current context is captured and restored for the continuation that is scheduled after the precedent task was completed.
 
@@ -78,58 +93,71 @@ In the snippet above `SomeAsyncMethod` and `AnotherAsyncMethod` are simply await
 
 snippet: HandlerConfigureAwaitNotSpecified
 
-Specify `ConfigureAwait(false)` on each awaited statement. Apply this principle to all asynchronous code that is called from handlers and sagas.
+Specify [`ConfigureAwait(false)`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.configureawait.aspx) on each awaited statement. Apply this principle to all asynchronous code that is called from handlers and sagas.
 
-### Concurrency
+
+## Concurrency
 
 Task based APIs enable to better compose asynchronous code and making conscious decisions whether to execute the asynchronous code sequentially or concurrent.
 
-#### Small amount of concurrent message operations
 
-By default, all outgoing message operations on the message handler contexts are batched (READ DOCO HERE). In summary batched means they are collected in memory and sent out when the handler is completed. So the IO-bound work happens outside the execution scope of a handler (individual transports may apply optimizations). For a few outgoing message operations, it makes sense, to reduce complexity, to sequentially await all the outgoing operations like shown below.  
+### Small amount of concurrent message operations
+
+
+#### Batched
+
+By default, all outgoing message operations on the message handler contexts are [batched](/nservicebus/messaging/batched-dispatch.md). Batching means messages are collected in memory and sent out when the handler is completed. So the IO-bound work happens outside the execution scope of a handler (individual transports may apply optimizations). For a few outgoing message operations, it makes sense, to reduce complexity, to sequentially await all the outgoing operations as shown below.
 
 snippet: BatchedDispatchHandler
 
-Immediate dispatch (READ DOCO HERE) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations, it might make sense execute them concurrently like shown below.
+
+#### Immediate dispatch
+
+[Immediate dispatch](/nservicebus/messaging/send-a-message.md#immediate-dispatch) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations, it might make sense execute them concurrently like shown below.
 
 snippet: ImmediateDispatchHandler
 
-#### Large amount of concurrent message operations
+
+### Large amount of concurrent message operations
 
 Unbounded concurrency can be problematic. For large numbers of concurrent message operations, it might make sense to package multiple outgoing operations together into batches. Therefore limiting the concurrency to the size of an individual batch (divide & conquer).
 
 snippet: PacketsImmediateDispatchHandler
 
-It is also possible to limit the concurrency by using `SemaphoreSlim` like shown below.
+It is also possible to limit the concurrency by using [`SemaphoreSlim`](https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim.aspx) like shown below.
 
 snippet: ConcurrencyLimittingImmediateDispatchHandler
 
-In practice packaging operations together has proved to be more effective both in regards to memory allocations and performance. The snippet is shown nonetheless for completeness reasons as well as because `SemaphoreSlim` is a useful concurrency primitive for various scenarios.
+In practice packaging operations together has proved to be more effective both in regards to memory allocations and performance. The snippet is shown nonetheless for completeness reasons as well as because [`SemaphoreSlim`](https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim.aspx) is a useful concurrency primitive for various scenarios.
 
-### Integration with non-tasked based APIs
 
-#### Events
+## Integration with non-tasked based APIs
 
-Sometimes it is necessary to integrate existing code which fires events into an asynchronous handler. Before async/await was introduced [`ManualResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.manualresetevent.aspx) or [`AutoResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.autoresetevent.aspx) were usually used to synchronize runtime code flow. Unfortunately, these synchronization primitives are of blocking nature. For asynchronous one-time event synchronization the [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) comes in handy.
+
+### Events
+
+Sometimes it is necessary to integrate existing code which fires events into an asynchronous handler. Before async/await was introduced [`ManualResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.manualresetevent.aspx) or [`AutoResetEvent`](https://msdn.microsoft.com/en-us/library/system.threading.autoresetevent.aspx) were usually used to synchronize runtime code flow. Unfortunately, these synchronization primitives are of blocking nature. For asynchronous one-time event synchronization the [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) can be used.
 
 snippet: HandlerWhichIntegratesWithEvent
 
-The above snippet shows how a task completion source can be used to asynchronously wait for an event to happen including cancellation support.
+The above snippet shows how a [`TaskCompletionSource<TResult>`](https://msdn.microsoft.com/en-us/library/dd449174.aspx) can be used to asynchronously wait for an event to happen including cancellation support.
 
-#### Asynchronous programming model pattern
+
+### Asynchronous programming model (APM) pattern
 
 For existing code which uses the [Asynchronous Programming Model (APM)](https://msdn.microsoft.com/en-us/library/ms228963.aspx) it is best to use [`Task.Factory.FromAsync`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.taskfactory.fromasync.asp) to wrap the `BeginOperationName` and `EndOperationName` methods with a task object.
 
 snippet: HandlerWhichIntegratesWithAPM
 
-#### Asynchronous RPC calls
 
-The Asynchronous Programming Model (APM) approach described above can be used to integration with remote procedure calls as shown in this snippet:
+### Asynchronous RPC calls
+
+The APM approach described above can be used to integration with remote procedure calls as shown in this snippet:
 
 snippet: HandlerWhichIntegratesWithRemotingWithAPM
 
-or use `Task.Run` directly in message handler:
+or use [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) directly in message handler:
 
 snippet: HandlerWhichIntegratesWithRemotingWithTask
 
-NOTE: `Task.Run` can have significantly less overhead than using a delegate with `BeginInvoke`/`EndInvoke`. By default, both APIs will use the worker thread pool as the underlying scheduling engine. Analyze and measure for the business scenarios involved.
+NOTE: [`Task.Run`](https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.run.aspx) can have significantly less overhead than using a delegate with `BeginInvoke`/`EndInvoke`. By default, both APIs will use the worker thread pool as the underlying scheduling engine. Analyze and measure for the business scenarios involved.

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -96,9 +96,15 @@ snippet: ImmediateDispatchHandler
 
 #### Large amount of concurrent message operations
 
+Unbounded concurrency can be problematic. For large numbers of concurrent message operations it might make sense to package multiple outgoing operations together into batches. Therefore limiting the concurrency to the size of an individual batch (divide & conquer).
+
 snippet: PacketsImmediateDispatchHandler
 
+It is also possible to limit the concurrency by using `SemaphoreSlim` like shown below.
+
 snippet: ConcurrencyLimittingImmediateDispatchHandler
+
+In practice packaging operations together has shown to be more effective both in regards to memory allocations and performance. The snippet is shown nonetheless for completness reasons as well as because `SemaphoreSlim` is a useful concurrency primitive for various scenarios.
 
 ### Integration with non-tasked based APIs
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -54,19 +54,31 @@ Wrap the compute-bound code in a `Task.Run` or `Task.Factory.StartNew` and `awai
 
 ### Return or await
 
-#### Returns the task
-
-snippet: HandlerReturnsATask
-
 #### Awaits the task
+
+For the majority of cases just mark the handler's Handle method with the `async` keyword and `await` all asynchronous calls inside the method.
 
 snippet: HandlerAwaitsTheTask
 
+#### Returns the task
+
+For high-troughput scenarios and if you have only one or two asynchronous exit points in the Handle method you can avoid the `async` keyword by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
+
+snippet: HandlerReturnsATask
+
+snippet: HandlerReturnsTwoTasks
+
 ### Usage of `ConfigureAwait`
+
+By default when you are awaiting a task a mechanism called context capturing is enabled. The current context is captured and restored for the continuation that is scheduled after the precedent task was completed.
 
 snippet: HandlerConfigureAwaitSpecified
 
+In the snippet above `SomeAsyncMethod` and `AnotherAsyncMethod` are simply awaited. So when entering `SomeAsyncMethod` the context is captured and restored before `AnotherAsyncMethod` is executed. The context capturing mechanism is almost never needed in code that is executed inside handlers or sagas. NServiceBus makes sure the context is not captured in the framework at all. So the following approach is preferred:
+
 snippet: HandlerConfigureAwaitNotSpecified
+
+Specify `ConfigureAwait(false)` on each awaited statement. Apply this principle to all your asynchronous code that is called from handlers and sagas.
 
 ### Concurrency
 

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -130,6 +130,6 @@ snippet: HandlerWhichIntegratesWithRemotingWithAPM
 
 or use `Task.Run` directly in message handler:
 
-snippet: HandlerWhichIntegratesWithTask
+snippet: HandlerWhichIntegratesWithRemotingWithTask
 
 NOTE: `Task.Run` can have significantly less overhead than using a delegate with `BeginInvoke`/`EndInvoke`. By default, both APIs will use the worker thread pool as the underlying scheduling engine. Analyze and measure for the business scenarios involved.

--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -16,7 +16,7 @@ There are two thread pools. The worker thread pool and the IO thread pool.
 
 ##### Worker thread pool
 Parallel / Compute-bound blocking work happens on the worker thread pool. Things like `Task.Run`, `Task.Factory.StartNew`, `Parallel.For` schedule tasks on the worker thread pool.
-On the other hand, if we schedule Compute bound work the worker thread pool will start expanding its worker threads. Let's call this phase ramp up phase. Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
+On the other hand, if compute bound work is scheduled the worker thread pool will start expanding its worker threads (ramp up phase). Ramping up more worker threads is expensive. The thread injection rate of the worker thread pool is limited.
 
 Offloading compute-bound work to the worker thread pool is a top-level concern only. Use `Task.Run` or `Task.Factory.StartNew` is high up in the hierarchy as possible (i.ex. in the message handler). Avoid those operations deeper down in the call stack. Group compute-bound operations together as much as possible. Make them coarse-grained instead of fine-grained.
 
@@ -32,7 +32,7 @@ Asynchronous code tends to use much less memory because the amount of memory sav
 ##### Sync vs. async
 If we'd examine each request in isolation, an asynchronous code would be slightly slower than the synchronous version. There might be extra kernel transitions, task scheduling, etc. involved. But the scalability more than makes up for it.
 
-From a server perspective if we compare asynchrony to synchrony by just looking at one method or one request at a time then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
+From a server perspective if asynchrony is compared to synchrony by just looking at one method or one request at a time, then synchrony might make more sense. But if asynchrony is compared to parallelism - watching the server as a whole - asynchrony wins. Every worker thread that can be freed up on a server is worth freeing up! It reduces the amount of memory needed, frees up the CPU for compute-bound work while saturating the IO system completely.
 
 WARN: It is hard to give generic advice how asynchronous code should be structured. It is important to understand compute-bound vs. IO-bound like summarized above. Avoid to copy paste the snippets blindly without further analysis if they provide benefit for the involved business scenarios. Don't assume. Measure it!
 
@@ -62,7 +62,7 @@ snippet: HandlerAwaitsTheTask
 
 #### Returns the task
 
-For high-throughput scenarios and if you have only one or two asynchronous exit points in the Handle method you can avoid the `async` keyword by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
+For high-throughput scenarios and if there are only one or two asynchronous exit points in the Handle method the `async` keyword can be avoided completely by returning the task instead of awaiting it. This will omit the state machine creation which drives the async code and reduce the number of allocations on the given code path.
 
 snippet: HandlerReturnsATask
 


### PR DESCRIPTION
Relates to #1563

This PR serves as a discussion startet about what kind of snippets we'd like to introduce to show async and sync code usage inside async handlers. Discussed this proposal approach with @SimonCropp and @weralabaj 

Using a bunch of simulations to show the difference between the approaches. Of course those simulations are not 100% accurate. They are also using `Task.Yield()` instead of a real IO bound operation.

## BatchedDispatch Concurrent vs Sequential

### Results

```ini

BenchmarkDotNet=v0.9.6.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz, ProcessorCount=8
Frequency=2728071 ticks, Resolution=366.5594 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1055.0

Type=BatchedVsImmediateSimulated  Mode=Throughput  TargetCount=1  

```
            Method | Platform | Concurrency |         Median |        StdDev | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------------------ |--------- |------------ |--------------- |-------------- |------ |------ |------ |------------------- |
 **ConcurrentBatched** |      **X64** |           **2** |   **6.5518 us** |  **0.7354 us** |     **-** |     **-** |     **-** |             **430.54** |
 SequentialBatched |      X64 |           2 |   6.1163 us |  0.7247 us |  0.40 |  0.20 |     - |             384.71 |
 ConcurrentBatched |      X86 |           2 |   6.1633 us |  0.1239 us |  2.09 |  0.27 |     - |             271.37 |
 SequentialBatched |      X86 |           2 |   4.6270 us |  0.0754 us |  1.58 |  0.28 |  0.06 |             223.23 |
 **ConcurrentBatched** |      **X64** |           **4** |  **10.3110 us** |  **0.4651 us** |  **0.36** |     **-** |     **-** |             **584.43** |
 SequentialBatched |      X64 |           4 |  12.2165 us |  0.1123 us |     - |     - |     - |             597.56 |
 ConcurrentBatched |      X86 |           4 |   9.8093 us |  1.3290 us |  2.72 |  0.50 |     - |             410.89 |
 SequentialBatched |      X86 |           4 |  10.7643 us |  2.0426 us |  2.94 |  0.56 |     - |             408.77 |
 **ConcurrentBatched** |      **X64** |           **8** |  **19.9435 us** |  **4.4437 us** |     **-** |     **-** |     **-** |           **1'173.20** |
 SequentialBatched |      X64 |           8 |  18.7928 us |  0.4152 us |     - |     - |     - |             814.73 |
 ConcurrentBatched |      X86 |           8 |  17.3243 us |  2.0390 us |  4.08 |  1.08 |     - |             652.81 |
 SequentialBatched |      X86 |           8 |  16.4706 us |  1.7227 us |  3.44 |  0.78 |     - |             497.67 |
 **ConcurrentBatched** |      **X64** |          **16** |  **55.5948 us** |  **4.2590 us** |     **-** |     **-** |     **-** |           **2'244.12** |
 SequentialBatched |      X64 |          16 |  35.7849 us |  5.5823 us |     - |     - |     - |           1'764.71 |
 ConcurrentBatched |      X86 |          16 |  30.3694 us |  1.5551 us |  8.54 |  2.08 |     - |           1'273.21 |
 SequentialBatched |      X86 |          16 |  35.7938 us |  4.9631 us |  4.91 |  1.09 |  0.36 |             754.74 |
 **ConcurrentBatched** |      **X64** |          **32** |  **71.0914 us** |  **3.9961 us** |     **-** |     **-** |     **-** |           **4'142.99** |
 SequentialBatched |      X64 |          32 |  59.0986 us |  5.1344 us |     - |     - |     - |           4'230.56 |
 ConcurrentBatched |      X86 |          32 |  56.0654 us |  1.1658 us | 13.85 |  4.15 |     - |           2'442.73 |
 SequentialBatched |      X86 |          32 |  55.7501 us |  2.1767 us | 16.80 |     - |     - |           2'217.36 |
 **ConcurrentBatched** |      **X64** |          **64** | **156.3723 us** | **11.2330 us** |     **-** |     **-** |     **-** |           **8'773.77** |
 SequentialBatched |      X64 |          64 | 139.2430 us | 19.3795 us |     - |     - |     - |           7'137.72 |
 ConcurrentBatched |      X86 |          64 | 113.8769 us | 18.4907 us | 24.00 |  7.00 |     - |           4'157.29 |
 SequentialBatched |      X86 |          64 | 116.2887 us |  9.5522 us | 23.27 |  8.00 |     - |           3'948.51 |
 **ConcurrentBatched** |      **X64** |         **100** |    **186.6103 us** |    **16.1529 us** |  **0.05** |  **0.05** |     **-** |          **12'610.70** |
 SequentialBatched |      X64 |         100 |    176.3460 us |    33.5363 us |  0.05 |     - |     - |          11'521.99 |
 ConcurrentBatched |      X86 |         100 |    154.3940 us |     9.2544 us |  0.32 |  0.06 |     - |           5'927.60 |
 SequentialBatched |      X86 |         100 |    153.5563 us |     7.4530 us |  0.26 |  0.04 |     - |           4'452.27 |
 **ConcurrentBatched** |      **X64** |         **200** |    **400.0897 us** |    **15.1035 us** |  **0.12** |  **0.12** |     **-** |          **27'674.14** |
 SequentialBatched |      X64 |         200 |    361.0574 us |     0.5559 us |     - |     - |     - |          26'640.63 |
 ConcurrentBatched |      X86 |         200 |    328.0984 us |    28.6531 us |  0.64 |  0.11 |  0.02 |          11'786.18 |
 SequentialBatched |      X86 |         200 |    322.0079 us |    12.1359 us |  0.57 |  0.11 |  0.01 |          11'254.83 |
 **ConcurrentBatched** |      **X64** |         **400** |    **742.2960 us** |    **50.5793 us** |  **0.27** |  **0.27** |     **-** |          **61'832.55** |
 SequentialBatched |      X64 |         400 |    676.2759 us |    30.8226 us |     - |     - |     - |          46'092.35 |
 ConcurrentBatched |      X86 |         400 |    602.2157 us |    18.1921 us |  0.99 |  0.15 |     - |          17'708.69 |
 SequentialBatched |      X86 |         400 |    639.7918 us |    71.5418 us |  1.54 |  0.24 |     - |          26'321.18 |
 **ConcurrentBatched** |      **X64** |         **800** |  **1,561.2967 us** |   **197.9837 us** |  **0.50** |  **0.50** |     **-** |         **114'347.87** |
 SequentialBatched |      X64 |         800 |  1,533.4704 us |    34.8812 us |  0.26 |     - |     - |          57'994.68 |
 ConcurrentBatched |      X86 |         800 |  1,309.3436 us |   114.7623 us |  3.03 |  0.53 |     - |          55'539.08 |
 SequentialBatched |      X86 |         800 |  1,236.5888 us |   181.3293 us |  2.91 |  0.59 |     - |          52'761.77 |
 **ConcurrentBatched** |      **X64** |        **1600** |  **3,117.3083 us** |   **389.1452 us** |  **0.87** |  **0.87** |     **-** |         **203'799.39** |
 SequentialBatched |      X64 |        1600 |  3,104.1551 us |    44.2841 us |  0.95 |     - |     - |         207'898.23 |
 ConcurrentBatched |      X86 |        1600 |  2,618.2305 us |   159.1508 us |  3.12 |  1.30 |  0.08 |          72'307.87 |
 SequentialBatched |      X86 |        1600 |  2,768.9279 us |   449.1695 us |  3.61 |  1.04 |     - |          71'853.95 |
 **ConcurrentBatched** |      **X64** |        **3200** |  **6,499.9110 us** |     **2.3328 us** |  **1.74** |  **1.74** |     **-** |         **401'811.17** |
 SequentialBatched |      X64 |        3200 |  6,362.4971 us |    82.7971 us |  1.26 |     - |     - |         268'038.52 |
 ConcurrentBatched |      X86 |        3200 |  5,504.2012 us |   455.6636 us |  5.95 |  5.72 |  0.46 |         215'601.07 |
 SequentialBatched |      X86 |        3200 |  4,833.9158 us |   375.7784 us |  4.81 |  2.40 |  0.13 |         125'165.55 |
 **ConcurrentBatched** |      **X64** |        **6400** | **10,469.9839 us** |    **91.9095 us** |     **-** |     **-** |     **-** |         **424'114.34** |
 SequentialBatched |      X64 |        6400 | 11,915.8888 us |   453.7966 us |  2.28 |     - |     - |         484'743.46 |
 ConcurrentBatched |      X86 |        6400 | 11,570.7388 us |   445.3079 us |  8.59 | 12.41 |  3.82 |         441'353.54 |
 SequentialBatched |      X86 |        6400 | 11,026.6100 us |   475.9012 us | 13.77 |  8.72 |  4.13 |         449'209.73 |
 **ConcurrentBatched** |      **X64** |       **12800** | **26,551.4763 us** |   **223.2007 us** |     **-** |     **-** | **10.88** |       **1'145'281.28** |
 SequentialBatched |      X64 |       12800 | 27,659.2646 us |   509.1918 us |     - |     - |  4.15 |         883'956.02 |
 ConcurrentBatched |      X86 |       12800 | 24,516.3730 us | 1,369.7407 us | 10.94 | 16.41 |  4.97 |         556'136.58 |
 SequentialBatched |      X86 |       12800 | 21,091.8608 us |   333.8290 us | 24.00 | 15.00 |  7.00 |         773'067.02 |



### Simulation used
``` 
   [Config(typeof(Config))]
    public class BatchedVsImmediateSimulated
    {
        private class Config : ManualConfig
        {
            public Config()
            {
                Add(MarkdownExporter.GitHub);
                Add(new MemoryDiagnoser());
                Add(new Job {Platform = Platform.X86}.WithTargetCount(1));
                Add(new Job {Platform = Platform.X64}.WithTargetCount(1));
            }
        }

        [Params(100, 200, 400, 800, 1600, 3200, 6400, 12800)]
        public int Concurrency { get; set; }


        [Benchmark]
        public async Task ConcurrentBatched()
        {
            var concurrentStack = new ConcurrentStack<MyMessage>();
            var context = new Context();

            var batches = new Task[Concurrency];
            for (var j = 0; j < Concurrency; j++)
            {
                batches[j] = context.Send(new MyMessage(), concurrentStack);
            }
            await Task.WhenAll(batches).ConfigureAwait(false);


            var actualSends = new List<Task>(Concurrency);
            foreach (var message in concurrentStack)
            {
                actualSends.Add(context.ActualSend(message));
            }
            await Task.WhenAll(actualSends).ConfigureAwait(false);
        }

        [Benchmark]
        public async Task SequentialBatched()
        {
            var concurrentStack = new ConcurrentStack<MyMessage>();
            var context = new Context();

            for (var j = 0; j < Concurrency; j++)
            {
                await context.Send(new MyMessage(), concurrentStack).ConfigureAwait(false);
            }

            var actualSends = new List<Task>(Concurrency);
            foreach (var message in concurrentStack)
            {
                actualSends.Add(context.ActualSend(message));
            }
            await Task.WhenAll(actualSends).ConfigureAwait(false);
        }

        class MyMessage { }

        class Context
        {
            public Task Send(MyMessage message, ConcurrentStack<MyMessage> stack)
            {
                stack.Push(message);
                return Task.CompletedTask; // assumes nothing else is happening
            }

            public async Task ActualSend(MyMessage message)
            {
                await Task.Yield();
            }
        }
    }
```
## Pakets vs Unbounded vs Semaphore

### Results
```ini

BenchmarkDotNet=v0.9.6.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz, ProcessorCount=8
Frequency=2728071 ticks, Resolution=366.5594 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1055.0

Type=ConcurrencyLimitting  Mode=Throughput  TargetCount=10  

```
               Method | Platform |         Median |        StdDev | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
--------------------- |--------- |--------------- |-------------- |------ |------ |------ |------------------- |
              Packets |      X64 |  1,195.8098 us |   982.1345 us |  9.76 |  4.33 |  0.15 |         214'602.59 |
            Unbounded |      X64 | 17,586.2129 us | 1,675.7880 us |     - |     - |     - |         937'255.20 |
  SemaphoreWaitInside |      X64 | 27,546.9313 us |   536.1042 us | 45.00 | 11.08 |     - |       1'670'340.16 |
 SemaphoreWaitOutside |      X64 |  1,502.5369 us | 6,562.5181 us | 25.48 |  5.36 |     - |       1'109'846.86 |
              Packets |      X86 |     94.1599 us | 2,270.5213 us |  0.41 | 15.31 |  0.26 |         217'817.14 |
            Unbounded |      X86 | 15,175.4149 us |   618.9030 us | 33.00 | 33.00 |  1.00 |         703'220.32 |
  SemaphoreWaitInside |      X86 | 25,790.5334 us | 1,290.4382 us | 19.51 | 71.52 | 12.35 |         952'539.52 |
 SemaphoreWaitOutside |      X86 |    582.5846 us | 1,078.9872 us |  0.37 |  9.70 |  0.50 |         142'371.51 |

### Simulation used

```
   [Config(typeof(Config))]
    public class ConcurrencyLimitting
    {

        private class Config : ManualConfig
        {
            public Config()
            {
                Add(MarkdownExporter.GitHub);
                Add(new MemoryDiagnoser());
                Add(new Job { Platform = Platform.X86 }.WithTargetCount(10));
                Add(new Job { Platform = Platform.X64 }.WithTargetCount(10));
            }
        }


        [Benchmark]
        public async Task Packets()
        {
            var context = new Context();
            for (var i = 0; i < 100; i++)
            {
                var tasks = new Task[100];
                for (var j = 0; j < 100; j++)
                {
                    var options = new SendOptions();
                    tasks[j] = context.Send(new MyMessage(), options);
                }
                await Task.WhenAll(tasks).ConfigureAwait(false);
            }
        }

        [Benchmark]
        public async Task Unbounded()
        {
            var context = new Context();
            var tasks = new Task[10000];

            for (var i = 0; i < 10000; i++)
            {
                var options = new SendOptions();
                tasks[i] = context.Send(new MyMessage(), options);
            }

            await Task.WhenAll(tasks).ConfigureAwait(false);
        }

        [Benchmark]
        public async Task SemaphoreWaitInside()
        {
            var context = new Context();
            var semaphore = new SemaphoreSlim(100);

            var tasks = new Task[10000];
            for (var i = 0; i < 10000; i++)
            {
                tasks[i] = SendWaitInside(context, semaphore);
            }
            await  Task.WhenAll(tasks);
        }

        static async Task SendWaitInside(Context context, SemaphoreSlim semaphore)
        {
            await semaphore.WaitAsync().ConfigureAwait(false);

            try
            {
                var options = new SendOptions();
                await context.Send(new MyMessage(), options).ConfigureAwait(false);
            }
            finally
            {
                semaphore.Release();
            }
        }

        [Benchmark]
        public async Task SemaphoreWaitOutside()
        {
            var context = new Context();
            var semaphore = new SemaphoreSlim(100);

            var tasks = new Task[10000];
            for (var i = 0; i < 10000; i++)
            {
                await semaphore.WaitAsync().ConfigureAwait(false);

                tasks[i] = SendWaitOutside(context, semaphore);
            }
            await Task.WhenAll(tasks);
        }

        static async Task SendWaitOutside(Context context, SemaphoreSlim semaphore)
        {
            try
            {
                var options = new SendOptions();
                await context.Send(new MyMessage(), options).ConfigureAwait(false);
            }
            finally
            {
                semaphore.Release();
            }
        }

        class SendOptions { }

        class MyMessage { }

        class Context
        {
            public async Task Send(MyMessage message, SendOptions options)
            {
                await Task.Yield();
            }
        }
    }
```