### PR TITLE
Add example queue table names for different deployment options

### DIFF
--- a/nservicebus/sqlserver/deployment-options.md
+++ b/nservicebus/sqlserver/deployment-options.md
@@ -23,6 +23,21 @@ NOTE: To properly identify the chosen deployment option all queues that the endp
 The transport will route messages to destination based on the configuration. If no specific configuration has been provided for a particular destination, the transport assumes the destination has the same configuration as the sending endpoint (i.e. identical schema, catalog and instance name). If the destination has a different configuration and it hasn't been provided, then exception will be thrown when sending a message, because the transport wouldn't be able to connect to the destination queue.
 
 
+### Example
+
+The following table shows sample possible fully qualified queue table names for different deployment options:
+
+| Deployment option | Endpoint | Queue table name                                                      |
+|-------------------|----------|-----------------------------------------------------------------------|
+| Default           | Sales    | `[sql_server_01]`.`[nsb_database]`.`[nsb_schema]`.`[Sales]`           |
+|                   | Billing  | `[sql_server_01]`.`[nsb_database]`.`[nsb_schema]`.`[Billing]`         |
+| Multi-schema      | Sales    | `[sql_server_01]`.`[nsb_database]`.**`[sales_schema]`**.`[Sales]`     |
+|                   | Billing  | `[sql_server_01]`.`[nsb_database]`.**`[billing_schema]`**.`[Billing]` |
+| Multi-catalog     | Sales    | `[sql_server_01]`.**`[sales_database]`**.`[nsb_schema]`.`[Sales]`     |
+|                   | Billing  | `[sql_server_01]`.**`[billing_database]`**.`[nsb_schema]`.`[Billing]` |
+| Multi-instance    | Sales    | **`[sql_server_01]`**.`[nsb_database]`.`[nsb_schema]`.`[Sales]`       |
+|                   | Billing  | **`[sql_server_02]`**.`[nsb_database]`.`[nsb_schema]`.`[Billing]`     |
+
 ## Modes overview
 
 

--- a/nservicebus/sqlserver/deployment-options.md
+++ b/nservicebus/sqlserver/deployment-options.md
@@ -23,20 +23,26 @@ NOTE: To properly identify the chosen deployment option all queues that the endp
 The transport will route messages to destination based on the configuration. If no specific configuration has been provided for a particular destination, the transport assumes the destination has the same configuration as the sending endpoint (i.e. identical schema, catalog and instance name). If the destination has a different configuration and it hasn't been provided, then exception will be thrown when sending a message, because the transport wouldn't be able to connect to the destination queue.
 
 
-### Example
+### Queues names examples
 
-The following table shows sample possible fully qualified queue table names for different deployment options:
+The following table shows the queue table name for each deployment option, where the SQL server name is `sql_server_instace_01`, the default NServiceBus database name is `nsb_database` and the default NServiceBus schema is `nsb_schema`:
 
 | Deployment option | Endpoint | Queue table name                                                      |
 |-------------------|----------|-----------------------------------------------------------------------|
-| Default           | Sales    | `[sql_server_01]`.`[nsb_database]`.`[nsb_schema]`.`[Sales]`           |
-|                   | Billing  | `[sql_server_01]`.`[nsb_database]`.`[nsb_schema]`.`[Billing]`         |
-| Multi-schema      | Sales    | `[sql_server_01]`.`[nsb_database]`.**`[sales_schema]`**.`[Sales]`     |
-|                   | Billing  | `[sql_server_01]`.`[nsb_database]`.**`[billing_schema]`**.`[Billing]` |
-| Multi-catalog     | Sales    | `[sql_server_01]`.**`[sales_database]`**.`[nsb_schema]`.`[Sales]`     |
-|                   | Billing  | `[sql_server_01]`.**`[billing_database]`**.`[nsb_schema]`.`[Billing]` |
-| Multi-instance    | Sales    | **`[sql_server_01]`**.`[nsb_database]`.`[nsb_schema]`.`[Sales]`       |
-|                   | Billing  | **`[sql_server_02]`**.`[nsb_database]`.`[nsb_schema]`.`[Billing]`     |
+| Default           | Sales    | `[sql_server_instace_01]`.`[nsb_database]`.`[nsb_schema]`.`[Sales]`           |
+|                   | Billing  | `[sql_server_instace_01]`.`[nsb_database]`.`[nsb_schema]`.`[Billing]`         |
+||||
+| Multi-schema      | Sales    | `[sql_server_instace_01]`.`[nsb_database]`.**`[sales_schema]`**.`[Sales]`     |
+|                   | Billing  | `[sql_server_instace_01]`.`[nsb_database]`.**`[billing_schema]`**.`[Billing]` |
+||||
+| Multi-catalog     | Sales    | `[sql_server_instace_01]`.**`[sales_database]`**.`[nsb_schema]`.`[Sales]`     |
+|                   | Billing  | `[sql_server_instace_01]`.**`[billing_database]`**.`[nsb_schema]`.`[Billing]` |
+||||
+| Multi-instance    | Sales    | **`[sql_server_instace_01]`**.`[nsb_database]`.`[nsb_schema]`.`[Sales]`       |
+|                   | Billing  | **`[sql_server_instace_02]`**.`[nsb_database]`.`[nsb_schema]`.`[Billing]`     |
+
+Note: The tables mentioned above will serve as the incoming queues for endpoints. NServiceBus will also create additional queues, e.g. retries queue. The names of additional queues are made up of the endpoint name and suffix, e.g. `[endpoint_queue_name].[Retries]`.
+
 
 ## Modes overview
 


### PR DESCRIPTION
I added example to illustrate how queue tables may be distributed among different database objects.

@Particular/sqlserver-transport-maintainers @Particular/docs-maintainers Please have a look if this adds any value. 

The motivation is [this](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/particularsoftware/3BDC7ev1lio/THo4ch57CAAJ) Google Group post.

I first tried to visualize this but failed to produce readable diagrams. Too many embedded boxes did not make it clear to me. Perhaps such a tabular form will be better.