### PR TITLE
Restore static loggers, within snippet, add note

### DIFF
--- a/tutorials/nservicebus-101/lesson-2/Solution/ClientUI/Program.cs
+++ b/tutorials/nservicebus-101/lesson-2/Solution/ClientUI/Program.cs
@@ -35,10 +35,10 @@ namespace ClientUI
 
         #region RunLoop
 
+        static ILog logger = LogManager.GetLogger<Program>();
+
         static async Task RunLoop(IEndpointInstance endpointInstance)
         {
-            var logger = LogManager.GetLogger<Program>();
-
             while (true)
             {
                 logger.Info("Press 'P' to place an order, or 'Q' to quit.");

--- a/tutorials/nservicebus-101/lesson-2/tutorial.md
+++ b/tutorials/nservicebus-101/lesson-2/tutorial.md
@@ -135,6 +135,8 @@ When complete, your `PlaceOrderHandler` class should look like this:
 
 snippet:PlaceOrderHandler
 
+INFO: Because `LogManager.GetLogger(..);` is an expensive call, it's important to [always implement loggers as static members](/nservicebus/logging/usage.md).
+
 
 ### Send a message
 

--- a/tutorials/nservicebus-101/lesson-3/Solution/ClientUI/Program.cs
+++ b/tutorials/nservicebus-101/lesson-3/Solution/ClientUI/Program.cs
@@ -38,10 +38,10 @@ namespace ClientUI
                 .ConfigureAwait(false);
         }
 
+        static ILog logger = LogManager.GetLogger<Program>();
+
         static async Task RunLoop(IEndpointInstance endpointInstance)
         {
-            var logger = LogManager.GetLogger<Program>();
-
             while (true)
             {
                 logger.Info("Press 'P' to place an order, or 'Q' to quit.");

--- a/tutorials/nservicebus-101/lesson-4/Solution/ClientUI/Program.cs
+++ b/tutorials/nservicebus-101/lesson-4/Solution/ClientUI/Program.cs
@@ -38,10 +38,10 @@ namespace ClientUI
                 .ConfigureAwait(false);
         }
 
+        static ILog logger = LogManager.GetLogger<Program>();
+
         static async Task RunLoop(IEndpointInstance endpointInstance)
         {
-            var logger = LogManager.GetLogger<Program>();
-
             while (true)
             {
                 logger.Info("Press 'P' to place an order, or 'Q' to quit.");

--- a/tutorials/nservicebus-101/lesson-5/Solution/ClientUI/Program.cs
+++ b/tutorials/nservicebus-101/lesson-5/Solution/ClientUI/Program.cs
@@ -38,10 +38,10 @@ namespace ClientUI
                 .ConfigureAwait(false);
         }
 
+        static ILog logger = LogManager.GetLogger<Program>();
+
         static async Task RunLoop(IEndpointInstance endpointInstance)
         {
-            var logger = LogManager.GetLogger<Program>();
-
             while (true)
             {
                 logger.Info("Press 'P' to place an order, or 'Q' to quit.");


### PR DESCRIPTION
By keeping the static logger as part of the existing snippet, it reduces the overall number of steps, which should make it easier to follow. The only downside is the static logger winds up in the middle of the file, which makes my OCD twitch just a little bit, but I think the tradeoff might be worth it.

@SimonCropp you OK with that?

Added the link to https://docs.particular.net/nservicebus/logging/usage where the first instance of a logger appears.