### PR TITLE
Command/event definitions and comparison

### DIFF
--- a/nservicebus/concept-overview.md
+++ b/nservicebus/concept-overview.md
@@ -14,8 +14,9 @@ A high level overview of the concepts, features and vernacular of NServiceBus.
 
 A Message is the unit of communication for NServiceBus. Messages are send and received by endpoints. There are two general types of messages:
 
- * [Command](/nservicebus/messaging/messages-events-commands.md): Used to request that an action should be taken.
- * [Event](/nservicebus/messaging/messages-events-commands.md): Used to communicate that some action has taken place.
+include: definition-command
+
+include: definition-event
 
 Message types can be set either using marker interfaces `ICommand` and `IEvent` or via [conventions](/nservicebus/messaging/unobtrusive-mode.md) (so called *unobtrusive mode*).
 

--- a/nservicebus/definition-command.include.md
+++ b/nservicebus/definition-command.include.md
@@ -1,0 +1,1 @@
+A [**command**](/nservicebus/messaging/messages-events-commands.md#command) is a message that is used to request that an action should be taken. It can be sent from one or more senders, and is processed by a single logical receiver.

--- a/nservicebus/definition-command.include.md
+++ b/nservicebus/definition-command.include.md
@@ -1,1 +1,1 @@
-A [**command**](/nservicebus/messaging/messages-events-commands.md#command) is a message that is used to request that an action should be taken. It can be sent from one or more senders, and is processed by a single logical receiver.
+A [**command**](/nservicebus/messaging/messages-events-commands.md#command) is a message that is used to request that an action should be taken. It can be sent from one or more endpoints, and is processed by a single logical endpoint.

--- a/nservicebus/definition-event.include.md
+++ b/nservicebus/definition-event.include.md
@@ -1,0 +1,1 @@
+An [**event**](/nservicebus/messaging/messages-events-commands.md#event) is a message that is used to communicate that some action has taken place. It is published from a single logical sender, and is processed by (potentially) many receivers.

--- a/nservicebus/definition-event.include.md
+++ b/nservicebus/definition-event.include.md
@@ -1,1 +1,1 @@
-An [**event**](/nservicebus/messaging/messages-events-commands.md#event) is a message that is used to communicate that some action has taken place. It is published from a single logical sender, and is processed by (potentially) many receivers.
+An [**event**](/nservicebus/messaging/messages-events-commands.md#event) is a message that is used to communicate that some action has taken place. It is published from a single logical endpoint, and is processed by potentially many subscribing endpoints.

--- a/nservicebus/messaging/command-event-comparison-table.include.md
+++ b/nservicebus/messaging/command-event-comparison-table.include.md
@@ -1,0 +1,9 @@
+|   | Commands | Events |
+|---|:--------:|:------:|
+| Marker Interface | `ICommand` | `IEvent` |
+| Logical Senders | Many | 1 |
+| Logical Receivers | 1 | Many (or none) |
+| Purpose | "Please do something" | "Something has happened" |
+| Naming (Tense) | Imperative | Past |
+| Examples | `PlaceOrder`<br/>`ChargeCreditCard` | `OrderPlaced`<br/>`CreditCardCharged` |
+| Coupling Style | Tight | Loose |

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -46,7 +46,7 @@ Note: For reply messages in a request and response pattern, use `IMessage` since
 
 ### Command/Event Comparison
 
-Here is a quick side-by-side comparison of some of the differences between commands and events:
+Here is a comparison of some of the differences between commands and events:
 
 include: command-event-comparison-table
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -44,6 +44,12 @@ Used to communicate that some action has taken place. An *Event* should be _publ
 
 Note: For reply messages in a request and response pattern, use `IMessage` since these replies are neither a Command nor an Event.
 
+### Command/Event Comparison
+
+Here is a quick side-by-side comparison of some of the differences between commands and events:
+
+include: command-event-comparison-table
+
 
 ### Validation Messages
 


### PR DESCRIPTION
This PR expands the "short" definitions of commands/events a bit, and moves them to includes so that they can be included in tutorials or elsewhere.

Also, a table of command/event comparisons developed for the intro tutorial.

@Particular/docs-maintainers please review