### PR TITLE
Adding the info that NServiceBus does work with other transports.

### DIFF
--- a/samples/step-by-step/sample.md
+++ b/samples/step-by-step/sample.md
@@ -39,6 +39,8 @@ Completing these steps will serve as an introduction to many important NServiceB
 
 ### MSMQ
 
+INFO: While this sample requires MSMQ as the queuing transport, it is possible to use NServiceBus with a variety of other transports such as [RabbitMQ](/nservicebus/rabbitmq/), [Azure Service Bus](/nservicebus/azure-service-bus/), [Azure Storage Queues](/nservicebus/azure-storage-queues/) and, [SQL Server](/nservicebus/sqlserver/). If any of these transports are already available, it is simple to configure the endpoints to use them instead of MSMQ. 
+
 Microsoft Message Queuing (MSMQ) must be properly installed and configured. The easiest way to do this is with the appropriate command line below. Alternatively, it can be installed via the Windows Features tool. For more details on installing and configuring MSMQ see [MSMQ Transport](/nservicebus/msmq/).
 
 


### PR DESCRIPTION
The Getting Started is linked from a lot of places and is geared for the new user. When a user gets here, the user can have the impression that NServiceBus only works with MSMQ as the pre-requisite says install MSMQ. This can put off users who dislike MSMQ and/or already using other transports. 

