### PR TITLE
Modified doco to match ASB RC4 change

### DIFF
--- a/nservicebus/azure-service-bus/configuration/full.md
+++ b/nservicebus/azure-service-bus/configuration/full.md
@@ -56,7 +56,7 @@ The topology will create entities it needs, based on the following settings:
 The following settings are available to define how queues should be created:
 
  * `MaxSizeInMegabytes(SizeInMegabytes)`: The size of the queue, in megabytes. Defaults to 1,024 MB.
- * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to 10.
+ * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. For endpoints with no retries and system queues defaults to 10.
  * `LockDuration(TimeSpan)`: The period of time that Azure Service Bus will lock a message before trying to redeliver it, defaults to 30 seconds.
  * `ForwardDeadLetteredMessagesTo(string)`: Forward all dead lettered messages to the specified entity. This setting is off by default.
  * `ForwardDeadLetteredMessagesTo(Func<string, bool>, string)`: Forward all dead lettered messages to the specified entity if the given condition equals to `true` (e.g. it allows to exclude forwarding dead lettered messages on the error queue). This setting is off by default.
@@ -102,7 +102,7 @@ The following settings are available to define how subscriptions should be creat
  * `ForwardDeadLetteredMessagesTo(string)`: Forwards all dead lettered messages to the specified entity. This setting is off by default.
  * `ForwardDeadLetteredMessagesTo(Func<string, bool>, string)`: Forwards all dead lettered messages to the specified entity if the given condition is `true`. This setting is off by default.
  * `LockDuration(TimeSpan)`: The period of time that Azure Service Bus will lock a message before trying to redeliver it, defaults to 30 seconds.
- * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to 10.
+ * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. For endpoints with no retries and system queues defaults to 10.  
  * `AutoDeleteOnIdle(TimeSpan)`: Automatically deletes the subscription if it hasn't been used for the specified time period. By default the subscription will not be automatically deleted.
  * `DescriptionFactory(Func<string, string, ReadOnlySettings, SubscriptionDescription>)`: A factory method that allows to create a `SubscriptionDescription` object from the Azure Service Bus SDK. Use this factory method to override any (future) setting that is not supported by the Subscription API.
 

--- a/nservicebus/azure-service-bus/configuration/full.md
+++ b/nservicebus/azure-service-bus/configuration/full.md
@@ -56,7 +56,7 @@ The topology will create entities it needs, based on the following settings:
 The following settings are available to define how queues should be created:
 
  * `MaxSizeInMegabytes(SizeInMegabytes)`: The size of the queue, in megabytes. Defaults to 1,024 MB.
- * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. For endpoints with no retries and system queues defaults to 10.
+ * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. In case Immediate Retries are disabled, the transport will default `MaxDeliveryCount` to 10 attempts.
  * `LockDuration(TimeSpan)`: The period of time that Azure Service Bus will lock a message before trying to redeliver it, defaults to 30 seconds.
  * `ForwardDeadLetteredMessagesTo(string)`: Forward all dead lettered messages to the specified entity. This setting is off by default.
  * `ForwardDeadLetteredMessagesTo(Func<string, bool>, string)`: Forward all dead lettered messages to the specified entity if the given condition equals to `true` (e.g. it allows to exclude forwarding dead lettered messages on the error queue). This setting is off by default.
@@ -102,7 +102,7 @@ The following settings are available to define how subscriptions should be creat
  * `ForwardDeadLetteredMessagesTo(string)`: Forwards all dead lettered messages to the specified entity. This setting is off by default.
  * `ForwardDeadLetteredMessagesTo(Func<string, bool>, string)`: Forwards all dead lettered messages to the specified entity if the given condition is `true`. This setting is off by default.
  * `LockDuration(TimeSpan)`: The period of time that Azure Service Bus will lock a message before trying to redeliver it, defaults to 30 seconds.
- * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. For endpoints with no retries and system queues defaults to 10.  
+ * `MaxDeliveryCount(int)`: Sets the maximum delivery count, defaults to the number of Immediate Retries + 1. In case Immediate Retries are disabled, the transport will default `MaxDeliveryCount` to 10 attempts.  
  * `AutoDeleteOnIdle(TimeSpan)`: Automatically deletes the subscription if it hasn't been used for the specified time period. By default the subscription will not be automatically deleted.
  * `DescriptionFactory(Func<string, string, ReadOnlySettings, SubscriptionDescription>)`: A factory method that allows to create a `SubscriptionDescription` object from the Azure Service Bus SDK. Use this factory method to override any (future) setting that is not supported by the Subscription API.
 

--- a/nservicebus/azure-service-bus/configuration/full.md
+++ b/nservicebus/azure-service-bus/configuration/full.md
@@ -8,7 +8,7 @@ tags:
 - Cloud
 redirects:
 - nservicebus/azure-service-bus/configuration/configuration
-reviewed: 2016-08-29
+reviewed: 2016-09-22
 ---
 
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -15,7 +15,7 @@ Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defin
 
 ## Immediate Retries and MaxDeliveryCount
 
-To implement Immediate Retries, NServiceBus is using Azure Service Bus native `MaxDeliveryCount` property of the `BrokeredMessage` to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists.
+To implement Immediate Retries, the native Azure Service Bus `MaxDeliveryCount` property of the `BrokeredMessage` is used to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists.
 
 A scaled out endpoint will retry the message by any of its instances, before one of them decides to send the message to the delayed retries or the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -32,7 +32,7 @@ For system queues, such as audit and error queues, if a custom value was configu
 
 ### Excessive prefetching and MaxDeliveryCount 
 
-When a message is received for processing, the transport will also [prefetch](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) additional messages. "If processing a message takes too long time, then the broker will consider that a failed processing attempt and increase `DeliveryCount` counter on the messages w/o processing attempt taking place.  
+When a message is received for processing, the transport will also [prefetch](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) additional messages. If processing a message takes too long time, then the broker will consider that a failed processing attempt and increase `DeliveryCount` counter on the messages w/o processing attempt taking place.  
 
 Endpoints with high `PrefetchCount` that take long time to process an incoming message can cause prefetched message to be sent to the `Delayed Retries` or the error queue without being retried the desired number of times. To prevent this issue, lower the `PrefetchCount`.
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -41,7 +41,9 @@ See [Message Receivers configuration](/nservicebus/azure-service-bus/configurati
 
 ## Retries and dead letter queues
 
-If a message could not be successfully processed even after retries, it will eventually end up in the error queue.. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. Each endpoint has its own DLQ. Monitoring multiple DLQs might be challenging. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
+If a message could not be successfully processed even after retries, it will eventually end up in the error queue. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to the Dead Letter Queue (DLQ). 
+
+Each endpoint has its own DLQ, however monitoring multiple DLQs might be challenging. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
 
 snippet:forward-deadletter-conditional-queue
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -15,11 +15,11 @@ Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defin
 
 ## Immediate Retries and MaxDeliveryCount
 
-To implement Immediate Retries, the native Azure Service Bus `MaxDeliveryCount` property of the `BrokeredMessage` is used to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists.
+To implement Immediate Retries, the native Azure Service Bus `MaxDeliveryCount` property of the `BrokeredMessage` is used to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists. In case Immediate Retries are disabled, the transport will default `MaxDeliveryCount` to 10 attempts.
 
-A scaled out endpoint will retry the message by any of its instances, before one of them decides to send the message to the delayed retries or the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
+A scaled out endpoint will retry the message by any of its instances. Once all Immediate Retries where exhausted, the message will be delegated to the Delayed Retries, if configured, or sent the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
 
-Versions 6 and below the default value for `MaxDeliveryCount` is 6. Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable immediate retries, immediate retries will be set to 10.
+Versions 6 and below the default value for `MaxDeliveryCount` is 6. Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable Immediate Retries, `MaxDeliverCount` will be set to 10.
 
 
 ### Keeping MaxDeliveryCount in sync with immediate retries
@@ -27,27 +27,25 @@ Versions 6 and below the default value for `MaxDeliveryCount` is 6. Versions 7 a
 Whenever an endpoint is redeployed with a new Immediate Retries value, endpoint specific queues, such as endpoint`s input queue, will be updated with the new value.
 
 
-### Modifying system queues MaxDeliveryCount
-
-A newly deployed or a re-deployed endpoint will not modify system queues `MaxDeliveryCount` set by end users.
+For system queues, such as audit and error queues, a newly deployed or a re-deployed endpoint will not modify system queues `MaxDeliveryCount` set by end users.
 
 
 ### Excessive prefetching and MaxDeliveryCount 
 
-When messages are received, client receivers prefetch messages. Endpoint taking a long time to process a message will cause prefetched messages to lose lock tokens. The broker will consider that as a failed processing attempt increase `DeliveryCount` counter on the messages w/o processing attempt.  
+When a message is received for processing, the transport will also [prefetch](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) additional messages. "If processing a message takes too long time, then the broker will consider that a failed processing attempt and increase `DeliveryCount` counter on the messages w/o processing attempt taking place.  
 
-This can cause a message to be sent to the Delayed Retries or the error queue without being retried the desired number of times. The problem can be addressed by reducing the `PrefetchCount` on message receivers and retrying the failed messages.
+Endpoints with high `PrefetchCount` that take long time to process an incoming message can cause prefetched message to be sent to the Delayed Retries or the error queue without being retried the desired number of times. To prevent this issue, lower the `PrefetchCount`.
 
 See [Message Receivers configuration](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) for more details.
 
 
 ## Retries and dead letter queues
 
-A valid message failing processing will be retried and eventually end up in the error queue. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. With multiple endpoints, monitoring multiple DLQs can be a challenge. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
+A valid message failing processing will be retried and eventually end up in the error queue. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. Each endpoint has its own DLQ. Monitoring multiple DLQs might be challenging. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
 
 snippet:forward-deadletter-conditional-queue
 
 
 ## Delayed Retries
 
-The problem with `MaxDeliveryCount` doesn't impact Delayed Retries. Since the message is deferred for a longer period of time, it will result in a resend operation inside the Azure Service Bus transport. That, in turn, will reset the delivery counter inside the brokered message.
+Delayed Retries are not affected by `MaxDeliveryCount` since the message is deferred for a longer period, it will result in a resend operation inside the Azure Service Bus transport. That, in turn, will reset the delivery counter inside the brokered message.

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -15,33 +15,33 @@ Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defin
 
 ## Immediate Retries and MaxDeliveryCount
 
-To implement Immediate Retries, the native Azure Service Bus `MaxDeliveryCount` property of the `BrokeredMessage` is used to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists. In case Immediate Retries are disabled, the transport will default `MaxDeliveryCount` to 10 attempts.
+To implement Immediate Retries, the native Azure Service Bus `MaxDeliveryCount` property of the `BrokeredMessage` is used to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to to the error queue in case error persists. If immediate retries are disabled for the endpoint, the transport will default `MaxDeliveryCount` to 10 attempts.
 
-A scaled out endpoint will retry the message by any of its instances. Once all Immediate Retries where exhausted, the message will be delegated to the Delayed Retries, if configured, or sent the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
+A scaled out endpoint will retry the message by any of its instances. If the endpoint has not successfully processed the message after all the configured number of Immediate Retry attempts, then the message will be forwarded to the Delayed Retries if configured and if the problem still persists, then the message will be forwarded to the configured error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
 
-Versions 6 and below the default value for `MaxDeliveryCount` is 6. Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable Immediate Retries, `MaxDeliverCount` will be set to 10.
+In versions 6 and below, the default value for `MaxDeliveryCount` is 6. Starting from Versions 7 and above, the new defaults for `MaxDeliveryCount` is one more than the configured value of Immediate Retries. The default value `MaxDeliveryCount` for system queues such as audit and error queues is 10. If the endpoint disables the `Immediate Retries` explicitly, then the `MaxDeliveryCount` will also be set to 10.
 
 
 ### Keeping MaxDeliveryCount in sync with immediate retries
 
-Whenever an endpoint is redeployed with a new Immediate Retries value, endpoint specific queues, such as endpoint`s input queue, will be updated with the new value.
+Whenever an endpoint is redeployed with a new `Immediate Retries` value, endpoint specific queues, such as endpoint`s input queue, will be updated with the new value.
 
 
-For system queues, such as audit and error queues, a newly deployed or a re-deployed endpoint will not modify system queues `MaxDeliveryCount` set by end users.
+For system queues, such as audit and error queues, if a custom value was configured for `MaxDeliveryCount` redeploying the endpoint will not overwrite the already configured value.
 
 
 ### Excessive prefetching and MaxDeliveryCount 
 
 When a message is received for processing, the transport will also [prefetch](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) additional messages. "If processing a message takes too long time, then the broker will consider that a failed processing attempt and increase `DeliveryCount` counter on the messages w/o processing attempt taking place.  
 
-Endpoints with high `PrefetchCount` that take long time to process an incoming message can cause prefetched message to be sent to the Delayed Retries or the error queue without being retried the desired number of times. To prevent this issue, lower the `PrefetchCount`.
+Endpoints with high `PrefetchCount` that take long time to process an incoming message can cause prefetched message to be sent to the `Delayed Retries` or the error queue without being retried the desired number of times. To prevent this issue, lower the `PrefetchCount`.
 
 See [Message Receivers configuration](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) for more details.
 
 
 ## Retries and dead letter queues
 
-A valid message failing processing will be retried and eventually end up in the error queue. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. Each endpoint has its own DLQ. Monitoring multiple DLQs might be challenging. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
+If a message could not be successfully processed even after retries, it will eventually end up in the error queue.. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. Each endpoint has its own DLQ. Monitoring multiple DLQs might be challenging. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
 
 snippet:forward-deadletter-conditional-queue
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -10,31 +10,46 @@ reviewed: 2016-09-21
 
 This article describes the relationship between the NServiceBus retry behavior and the Azure Service Bus native retry behavior.
 
-NServiceBus supports Immediate Retries (previously known as First Level Retries) and Delayed Retries (previously known as Second Level) at the endpoint instance level as described in the [recoverability](/nservicebus/recoverability/) article.
+NServiceBus supports Immediate Retries (formerly known as First Level Retries) and Delayed Retries (previously known as Second Level) at the endpoint instance level as described in the [recoverability](/nservicebus/recoverability/) article.
 
 Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defines how many times Azure Service Bus attempts to deliver a message before sending it to the dead letter queue. Refer to [the full configuration API](/nservicebus/azure-service-bus/configuration/full.md#controlling-entities-queues) article to learn how to adjust this setting.
 
 
-## Immediate Retries vs MaxDeliveryCount
+## Immediate Retries and MaxDeliveryCount
 
-In order to implement Immediate Retries, NServiceBus maintains an internal counter to track the processing attempts by the endpoint instance for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the error queue.
+To implement Immediate Retries, NServiceBus is using Azure Service Bus native `MaxDeliveryCount` property of the `BrokeredMessage` to track the processing attempts by the endpoint instances for a specific message. If the number of attempts exceeds the `MaxRetries` setting, then the message will be forwarded to the delayed retries if configured, and eventually to at the error queue in case error persists.
 
-Each endpoint's instance maintains its own internal counter for retries. If an endpoint is scaled out then the message can be retried a few times by each instance, before one of them decides to send the message to the error queue. So in effect the global retry count, as seen by the Azure Service Bus entity, will in the worst case scenario be equal to `MaxRetries * number of instances`.
+A scaled out endpoint will retry the message by any of its instances, before one of them decides to send the message to the delayed retries or the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
 
-In Azure Service Bus Versions 6 and below the default value for `MaxDeliveryCount` is 6. In Azure Service Bus Versions 7 and higher it has been changed to 10, based on the assumption that by default there are 2 instances of each endpoint and `MaxRetries` has the default value of 5.
+In Azure Service Bus Versions 6 and below the default value for `MaxDeliveryCount` is 6. In Azure Service Bus Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable immediate retries, immediate retries will be set to 10.
 
 
-### Elastic Scale
+### Keeping MaxDeliveryCount in sync with immediate retries
 
-The `MaxDeliveryCount` setting becomes a property on the Azure Service Bus entity. It can't be easily modified after the entity has been created. At the same time the number of instances can be changed just by dragging a slider in the Azure administration portal.
+Whenever an endpoint is redeployed with a new Immediate Retries value, endpoint specific queues, such as endpoint`s input queue, will be updated with the new value.
 
-This becomes a problem when the number of instances exceeds what was originally planned. The messages can be dead lettered when the total retry value exceeds the value configured in `MaxDeliveryCount`, which was adjusted for a smaller number of instances.
 
-One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
+### Modifying system queues MaxDeliveryCount
+
+A newly deployed or a re-deployed endpoint will not modify system queues `MaxDeliveryCount` set by end users.
+
+
+### Excessive prefetching and MaxDeliveryCount 
+
+When messages are received, client receivers prefetch messages. Endpoint taking a long time to process a message will cause prefetched messages to lose lock tokens. The broker will consider that as a failed processing attempt increase `DeliveryCount` counter on the messages w/o processing attempt.  
+
+This can cause a message to be sent to the Delayed Retries or the error queue without being retried the desired number of times. The problem can be addressed by reducing the `PrefetchCount` on message receivers and retrying the failed messages.
+
+See [Message Receivers configuration](/nservicebus/azure-service-bus/configuration/full.md#controlling-connectivity-message-receivers) for more details.
+
+
+## Retries and dead letter queues
+
+A valid message failing processing will be retried and eventually end up in the error queue. If a message is poisonous or cannot be moved to an error queue, it will be moved by the broker to a dead letter queue. With multiple endpoints, monitoring multiple DLQs can be a challenge. One way to solve this problem is to configure the entity to forward dead letter messages to the error queue:
 
 snippet:forward-deadletter-conditional-queue
 
 
 ## Delayed Retries
 
-The problem with `MaxDeliveryCount` doesn't impact Delayed Retries. Since the message is deferred for a longer period of time, it will result in a resend operation inside the Azure Service Bus transport. That in turn will reset the delivery counter inside the brokered message.
+The problem with `MaxDeliveryCount` doesn't impact Delayed Retries. Since the message is deferred for a longer period of time, it will result in a resend operation inside the Azure Service Bus transport. That, in turn, will reset the delivery counter inside the brokered message.

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -24,7 +24,7 @@ In versions 6 and below, the default value for `MaxDeliveryCount` is 6. Starting
 
 ### Keeping MaxDeliveryCount in sync with immediate retries
 
-Whenever an endpoint is redeployed with a new `Immediate Retries` value, endpoint specific queues, such as endpoint`s input queue, will be updated with the new value.
+Whenever an endpoint is redeployed with a new `Immediate Retries` value, endpoint specific queues, such as endpoint's input queue, will be updated with the new value.
 
 
 For system queues, such as audit and error queues, if a custom value was configured for `MaxDeliveryCount` redeploying the endpoint will not overwrite the already configured value.

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -5,7 +5,7 @@ tags:
 - Cloud
 - Azure
 - Transport
-reviewed: 2016-09-21
+reviewed: 2016-09-22
 ---
 
 This article describes the relationship between the NServiceBus retry behavior and the Azure Service Bus native retry behavior.

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -10,7 +10,7 @@ reviewed: 2016-09-22
 
 This article describes the relationship between the NServiceBus retry behavior and the Azure Service Bus native retry behavior.
 
-NServiceBus supports Immediate Retries (formerly known as First Level Retries) and Delayed Retries (previously known as Second Level) at the endpoint instance level as described in the [recoverability](/nservicebus/recoverability/) article.
+NServiceBus supports Immediate Retries and Delayed Retries at the endpoint instance level as described in the [recoverability](/nservicebus/recoverability/) article.
 
 Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defines how many times Azure Service Bus attempts to deliver a message before sending it to the dead letter queue. Refer to [the full configuration API](/nservicebus/azure-service-bus/configuration/full.md#controlling-entities-queues) article to learn how to adjust this setting.
 

--- a/nservicebus/azure-service-bus/retries.md
+++ b/nservicebus/azure-service-bus/retries.md
@@ -8,9 +8,7 @@ tags:
 reviewed: 2016-09-22
 ---
 
-This article describes the relationship between the NServiceBus retry behavior and the Azure Service Bus native retry behavior.
-
-NServiceBus supports Immediate Retries and Delayed Retries at the endpoint instance level as described in the [recoverability](/nservicebus/recoverability/) article.
+This article describes the relationship between [recoverability behavior](/nservicebus/recoverability/) and the Azure Service Bus native retry behavior.
 
 Azure Service Bus supports a `MaxDeliveryCount` at the entity level, which defines how many times Azure Service Bus attempts to deliver a message before sending it to the dead letter queue. Refer to [the full configuration API](/nservicebus/azure-service-bus/configuration/full.md#controlling-entities-queues) article to learn how to adjust this setting.
 
@@ -21,7 +19,7 @@ To implement Immediate Retries, NServiceBus is using Azure Service Bus native `M
 
 A scaled out endpoint will retry the message by any of its instances, before one of them decides to send the message to the delayed retries or the error queue. So in effect, the number of immediate retries attempts will never exceed the defined number of immediate retries for an endpoint.
 
-In Azure Service Bus Versions 6 and below the default value for `MaxDeliveryCount` is 6. In Azure Service Bus Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable immediate retries, immediate retries will be set to 10.
+Versions 6 and below the default value for `MaxDeliveryCount` is 6. Versions 7 and higher it has been changed to be equal to a number of immediate retries for an endpoint plus one. For system queues, such as audit and error queues, the default was changed to 10. Should endpoint disable immediate retries, immediate retries will be set to 10.
 
 
 ### Keeping MaxDeliveryCount in sync with immediate retries

--- a/nservicebus/upgrades/asb-6to7.md
+++ b/nservicebus/upgrades/asb-6to7.md
@@ -54,11 +54,10 @@ snippet:6to7_setting_asb_connection_string
 
 The default values of the following settings have been changed:
 
- * `BatchSize`, which had a default value of 1000, is replaced by `PrefetchCount` with a default value of 200.
- * `MaxDeliveryCount` changed from 6 to 10.
+ * `BatchSize`, which had a default value of 1000, is replaced by `PrefetchCount` with a default value of 200. 
+ * `MaxDeliveryCount` is set to number of immediate retries + 1. For system queues the value has changed from 6 to 10.
 
-For more details refer to the [ASB Batching](/nservicebus/azure-service-bus/batching.md) and [ASB Retry behavior](/nservicebus/azure-service-bus/retries.md) articles.
-
+For more details refer to the [ASB Batching](/nservicebus/azure-service-bus/batching.md) and [ASB Retry behavior](/nservicebus/azure-service-bus/retries.md) articles. 
 
 ### Setting Entity Property Values
 

--- a/nservicebus/upgrades/asb-6to7.md
+++ b/nservicebus/upgrades/asb-6to7.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Service Bus Transport Upgrade Version 6 to 7
 summary: Instructions on how to upgrade Azure Service Bus Transport Version 6 to 7.
-reviewed: 2016-09-19
+reviewed: 2016-09-22
 tags:
  - upgrade
  - migration


### PR DESCRIPTION
ASB is now setting default `MaxDeliveryCount` to match the value of Immediate Retries since message cannot be processed more than that.