### PR TITLE
Add note about reply behavior when using bus.defer

### DIFF
--- a/nservicebus/messaging/delayed-delivery.md
+++ b/nservicebus/messaging/delayed-delivery.md
@@ -18,6 +18,7 @@ NOTE: Only send operations can be deferred. Publish and reply operations cannot 
 
 partial:intro
 
+Note: Similar to `bus.SendLocal`, `bus.Defer` will also change the message's reply-to address to the endpoint deferring the message. Calling `bus.Reply` on a deferred message will send the reply to itself.
 
 ## Using a TimeSpan
 

--- a/nservicebus/messaging/delayed-delivery.md
+++ b/nservicebus/messaging/delayed-delivery.md
@@ -18,7 +18,7 @@ NOTE: Only send operations can be deferred. Publish and reply operations cannot 
 
 partial:intro
 
-Note: Similar to `bus.SendLocal`, `bus.Defer` will also change the message's reply-to address to the endpoint deferring the message. Calling `bus.Reply` on a deferred message will send the reply to itself.
+Note: Similar to `SendLocal`, `Defer` will also change the message's reply-to address to the endpoint deferring the message. Calling `Reply` on a deferred message will send the reply to itself.
 
 ## Using a TimeSpan
 

--- a/nservicebus/messaging/delayed-delivery.md
+++ b/nservicebus/messaging/delayed-delivery.md
@@ -20,6 +20,7 @@ partial:intro
 
 Note: Similar to `SendLocal`, `Defer` will also change the message's reply-to address to the endpoint deferring the message. Calling `Reply` on a deferred message will send the reply to itself.
 
+
 ## Using a TimeSpan
 
 Delays delivery of a message for a specified duration.


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/2710

Do transports support native deferral behave the same? @andreasohlund 