### PR TITLE
Correct the v6 Delayed Delivery caveat

### DIFF
--- a/nservicebus/messaging/delayed-delivery_caveatsnote_core_[6,).partial.md
+++ b/nservicebus/messaging/delayed-delivery_caveatsnote_core_[6,).partial.md
@@ -1,1 +1,1 @@
-NOTE: The Timeout Manager is enabled by default. However, it is automatically disabled for send-only endpoints and transports that support delayed delivery natively (i.e. Azure Service Bus, Azure Storage Queues and RabbitMQ).
+NOTE: The Timeout Manager is enabled by default. However, it is automatically disabled for send-only endpoints and transports that support delayed delivery natively (i.e. Azure Service Bus).


### PR DESCRIPTION
This note is incorrect. Only ASB supports delayed delivery natively.