### PR TITLE
Removed component tag from pages where it did not make sense.

### DIFF
--- a/nservicebus/azure-service-bus/message-lock-renewal.md
+++ b/nservicebus/azure-service-bus/message-lock-renewal.md
@@ -1,7 +1,6 @@
 ---
 title: Azure Service Bus Transport Message lock renewal
 summary: Extending message lock for long handler operation
-component: ASB
 tags:
 - Cloud
 - Azure

--- a/nservicebus/azure-service-bus/namespace-hierarchy.md
+++ b/nservicebus/azure-service-bus/namespace-hierarchy.md
@@ -2,6 +2,7 @@
 title: Namespace hierarchy support
 summary: Configuring Azure Service Bus transport to support namespace hierarchies.
 component: ASB
+versions: "[7,)"
 tags:
 - Cloud
 - Azure

--- a/nservicebus/azure-service-bus/publisher-names-configuration.md
+++ b/nservicebus/azure-service-bus/publisher-names-configuration.md
@@ -2,11 +2,12 @@
 title: Publishers name configuration
 summary: Configuration mapping between publisher names and event types for Endpoint Oriented Topology
 component: ASB
+versions: "[7,)"
 tags:
 - Cloud
 - Azure
 - Transports
-reviewed: 2016-04-18
+reviewed: 2016-08-08
 ---
 
 When the [`EndpointOrientedTopology`](/nservicebus/azure-service-bus/topologies/#version-7-and-above-endpoint-oriented-topology) is selected, a mapping between publisher names and event types has to be properly configured, in order to ensure that subscriber can receive event messages. 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -1,7 +1,6 @@
 ---
 title: Azure Service Bus Transport Retry behavior
 summary: Describes the relationship between NServiceBus' retry behavior and Azure Service Bus' native retry behavior
-component: ASB
 tags:
 - Cloud
 - Azure

--- a/nservicebus/azure-service-bus/sanitization.md
+++ b/nservicebus/azure-service-bus/sanitization.md
@@ -41,49 +41,7 @@ To perform manual sanitization, inspect entity name for invalid characters and n
 
 ## Automated sanitization
 
-
-### Versions 6 and below
-
-All entities treated the same for allowed characters. Only letters, numbers, periods (`.`), hyphens (`-`), and underscores (`_`) were allowed. Maximum length was predefined by the transport.
-
-In Version 6.4.x [Naming Conventions](/nservicebus/azure-service-bus/naming-conventions.md) were added to allow custom sanitization of queues, topics, and subscriptions.
-
-
-### Versions 7 and above
-
-By default, the transport uses the `ThrowOnFailedValidation` sanitization strategy. This strategy allows sanitization rules to be specified that remove invalid characters and hashing algorithm to shorten entity path/name that is exceeding maximum length. For an invalid entity path/name, an exception is thrown. Validation rules can be adjusted by providing custom validation rules per entity type.
-
-snippet: asb-ThrowOnFailedValidation-sanitization-overrides
-
-Where `ValidationResult` provides the following
-
- * Characters are valid or not
- * Length is valid or not
-
-To customize sanitization for some of the entities, `ValidateAndHashIfNeeded` strategy can be used. This strategy allows to specify sanitization rules to remove invalid characters and hashing algorithm to shorten entity path/name that is exceeding maximum length.
-
-NOTE: `ValidateAndHashIfNeeded` is using validation rules to determine what needs to be sanitized. First step, invalid characters are removed. Second step, hashing is applied if length is still exceeding the maximum allowed length.
-
-snippet: asb-ValidateAndHashIfNeeded-sanitization-overrides
-
-In cases where an alternative sanitization is required, a custom sanitization can be applied.
-
-snippet: asb-custom-sanitization
-
-Custom sanitization strategy definition:
-
-snippet: asb-custom-sanitization-strategy
-
-If the implementation of a sanitization strategy requires configuration settings, these settings can be accessed using [Dependency Injection](/nservicebus/containers/) to access an instance of `ReadOnlySettings`.
-
-snippet: custom-sanitization-strategy-with-settings
-
-
-### Backward compatibility with versions 6 and below
-
-To remain backward compatible with endpoints versions 6 and below, endpoints version 7 and above should be configured to perform sanitization based on version 6 and below rules. The following custom sanitization will ensure entities are sanitized in a backwards compatible manner.
-
-snippet: asb-backward-compatible-custom-sanitiaztion-strategy
+partial:auto
 
 
 ## Future consideration prior to using sanitization

--- a/nservicebus/azure-service-bus/sanitization_auto_asb_[,7).partial.md
+++ b/nservicebus/azure-service-bus/sanitization_auto_asb_[,7).partial.md
@@ -1,0 +1,3 @@
+All entities treated the same for allowed characters. Only letters, numbers, periods (`.`), hyphens (`-`), and underscores (`_`) were allowed. Maximum length was predefined by the transport.
+
+In Version 6.4.x [Naming Conventions](/nservicebus/azure-service-bus/naming-conventions.md) were added to allow custom sanitization of queues, topics, and subscriptions.

--- a/nservicebus/azure-service-bus/sanitization_auto_asb_[7,).partial.md
+++ b/nservicebus/azure-service-bus/sanitization_auto_asb_[7,).partial.md
@@ -1,0 +1,33 @@
+By default, the transport uses the `ThrowOnFailedValidation` sanitization strategy. This strategy allows sanitization rules to be specified that remove invalid characters and hashing algorithm to shorten entity path/name that is exceeding maximum length. For an invalid entity path/name, an exception is thrown. Validation rules can be adjusted by providing custom validation rules per entity type.
+
+snippet: asb-ThrowOnFailedValidation-sanitization-overrides
+
+Where `ValidationResult` provides the following
+
+ * Characters are valid or not
+ * Length is valid or not
+
+To customize sanitization for some of the entities, `ValidateAndHashIfNeeded` strategy can be used. This strategy allows to specify sanitization rules to remove invalid characters and hashing algorithm to shorten entity path/name that is exceeding maximum length.
+
+NOTE: `ValidateAndHashIfNeeded` is using validation rules to determine what needs to be sanitized. First step, invalid characters are removed. Second step, hashing is applied if length is still exceeding the maximum allowed length.
+
+snippet: asb-ValidateAndHashIfNeeded-sanitization-overrides
+
+In cases where an alternative sanitization is required, a custom sanitization can be applied.
+
+snippet: asb-custom-sanitization
+
+Custom sanitization strategy definition:
+
+snippet: asb-custom-sanitization-strategy
+
+If the implementation of a sanitization strategy requires configuration settings, these settings can be accessed using [Dependency Injection](/nservicebus/containers/) to access an instance of `ReadOnlySettings`.
+
+snippet: custom-sanitization-strategy-with-settings
+
+
+### Backward compatibility with versions 6 and below
+
+To remain backward compatible with endpoints versions 6 and below, endpoints version 7 and above should be configured to perform sanitization based on version 6 and below rules. The following custom sanitization will ensure entities are sanitized in a backwards compatible manner.
+
+snippet: asb-backward-compatible-custom-sanitiaztion-strategy

--- a/nservicebus/azure-service-bus/securing-connection-strings.md
+++ b/nservicebus/azure-service-bus/securing-connection-strings.md
@@ -1,7 +1,6 @@
 ---
 title: Securing Connection Strings To Namespaces
 summary: 'Azure Service Bus Transport: Securing connection strings to namespaces.'
-component: ASB
 tags:
 - Cloud
 - Azure

--- a/nservicebus/azure-service-bus/token-provider.md
+++ b/nservicebus/azure-service-bus/token-provider.md
@@ -1,7 +1,6 @@
 ---
 title: Custom Token Provider
 summary: Configuring Azure Service Bus transport to use a custom token provider for authentication
-component: ASB
 tags:
  - Cloud
  - Azure

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -2,6 +2,8 @@
 title: Outbox
 summary: Reliable messaging without distributed transactions
 reviewed: 2016-08-03
+component: Core
+versions: "[5,)"
 tags:
 - MSDTC
 redirects:


### PR DESCRIPTION
And added version range to component pages where it did make sense. 

This is required for https://github.com/Particular/DocsEngine/pull/229 to generate all the doco without errors.