### PR TITLE
Fix casing in msmq routing file snippet

### DIFF
--- a/Snippets/Core/Core_6/Routing/MSMQ/InstanceMappingFile.xml
+++ b/Snippets/Core/Core_6/Routing/MSMQ/InstanceMappingFile.xml
@@ -3,13 +3,13 @@
   <!-- startcode InstanceMappingFile -->
   <endpoints>
     <endpoint name="Sales">
-      <instance Machine="VM-1"/>
+      <instance machine="VM-1"/>
     </endpoint>
     <endpoint name="Shipping">
-      <instance Machine="VM-2"/>
+      <instance machine="VM-2"/>
     </endpoint>
     <endpoint name="Billing">
-      <instance Machine="VM-3"/>
+      <instance machine="VM-3"/>
     </endpoint>
   </endpoints>
   <!-- endcode -->


### PR DESCRIPTION
@timbussmann @SzymonPobiega should we consider making the comparison case insensetive to avoid issues with casing? (see https://groups.google.com/d/msgid/particularsoftware/a3312514-c2bf-4f5c-aa6e-d9f988441f41%40googlegroups.com?utm_medium=email&utm_source=footer) 