### PR TITLE
Rework licensing  info

### DIFF
--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -108,14 +108,11 @@ Additional parameters for `Invoke-ServiceControlInstanceUpgrade` may be required
 
 ### Licensing
 
-Adding the license file to the registry can be done by running the following cmdlet. The license file is now machine wide and is available to be used by all instances of ServiceControl.
+Adding the license file to the registry can be done by running the following cmdlet. The license file is  is available to be used by all instances of ServiceControl. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl
 
 ```ps
 Import-ServiceControlLicense <License-File>
 ```
-
-It is also possible to apply a license to an individual instance rather than globally. This can be done by by creating a license file under the installation path of an instance and copying the `license.xml` to that directory.
-Adding a license this way is deprecated and not supported via the ServiceControl Management Utility or the PowerShell module.
 
 ### Building an unattended install file
 

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -115,8 +115,7 @@ Import-ServiceControlLicense <License-File>
 ```
 
 It is also possible to apply a license to an individual instance rather than globally. This can be done by by creating a license file under the installation path of an instance and copying the `license.xml` to that directory.
-Adding a license this way is not supported via the ServiceControl Management Utility or the PowerShell module.
-
+Adding a license this way is deprecated and not supported via the ServiceControl Management Utility or the PowerShell module.
 
 ### Building an unattended install file
 

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -106,13 +106,17 @@ Invoke-ServiceControlInstanceUpgrade -Name <Instance To upgrade>
 The upgrade will stop the service if it is running.
 Additional parameters for `Invoke-ServiceControlInstanceUpgrade` may be required. The configuration file of the existing version is examined prior to deter,in e if all the required settings are present. If a configuration setting is missing  then the cmdlet will throw an error indicating the required additional parameter.
 
+
 ### Licensing
 
-Adding the license file to the registry can be done by running the following cmdlet. The license file is  is available to be used by all instances of ServiceControl. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl
+Add the license file to the registry by running the following cmdlet. 
 
 ```ps
 Import-ServiceControlLicense <License-File>
 ```
+
+The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to all instances of ServiceControl installed on the machine.
+
 
 ### Building an unattended install file
 

--- a/servicecontrol/license.md
+++ b/servicecontrol/license.md
@@ -1,5 +1,5 @@
 ---
-title: Install the license in ServiceControl
+title: Licensing ServiceControl
 tags:
  - servicecontrol
  - license
@@ -7,22 +7,38 @@ tags:
 ---
 
 
-## Using the ServiceControl Management Utility
+## Licensing ServiceControl
 
-The ServiceControl Management utility allow has a simple Add License user interface  option which will import the designated license file into the registry.
+The following options outline how to add a license to ServiceControl.
+
+### ServiceControl Management Utility
+
+The ServiceControl Management utility allow has a simple Add License user interface  option which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl regardless of the service account used.
+  
 
 ![](managementutil-addlicense.png)
 
-When the license is [installed in the registry](/nservicebus/licensing/license-management.md) it is available machine wide and applied to all Particular products running on that machine.
 
-This screen utility has a corresponding [PowerShell cmdlet](installation-powershell.md) to allow the same action to be scripted.
+### ServiceControl PowerShell
+
+To import a license using PowerShell:
+
+* Start the ServiceControl PowerShell Management Console from the start menu 
+* Execute the following cmdlet with the path to the license file.
+
+```bat
+Import-ServiceControlLicense <LicenseFile>
+```
+
+### Deprecated Licensing method
+It is also possible to apply a license to an individual instance rather than globally. This can be done by by creating a license folder under the installation path of an instance and copying the `license.xml` to that directory.
+Adding a license this way is not supported via the ServiceControl Management Utility or the PowerShell module.
 
 
-## Using the registry
-
-When the license is [installed in the registry](/nservicebus/licensing/license-management.md) it is available machine wide and applied to all Particular products running on that machine.
+### Troubleshooting
 
 
-## Using the license file
+#### ServiceControl license was updated but ServicePulse reports the license has expired
 
-Create a folder called `License` under the folder where ServiceControl is installed and copy `license.xml` file there. E.g. `{servicecontrol-directory}/license/license.xml`
+ServiceControl reads license information at service start up and caches it.  Once a new license is applied the ServiceControl instance must be restarted to pick up the license change, in the meantime the license status shown in ServicePulse is based on the cached state.
+

--- a/servicecontrol/license.md
+++ b/servicecontrol/license.md
@@ -13,7 +13,7 @@ The following options outline how to add a license to ServiceControl.
 
 ### ServiceControl Management Utility
 
-The ServiceControl Management utility allow has a license user interface which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl regardless of the service account used.
+The ServiceControl Management utility has a license user interface which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it is available to all instances of ServiceControl regardless of the service account used.
 
 ![](managementutil-addlicense.png)
 
@@ -29,12 +29,14 @@ To import a license using PowerShell:
 Import-ServiceControlLicense <LicenseFile>
 ```
 
-### Deprecated Licensing method
-It is also possible to apply a license to an individual instance rather than using the registry method. This can be done by by creating a `license` folder under the installation path of an instance and copying the `license.xml` to that directory.
-Adding a license in this manner is deprecated.   The ServiceControl Management Utility and PowerShell module only manage the registry license location
+### Instance Licensing
+
+In Version 1.17 and below, a license can be applied to an individual instance rather than using a license installed in the registry. To do this, copy the `license.xml` file to a `license` folder under the installation path of the instance.
+
+NOTE: Instance Licensing is deprecated in Version 1.18 and above. Use the ServiceControl Management Utility or PowerShell module to install the license file to the registry. 
 
 ### Troubleshooting
 
 #### ServiceControl license was updated but ServicePulse reports the license has expired
 
-ServiceControl reads license information at service start up and caches it.  Once a new license is applied the ServiceControl instance must be restarted to detect the license change, until then the license status shown in ServicePulse is based on the cached state.
+ServiceControl reads license information at service start up and caches it. Once a new license is applied the ServiceControl instance must be restarted to detect the license change, until then the license status shown in ServicePulse is based on the cached state.

--- a/servicecontrol/license.md
+++ b/servicecontrol/license.md
@@ -13,8 +13,7 @@ The following options outline how to add a license to ServiceControl.
 
 ### ServiceControl Management Utility
 
-The ServiceControl Management utility allow has a simple Add License user interface  option which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl regardless of the service account used.
-  
+The ServiceControl Management utility allow has a license user interface which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to be all instances of ServiceControl regardless of the service account used.
 
 ![](managementutil-addlicense.png)
 
@@ -26,19 +25,16 @@ To import a license using PowerShell:
 * Start the ServiceControl PowerShell Management Console from the start menu 
 * Execute the following cmdlet with the path to the license file.
 
-```bat
+```ps
 Import-ServiceControlLicense <LicenseFile>
 ```
 
 ### Deprecated Licensing method
-It is also possible to apply a license to an individual instance rather than globally. This can be done by by creating a license folder under the installation path of an instance and copying the `license.xml` to that directory.
-Adding a license this way is not supported via the ServiceControl Management Utility or the PowerShell module.
-
+It is also possible to apply a license to an individual instance rather than using the registry method. This can be done by by creating a `license` folder under the installation path of an instance and copying the `license.xml` to that directory.
+Adding a license in this manner is deprecated.   The ServiceControl Management Utility and PowerShell module only manage the registry license location
 
 ### Troubleshooting
 
-
 #### ServiceControl license was updated but ServicePulse reports the license has expired
 
-ServiceControl reads license information at service start up and caches it.  Once a new license is applied the ServiceControl instance must be restarted to pick up the license change, in the meantime the license status shown in ServicePulse is based on the cached state.
-
+ServiceControl reads license information at service start up and caches it.  Once a new license is applied the ServiceControl instance must be restarted to detect the license change, until then the license status shown in ServicePulse is based on the cached state.


### PR DESCRIPTION
Update ServiceControl licensing to specify that the registry is the place we expect licenses and that the file based approach shouldn't be used.

@mikeminutillo  @SimonCropp  please review 