### PR TITLE
Removed the usage of the keyword routing in Logging

### DIFF
--- a/nservicebus/logging/common-logging.md
+++ b/nservicebus/logging/common-logging.md
@@ -1,6 +1,6 @@
 ---
-title: Routing to CommonLogging
-summary: Route all NServiceBus log entries to CommonLogging.
+title: CommonLogging
+summary: Logging all NServiceBus entries using CommonLogging.
 reviewed: 2016-03-17
 tags:
 - Common Logging
@@ -8,9 +8,9 @@ related:
 - samples/logging/commonlogging
 ---
 
-Support for routing log entries to CommonLogging is compatible with NServiceBus 5 and above.
+Support for using [CommonLogging](http://netcommon.sourceforge.net/) is available starting with NServiceBus Versions 5 and above.
 
-There is a [nuget](https://www.nuget.org/packages/NServiceBus.CommonLogging/) package available that allows for simple integration of NServiceBus and [CommonLogging](http://netcommon.sourceforge.net/).
+The [NServiceBus.CommonLogging NuGet package](https://www.nuget.org/packages/NServiceBus.CommonLogging/) facilitates logging of all NServiceBus entries in the endpoint using CommonLogging.
 
 
 ## Usage

--- a/nservicebus/logging/log4net.md
+++ b/nservicebus/logging/log4net.md
@@ -1,6 +1,6 @@
 ---
-title: Routing to Log4Net
-summary: Route all NServiceBus log entries to Log4Net.
+title: Log4Net
+summary: Logging using Log4Net.
 reviewed: 2016-03-17
 tags:
 - log4net
@@ -8,17 +8,17 @@ related:
 - samples/logging/log4net-custom
 ---
 
-Support for routing log entries to [Log4Net](http://logging.apache.org/log4net/) is compatible with NServiceBus Version 3 and above.
+Support for [Log4Net](http://logging.apache.org/log4net/) is available starting with NServiceBus Versions 3 and above.
 
 
-### NServiceBus Version 4 and below
+### NServiceBus Versions 4 and below
 
 NServiceBus Log4Net support was built in.
 
 
-### NServiceBus Version 5 and above
+### NServiceBus Versions 5 and above
 
-Log4Net was externalized to its own [nuget](https://www.nuget.org/packages/NServiceBus.Log4Net/) package available that allows for simple integration of NServiceBus.
+Log4Net was externalized to its own NuGet package, [NServiceBus.Log4Net](https://www.nuget.org/packages/NServiceBus.Log4Net/) to facilitate logging all NServiceBus entries in the endpoint using Log4Net.
 
 
 ## Usage
@@ -28,7 +28,7 @@ snippet:Log4netInCode
 
 ## Filtering
 
-If NServiceBus writes a significant amount of information to the log. To limit this information use the filtering features of the underlying logging framework.
+NServiceBus can write a significant amount of information to the log. To limit this information use the filtering features of the underlying logging framework.
 
 For example to limit log output to a specific namespace.
 

--- a/nservicebus/logging/nlog.md
+++ b/nservicebus/logging/nlog.md
@@ -1,6 +1,6 @@
 ---
-title: Routing to NLog
-summary: Route all NServiceBus log entries to NLog.
+title: NLog
+summary: Logging using NLog.
 reviewed: 2016-03-17
 tags:
 - Logging
@@ -9,9 +9,9 @@ related:
 - samples/logging/nlog-custom
 ---
 
-Support for routing log entries to [NLog](http://nlog-project.org/) is compatible with NServiceBus 5 and above.
+Support for [NLog](http://nlog-project.org/) is available starting with NServiceBus Versions 5 and above.
 
-There is a [nuget](https://www.nuget.org/packages/NServiceBus.NLog/) package available that allows for simple integration of NServiceBus and NLog.
+The [NServiceBus.NLog NuGet package](https://www.nuget.org/packages/NServiceBus.NLog/) facilitates logging in the endpoint using NLog.
 
 
 ## Usage
@@ -21,7 +21,7 @@ snippet:NLogInCode
 
 ## Filtering
 
-If NServiceBus writes a significant amount of information to the log. To limit this information use the filtering features of the underlying logging framework.
+NServiceBus can write a significant amount of information to the log. To limit this information use the filtering features of the underlying logging framework.
 
 For example to limit log output to a specific namespace.
 

--- a/nservicebus/logging/nlog.md
+++ b/nservicebus/logging/nlog.md
@@ -11,7 +11,7 @@ related:
 
 Support for [NLog](http://nlog-project.org/) is available starting with NServiceBus Versions 5 and above.
 
-The [NServiceBus.NLog NuGet package](https://www.nuget.org/packages/NServiceBus.NLog/) facilitates logging in the endpoint using NLog.
+The [NServiceBus.NLog NuGet package](https://www.nuget.org/packages/NServiceBus.NLog/) facilitates logging of all NServiceBus entries in the endpoint using NLog.
 
 
 ## Usage


### PR DESCRIPTION
Routing is a keyword and has other meanings in NServiceBus, such as adding routing information to the endpoints for sending messages. Therefore the use of the word routing can be confusing in how to integrate with Logging in NServiceBus articles. 

- [x] Change NLog.md
- [x] Change common-logging.md
- [x] Change Log4net.md
