### PR TITLE
Removed redundant implementations of `void Handle`

### DIFF
--- a/samples/step-by-step/Core_6/Server/PlaceOrderHandler.cs
+++ b/samples/step-by-step/Core_6/Server/PlaceOrderHandler.cs
@@ -10,10 +10,6 @@ public class PlaceOrderHandler :
 {
     static ILog log = LogManager.GetLogger<PlaceOrderHandler>();
 
-    public void Handle(PlaceOrder message)
-    {
-    }
-
     public Task Handle(PlaceOrder message, IMessageHandlerContext context)
     {
         log.Info($"Order for Product:{message.Product} placed with id: {message.Id}");

--- a/samples/step-by-step/Core_6/Subscriber/OrderCreatedHandler.cs
+++ b/samples/step-by-step/Core_6/Subscriber/OrderCreatedHandler.cs
@@ -9,10 +9,6 @@ public class OrderCreatedHandler :
 {
     static ILog log = LogManager.GetLogger<OrderCreatedHandler>();
 
-    public void Handle(OrderPlaced message)
-    {
-    }
-
     public Task Handle(OrderPlaced message, IMessageHandlerContext context)
     {
         log.Info($"Handling: OrderPlaced for Order Id: {message.OrderId}");


### PR DESCRIPTION
Removed redundant implementations of `void Handle` from the v6 step-by-step sample code