### PR TITLE
Show snippet for DefineEndpointname

### DIFF
--- a/Snippets/CloudServicesHost/CloudServicesHost_7/CloudServicesHost_7.csproj
+++ b/Snippets/CloudServicesHost/CloudServicesHost_7/CloudServicesHost_7.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core5to6\StartupInterface.cs" />
+    <Compile Include="EndpointNameInCode.cs" />
     <Compile Include="Definitions.cs" />
     <Compile Include="HostingAndConfiguration.cs" />
     <Compile Include="Usage.cs" />

--- a/Snippets/CloudServicesHost/CloudServicesHost_7/EndpointNameInCode.cs
+++ b/Snippets/CloudServicesHost/CloudServicesHost_7/EndpointNameInCode.cs
@@ -1,0 +1,13 @@
+﻿namespace CloudServicesHost_7
+{
+    using NServiceBus;
+    public class EndpointNameInCode : IConfigureThisEndpoint
+    {
+        #region EndpointNameInCodeForAzureHost
+        public void Customize(EndpointConfiguration configuration)
+        {
+            configuration.DefineEndpointName("CustomEndpointName");
+        }
+        #endregion
+    }
+}

--- a/Snippets/Host/Host_7/EndpointNameInCode.cs
+++ b/Snippets/Host/Host_7/EndpointNameInCode.cs
@@ -1,0 +1,14 @@
+﻿namespace MyServer
+{
+    using NServiceBus;
+
+    public class EndpointNameInCode : IConfigureThisEndpoint
+    {
+        #region EndpointNameInCode
+        public void Customize(EndpointConfiguration configuration)
+        {
+            configuration.DefineEndpointName("CustomEndpointName");
+        }
+        #endregion
+    }
+}

--- a/Snippets/Host/Host_7/Host_7.csproj
+++ b/Snippets/Host/Host_7/Host_7.csproj
@@ -41,6 +41,7 @@
     <Compile Include="CustomizingHost.cs" />
     <Compile Include="EndpointConfigByNamespace.cs" />
     <Compile Include="EndpointConfigWithAttribute.cs" />
+    <Compile Include="EndpointNameInCode.cs" />
     <Compile Include="EndpointStartAndStop.cs" />
     <Compile Include="OverrideLoggingViaProfile.cs" />
     <Compile Include="PerformanceMonitoring.cs" />

--- a/nservicebus/endpoints/specify-endpoint-name.md
+++ b/nservicebus/endpoints/specify-endpoint-name.md
@@ -31,7 +31,7 @@ snippet:EndpointNameByNamespace
 
 ### Defined in code
 
-Set the endpoint name using the `DefineEndpointName` extension method on the endpoint configuration.
+Set the endpoint name using the `DefineEndpointName(name)` extension method on the endpoint configuration.
 
 snippet:EndpointNameInCode
 
@@ -59,7 +59,7 @@ NOTE: Only use code **OR** commandline/installation parameters.
 
 ### Defined in code
 
-Set the endpoint name using the `DefineEndpointName` extension method on the endpoint configuration.
+Set the endpoint name using the `DefineEndpointName(name)` extension method on the endpoint configuration.
 
 snippet:EndpointNameInCodeForAzureHost
 

--- a/nservicebus/endpoints/specify-endpoint-name.md
+++ b/nservicebus/endpoints/specify-endpoint-name.md
@@ -29,6 +29,11 @@ When using NServiceBus.Host, the namespace of the class implementing `IConfigure
 
 snippet:EndpointNameByNamespace
 
+### Defined in code
+
+Set the endpoint name using the `DefineEndpointName` extension method on the endpoint configuration.
+
+snippet:EndpointNameInCode
 
 ### EndpointName attribute
 
@@ -50,6 +55,13 @@ Specify a endpoint name when running the NServiceBus host: `/endpointName:"MyEnd
 
 NOTE: Only use code **OR** commandline/installation parameters.
 
+## When using NServiceBus.Hosting.Azure.HostProcess.exe
+
+### Defined in code
+
+Set the endpoint name using the `DefineEndpointName` extension method on the endpoint configuration.
+
+snippet:EndpointNameInCodeForAzureHost
 
 ## Input queue
 


### PR DESCRIPTION
For
* Azure Cloud Service Host
* NSB Host

Issue raised https://github.com/Particular/NServiceBus.Host.AzureCloudService/issues/57

Related PRs

* https://github.com/Particular/NServiceBus.Host/pull/92
* https://github.com/Particular/NServiceBus.Host.AzureCloudService/pull/58

Interestingly I could not find a specific configuration page which explains how the Azure host works and how things like conventions, endpoint name attribute etc. are applied. So my assumption was that we assume customers make the mental leap to connect the functionality to the NSB Host. If that assumption was wrong we need to do a lot more work than outlined here in this PR.

The two linked PRs need to go in first.

Thoughts @Particular/docs-maintainers ?

// cc @Particular/azure-host-maintainers 