### PR TITLE
Adjusted guide to make sequence of steps more logical

### DIFF
--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -8,6 +8,7 @@ redirects:
 
 WARNING: The completed sample code can be downloaded above but following this guide is strongly encouraged.
 
+
 ## Introduction
 
 This guide illustrates essential NServiceBus concepts by showing how to build a simple system that uses messaging to:
@@ -64,7 +65,7 @@ The finished solution will contain four projects. Create a new Visual Studio sol
  * A Console Application named `Subscriber`
  * A Class Library named `Shared`
 
-Each of the console applications will be configured to be **messaging endpoints**, meaning they are able to send and receive NServiceBus messages. Commonly they will be referred to simply as **endpoints**.
+Each of the console applications will be configured to be **messaging endpoints**, meaning they are able to send and receive NServiceBus messages. Commonly they will be referred to simply as [endpoints](/nservicebus/endpoints/).
 
 The client endpoint's job will be to send `PlaceOrder` commands to the server. The server endpoint will process the `PlaceOrder` commands, and then publish an `OrderPlaced` event to any interested subscribers. The subscriber endpoint will subscribe to `OrderPlaced` events published from the server, and process those events when they arrive.
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -86,10 +86,7 @@ In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Sh
 To install the `NServiceBus` NuGet package, copy-paste and run the following block in the package manager console:
 
 ```ps
-Install-Package NServiceBus -Project Client
-Install-Package NServiceBus -Project Server
-Install-Package NServiceBus -Project Subscriber
-Install-Package NServiceBus -Project Shared
+Get-Project -All | Install-Package nservicebus
 ```
 
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -6,7 +6,7 @@ redirects:
 - nservicebus/nservicebus-step-by-step-guide
 ---
 
-The completed sample code can be downloaded above but following this guide is strongly encouraged.
+WARNING: The completed sample code can be downloaded above but following this guide is strongly encouraged.
 
 ## Introduction
 
@@ -19,24 +19,27 @@ This guide illustrates essential NServiceBus concepts by showing how to build a 
 
 Completing these steps will serve as an introduction to many important NServiceBus concepts:
 
-* Basic project setup
-* [Self-hosting NServiceBus](/nservicebus/hosting/) within a console application
-* [Defining commands and events](/nservicebus/messaging/messages-events-commands.md)
-* [Sending commands](/nservicebus/messaging/send-a-message.md)
-* [Handling messages](/nservicebus/handlers/)
-* [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
-* [Logging](/nservicebus/logging/)
+ * Basic project setup
+ * [Self-hosting NServiceBus](/nservicebus/hosting/) within a console application
+ * [Defining commands and events](/nservicebus/messaging/messages-events-commands.md)
+ * [Sending commands](/nservicebus/messaging/send-a-message.md)
+ * [Handling messages](/nservicebus/handlers/)
+ * [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
+ * [Logging](/nservicebus/logging/)
 
 
 ## Prerequisites
+
 
 ### .NET Framework Version 4.5.2
 
 [Download the .NET Framework Version 4.5.2](https://www.microsoft.com/en-au/download/details.aspx?id=42642) and install it.
 
+
 ### MSMQ
 
-* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
+Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
+
 
 #### Enable MSMQ on Windows 7
 
@@ -44,20 +47,22 @@ Run the following command on the command line:
 
 `DISM.exe /Online /NoRestart /English /Enable-Feature /FeatureName:MSMQ-Container /FeatureName:MSMQ-Server`
 
+
 #### Enable MSMQ on Windows 8.x and 10
 
 Run the following command on the command line:
 
 `DISM.exe /Online /NoRestart /English /Enable-Feature /all /FeatureName:MSMQ-Server`
 
+
 ## Project structure
 
 The finished solution will contain four projects. Create a new Visual Studio solution containing the following:
 
-* A Console Application named `Client`
-* A Console Application named `Server`
-* A Console Application named `Subscriber` 
-* A Class Library named `Shared`
+ * A Console Application named `Client`
+ * A Console Application named `Server`
+ * A Console Application named `Subscriber`
+ * A Class Library named `Shared`
 
 Each of the console applications will be configured to be **messaging endpoints**, meaning they are able to send and receive NServiceBus messages. Commonly they will be referred to simply as **endpoints**.
 
@@ -70,20 +75,23 @@ NOTE: Storing all message definitions in a single location is not a best practic
 
 ### Setting dependencies
 
+
 #### Reference the Shared project.
 
 In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Shared` project.
+
 
 #### Reference the NServiceBus NuGet package
 
 To install the `NServiceBus` NuGet package, copy-paste and run the following block in the package manager console:
 
-```
+```ps
 Install-Package NServiceBus -Project Client
 Install-Package NServiceBus -Project Server
 Install-Package NServiceBus -Project Subscriber
 Install-Package NServiceBus -Project Shared
 ```
+
 
 ## Defining messages
 
@@ -141,9 +149,9 @@ snippet:PlaceOrderHandler
 
 This class is the message handler that processes the `PlaceOrder` command being sent by the Client. A handler is where a message is processed; very often this will involve saving information from the message into a database, calling a web service, or some other business function. In this example, the message is logged, so the fact the message was received will be visible in the Console window. Next, the handler publishes a new `OrderPlaced` event.
 
-The handler class is automatically discovered by NServiceBus because it implements the `IHandleMessages<T>` interface. The [dependency injection system](/nservicebus/containers/) (which supports constructor or property injection) injects the `IBus` instance into the handler to access messaging operations. When a `PlaceOrder` command is received, NServiceBus will create a new instance of the `PlaceOrderHandler` class and invoke the `Handle(PlaceOrder message)` method. 
+The handler class is automatically discovered by NServiceBus because it implements the `IHandleMessages<T>` interface. The [dependency injection system](/nservicebus/containers/) (which supports constructor or property injection) injects the `IBus` instance into the handler to access messaging operations. When a `PlaceOrder` command is received, NServiceBus will create a new instance of the `PlaceOrderHandler` class and invoke the `Handle(PlaceOrder message)` method.
 
- The next step is to create a subscriber for this event.
+The next step is to create a subscriber for this event.
 
 NOTE: The solution could be executed at this stage and would run without exceptions. However, there are no subscribers to the `OrderPlaced` event, so the sample is not yet complete. In practice it's perfectly valid to have a publisher with no subscribers; a new subscriber can be added at a later date. In such a situation, no messages are exchanged on the transport level, meaning there's no actual communication between endpoints when the event is published.
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -25,7 +25,7 @@ Completing these steps will serve as an introduction to many important NServiceB
 * [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
 * [Logging](/nservicebus/logging/)
 
-The complete sample code can be [downloaded here](http://docs.particular.net/samples/step-by-step/step-by-step.zip), but following this guide is strongly encouraged for a better learning experience.
+The complete sample code can be [downloaded here](/samples/step-by-step/step-by-step.zip), but following this guide is strongly encouraged for a better learning experience.
 
 ## Prerequisites
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -6,12 +6,9 @@ redirects:
 - nservicebus/nservicebus-step-by-step-guide
 ---
 
-This sample illustrates basic NServiceBus concepts in a step-by-step fashion. Alternatively, the completed sample code can be downloaded above.
+## Introduction
 
-
-## Concepts
-
-The goal of this step-by-step sample is to show how to build a simple system that uses messaging to:
+This guide illustrates essential NServiceBus concepts by showing how to build a simple system that uses messaging to:
 
  * Send a command from a client to a server
  * Receive that message and process it on the server
@@ -28,12 +25,29 @@ Completing these steps will serve as an introduction to many important NServiceB
 * [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
 * [Logging](/nservicebus/logging/)
 
+You can also [download the completed sample code](http://docs.particular.net/samples/step-by-step/step-by-step.zip), but we strongly encourage you to follow this guide for a better learning experience.
 
 ## Prerequisites
 
-* [.NET Framework Version 4.5.2](https://www.microsoft.com/en-au/download/details.aspx?id=42642)
-* Microsoft Message Queueing (MSMQ) must be [properly installed and configured](/nservicebus/msmq/). The easiest way to do this is using the [Platform Installer](/platform/installer/) tool.
+### .NET Framework Version 4.5.2
 
+You need to [download the .NET Framework Version 4.5.2](https://www.microsoft.com/en-au/download/details.aspx?id=42642) and install it on your machine.
+
+### MSMQ
+
+* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is using DISM command line as specified below. If you prefer to do it via the Windows GUI, follow our [MSMQ guide](/platform/installer/).
+
+#### Enable MSMQ on Windows 7
+
+Run the following command on the DISM command line:
+
+`DISM.exe /Online /NoRestart /English /Enable-Feature /FeatureName:MSMQ-Container /FeatureName:MSMQ-Server`
+
+#### Enable MSMQ on Windows 8.x and 10
+
+Run the following command on the DISM command line:
+
+`DISM.exe /Online /NoRestart /English /Enable-Feature /all /FeatureName:MSMQ-Server`
 
 ## Project structure
 
@@ -55,11 +69,20 @@ NOTE: Storing all message definitions in a single location is not a best practic
 
 ### Setting dependencies
 
-First, set up the necessary dependencies:
+#### Reference the `Shared` project.
 
-* In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Shared` project.
-* In each project, add a reference to the `NServiceBus` NuGet package.
+In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Shared` project.
 
+#### Reference the `NServiceBus` NuGet package
+
+To install the `NServiceBus` NuGet package, copy-paste and run the following block in the package manager console:
+
+```
+Install-Package NServiceBus -Project Client
+Install-Package NServiceBus -Project Server
+Install-Package NServiceBus -Project Subscriber
+Install-Package NServiceBus -Project Shared
+```
 
 ## Defining messages
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -35,17 +35,17 @@ The complete sample code can be [downloaded here](http://docs.particular.net/sam
 
 ### MSMQ
 
-* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate DISM command line below. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
+* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
 
 #### Enable MSMQ on Windows 7
 
-Run the following command on the DISM command line:
+Run the following command on the command line:
 
 `DISM.exe /Online /NoRestart /English /Enable-Feature /FeatureName:MSMQ-Container /FeatureName:MSMQ-Server`
 
 #### Enable MSMQ on Windows 8.x and 10
 
-Run the following command on the DISM command line:
+Run the following command on the command line:
 
 `DISM.exe /Online /NoRestart /English /Enable-Feature /all /FeatureName:MSMQ-Server`
 
@@ -73,7 +73,7 @@ NOTE: Storing all message definitions in a single location is not a best practic
 
 In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Shared` project.
 
-#### Reference the `NServiceBus` NuGet package
+#### Reference the NServiceBus NuGet package
 
 To install the `NServiceBus` NuGet package, copy-paste and run the following block in the package manager console:
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -38,7 +38,7 @@ Completing these steps will serve as an introduction to many important NServiceB
 
 ### MSMQ
 
-Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
+Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/nservicebus/msmq/).
 
 
 #### Enable MSMQ on Windows 7

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -83,7 +83,7 @@ In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Sh
 
 #### Reference the NServiceBus NuGet package
 
-To install the `NServiceBus` NuGet package, copy-paste and run the following block in the package manager console:
+To install the `NServiceBus` NuGet package, copy-paste and run the following command in the [Package Manager Console](https://docs.nuget.org/consume/package-manager-console):
 
 ```ps
 Get-Project -All | Install-Package nservicebus

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -25,17 +25,17 @@ Completing these steps will serve as an introduction to many important NServiceB
 * [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
 * [Logging](/nservicebus/logging/)
 
-You can also [download the completed sample code](http://docs.particular.net/samples/step-by-step/step-by-step.zip), but we strongly encourage you to follow this guide for a better learning experience.
+The complete sample code can be [downloaded here](http://docs.particular.net/samples/step-by-step/step-by-step.zip), but following this guide is strongly encouraged for a better learning experience.
 
 ## Prerequisites
 
 ### .NET Framework Version 4.5.2
 
-You need to [download the .NET Framework Version 4.5.2](https://www.microsoft.com/en-au/download/details.aspx?id=42642) and install it on your machine.
+[Download the .NET Framework Version 4.5.2](https://www.microsoft.com/en-au/download/details.aspx?id=42642) and install it.
 
 ### MSMQ
 
-* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is using DISM command line as specified below. If you prefer to do it via the Windows GUI, follow our [MSMQ guide](/platform/installer/).
+* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate DISM command line below. Alternatively, it can be installed via the Windows GUI following our [MSMQ guide](/platform/installer/).
 
 #### Enable MSMQ on Windows 7
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -39,7 +39,7 @@ Completing these steps will serve as an introduction to many important NServiceB
 
 ### MSMQ
 
-Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command below from the command line. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/nservicebus/msmq/).
+Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command line below. Alternatively, it can be installed via the Windows Features tool. For more details on installing and configuring MSMQ see [MSMQ Transport](/nservicebus/msmq/).
 
 
 #### Enable MSMQ on Windows 7

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -6,6 +6,8 @@ redirects:
 - nservicebus/nservicebus-step-by-step-guide
 ---
 
+The completed sample code can be downloaded above but following this guide is strongly encouraged.
+
 ## Introduction
 
 This guide illustrates essential NServiceBus concepts by showing how to build a simple system that uses messaging to:
@@ -25,7 +27,6 @@ Completing these steps will serve as an introduction to many important NServiceB
 * [Publishing events](/nservicebus/messaging/publish-subscribe/publish-handle-event.md)
 * [Logging](/nservicebus/logging/)
 
-The complete sample code can be [downloaded here](/samples/step-by-step/step-by-step.zip), but following this guide is strongly encouraged for a better learning experience.
 
 ## Prerequisites
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -35,7 +35,7 @@ The complete sample code can be [downloaded here](http://docs.particular.net/sam
 
 ### MSMQ
 
-* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate DISM command line below. Alternatively, it can be installed via the Windows GUI following our [MSMQ guide](/platform/installer/).
+* Microsoft Message Queueing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate DISM command line below. Alternatively, it can be installed via the Windows GUI following the [MSMQ guide](/platform/installer/).
 
 #### Enable MSMQ on Windows 7
 

--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -69,7 +69,7 @@ NOTE: Storing all message definitions in a single location is not a best practic
 
 ### Setting dependencies
 
-#### Reference the `Shared` project.
+#### Reference the Shared project.
 
 In the `Client`, `Server`, and `Subscriber` projects, add a reference to the `Shared` project.
 


### PR DESCRIPTION
Adjusted guide to make the sequence of steps more logical and give MSMQ installation instructions directly to avoid having to move away from this page. This is also to prevent the requirement of having to run the Platform Installer which doesn't really seem to simplify the set up of MSMQ.

Note: In order for this PR to be effective:
- the NuGet section at the top should be omitted (because the NuGet package installation is not the first thing the guide should start with, it's just a step in the guide).
- the "Download" and "Browse on GitHub" buttons should be hidden to discourage readers from straying away from following the guide