### PR TITLE
Update best-practice-enforcement.md

### DIFF
--- a/nservicebus/messaging/best-practice-enforcement.md
+++ b/nservicebus/messaging/best-practice-enforcement.md
@@ -7,9 +7,7 @@ tags:
 - Event
 ---
 
-By default NServiceBus will ensure [messaging best practices](messages-events-commands.md) for messages define as either Commands or Events. While this worked it caused other features like [auto subscribe](publish-subscribe/controlling-what-is-subscribed.md) to stop working since only `Events` are auto subscribed.
-
-These enforcements can be bypassed by defining all messages as plain messages.
+By default NServiceBus will ensure [messaging best practices](messages-events-commands.md) for messages define as either Commands or Events.
 
 NOTE: In Versions 6 and above the default behavior can be overridden.
 


### PR DESCRIPTION
> While this worked it caused other features like [auto subscribe](publish-subscribe/controlling-what-is-subscribed.md) to stop working since only `Events` are auto subscribed.

This sentence is confusing. The autosubscribe doc explicitly states that it only works for messages marked as IEvent or with an appropriate convention.

> These enforcements can be bypassed by defining all messages as plain messages.

Using plain messages without any conventions throws exceptions at the message handler registry, so that sentence doesn't seem to be right?