### PR TITLE
Fix for multi instance so that satellite queues are created using the correct instance

### DIFF
--- a/samples/sqltransport/multi-instance/SqlServer_2/EndpointConnectionLookup/ConnectionProvider.cs
+++ b/samples/sqltransport/multi-instance/SqlServer_2/EndpointConnectionLookup/ConnectionProvider.cs
@@ -8,8 +8,9 @@ public class ConnectionProvider
 
     public static ConnectionInfo GetConnection(string transportAddress)
     {
-        var connectionString = transportAddress.Equals("Samples.SqlServer.MultiInstanceSender")
-                                                ? SenderConnectionString : ReceiverConnectionString;
+        var connectionString = transportAddress.StartsWith("Samples.SqlServer.MultiInstanceSender")
+                                                ? SenderConnectionString
+                                                : ReceiverConnectionString;
         return ConnectionInfo.Create()
                 .UseConnectionString(connectionString);
     }

--- a/samples/sqltransport/multi-instance/SqlServer_3/EndpointConnectionLookup/ConnectionProvider.cs
+++ b/samples/sqltransport/multi-instance/SqlServer_3/EndpointConnectionLookup/ConnectionProvider.cs
@@ -9,8 +9,9 @@ public class ConnectionProvider
 
     public static async Task<SqlConnection> GetConnection(string transportAddress)
     {
-        var connectionString = transportAddress.Equals("Samples.SqlServer.MultiInstanceSender@[dbo]")
-                                                ? ReceiverConnectionString : SenderConnectionString;
+        var connectionString = transportAddress.StartsWith("Samples.SqlServer.MultiInstanceSender")
+                                                ? SenderConnectionString
+                                                : ReceiverConnectionString;
         var connection = new SqlConnection(connectionString);
 
         await connection.OpenAsync()


### PR DESCRIPTION
* Both V2 and V3 sample now use a *StartsWith*
* Fixed behavior of V3 sample that previously returned sender connection for receiver endpoint and vice versa.