### PR TITLE
Obsolete wellknownstep

### DIFF
--- a/Snippets/Core/Core_6/Pipeline/NewPipelineStep.cs
+++ b/Snippets/Core/Core_6/Pipeline/NewPipelineStep.cs
@@ -10,8 +10,6 @@
         public NewPipelineStep()
             : base("NewPipelineStep", typeof(SampleBehavior), "Logs a warning when processing takes too long")
         {
-            // Optional: Specify where it needs to be invoked in the pipeline, for example InsertBefore or InsertAfter
-            InsertBefore(WellKnownStep.InvokeHandlers);
         }
     }
 

--- a/nservicebus/pipeline/manipulate-with-behaviors.md
+++ b/nservicebus/pipeline/manipulate-with-behaviors.md
@@ -24,8 +24,6 @@ In the above code snippet the `SampleBehavior` class derives from the Behavior c
 
 Warning: Each behavior is responsible to call the next step in the pipeline chain by invoking `next()`.
 
-NOTE: Steps can be ordered by using `WellKnownSteps`. It is recommended not rely on the existence of certain steps but to choose the appropriate stage instead.
-
 
 ## Add a new step
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -237,7 +237,7 @@ The `IMessageMutator` and `IMutateTransportMessages` interfaces are no longer av
  
 #### WellKnownStep
 
-`WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead of ordering behaviors, place your behavior in an appropriate stage of the pipeline. Please contact the support if custom behavior depend on a specific order within the pipeline stage.
+`WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead of ordering behaviors, place your behavior in an appropriate stage of the pipeline. [Contact support](http://particular.net/support) if custom behavior depend on a specific order within the pipeline stage.
 
 
 ### PipelineExecutor

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -234,6 +234,10 @@ The `IMessageMutator` and `IMutateTransportMessages` interfaces are no longer av
 
  * `IncomingContext` and `OutgoingContext` have been replaced with multiple contexts ("stages") per pipeline offering more useful information depending on the requirements. [Pipeline Steps Stages and Connectors](/nservicebus/pipeline/steps-stages-connectors.md) provides more details about the available stages.
  * `Behavior<TContext>` now provides the base class for implementing custom behaviors and replaces `IBehavior<TContext>`.
+ 
+#### WellKnownSteps
+
+`WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead of ordering behaviors, place your behavior in an appropriate stage of the pipeline. Please contact the support if custom behavior depend on a specific order within the pipeline stage.
 
 
 ### PipelineExecutor

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -235,7 +235,7 @@ The `IMessageMutator` and `IMutateTransportMessages` interfaces are no longer av
  * `IncomingContext` and `OutgoingContext` have been replaced with multiple contexts ("stages") per pipeline offering more useful information depending on the requirements. [Pipeline Steps Stages and Connectors](/nservicebus/pipeline/steps-stages-connectors.md) provides more details about the available stages.
  * `Behavior<TContext>` now provides the base class for implementing custom behaviors and replaces `IBehavior<TContext>`.
  
-#### WellKnownSteps
+#### WellKnownStep
 
 `WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead of ordering behaviors, place your behavior in an appropriate stage of the pipeline. Please contact the support if custom behavior depend on a specific order within the pipeline stage.
 

--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -237,7 +237,7 @@ The `IMessageMutator` and `IMutateTransportMessages` interfaces are no longer av
  
 #### WellKnownStep
 
-`WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead of ordering behaviors, place your behavior in an appropriate stage of the pipeline. [Contact support](http://particular.net/support) if custom behavior depend on a specific order within the pipeline stage.
+`WellKnownStep` has been obsoleted and should no longer be used to order behaviors with `InsertBefore` and `InsertAfter`. Instead place the behavior in an appropriate [stage of the pipeline](/nservicebus/pipeline/steps-stages-connectors.md). [Contact support](http://particular.net/support) if custom behavior depend on a specific order within the pipeline stage.
 
 
 ### PipelineExecutor

--- a/samples/feature/Core_6/Sample/Handler/HandlerTimerFeature.cs
+++ b/samples/feature/Core_6/Sample/Handler/HandlerTimerFeature.cs
@@ -1,5 +1,4 @@
 ﻿using NServiceBus.Features;
-using NServiceBus.Pipeline;
 
 #region HandlerTimerFeature
 
@@ -13,15 +12,7 @@ public class HandlerTimerFeature : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
-        context.Pipeline.Register<Registration>();
-    }
-
-    class Registration : RegisterStep
-    {
-        public Registration()
-            : base("HandlerTimer", typeof(HandlerTimerBehavior), "Logs handler time")
-        {
-        }
+        context.Pipeline.Register("HandlerTimer", typeof(HandlerTimerBehavior), "Logs handler time");
     }
 }
 

--- a/samples/feature/Core_6/Sample/Saga/SagaStateAuditFeature.cs
+++ b/samples/feature/Core_6/Sample/Saga/SagaStateAuditFeature.cs
@@ -1,5 +1,4 @@
 ﻿using NServiceBus.Features;
-using NServiceBus.Pipeline;
 
 #region SagaStateAuditFeature
 
@@ -14,16 +13,7 @@ public class SagaStateAuditFeature : Feature
 
     protected override void Setup(FeatureConfigurationContext context)
     {
-        context.Pipeline.Register<Registration>();
-    }
-
-    class Registration : RegisterStep
-    {
-        public Registration()
-            : base("SagaStateAudit", typeof(SagaStateAuditBehavior), "Logs Saga State")
-        {
-            InsertBefore(WellKnownStep.InvokeSaga);
-        }
+        context.Pipeline.Register("SagaStateAudit", typeof(SagaStateAuditBehavior), "Logs Saga State");
     }
 }
 

--- a/samples/pipeline/stream-properties/Core_6/Shared/StreamConfig.cs
+++ b/samples/pipeline/stream-properties/Core_6/Shared/StreamConfig.cs
@@ -22,7 +22,7 @@ public class StreamReceiveRegistration : RegisterStep
     public StreamReceiveRegistration()
         : base("StreamReceive", typeof(StreamReceiveBehavior), "Copies the shared data back to the logical messages")
     {
-        InsertAfter(WellKnownStep.MutateIncomingMessages);
+        InsertAfter("MutateIncomingMessages");
         //Note that in V6 invocation of handlers is in a different stage so no "before" is needed
     }
 }
@@ -32,7 +32,7 @@ public class StreamSendRegistration : RegisterStep
     public StreamSendRegistration()
         : base("StreamSend", typeof(StreamSendBehavior), "Saves the payload into the shared location")
     {
-        InsertAfter(WellKnownStep.MutateOutgoingMessages);
+        InsertAfter("MutateOutgoingMessages");
         InsertBefore("ApplyTimeToBeReceived");
     }
 }


### PR DESCRIPTION
Decision was made to obsolete WellKnownStep for v6 and essentially make InsertBefore/After more difficult and treat it as a "hidden api" (since we want to remove it in the future)