### PR TITLE
Remove manual "Related Articles" in SP doco

### DIFF
--- a/serviceinsight/index.md
+++ b/serviceinsight/index.md
@@ -7,8 +7,6 @@ tags:
 redirects:
 - serviceinsight/getting-started-overview
 - servicepulse/introduction-and-installing-servicepulse
-related:
-- serviceinsight/managing-errors-and-retries
 ---
 
 include: serviceinsight

--- a/serviceinsight/index.md
+++ b/serviceinsight/index.md
@@ -7,6 +7,8 @@ tags:
 redirects:
 - serviceinsight/getting-started-overview
 - servicepulse/introduction-and-installing-servicepulse
+related:
+- serviceinsight/managing-errors-and-retries
 ---
 
 include: serviceinsight
@@ -112,31 +114,3 @@ ServiceInsight obviates the need for MSMQ tools provided by Windows. ServiceInsi
 ServiceInsight leverages the ServiceControl API to retrieve information. The Log tab of the Flow Diagram window displays details of the interactions as ServiceInsight polls ServiceControl for more data.
 
 ![Log View Tab](images/overview-logview.png)
-
-
-## Errors and Retries
-
-ServiceInsight provides added visibility, and NServiceBus provides durability and retries. Where intervention is required, no manually correlation of log files or access remote servers to research an error. The views within ServiceInsight illustrate messages with errors and supply the error information.
-
-
-### Status in the Message List
-
-The status of an errant message is illustrated in the message window.
-
-![An Error in the Message Window](images/overview-messagewindowerror.png)
-
-
-### The Flow Diagram
-
-The flow diagram highlights errors in red and provides details with access to the stack trace.
-
-![Error in the flow diagram](images/overview-flowdiagramwitherror.png)
-
-
-### The Sequence Diagram
-
-The sequence diagram highlights handlers with errors in red.
-
-![Error in the sequence diagram](images/overview-sequence-diagram-witherror.png)
-
-After the NServiceBus completes auto-retry, the errant message goes to an error queue. Instead of using the return-to-sender console application, to return the message to the queue from where it originated, click `Retry Message`.

--- a/serviceinsight/managing-errors-and-retries.md
+++ b/serviceinsight/managing-errors-and-retries.md
@@ -1,0 +1,37 @@
+---
+title: Managing Errors and Retries in ServiceInsight
+summary: How to view the details of Failed Messages with ServiceInsight and the Retry them
+reviewed: 2016-06-02
+tags:
+- ServiceInsight
+---
+
+When message processing fails NServiceBus will [automatically retry it](/nservicebus/errors/automatic-retries). If a message continues to fail it will be forwarded to the [configured error queue](http://docs.particular.net/nservicebus/errors/) and become visible within ServiceInsight.
+
+The views in ServiceInsight show information about message processing failure with the message. No manual correlation of log files or accessing of remote servers is necessary to research the reasons for an error. 
+
+
+## Status in the Message List
+
+The status of an errant message is illustrated in the message window.
+
+![An Error in the Message Window](images/overview-messagewindowerror.png)
+
+
+## The Flow Diagram
+
+The flow diagram highlights errors in red and provides details with access to the stack trace.
+
+![Error in the flow diagram](images/overview-flowdiagramwitherror.png)
+
+
+## The Sequence Diagram
+
+The sequence diagram highlights handlers with errors in red.
+
+![Error in the sequence diagram](images/overview-sequence-diagram-witherror.png)
+
+
+## Retrying a failed message
+
+Once the underlying cause for message processing failure has been resolved it is possible to rety a failed message from within ServiceInsight. Find the message to be retried and click `Retry Message`.

--- a/servicepulse/intro-failed-messages.md
+++ b/servicepulse/intro-failed-messages.md
@@ -4,6 +4,8 @@ summary: Describes how ServicePulse detects and monitors failed messages, and al
 tags:
 - ServicePulse
 reviewed: 2016-03-02 
+related:
+- serviceinsight/managing-errors-and-retries
 ---
 
 When an NServiceBus endpoint fails to process a message, it performs a set of configurable attempts to recover from this failure. These attempts are referred to as First Level Retries (FLR) and Second Level Retries (SLR) and in many cases allow the endpoint to overcome intermittent communication failures. For more details see [Second Level Retries](/nservicebus/errors/automatic-retries.md).
@@ -57,10 +59,6 @@ If a message fails repeated retry attempts, an indication is added, including th
 ![Repeated failure indication](images/failed-messages-repeated-failure.png)
 
 NOTE: The number of retry attempts for a message can be significant if the handler for that message is not [idempotent](/nservicebus/concept-overview.md#idempotence). Any processing attempt that invokes logic that does not participate in the NServiceBus transactional processing will not be rolled back on processing failure.
-
-**Related articles:**
-
-* [Failed Messages display and Retry in ServiceInsight](/serviceinsight/#errors-and-retries)
 
 
 ### Archiving Failed Messages


### PR DESCRIPTION
Relates to #1238 

Takes the Error Handling part of the ServiceInsight doco and puts in a different page in the doco so that it can be referred by the ServicePulse doco.

@Particular/serviceinsight-maintainers can you please review this and see if you're happy with the change. 