### PR TITLE
Showing new way of callback cancellation and update to NSB.Callbacks 1.0.0-Beta2

### DIFF
--- a/Snippets/Callbacks/Callbacks_1/Callbacks_1.csproj
+++ b/Snippets/Callbacks/Callbacks_1/Callbacks_1.csproj
@@ -27,11 +27,13 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NServiceBus.Callbacks">
-      <HintPath>..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0001\lib\net452\NServiceBus.Callbacks.dll</HintPath>
+    <Reference Include="NServiceBus.Callbacks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0002\lib\net452\NServiceBus.Callbacks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.Core">
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NServiceBus.6.0.0-beta0006\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -54,10 +56,7 @@
     <Compile Include="UpgradeGuides\5to6\Callbacks.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Snippets/Callbacks/Callbacks_1/Cancellation/Usage.cs
+++ b/Snippets/Callbacks/Callbacks_1/Cancellation/Usage.cs
@@ -11,14 +11,12 @@
         {
             #region CancelCallback
 
-            var sendOptions = new SendOptions();
-            var cancellationToken = new CancellationTokenSource();
-            sendOptions.RegisterCancellationToken(cancellationToken.Token);
-            cancellationToken.CancelAfter(TimeSpan.FromSeconds(5));
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(5));
             var message = new Message();
             try
             {
-                var response = await endpoint.Request<int>(message, sendOptions)
+                var response = await endpoint.Request<int>(message, cancellationTokenSource.Token)
                     .ConfigureAwait(false);
             }
             catch (OperationCanceledException)

--- a/Snippets/Callbacks/Callbacks_1/Enum/Usage.cs
+++ b/Snippets/Callbacks/Callbacks_1/Enum/Usage.cs
@@ -6,11 +6,11 @@
 
     class Usage
     {
-        async Task Simple(IEndpointInstance endpoint, SendOptions sendOptions, ILog log)
+        async Task Simple(IEndpointInstance endpoint, ILog log)
         {
             #region EnumCallback
             var message = new Message();
-            var response = await endpoint.Request<Status>(message, sendOptions)
+            var response = await endpoint.Request<Status>(message)
                 .ConfigureAwait(false);
             log.Info($"Callback received with response:{response}");
             #endregion

--- a/Snippets/Callbacks/Callbacks_1/Int/Usage.cs
+++ b/Snippets/Callbacks/Callbacks_1/Int/Usage.cs
@@ -6,13 +6,13 @@
 
     class Usage
     {
-        async Task Simple(IEndpointInstance endpoint, SendOptions sendOptions, ILog log)
+        async Task Simple(IEndpointInstance endpoint, ILog log)
         {
 
             #region IntCallback
 
             var message = new Message();
-            var response = await endpoint.Request<int>(message, sendOptions)
+            var response = await endpoint.Request<int>(message)
                 .ConfigureAwait(false);
             log.Info($"Callback received with response:{response}");
 

--- a/Snippets/Callbacks/Callbacks_1/Object/Usage.cs
+++ b/Snippets/Callbacks/Callbacks_1/Object/Usage.cs
@@ -6,7 +6,7 @@
 
     class Usage
     {
-        async Task Simple(EndpointConfiguration endpointConfiguration, IEndpointInstance endpoint, SendOptions sendOptions, ILog log)
+        async Task Simple(EndpointConfiguration endpointConfiguration, IEndpointInstance endpoint, ILog log)
         {
             #region Callbacks-InstanceId
 
@@ -17,7 +17,7 @@
             #region ObjectCallback
 
             var message = new Message();
-            var response = await endpoint.Request<ResponseMessage>(message, sendOptions)
+            var response = await endpoint.Request<ResponseMessage>(message)
                 .ConfigureAwait(false);
             log.Info($"Callback received with response:{response.Property}");
 

--- a/Snippets/Callbacks/Callbacks_1/UpgradeGuides/5to6/Callbacks.cs
+++ b/Snippets/Callbacks/Callbacks_1/UpgradeGuides/5to6/Callbacks.cs
@@ -6,7 +6,7 @@
 
     class Callbacks
     {
-        async Task Simple(EndpointConfiguration endpointConfiguration, IEndpointInstance endpoint, SendOptions sendOptions)
+        async Task Simple(EndpointConfiguration endpointConfiguration, IEndpointInstance endpoint)
         {
             #region 5to6-Callbacks-InstanceId
             endpointConfiguration.MakeInstanceUniquelyAddressable(ConfigurationManager.AppSettings["InstanceId"]);
@@ -15,7 +15,7 @@
             #region 5to6-Callbacks
 
             var message = new RequestMessage();
-            var response = await endpoint.Request<ResponseMessage>(message, sendOptions)
+            var response = await endpoint.Request<ResponseMessage>(message)
                 .ConfigureAwait(false);
 
             #endregion

--- a/Snippets/Callbacks/Callbacks_1/packages.config
+++ b/Snippets/Callbacks/Callbacks_1/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.0.0-beta0006" targetFramework="net452" />
-  <package id="NServiceBus.Callbacks" version="1.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus.Callbacks" version="1.0.0-beta0002" targetFramework="net452" />
 </packages>

--- a/nservicebus/messaging/handling-responses-on-the-client-side.md
+++ b/nservicebus/messaging/handling-responses-on-the-client-side.md
@@ -86,7 +86,6 @@ partial:fakeHandler
 
 snippet:ObjectCallbackResponse
 
-
 partial:cancellation
 
 

--- a/nservicebus/messaging/handling-responses-on-the-client-side_cancellation_callbacks_1.partial.md
+++ b/nservicebus/messaging/handling-responses-on-the-client-side_cancellation_callbacks_1.partial.md
@@ -3,6 +3,6 @@
 
 This API was added in the externalized Callbacks feature.
 
-The asynchronous callback can be canceled by registering a `CancellationToken` provided by a `CancellationTokenSource`. The token needs to be registered on the `SendOptions` as shown below.
+The asynchronous callback can be canceled by registering a `CancellationToken` provided by a `CancellationTokenSource`. The token needs to be passed into the `Request` method as shown below.
 
 snippet:CancelCallback

--- a/samples/callbacks/Callbacks_1/Receiver/Program.cs
+++ b/samples/callbacks/Callbacks_1/Receiver/Program.cs
@@ -17,8 +17,7 @@ class Program
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");
-        var scaleOut = endpointConfiguration.ScaleOut();
-        scaleOut.InstanceDiscriminator("1");
+        endpointConfiguration.MakeInstanceUniquelyAddressable("1");
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/callbacks/Callbacks_1/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_1/Receiver/Receiver.csproj
@@ -33,10 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Callbacks">
-      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0001\lib\net452\NServiceBus.Callbacks.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0002\lib\net452\NServiceBus.Callbacks.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0006\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/callbacks/Callbacks_1/Receiver/packages.config
+++ b/samples/callbacks/Callbacks_1/Receiver/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
-  <package id="NServiceBus.Callbacks" version="1.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0006" targetFramework="net452" />
+  <package id="NServiceBus.Callbacks" version="1.0.0-beta0002" targetFramework="net452" />
 </packages>

--- a/samples/callbacks/Callbacks_1/Sender/Program.cs
+++ b/samples/callbacks/Callbacks_1/Sender/Program.cs
@@ -15,8 +15,7 @@ class Program
         Console.Title = "Samples.Callbacks.Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Sender");
         endpointConfiguration.UseSerialization<JsonSerializer>();
-        var scaleOut = endpointConfiguration.ScaleOut();
-        scaleOut.InstanceDiscriminator("1");
+        endpointConfiguration.MakeInstanceUniquelyAddressable("1");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/callbacks/Callbacks_1/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_1/Sender/Sender.csproj
@@ -33,10 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Callbacks">
-      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0001\lib\net452\NServiceBus.Callbacks.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0002\lib\net452\NServiceBus.Callbacks.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0006\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/callbacks/Callbacks_1/Sender/packages.config
+++ b/samples/callbacks/Callbacks_1/Sender/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
-  <package id="NServiceBus.Callbacks" version="1.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0006" targetFramework="net452" />
+  <package id="NServiceBus.Callbacks" version="1.0.0-beta0002" targetFramework="net452" />
 </packages>

--- a/samples/callbacks/Callbacks_1/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_1/Shared/Shared.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0006\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/callbacks/Callbacks_1/Shared/packages.config
+++ b/samples/callbacks/Callbacks_1/Shared/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0006" targetFramework="net452" />
 </packages>

--- a/samples/callbacks/Callbacks_1/WebSender/Global.asax.cs
+++ b/samples/callbacks/Callbacks_1/WebSender/Global.asax.cs
@@ -32,8 +32,7 @@ public class MvcApplication :
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");
-        endpointConfiguration.ScaleOut()
-            .InstanceDiscriminator("1");
+        endpointConfiguration.MakeInstanceUniquelyAddressable("1");
 
         EndpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/callbacks/Callbacks_1/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_1/WebSender/WebSender.csproj
@@ -35,10 +35,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Callbacks">
-      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0001\lib\net452\NServiceBus.Callbacks.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.Callbacks.1.0.0-beta0002\lib\net452\NServiceBus.Callbacks.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core">
-      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NServiceBus.6.0.0-beta0006\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/samples/callbacks/Callbacks_1/WebSender/packages.config
+++ b/samples/callbacks/Callbacks_1/WebSender/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
-  <package id="NServiceBus.Callbacks" version="1.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0006" targetFramework="net452" />
+  <package id="NServiceBus.Callbacks" version="1.0.0-beta0002" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
@Particular/docs-maintainers this shows the new way of callback cancellation introduced in

https://github.com/Particular/NServiceBus.Callbacks/pull/27

Those changes haven't been released yet!

While reviewing the documentation here I also sent in

https://github.com/Particular/NServiceBus.Callbacks/pull/34

Should we change the snippets to only show `SendOptions` overload when really necessary?