### PR TITLE
Add section documenting the deprecated WCF integration

### DIFF
--- a/nservicebus/hosting/expose-an-endpoint-as-a-web-wcf-service.md
+++ b/nservicebus/hosting/expose-an-endpoint-as-a-web-wcf-service.md
@@ -10,7 +10,7 @@ related:
  - samples/web/wcf-callbacks
 ---
 
-Note: NServiceBus Version 6 and above no longer provide built-in support for WCF integration. Refer to the [Upgrade Guide](/nservicebus/upgrades/host-6to7) for further information.
+Note: Starting from NServiceBus Core Versions 6 and above, the built-in support for WCF integration has been removed. For more details refer to the [Upgrade Guide](/nservicebus/upgrades/host-6to7).
 
 Inherited from `NServiceBus.WcfService<TCommand, TErrorCode>`, as shown below. `TCommand` is the message type of the request. `TErrorCode` must be an enumerated type, and should represent the result of processing the command. Example:
 

--- a/nservicebus/hosting/expose-an-endpoint-as-a-web-wcf-service.md
+++ b/nservicebus/hosting/expose-an-endpoint-as-a-web-wcf-service.md
@@ -10,6 +10,8 @@ related:
  - samples/web/wcf-callbacks
 ---
 
+Note: NServiceBus Version 6 and above no longer provide built-in support for WCF integration. Refer to the [Upgrade Guide](/nservicebus/upgrades/host-6to7) for further information.
+
 Inherited from `NServiceBus.WcfService<TCommand, TErrorCode>`, as shown below. `TCommand` is the message type of the request. `TErrorCode` must be an enumerated type, and should represent the result of processing the command. Example:
 
 snippet:ExposeWCFService

--- a/nservicebus/upgrades/host-6to7.md
+++ b/nservicebus/upgrades/host-6to7.md
@@ -40,3 +40,8 @@ The `IMessageSession` parameter provides all the necessary methods to send messa
 include:5to6removePShelpers
 
 WARNING: If an `EndpointConfig.cs` file already exists in the project, be careful to not overwrite it when upgrading the `NServiceBus.Host` package. If Visual Studio detects a conflict, it will ask whether the file should be overwritten. To keep the old configuration, choose `No`.
+
+
+## WCF Integration
+
+The WCF integration using `WcfService` has been removed from the host. The [WCF request response via Callbacks](/samples/web/wcf-callbacks) sample shows how to expose message handlers over WCF services using NServiceBus Version 6 and the NServiceBus.Callbacks package.


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus.Host/pull/103

Further plans as stated [here](https://github.com/Particular/V6Launch/issues/122#issuecomment-245542817) are to make a wcf integration package available under the particular labs repository. At that point we can point to this repository on this section. /cc @danielmarbach 