### PR TITLE
Remove paragraph about running multiple versions of the same gateway

### DIFF
--- a/nservicebus/gateway/index.md
+++ b/nservicebus/gateway/index.md
@@ -76,5 +76,3 @@ partial: recoverability
 The Gateway component ensures only forward compatibility for one major version. That means a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the Gateway package targeting NServiceBus 5.x).
 
 However, a message sent by the NServiceBus 3.x Gateway will not be understood by NServiceBus.Gateway 1.x (NServiceBus 5.x) as this skips a major version. Likewise, a message sent by NServiceBus.Gateway 2.x will not be understood by NServiceBus.Gateway 1.x, as backwards communication is not supported.
-
-Since a Gateway on the receiving end exists to receive HTTP requests and translate them to messages on the queue, it's possible to deploy multiple Gateway instances using different major versions, either on different servers, or using different ports on the same server. This can be useful during a gradual, endpoint-by-endpoint upgrade to ensure that each deployed endpoint can communicate with a remote Gateway instance that is compatible with it.


### PR DESCRIPTION
Running multiple gateways is unfortunately not possible ATM. Gateways currently route to their local input queues only. If you run multiple versions with the same endpoint name on the same machine, they will all put the incoming messages on the same queue. The different versions will then use competing consumer against this queue, meaning you have no control if the incoming vX message will have handlers run on the vX endpoint or the vX+1 endpoint. This is not safe, as there is no guarantee that vX and vX+1 will handle the same message type and if they do, will not necessarily have the same handlers.