### PR TITLE
[WIP] ASQ aliases moved to a separate page

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -415,6 +415,8 @@
       Title: Avoiding Transactions
     - Url: nservicebus/azure-storage-queues/configuration
       Title: Configuration
+    - Url: nservicebus/azure-storage-queues/aliases
+      Title: Aliases for connection strings
     - Url: nservicebus/azure-storage-queues/performance-tuning
       Title: Performance Tuning
     - Url: nservicebus/azure-storage-queues/multi-storageaccount-support

--- a/nservicebus/azure-storage-queues/aliases.include.md
+++ b/nservicebus/azure-storage-queues/aliases.include.md
@@ -1,0 +1,22 @@
+In order to prevent accidentally leaking connection string values, it is recommended to use aliases instead of raw connection strings. When applied, raw connection string values are replaced with registered aliases removing the possibility of leaking a connection string value. The concept of using aliases for connection strings to storage accounts has been introduced in Version 7. When using a single account, aliasing connection string is limited to just enabling it. When multiple accounts are used, an alias has to be registered for each storage account.
+
+Consider the following example:
+
+ * Two endpoints using different accounts `account_A` and `account_B` for their input queues.
+ * The `account_A` endpoint uses account with the following connection string `account_A_connection_string`.
+ * The `account_B` endpoint uses account with the following connection string `account_B_connection_string`.
+ * Every endpoint sends/replies to messages to the other using `@` notation.
+  * `queue@account_A` is a `queue` of the `account_A` endpoint where `account_B` endpoint sends messages to.
+  * `queue@account_B` is a `queue` of the `account_B` endpoint where `account_A` endpoint sends messages to.
+
+To enable sending from `account_A` to `account_B`, following configuration has to be applied in the `account_A` endpoint
+
+snippet:AzureStorageQueueUseMultipleAccountAliasesInsteadOfConnectionStrings1
+
+To enable sending from `account_B` to `account_A`, following configuration has to be applied in the `account_B` endpoint
+
+snippet:AzureStorageQueueUseMultipleAccountAliasesInsteadOfConnectionStrings2
+
+Aliases can be provided for both the endpoint's connection string as well as other accounts' connection strings. This enables using `@` notation for destination addresses `queue_name@accountName`.
+
+NOTE: The examples above use different default accounts' aliases to enable a coherent addressing. Using the same name, like `default`, for all main accounts is highly discouraged as it introduces ambiguity in resolving addresses like `queue@default`. For example, when an address is interpreted as a reply address, the name `default` will point to a different connection string.

--- a/nservicebus/azure-storage-queues/aliases.md
+++ b/nservicebus/azure-storage-queues/aliases.md
@@ -1,0 +1,14 @@
+---
+title: Azure Storage Queues Transport Configuration
+component: ASQ
+tags:
+- Azure
+- Cloud
+- ASQ
+- Azure Storage Queues
+---
+
+
+## Using aliases for connection strings to storage accounts
+
+include: aliases

--- a/nservicebus/azure-storage-queues/aliases.md
+++ b/nservicebus/azure-storage-queues/aliases.md
@@ -1,6 +1,5 @@
 ---
 title: Azure Storage Queues Transport Configuration
-component: ASQ
 tags:
 - Azure
 - Cloud

--- a/nservicebus/azure-storage-queues/multi-storageaccount-support_aliases_asq_[7,].partial.md
+++ b/nservicebus/azure-storage-queues/multi-storageaccount-support_aliases_asq_[7,].partial.md
@@ -1,24 +1,3 @@
 ## Using aliases for connection strings to storage accounts for Scale Out
 
-In order to prevent accidentally leaking connection string values, it is recommended to use aliases instead of raw connection strings. When applied, raw connection string values are replaced with registered aliases removing the possibility of leaking a connection string value. The concept of using aliases for connection strings to storage accounts has been introduced in Version 7. When using a single account, aliasing connection string is limited to just enabling it. When multiple accounts are used, an alias has to be registered for each storage account.
-
-Consider the following example:
-
- * Two endpoints using different accounts `account_A` and `account_B` for their input queues.
- * The `account_A` endpoint uses account with the following connection string `account_A_connection_string`.
- * The `account_B` endpoint uses account with the following connection string `account_B_connection_string`.
- * Every endpoint sends/replies to messages to the other using `@` notation.
-  * `queue@account_A` is a `queue` of the `account_A` endpoint where `account_B` endpoint sends messages to.
-  * `queue@account_B` is a `queue` of the `account_B` endpoint where `account_A` endpoint sends messages to.
-
-To enable sending from `account_A` to `account_B`, following configuration has to be applied in the `account_A` endpoint
-
-snippet:AzureStorageQueueUseMultipleAccountAliasesInsteadOfConnectionStrings1
-
-To enable sending from `account_B` to `account_A`, following configuration has to be applied in the `account_B` endpoint
-
-snippet:AzureStorageQueueUseMultipleAccountAliasesInsteadOfConnectionStrings2
-
-Aliases can be provided for both the endpoint's connection string as well as other accounts' connection strings. This enables using `@` notation for destination addresses `queue_name@accountName`.
-
-NOTE: The examples above use different default accounts' aliases to enable a coherent addressing. Using the same name, like `default`, for all main accounts is highly discouraged as it introduces ambiguity in resolving addresses like `queue@default`. For example, when an address is interpreted as a reply address, the name `default` will point to a different connection string.
+include: aliases


### PR DESCRIPTION
Connects to #1865

This PR extracts aliases for multiple accounts to a separate `aliases.include.md`. The include is used in the scale out page as well as in the newly created separate page for aliases. 

My personal doubt: this menu item unfortunately is visible for all versions of NSB as there's no menu versioning. I can't provide a general article as this page describes a feature that has been introduced in the ASQ 7.