### PR TITLE
[WIP] Azure Storage Persistence - configuration.md review & update

### DIFF
--- a/nservicebus/azure-storage-persistence/configuration.md
+++ b/nservicebus/azure-storage-persistence/configuration.md
@@ -11,7 +11,7 @@ reviewed: 2016-11-07
 
 In NServiceBus.Azure the behavior of the `AzureStoragePersister` can be controlled by working with the appropriate configuration section(s) in the `app.config` or by using the code via the [`IProvideConfiguration` adapter](/nservicebus/hosting/custom-configuration-providers.md). Both approaches to configuring the persister can access the same configuration options.
 
-In NServiceBus.Persistence.AzureStorage Version 1 XML-based configuration is no longer available. Configuring the behavior of the persister is done using the code configuration API.
+NOTE: In NServiceBus.Persistence.AzureStorage Version 1 XML-based configuration is no longer available. Configuring the behavior of the persister is done using the code configuration API.
 
 partial:sections
 
@@ -29,7 +29,7 @@ NOTE: Subscriptions and Timeouts persistence configurations have no effect when 
 When using XML-based configuration, the following properties can be set through the `AzureSagaPersisterConfig` section:
 
  * `ConnectionString`: Sets the connectionstring for the storage account to be used for storing saga information.
-  * NServiceBus.Azure Versions 6 and below defaults to `UseDevelopmentStorage=true`.
+  * NServiceBus.Azure defaults to `UseDevelopmentStorage=true`.
   * NServiceBus.Persistence.AzureStorage Version 1 defaults to `null`.
  * `CreateSchema`: Instructs the persister to create the table automatically.
   * defaults to `true`.
@@ -40,7 +40,7 @@ When using XML-based configuration, the following properties can be set through 
 The following settings are available for changing the behavior of subscription persistence:
 
  * `ConnectionString`: Sets the connection string for the storage account to be used for storing subscription information.
-  * NServiceBus.Azure Versions 6 and below defaults to `UseDevelopmentStorage=true`.
+  * NServiceBus.Azure defaults to `UseDevelopmentStorage=true`.
   * NServiceBus.Persistence.AzureStorage Version 1 defaults to `null`.
  * `CreateSchema`: Instructs the persister to create the table automatically.
   * defaults to `true`.

--- a/nservicebus/azure-storage-persistence/configuration.md
+++ b/nservicebus/azure-storage-persistence/configuration.md
@@ -1,45 +1,21 @@
 ---
 title: Configuration
+component: ASP
 summary: Configuring Azure Storage as persistence
 tags:
  - Azure
  - Cloud
  - Persistence
+reviewed: 2016-11-07
 ---
 
 In NServiceBus.Azure the behavior of the `AzureStoragePersister` can be controlled by working with the appropriate configuration section(s) in the `app.config` or by using the code via the [`IProvideConfiguration` adapter](/nservicebus/hosting/custom-configuration-providers.md). Both approaches to configuring the persister can access the same configuration options.
 
-
 In NServiceBus.Persistence.AzureStorage Version 1 XML-based configuration is no longer available. Configuring the behavior of the persister is done using the code configuration API.
 
+partial:sections
 
-### Configuration with Configuration Section
-
-In NServiceBus.Azure Version 6 and lower configuration can be performed using configuration sections and properties in the `app.config` file.
-
-snippet:AzurePersistenceFromAppConfig
-
-
-### Configuration with Code
-
-Configuration of the persister via the code API is available to NServiceBus.Azure Version 6 and below as well as NServiceBus.Persistence.AzureStorage Version 1.
-
-For Sagas, Subscriptions and for Timeouts:
-
-snippet:AzurePersistenceSubscriptionsAllConnectionsCustomization
-
-For Sagas:
-
-snippet:AzurePersistenceSagasCustomization
-
-For Subscriptions:
-
-snippet:AzurePersistenceSubscriptionsCustomization
-
-For Timeouts:
-
-snippet:AzurePersistenceTimeoutsCustomization
-
+partial:code
 
 ### Configuration Properties
 
@@ -61,7 +37,7 @@ When using XML-based configuration, the following properties can be set through 
 
 #### Subscription Configuration
 
-The following settings are available for changing the behavior of subscription persistence through the `AzureSubscriptionStorageConfig` section:
+The following settings are available for changing the behavior of subscription persistence:
 
  * `ConnectionString`: Sets the connection string for the storage account to be used for storing subscription information.
   * NServiceBus.Azure Versions 6 and below defaults to `UseDevelopmentStorage=true`.
@@ -74,7 +50,7 @@ The following settings are available for changing the behavior of subscription p
 
 #### Timeout Configuration
 
-The following settings are available for changing the behavior of timeout persistence through the `AzureTimeoutPersisterConfig` section:
+The following settings are available for changing the behavior of timeout persistence:
 
  * `ConnectionString`: Sets the connectionstring for the storage account to be used for storing timeout information.
   * NServiceBus.Azure Versions 6 and below Defaults to `UseDevelopmentStorage=true`.

--- a/nservicebus/azure-storage-persistence/configuration.md
+++ b/nservicebus/azure-storage-persistence/configuration.md
@@ -11,8 +11,6 @@ reviewed: 2016-11-07
 
 In NServiceBus.Azure the behavior of the `AzureStoragePersister` can be controlled by working with the appropriate configuration section(s) in the `app.config` or by using the code via the [`IProvideConfiguration` adapter](/nservicebus/hosting/custom-configuration-providers.md). Both approaches to configuring the persister can access the same configuration options.
 
-NOTE: In NServiceBus.Persistence.AzureStorage Version 1 XML-based configuration is no longer available. Configuring the behavior of the persister is done using the code configuration API.
-
 partial:sections
 
 partial:code

--- a/nservicebus/azure-storage-persistence/configuration_code_asp_[1,].partial.md
+++ b/nservicebus/azure-storage-persistence/configuration_code_asp_[1,].partial.md
@@ -1,0 +1,17 @@
+### Configuration with Code
+
+For Sagas, Subscriptions and for Timeouts:
+
+snippet:AzurePersistenceSubscriptionsAllConnectionsCustomization
+
+For Sagas:
+
+snippet:AzurePersistenceSagasCustomization
+
+For Subscriptions:
+
+snippet:AzurePersistenceSubscriptionsCustomization
+
+For Timeouts:
+
+snippet:AzurePersistenceTimeoutsCustomization

--- a/nservicebus/azure-storage-persistence/configuration_code_azure_[6,].partial.md
+++ b/nservicebus/azure-storage-persistence/configuration_code_azure_[6,].partial.md
@@ -1,0 +1,13 @@
+### Configuration with Code
+
+For Sagas:
+
+snippet:AzurePersistenceSagasCustomization
+
+For Subscriptions:
+
+snippet:AzurePersistenceSubscriptionsCustomization
+
+For Timeouts:
+
+snippet:AzurePersistenceTimeoutsCustomization

--- a/nservicebus/azure-storage-persistence/configuration_sections_asp_[1,].partial.md
+++ b/nservicebus/azure-storage-persistence/configuration_sections_asp_[1,].partial.md
@@ -1,0 +1,2 @@
+
+NOTE: In NServiceBus.Persistence.AzureStorage Version 1 XML-based configuration is no longer available. Configuring the behavior of the persister is done using the code configuration API.

--- a/nservicebus/azure-storage-persistence/configuration_sections_azure_[,6.2].partial.md
+++ b/nservicebus/azure-storage-persistence/configuration_sections_azure_[,6.2].partial.md
@@ -1,0 +1,5 @@
+### Configuration with Configuration Section
+
+In NServiceBus.Azure configuration can be performed using configuration sections and properties in the `app.config` file.
+
+snippet:AzurePersistenceFromAppConfig


### PR DESCRIPTION
Connects to #2157

This PR introduced `component: ASP` to `configuration.md`. This enabled me to use versioning with three effective ranges and split configuration to the partials to have one, properly versioned page and remove all the `In version x ...` and leave it as intro in the beginning of the article.

|Package | config sections | config via code|
|---|:---:|:---:|
|`NServiceBus.Azure [,6)`| 👍 | |
|`NServiceBus.Azure [6,]` | 👍 | 👍 |
|`NServiceBus.Persistence.AzureStorage [1.)` | | 👍|