### PR TITLE
Clarify that we no longer allow correlated properties to have a null …

### DIFF
--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -107,6 +107,8 @@ snippet:5to6-ConfigureHowToFindSaga
 
 Version 6 automatically correlates incoming message properties to its saga data counterparts. Any saga data correlation in the message handler code can be safely removed. Correlated properties (for existing saga instances) will not be changed once set.
 
+NOTE: NServiceBus will no longer allow a correlated property to have a null/default value. Use a custom finder for the relevant message to override this validation.
+
 snippet:5to6-NoSagaDataCorrelationNeeded
 
 Version 6 will only support correlating messages to a single saga property. Correlating on more than one property is still supported by creating a custom [saga finder](/nservicebus/sagas/saga-finding.md).

--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -107,11 +107,11 @@ snippet:5to6-ConfigureHowToFindSaga
 
 Version 6 automatically correlates incoming message properties to its saga data counterparts. Any saga data correlation in the message handler code can be safely removed. Correlated properties (for existing saga instances) will not be changed once set.
 
-NOTE: Correlated properties must have a non [null/default value](https://msdn.microsoft.com/en-us/library/83fhsxwc.aspx) assigned when the saga is persisted. 
+NOTE: Correlated properties must have a non [null or empty value](https://msdn.microsoft.com/en-us/library/83fhsxwc.aspx) assigned when persisted. 
 If not the following exception will be thrown: 
 `We detected that the correlated property 'MyPropery' on saga 'MySaga' does not have a value'.
 All correlated properties must have a non null or empty value assigned to them when a new saga instance is created.`
-Use a custom finder for the received message to override this validation.
+Use a [custom finder](/nservicebus/sagas/saga-finding.md) for the received message to override this validation.
 
 snippet:5to6-NoSagaDataCorrelationNeeded
 

--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -107,7 +107,11 @@ snippet:5to6-ConfigureHowToFindSaga
 
 Version 6 automatically correlates incoming message properties to its saga data counterparts. Any saga data correlation in the message handler code can be safely removed. Correlated properties (for existing saga instances) will not be changed once set.
 
-NOTE: NServiceBus will no longer allow a correlated property to have a null/default value. Use a custom finder for the relevant message to override this validation.
+NOTE: Correlated properties must have a non [null/default value](https://msdn.microsoft.com/en-us/library/83fhsxwc.aspx) assigned when the saga is persisted. 
+If not the following exception will be thrown: 
+`We detected that the correlated property 'MyPropery' on saga 'MySaga' does not have a value'.
+All correlated properties must have a non null or empty value assigned to them when a new saga instance is created.`
+Use a custom finder for the received message to override this validation.
 
 snippet:5to6-NoSagaDataCorrelationNeeded
 

--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -107,15 +107,19 @@ snippet:5to6-ConfigureHowToFindSaga
 
 Version 6 automatically correlates incoming message properties to its saga data counterparts. Any saga data correlation in the message handler code can be safely removed. Correlated properties (for existing saga instances) will not be changed once set.
 
-NOTE: Correlated properties must have a non [null or empty value](https://msdn.microsoft.com/en-us/library/83fhsxwc.aspx) assigned when persisted. 
-If not the following exception will be thrown: 
-`We detected that the correlated property 'MyPropery' on saga 'MySaga' does not have a value'.
-All correlated properties must have a non null or empty value assigned to them when a new saga instance is created.`
+{{NOTE: Correlated properties must have a non [default](https://msdn.microsoft.com/en-us/library/83fhsxwc.aspx) value, i.e. not null and not empty, assigned when persisted. If not the following exception will be thrown: 
+
+```no-highlight
+The correlated property 'MyPropery' on saga 'MySaga' does not have a value.
+A correlated property must have a non default (i.e. non null and non-empty) value assigned when a new saga instance is created.
+```
+
 Use a [custom finder](/nservicebus/sagas/saga-finding.md) for the received message to override this validation.
+}}
 
 snippet:5to6-NoSagaDataCorrelationNeeded
 
-Version 6 will only support correlating messages to a single saga property. Correlating on more than one property is still supported by creating a custom [saga finder](/nservicebus/sagas/saga-finding.md).
+Versions 6 and above will only support correlating messages to a single saga property. Correlating on more than one property is still supported by creating a custom [saga finder](/nservicebus/sagas/saga-finding.md).
 
 
 ### Saga persisters & finders


### PR DESCRIPTION
…or default value

And how to workaround it using a custom finder