### PR TITLE
Mark v4 as unsupported

### DIFF
--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -23,9 +23,7 @@ If a version is not listed or has expired but support is required [contact Parti
 
 ### NServiceBus 4.x
 
-| Version | Major Released | Minor Released | Support Expires |
-|:-------:|----------------|----------------|:---------------:|
-|   4.x   | 2013-07-11     | 2014-10-07     |    2016-07-11   |
+As of 11 July 2016, Version 4 is no longer supported. If support is required [contact Particular](http://particular.net/contactus).
 
 
 ### NServiceBus 3.x


### PR DESCRIPTION
According to our support policy, v4 is deprecated. If there is no decision to do otherwise, I think we should make this more obvious here.

I already pinged @Particular/customer-success @Particular/customersuccess-squad  (which one is the right group?) if we need to taker further actions (e.g. announcements or otherwise), but I did not get any response so far. Maybe they want to chime in here.