### PR TITLE
FeatureStartupTask note clarification

### DIFF
--- a/nservicebus/pipeline/features.md
+++ b/nservicebus/pipeline/features.md
@@ -124,9 +124,7 @@ snippet:FeatureStartupTaskRegistration
 
 The task will only be created and called if the feature is enabled. The `FeatureStartupTask`s are activated and started in random order.
 
-Note: In Version 5 `FeatureStartupTask` are executed synchronously. Avoid long running operations which will delay the bus startup time.
-
-Note: In Versions 6 and above `FeatureStartupTask` run asynchronously the calling thread which initialized the endpoint.
+Note: Avoid long running operations which will delay the bus startup time.
 
 
 ### Accessing the Endpoint Instance


### PR DESCRIPTION
The differences of internal details of implementation between version 5 and 6 should not matter. Final result to the users is the same. In v6, we're awaiting for all the `FeatureStartupTask`s to complete, so in essence delaying the endpoint startup. Just like in v5.

@Particular/nservicebus-maintainers please confirm and let know if the change makes sense.