### PR TITLE
Wording

### DIFF
--- a/nservicebus/handlers/async-handlers.md
+++ b/nservicebus/handlers/async-handlers.md
@@ -129,7 +129,7 @@ snippet: BatchedDispatchHandler
 
 #### Immediate dispatch
 
-[Immediate dispatch](/nservicebus/messaging/send-a-message.md#immediate-dispatch) means outgoing message operations will be immediately dispatched to the transport of choice. For immediate dispatch operations, it might make sense execute them concurrently like shown below.
+[Immediate dispatch](/nservicebus/messaging/send-a-message.md#immediate-dispatch) means outgoing message operations will be immediately dispatched to the underlying transport. For immediate dispatch operations, it might make sense execute them concurrently like shown below.
 
 snippet: ImmediateDispatchHandler
 


### PR DESCRIPTION
> Immediate dispatch means outgoing message operations will be immediately dispatched to the transport of choice

"transport of choice" isn't so appropriate here - "underlying transport" would be better.