### PR TITLE
Don't hide upgrading existing handlers under a separate heading

### DIFF
--- a/nservicebus/upgrades/5to6.md
+++ b/nservicebus/upgrades/5to6.md
@@ -45,15 +45,15 @@ WARNING: Do not `return null` from the message handlers. A `null` will result in
 
 snippet:5to6-messagehandler
 
+For a step by step upgrade of existing handlers or sagas, see: [Migrate existing handlers/sagas](/nservicebus/upgrades/5to6-migrate-existing-handlers.md).
+
+
 ### Bus Send and Receive
 
 There is also a change in the parameters, giving access to the `IMessageHandlerContext`, which provides the methods that used to be called from `IBus`. Use the `IMessageHandlerContext` to send and publish messages.
 
 snippet:5to6-bus-send-publish
 
-### Migrate existing handlers
-
-For a step by step upgrade of existing handlers or sagas, see: [Migrate existing handlers/sagas](/nservicebus/upgrades/5to6-migrate-existing-handlers.md).
 
 ### Message handler ordering
 


### PR DESCRIPTION
I went looking for this link and couldn't find it, in part because the section "Message handlers" that I thought should have linked to it did not contain the link. There's no reason for a separate heading containing one line of text.