### PR TITLE
Refer to ServiceControl Management consistently

### DIFF
--- a/servicecontrol/backup-sc-database.md
+++ b/servicecontrol/backup-sc-database.md
@@ -4,14 +4,14 @@ summary: How to backup the ServiceControl RavenDB Embedded instance
 tags:
 - ServiceControl
 - RavenDB
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 ServiceControl utilizes an embedded RavenDB for data storage. To backup or restore the database instance follow these procedures:
 
 
 ### Backup
 
- 1. Open the ServiceControl Management Utility to view the list of ServiceControl Service instances
+ 1. Open ServiceControl Management to view the list of ServiceControl Service instances
   ![](managementutil-instance.png 'width=500')
  1. Stop the service from the action icons.
  1. Click the link under data path to go to the data directory.
@@ -21,7 +21,7 @@ ServiceControl utilizes an embedded RavenDB for data storage. To backup or resto
 
 ### Restore
 
- 1. Open the ServiceControl Management Utility to view the list of ServiceControl Service instances
+ 1. Open ServiceControl Management to view the list of ServiceControl Service instances
  1. Stop the service from the action icons.
  1. Click the link under data path to go to the data directory.
  1. Replace the contents of this directory with the previously copied data,

--- a/servicecontrol/configure-non-privileged-service-account.md
+++ b/servicecontrol/configure-non-privileged-service-account.md
@@ -3,7 +3,7 @@ title: Configuring a Non-Privileged Account
 summary: Using low privilege account for ServiceControl
 tags:
 - ServiceControl
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
 To allow a non-privileged account to function as the the service account for ServiceControl the following things should be considered:
@@ -26,7 +26,7 @@ In addition the Service requires rights to the configured audit and error queues
  * `error.log`
  * `audit.log`
 
-If the service account user does not have appropriate rights the service will fail to start. 
+If the service account user does not have appropriate rights the service will fail to start.
 
 
 ### Configuration Changes
@@ -83,7 +83,7 @@ If the command returns the error below then the user account cannot be tested th
 Once logon rights are granted proceed:
 
  1. Ensure that the service is stopped.
- 1. From the command prompt running as the service account, change to the ServiceControl installation directory and run `ServiceControl.exe` with the `--serviceName` parameter. In the following example the default name has been used. Check the ServiceControl Management Utility if unsure of the service name
+ 1. From the command prompt running as the service account, change to the ServiceControl installation directory and run `ServiceControl.exe` with the `--serviceName` parameter. In the following example the default name has been used. Check ServiceControl Management if unsure of the service name
  1. Examine the output and confirm that there are no critical errors.
  1. Shut down the console session.
  1. Start the service.

--- a/servicecontrol/configure-ravendb-location.md
+++ b/servicecontrol/configure-ravendb-location.md
@@ -4,21 +4,21 @@ summary: Increase space for monitored data by configuring ServiceControl to save
 tags:
 - ServiceControl
 - RavenDB Embedded
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
 Each ServiceControl service stores its data in a RavenDB embedded database. The location of the database is set at install time.
 
-To see the current database location, open the ServiceControl Management Utility and the location is listed in the instance details.
+To see the current database location, open ServiceControl Management and view the location is listed in the instance details.
 
 ![](managementutil-instance-datapath.png 'width=500')
 
 
 ### Setting a Different Location for RavenDB Embedded Database
 
-The ServiceControl Management Utility does not provide a means of moving the ServiceControl database. To move the database to a different disk location follow this process:
+ServiceControl Management does not provide a means of moving the ServiceControl database. To move the database to a different disk location follow this process:
 
- * Open the ServiceControl Management Utility
+ * Open ServiceControl Management
  * Stop the service from the provided options
  * The current database path will be listed in the utility. Copy the contents of this directory to the new location
  * The new database location should not be a sub folder of one of the existing locations (Installation path, Log Path etc)
@@ -28,4 +28,3 @@ The ServiceControl Management Utility does not provide a means of moving the Ser
  * Remove the old database directory and contents
 
 This will generate a new instance of the RavenDB embedded instance in the specified path.
-

--- a/servicecontrol/creating-config-file.md
+++ b/servicecontrol/creating-config-file.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration Settings
 summary: Categorized list of ServiceControl configuration settings.
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
 - ServiceControl
 ---
@@ -9,7 +9,7 @@ tags:
 
 ## Configuration Settings
 
-The configuration of a ServiceControl instance can be adjusted via the ServiceControl Management utility or by directly modifying the `ServiceControl.exe.config` file. The settings listed are applicable to the app settings section of the configuration file unless otherwise specified.
+The configuration of a ServiceControl instance can be adjusted via ServiceControl Management or by directly modifying the `ServiceControl.exe.config` file. The settings listed are applicable to the app settings section of the configuration file unless otherwise specified.
 
 
 ## Host Settings

--- a/servicecontrol/db-compaction.md
+++ b/servicecontrol/db-compaction.md
@@ -4,7 +4,7 @@ summary: How to compact (release disk space to OS) the RavenDB database backing 
 tags:
 - ServiceControl
 - RavenDB
-reviewed: 2016-10-04
+reviewed: 2016-11-09
 ---
 
 
@@ -16,7 +16,7 @@ ServiceControl's embedded RavenDB database can be compacted in one of two ways. 
 
 ### Step 1: Stop ServiceControl
 
-* Open the ServiceControl Management utility.
+* Open ServiceControl Management.
 * Stop the Service from the actions icons.
 * Note down the "DATA PATH" for the service.   ![](managementutil-instance-datapath.png 'width=500')
 
@@ -38,7 +38,7 @@ WARNING: For the `esentutl` command line utility to work properly, ServiceContro
 Extensible Storage Engine Utilities for Microsoft(R) Windows(R)
 Version 10.0
 Copyright (C) Microsoft Corporation. All Rights Reserved.
-	
+
 Initiating RECOVERY mode...
    Logfile base name: RVN
    Log files: logs
@@ -82,7 +82,7 @@ Once ServiceControl is running in this mode the following procedure can be used 
 
 ### Step 1: Start ServiceControl in the maintenance mode
 
-* Open the ServiceControl Management utility.
+* Open ServiceControl Management.
 * Click on the "ADVANCED OPTIONS" icon of the instance that needs to be run in maintenance mode.  
   ![](managementutil-advancedoptions.png)
 * Click on the "Start Maintenance Mode" button.  
@@ -101,7 +101,7 @@ Once ServiceControl is running in this mode the following procedure can be used 
   ![](export-database-step3.png 'width=500')
 * Wait for the export operation to complete.  
   ![](export-database-step4.png)
-* Once the export operation is complete, stop ServiceControl (from the ServiceControl Management utility).
+* Once the export operation is complete, stop ServiceControl (from ServiceControl Management).
 
 ### Step 3: Delete the existing database
 
@@ -123,7 +123,7 @@ NOTE: At this point it is advisable to take a backup copy of the existing databa
 * Wait for the operation to complete.
 * After the operation has completed wait for the stale index count in the footer to indicate there are no stale indexes.  
   ![](import-database-step4.png 'width=500')
-* Stop ServiceControl (from the ServiceControl Management utility).
+* Stop ServiceControl (from ServiceControl Management).
 
 NOTE: If an `System.OutOfMemoryException` occurs during import work around this error by reducing the batch size in advanced settings.
 

--- a/servicecontrol/errorlog-auditlog-behavior.md
+++ b/servicecontrol/errorlog-auditlog-behavior.md
@@ -3,7 +3,7 @@ title: ServiceControl Forwarding Queues
 summary: Details the ServiceControl Audit and Error forwarding behavior and configuration
 tags:
 - ServiceControl
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
 ### Audit and Error queues
@@ -15,7 +15,7 @@ ServiceControl can also forward these messages to two forwarding queues.
  * Error messages are optionally forwarded to the Error forwarding queue.
  * Audit messages are optionally forwarded to the Audit forwarding queue.
 
-This behavior can be set through the ServiceControl Management utility.
+This behavior can be set through ServiceControl Management.
 
 
 ### Error and Audit Forwarding Queues

--- a/servicecontrol/how-purge-expired-data.md
+++ b/servicecontrol/how-purge-expired-data.md
@@ -7,9 +7,9 @@ related:
 tags:
 - ServiceControl
 - Expiration
-reviewed: 2016-10-05
+reviewed: 2016-11-09
 ---
 
-ServiceControl stores audit and error data. Any audit and error data that is older than the specified mandatory thresholds is deleted from the embedded RavenDB. The expiration thresholds for both faulted and audited messages needs to be set at installation time. These value can be modified later on by launching the ServiceControl Management Utility and editing the configuration settings for the instance.
+ServiceControl stores audit and error data. Any audit and error data that is older than the specified mandatory thresholds is deleted from the embedded RavenDB. The expiration thresholds for both faulted and audited messages needs to be set at installation time. These value can be modified later on by launching ServiceControl Management and editing the configuration settings for the instance.
 
-Note: The expiration process only curates the data in the embedded RavenDB. Audit and Error forwarding queues are not curated and or managed by ServiceControl. To turn these off launch the ServiceControl Management Utility and edit the configuration settings for the instance.
+Note: The expiration process only curates the data in the embedded RavenDB. Audit and Error forwarding queues are not curated and or managed by ServiceControl. To turn these off launch ServiceControl Management and edit the configuration settings for the instance.

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Instances via PowerShell
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
  - ServiceControl
  - Installation

--- a/servicecontrol/installation-silent.md
+++ b/servicecontrol/installation-silent.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Silently
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
 - ServiceControl
 - Installation
@@ -10,27 +10,27 @@ tags:
 
 Note: This documentation covers silent installation instructions for ServiceControl Version 1.7 or greater.
 
-The command line examples referred to the ServiceControl installation exe as `<install.exe>`.   Replace this with the specific exe name for the version being deployed.  (e.g. Particular.ServiceControl-1.22.0.exe) 
+The command line examples referred to the ServiceControl installation exe as `<install.exe>`.   Replace this with the specific exe name for the version being deployed.  (e.g. Particular.ServiceControl-1.22.0.exe)
 
 
-The following command line will silently install the ServiceControl Management utility only.
+The following command line will silently install ServiceControl Management.
 
 ```dos
  <install.exe> /quiet
 ```
 
-Instances of the ServiceControl service can be deleted, added or upgraded via the Utility.
+Instances of the ServiceControl service can be deleted, added or upgraded via the ServiceControl Management application or ServiceControl Management Powershell console .
 
 
 #### Silently Add ServiceControl during installation
 
-The following command line will silently install the ServiceControl Management and a ServiceControl instance.
+The following command line will silently install the ServiceControl Management application and an instance of the ServiceControl service.
 
 ```bat
  <install.exe> /quiet /LV* install.log UNATTENDEDFILE=unattendfile.xml
 ```
 
-For details on how to make the `unattendedfile.xml` file refer to ServiceControl Management [PowerShell](installation-powershell.md) documentation. The installed instance will use `localsystem` as the service account. To specify an alternative service account use the `SERVICEACCOUNT` and `PASSWORD` command line switches.
+For details on how to make the `unattendedfile.xml` file refer to the ServiceControl Management [PowerShell](installation-powershell.md) documentation. The installed instance will use `localsystem` as the service account. To specify an alternative service account use the `SERVICEACCOUNT` and `PASSWORD` command line switches.
 
 ```dos
 <install.exe> /quiet /LV* install.log UNATTENDEDFILE=unattendfile.xml SERVICEACCOUNT=MyServiceAccount PASSWORD=MyPassword
@@ -43,13 +43,13 @@ NOTE: The settings contained in an unattended installation files are version spe
 
 If an existing service matching the name specified in the unattended XML file already exists the unattended install option is ignored. To update one or more instances of ServiceControl as part of the silent installation the command line switch `UPGRADEINSTANCES` command line argument can be used.
 
-In this example the ServiceControl Management Utility is silently installed and attempt to upgrade all the installed instances of the ServiceControl service. Either `*` or `ALL` can be used to specify all instances should be upgraded.
+In this example ServiceControl Management is silently installed and an upgrade is attempted for all the installed instances of the ServiceControl service. Either `*` or `ALL` can be used to specify all instances should be upgraded.
 
 ```dos
 <install.exe> /quiet /LV* install.log UPGRADEINSTANCES=ALL
 ```
 
-In this example the ServiceControl Management Utility is silently installed and attempt to upgrade just one instance called `TestServiceControl`.
+In this example ServiceControl Management is silently installed and attempt to upgrade just one instance called `TestServiceControl`.
 
 ```dos
 <install.exe> /quiet /LV* install.log UPGRADEINSTANCES=TestServiceControl
@@ -64,7 +64,7 @@ To specify multiple instances use a comma separated list:
 
 #### Add the license file as part of the Silent installation
 
-In this example the ServiceControl Management Utility is silently installed and import the license file.
+In this example ServiceControl Management is silently installed and a license license file is imported
 
 ```dos
 <install.exe> /quiet /LV* install.log LICENSEFILE=license.xml
@@ -124,7 +124,7 @@ The command line `UPGRADEINSTANCES` can be combined with `FORWARDERRORMESSAGES`,
 
 #### Command line Uninstall
 
-The following command can be used to uninstall ServiceControl Management Utility silently:
+The following command can be used to uninstall ServiceControl Management silently:
 
 ```dos
 wmic product where (name like '%servicecontrol%') call uninstall
@@ -135,7 +135,7 @@ NOTE: This command will not remove any ServiceControl service instances that are
 
 #### Logging and Failures
 
-In each of the samples above a log file was specified on the command line. The silent install actions will log to the MSI log file specified. For Version 1.6.3 and below if an installation action failed the installation was rolled back, this resulted in failed upgrades acting like a complete uninstall of the product. For Version 1.7 and above a failure to do an unattended install action will be logged but the overall installation will not rollback, in this scenario only the ServiceControl Management Utility will have been updated. Instances can subsequently be upgrade through the ServiceControl Management Utility.
+In each of the samples above a log file was specified on the command line. The silent install actions will log to the MSI log file specified. For Version 1.6.3 and below if an installation action failed the installation was rolled back, this resulted in failed upgrades acting like a complete uninstall of the product. For Version 1.7 and above a failure to do an unattended install action will be logged but the overall installation will not rollback, in this scenario only the ServiceControl Management will have been updated. Instances can subsequently be upgrade through the ServiceControl Management.
 
 
 #### PowerShell

--- a/servicecontrol/installation.md
+++ b/servicecontrol/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installing ServiceControl
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
 - ServiceControl
 - Installation
@@ -22,7 +22,7 @@ If ServiceControl is installed via the Particular Software Platform Installer th
 
 ### Transport Support
 
-From ServiceControl 1.7 the transport DLLs are managed by the installation and do not need to be downloaded from NuGet. ServiceControl can be configured to use one of the NServiceBus supported transports listed below using the ServiceControl Management Utility:
+From ServiceControl 1.7 the transport DLLs are managed by the installation and do not need to be downloaded from NuGet. ServiceControl can be configured to use one of the NServiceBus supported transports listed below using the ServiceControl Management application:
 
  * Microsoft Message Queuing (MSMQ)
  * Azure Storage Queues
@@ -42,15 +42,15 @@ For instructions on how to install the Performance Counters without the Platform
 The installation of the NServiceBus Performance counters is optional for ServiceControl 1.7 or higher. When using the Particular Platform Installer the Performance counters are added as part of the `NServiceBus Pre-Requisites` option.
 
 
-#### Using the ServiceControl Management Utility to upgrade ServiceControl instances.
+#### Using ServiceControl Management to upgrade ServiceControl instances.
 
-The ServiceControl Management Utility provides a simple means of setting up one or more instances of the ServiceControl service. For production systems it is recommended to limit the number of instances per machine to one.
+ServiceControl Managementprovides a simple means of setting up one or more instances of the ServiceControl service. For production systems it is recommended to limit the number of instances per machine to one.
 
 WARNING: The ability to add multiple instances is primarily intended to assist development and test environments.
 
-The ServiceControl Management Utility can be launched automatically at the end of the installation process to enable adding or upgrading ServiceControl instances.
+ServiceControl Management can be launched automatically at the end of the installation process to enable adding or upgrading ServiceControl instances.
 
-The Management Utility will display the instances of the ServiceControl service installed. If the version of the binaries used by an instance are older that those shipped with the ServiceControl Management Utility an upgrade link will be shown against the version label.
+ServiceControl Management will display the instances of the ServiceControl service installed. If the version of the binaries used by an instance are older that those shipped with ServiceControl Management an upgrade link will be shown against the version label.
 
 ![](managementutil-upgradelink.png 'width=500')
 
@@ -65,7 +65,7 @@ Clicking the upgrade link will
  * Start the Service.
 
 
-#### Using the ServiceControl Management Utility to add ServiceControl instances.
+#### Using ServiceControl Management to add ServiceControl instances.
 
 If this is a new installation of ServiceControl click on the `Add New Instance` button in the center of the screen or the "New Instance" link at the top of the screen,  both options launch the same "New instance form". Complete the form to register a new ServiceControl service.
 

--- a/servicecontrol/license.md
+++ b/servicecontrol/license.md
@@ -1,6 +1,6 @@
 ---
 title: Licensing
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
  - servicecontrol
  - license
@@ -13,9 +13,9 @@ tags:
 The following options outline how to add a license to ServiceControl.
 
 
-### ServiceControl Management Utility
+### ServiceControl Management
 
-The ServiceControl Management utility has a license user interface which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it is available to all instances of ServiceControl regardless of the service account used.
+ServiceControl Management  has a license user interface which will import the designated license file into the registry. The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it is available to all instances of ServiceControl regardless of the service account used.
 
 ![](managementutil-addlicense.png 'width=500')
 
@@ -36,7 +36,7 @@ Import-ServiceControlLicense <LicenseFile>
 
 In Version 1.17 and below, a license can be applied to an individual instance rather than using a license installed in the registry. To do this, copy the `license.xml` file to a `license` directory under the installation path of the instance.
 
-NOTE: Instance Licensing is deprecated in Version 1.18 and above. Use the ServiceControl Management Utility or PowerShell module to install the license file to the registry.
+NOTE: Instance Licensing is deprecated in Version 1.18 and above. Use ServiceControl Management or the ServiceControl PowerShell module to install the license file to the registry.
 
 
 ### Troubleshooting

--- a/servicecontrol/logging.md
+++ b/servicecontrol/logging.md
@@ -1,6 +1,6 @@
 ---
 title: Logging
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 tags:
 - ServiceControl
 - Logging
@@ -10,7 +10,7 @@ redirects:
 
 ### Logging Location
 
-The location of the ServiceControl logs are specified at install time or can also be modified later on by launching the ServiceControl Management Utility and editing the configuration settings for the instance.
+The location of the ServiceControl logs are specified at install time or can also be modified later on by launching ServiceControl Management and editing the configuration settings for the instance.
 
 The default logging location is `%LOCALAPPDATA%\Particular\ServiceControl\logs`.
 
@@ -36,18 +36,18 @@ Note: Browsing to this location can be problematic as the default NTFS permissio
 NOTE: If multiple Service Control instances are configured on the same machine ensure that the log locations for each instance are unique
 
 
-#### Changing logging location via the ServiceControl Management Utility
+#### Changing logging location via ServiceControl Management
 
 To change the location ServiceControl stores its logs:
 
- * Open the ServiceControl Management Utility
+ * Open ServiceControl Management
  * Click the Configuration icon for the instance to modify.
 
 ![](managementutil-configuration.png)
 
  * Change the Log Path and click Save
 
-When Save is clicked the the service with be restarted to apply the change.
+When Save is clicked the service with be restarted to apply the change.
 
 
 ### Log File Names and Retention
@@ -72,7 +72,7 @@ NOTE: The change in log naming will result in logs produced prior to Version 1.1
 
 ### Logging Levels
 
-Instances of the ServiceControl service write logging information and failed message import stack traces to the file system. 
+Instances of the ServiceControl service write logging information and failed message import stack traces to the file system.
 
 
 #### Versions 1.8.3 and below

--- a/servicecontrol/setting-custom-hostname.md
+++ b/servicecontrol/setting-custom-hostname.md
@@ -4,7 +4,7 @@ summary: How to configure ServiceControl to be exposed through a custom hostname
 tags:
 - ServiceControl
 - ServicePulse
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
 
@@ -12,16 +12,16 @@ reviewed: 2016-10-06
 
 To set a custom hostname and IP port for an instance of the ServiceControl service:
 
-NOTE: Anyone who can access the ServiceControl URL has complete access to the message data stored within ServiceControl. This is  why the default is to only respond to the localhost. Consider carefully the implications of exposing ServiceControl via a custom or wildcard URI. 
+NOTE: Anyone who can access the ServiceControl URL has complete access to the message data stored within ServiceControl. This is  why the default is to only respond to the localhost. Consider carefully the implications of exposing ServiceControl via a custom or wildcard URI.
 
 
-### Using the ServiceControl Management Utility
+### Using ServiceControl Management
 
  1. Click the Configuration Icon for for the Service Instance to modify.
  1. Change the Host and Port number fields to the desired values.
  1. Click Save.
 
-The ServiceControl Management Utility will then validate the settings changes and restart the service to apply the changes.
+ServiceControl Management will then validate the settings changes and restart the service to apply the changes.
 
 
 ### Updating ServicePulse Configuration to ServiceControl Custom Hostname

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -4,18 +4,17 @@ summary: Troubleshooting ServiceControl installation and common issues
 tags:
 - ServiceControl
 - Troubleshooting
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
 
-### Check the configuration via the Management utility
+### Check the configuration via ServiceControl Management
 
-Open the ServiceControl Management utility and review the configuration. The Management utility is a quick way to get the information needed to troubleshoot a ServiceControl issue.
-
+Open ServiceControl Management and review the instance configuration. The user interface presents basic installation information for each instance of the ServiceControl service installed. To review the application configuration file for a specific instance click the installation path and then locate `servicecontrol.exe.config` from the Explorer window.
 
 ### Service fails to start
 
-There are various reasons that can cause the ServiceControl windows service fail to start. If a critical exception is thrown at service start up this is reported via an error message in the `Application` Windows Event Log. Additional information may also be present in the [ServiceControl logs](logging.md). 
+There are various reasons that can cause the ServiceControl windows service fail to start. If a critical exception is thrown at service start up this is reported via an error message in the `Application` Windows Event Log. Additional information may also be present in the [ServiceControl logs](logging.md).
 
 ### The port is already in use
 
@@ -26,7 +25,7 @@ In the event that the service fails to start check if the configured port (typic
 ```dos
 netstat -a -b
 ```
-or use the provided ServiceControl Management PowerShell cmdlet to check a specific port: 
+or use the provided ServiceControl Management PowerShell cmdlet to check a specific port:
 
 ```ps
 Test-IfPortIsAvailable -Port 33333
@@ -36,7 +35,7 @@ Test-IfPortIsAvailable -Port 33333
 
 ### Missing queue
 
-The service expects to be able to connect to the error, audit and forwarding queues specified in the configuration. If the configuration has been manually changes ensure the specified queues exist. 
+The service expects to be able to connect to the error, audit and forwarding queues specified in the configuration. If the configuration has been manually changes ensure the specified queues exist.
 
 
 ### Cannot connect to the queues
@@ -93,7 +92,7 @@ The value is the size of the version store in MB.
 ### Unable to connect to ServiceControl from either ServiceInsight or ServicePulse
 
  1. Log on to the PC hosting ServiceControl.
- 1. Open the ServiceControl Management Utility.
+ 1. Open ServiceControl Management.
  1. Click the ServiceControl instance is Running.
  1. Click the URL under 'Host'. A valid response with JSON data will be received.
  1. If having issues remotely connecting to ServiceControl. Verify that firewall settings do not block access to the ServiceControl port specified in the URL.
@@ -107,7 +106,7 @@ The `ExposeRavenDB` setting enables the embedded RavenDB Management Studio to be
 When this setting is used in combination with a low privilege service account it can cause the service fail on startup.
 This is because a URLACL is required and the service account does not have rights to create it.
 
-To workaround this create the required URLACL. This can be done using the ServiceControl Management PowerShell module. 
+To workaround this create the required URLACL. This can be done using the ServiceControl Management PowerShell module.
 
 NOTE: Replace the `<hostname>` and `<port>` values in the sample commands below with the appropriate values from the ServiceControl configuration.
 
@@ -119,4 +118,4 @@ If the `ExposeRavenDB` setting is removed or disabled in the configuration then 
 
 ```ps
 urlacl-list | ? VirtualDirectory -eq storage | ? Port -eq <port> | urlacl-delete
-``` 
+```

--- a/servicecontrol/use-ravendb-studio.md
+++ b/servicecontrol/use-ravendb-studio.md
@@ -4,10 +4,10 @@ summary: How to configure ServiceControl to allow direct access to the embedded 
 tags:
 - ServiceControl
 - RavenDB
-reviewed: 2016-10-06
+reviewed: 2016-11-09
 ---
 
-ServiceControl stores its data in a RavenDB embedded instance. By default, the RavenDB instance is accessible only by the ServiceControl service. If direct access to the RavenDB instance is required, run the instance in Maintenance Mode by launching the ServiceControl Management Utility.
+ServiceControl stores its data in a RavenDB embedded instance. By default, the RavenDB instance is accessible only by the ServiceControl service. If direct access to the RavenDB instance is required, run the instance in Maintenance Mode by launching ServiceControl Management and follow these steps:
 
 1. Open Advanced Options
 ![](managementutil-advancedoptions.png)

--- a/servicecontrol/use-ravendb-studio.md
+++ b/servicecontrol/use-ravendb-studio.md
@@ -7,7 +7,7 @@ tags:
 reviewed: 2016-11-09
 ---
 
-ServiceControl stores its data in a RavenDB embedded instance. By default, the RavenDB instance is accessible only by the ServiceControl service. If direct access to the RavenDB instance is required, run the instance in Maintenance Mode by launching ServiceControl Management and follow these steps:
+ServiceControl stores its data in a RavenDB embedded instance. By default, the RavenDB instance is accessible only by the ServiceControl service. If direct access to the RavenDB instance is required, run the instance in Maintenance Mode by launching ServiceControl Management and following these steps:
 
 1. Open Advanced Options
 ![](managementutil-advancedoptions.png)


### PR DESCRIPTION
Relates to  https://github.com/Particular/ServiceControl/issues/833

In ServceControl 1.26 the word "Utility" was removed from the Management application's name and we've decided to refer to it as just ServiceControl Management.  This PR updates the doco to reflect that change