### PR TITLE
Gateway version compatibility

### DIFF
--- a/nservicebus/gateway/index.md
+++ b/nservicebus/gateway/index.md
@@ -69,3 +69,12 @@ snippet:GatewayConfiguration
 ### Recoverability
 
 partial: recoverability
+
+
+### Version compatibility
+
+The Gateway component ensures only forward compatibility for one major version. So a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the independent package targeting NServiceBus 5.x).
+
+However, a message sent by the NServiceBus 3.x Gateway will not be understood by NServiceBus.Gateway 1.x (NServiceBus 5.x) as this skips a major version. Likewise, a message sent by NServiceBus.Gateway 2.x will not be understood by NServiceBus.Gateway 1.x, as backwards communication is not supported.
+
+Since a Gateway on the receiving end exists to receive HTTP requests and translate them to messages on the queue, it's possible to deploy multiple Gateway instances using different major versions, either on different servers, or using different ports on the same server. As long as these Gateway instances contain the same message routing settings, they don't require any handler logic. This can be useful during a gradual, endpoint-by-endpoint upgrade to ensure that each deployed endpoint can communicate with a remote Gateway instance that is compatible with it.

--- a/nservicebus/gateway/index.md
+++ b/nservicebus/gateway/index.md
@@ -73,8 +73,8 @@ partial: recoverability
 
 ### Version compatibility
 
-The Gateway component ensures only forward compatibility for one major version. So a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the independent package targeting NServiceBus 5.x).
+The Gateway component ensures only forward compatibility for one major version. That means a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the Gateway package targeting NServiceBus 5.x).
 
 However, a message sent by the NServiceBus 3.x Gateway will not be understood by NServiceBus.Gateway 1.x (NServiceBus 5.x) as this skips a major version. Likewise, a message sent by NServiceBus.Gateway 2.x will not be understood by NServiceBus.Gateway 1.x, as backwards communication is not supported.
 
-Since a Gateway on the receiving end exists to receive HTTP requests and translate them to messages on the queue, it's possible to deploy multiple Gateway instances using different major versions, either on different servers, or using different ports on the same server. As long as these Gateway instances contain the same message routing settings, they don't require any handler logic. This can be useful during a gradual, endpoint-by-endpoint upgrade to ensure that each deployed endpoint can communicate with a remote Gateway instance that is compatible with it.
+Since a Gateway on the receiving end exists to receive HTTP requests and translate them to messages on the queue, it's possible to deploy multiple Gateway instances using different major versions, either on different servers, or using different ports on the same server. This can be useful during a gradual, endpoint-by-endpoint upgrade to ensure that each deployed endpoint can communicate with a remote Gateway instance that is compatible with it.

--- a/samples/servicecontrol/events-subscription/Core_V6/index.md
+++ b/samples/servicecontrol/events-subscription/Core_V6/index.md
@@ -1,4 +1,0 @@
----
-title: Custom Checks Samples
-reviewed: 2016-03-21
----

--- a/samples/servicecontrol/events-subscription/Core_V6/index.md
+++ b/samples/servicecontrol/events-subscription/Core_V6/index.md
@@ -1,0 +1,4 @@
+---
+title: Custom Checks Samples
+reviewed: 2016-03-21
+---


### PR DESCRIPTION
Attempting to document Gateway version compatibility, related to https://github.com/Particular/NServiceBus.Gateway/issues/55#issuecomment-240630778.

I admit, it gets awkward when describing about the versions, especially since Gateway got split out from Core V5.

The last paragraph is also a bit of hand-wavyness on my part. Please bash freely.

//cc @Particular/docs-maintainers @Particular/nservicebus-maintainers @indualagarsamy @andreasohlund @johnsimons @boblangley