### PR TITLE
Mention removed satellite pipeline performance counters

### DIFF
--- a/nservicebus/upgrades/5to6/extension-seams.md
+++ b/nservicebus/upgrades/5to6/extension-seams.md
@@ -39,9 +39,17 @@ Feature Dependencies, using the string API, now need to be declared using the ta
 snippet: 5to6-DependentFeature
 
 
+## Satellites
+
+
 ### ISatellite and IAdvancedSatellite interfaces are obsolete
 
 Both the `ISatellite` and the `IAdvancedSatellite` interfaces are deprecated. The same functionality is available via the `AddSatelliteReceiver` method on the context passed to the [features](/nservicebus/pipeline/features.md#feature-api) `Setup` method. The [satellite documentation](/nservicebus/satellites/) shows this in detail.
+
+
+### Performance Counters
+
+Satellite pipelines (e.g. retries or timeouts) no longer create Performance Counters. Endpoints provide a single performance counter instance related to the main message processing pipeline.
 
 
 ## Transport Seam

--- a/nservicebus/upgrades/5to6/extension-seams.md
+++ b/nservicebus/upgrades/5to6/extension-seams.md
@@ -51,6 +51,8 @@ Both the `ISatellite` and the `IAdvancedSatellite` interfaces are deprecated. Th
 
 Satellite pipelines (e.g. retries or timeouts) no longer create Performance Counters. Endpoints provide a single performance counter instance related to the main message processing pipeline.
 
+To learn more about using Perfomance Cunters in NServiceBus, refer to the [Performance Counter Usage](/samples/performance-counters/) sample and [Performance Counters](/nservicebus/operations/performance-counters.md) article.
+
 
 ## Transport Seam
 


### PR DESCRIPTION
We also use screenshots of performance counters in the related sample here: https://docs.particular.net/samples/performance-counters/

is there value in providing update screenshots for v6 which do not contain the satellite instances? @Particular/docs-maintainers 