### PR TITLE
Sender side distribution sample bug

### DIFF
--- a/samples/scaleout/senderside/Core_6/AwareClient/Program.cs
+++ b/samples/scaleout/senderside/Core_6/AwareClient/Program.cs
@@ -34,6 +34,8 @@ class Program
             .ConfigureAwait(false);
         Console.WriteLine("Press enter to send a message");
         Console.WriteLine("Press any key to exit");
+
+        var sequenceId = 0;
         while (true)
         {
             var key = Console.ReadKey();
@@ -41,9 +43,10 @@ class Program
             {
                 break;
             }
-            await endpointInstance.Send(new DoSomething())
+            var command = new DoSomething { SequenceId = ++sequenceId };
+            await endpointInstance.Send(command)
                 .ConfigureAwait(false);
-            Console.WriteLine("Message Sent");
+            Console.WriteLine($"Message {command.SequenceId} Sent");
         }
         await endpointInstance.Stop()
             .ConfigureAwait(false);

--- a/samples/scaleout/senderside/Core_6/AwareClient/routes.xml
+++ b/samples/scaleout/senderside/Core_6/AwareClient/routes.xml
@@ -2,7 +2,7 @@
 <root>
   <!-- startcode Physical-Routes -->
   <endpoints>
-    <endpoint name="Server">
+    <endpoint name="Samples.SenderSideScaleOut.Server">
       <!-- Scaled-out endpoint -->
       <instance discriminator="instance1" />
       <instance discriminator="instance2" />

--- a/samples/scaleout/senderside/Core_6/Messages/DoSomething.cs
+++ b/samples/scaleout/senderside/Core_6/Messages/DoSomething.cs
@@ -2,4 +2,5 @@
 
 public class DoSomething : ICommand
 {
+    public int SequenceId { get; set; }
 }

--- a/samples/scaleout/senderside/Core_6/Server1/DoSomethingHandler.cs
+++ b/samples/scaleout/senderside/Core_6/Server1/DoSomethingHandler.cs
@@ -9,7 +9,7 @@ public class DoSomethingHandler : IHandleMessages<DoSomething>
 
     public Task Handle(DoSomething message, IMessageHandlerContext context)
     {
-        log.Info("Message received.");
+        log.Info($"Message {message.SequenceId} received.");
         return Task.FromResult(0);
     }
 }

--- a/samples/scaleout/senderside/Core_6/Server2/DoSomethingHandler.cs
+++ b/samples/scaleout/senderside/Core_6/Server2/DoSomethingHandler.cs
@@ -8,7 +8,7 @@ public class DoSomethingHandler : IHandleMessages<DoSomething>
 
     public Task Handle(DoSomething message, IMessageHandlerContext context)
     {
-        log.Info("Message received.");
+        log.Info($"Message {message.SequenceId} received.");
         return Task.FromResult(0);
     }
 }

--- a/samples/scaleout/senderside/Core_6/UnawareClient/Program.cs
+++ b/samples/scaleout/senderside/Core_6/UnawareClient/Program.cs
@@ -23,6 +23,7 @@ class Program
             .ConfigureAwait(false);
         Console.WriteLine("Press enter to send a message");
         Console.WriteLine("Press any key to exit");
+        var sequenceId = 0;
         while (true)
         {
             var key = Console.ReadKey();
@@ -30,9 +31,10 @@ class Program
             {
                 break;
             }
-            await endpointInstance.Send(new DoSomething())
+            var command = new DoSomething { SequenceId = ++sequenceId };
+            await endpointInstance.Send(command)
                 .ConfigureAwait(false);
-            Console.WriteLine("Message Sent");
+            Console.WriteLine($"Message {command.SequenceId} Sent");
         }
         await endpointInstance.Stop()
             .ConfigureAwait(false);


### PR DESCRIPTION
Fix bug in sender-side distribution sample, add SequenceId to the message for clarity, so you can see the even and odd ones segregated when using the round-robin routing in the AwareClient.