### PR TITLE
Update to new core default for concurrency

### DIFF
--- a/nservicebus/operations/tuning.md
+++ b/nservicebus/operations/tuning.md
@@ -9,7 +9,7 @@ related:
 - nservicebus/licensing/licensing-limitations
 ---
 
-NServiceBus will by default try to optimize for maximum performance when it comes to message processing. While this is usually the preferred mode of operation there are situations where tuning needs to be applied.
+NServiceBus uses defaults that ensure good performance in most common cases. While this is usually the preferred mode of operation there are situations where tuning needs to be applied.
 
 
 ## Tuning concurrency

--- a/nservicebus/operations/tuning.md
+++ b/nservicebus/operations/tuning.md
@@ -9,12 +9,12 @@ related:
 - nservicebus/licensing/licensing-limitations
 ---
 
-NServiceBus will by default allow the transport to optimize for maximum performance when it comes to message processing. While this is usually the preferred mode of operation there are situations where tuning needs to be applied.
+NServiceBus will by default try to optimize for maximum performance when it comes to message processing. While this is usually the preferred mode of operation there are situations where tuning needs to be applied.
 
 
 ## Tuning concurrency
 
-NOTE: The default concurrency limit for NServiceBus Versions 5 and below is `1`, for Versions 6 and above `100`.
+NOTE: The default concurrency limit for NServiceBus Versions 5 and below is `1`, for Versions 6 and above `max(Number of logical processors,2)`.
 
 Define a maximum concurrency setting that will make sure that no more messages than the specified value is ever being processed at the same time. Set this value to `1` to process messages sequentially. If not specified the transport will choose an optimal value.
 


### PR DESCRIPTION
I removed the part that talked about "allow the transport to optimize" since that isn't true.

The current statement isn't 100% correct but perhaps close enough?

Related to https://github.com/Particular/NServiceBus/pull/4092