### PR TITLE
Remove frequency from release policy

### DIFF
--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -71,7 +71,6 @@ The following table summarize the risk effort and urgency for the different type
 | Risk | Extremely low | Medium | High |
 | Urgency | High to medium | Low | Low |
 | Effort | Minimal | Low | High |
-| Frequency | As needed | Every 1-2 Months | Yearly |
 
 
 ### Patch


### PR DESCRIPTION
It seems to me that the release frequency is not something we are following as described, so it probably makes sense to remove that section from the table?