### PR TITLE
[WIP]Clarify that UOW can't access message context in v6

### DIFF
--- a/nservicebus/pipeline/unit-of-work.md
+++ b/nservicebus/pipeline/unit-of-work.md
@@ -7,6 +7,7 @@ redirects:
  - nservicebus/unit-of-work-in-nservicebus
 related:
  - samples/unit-of-work
+ - samples/pipeline/unit-of-work
 ---
 
 partial: transaction-scope
@@ -28,6 +29,8 @@ The semantics are that `Begin()` is called when the transport messages enters th
 The `End()` method is called when the processing is complete. If there is an exception, it is passed into the method.
 
 This gives a way to perform different actions depending on the outcome of the message(s).
+
+partial: access-to-context
 
 partial: imanageunitsofwork-outbox
 

--- a/nservicebus/pipeline/unit-of-work_access-to-context_core_[6.0,].partial.md
+++ b/nservicebus/pipeline/unit-of-work_access-to-context_core_[6.0,].partial.md
@@ -1,0 +1,1 @@
+include: uow-access-to-context

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,1 +1,1 @@
-NOTE: In Versions 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/sample.md).
+NOTE: In Version 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/sample.md).

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,1 +1,1 @@
-NOTE: In Version 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/sample.md).
+NOTE: In Version 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/).

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,1 +1,1 @@
-NOTE: In NServiceBus Versions 6 `IManageUnitsOfWorks` doesn't have access to the incomming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](samples/pipeline/unit-of-work).
+NOTE: In NServiceBus Versions 6 `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](samples/pipeline/unit-of-work).

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,1 +1,1 @@
-NOTE: In NServiceBus Versions 6 `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](samples/pipeline/unit-of-work).
+NOTE: In Versions 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/sample.md).

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,1 +1,1 @@
-NOTE: In Version 6 and above `IManageUnitsOfWorks` doesn't have access to the incoming message context. If access to headers and/or message body is needed implement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/).
+NOTE: In Versions 6 and above [`IManageUnitsOfWorks`](/nservicebus/pipeline/unit-of-work.md) does not have access to the incoming message context. If access to headers and/or message body is required instead implement a [unit of work using behaviors instead](/samples/pipeline/unit-of-work/).

--- a/nservicebus/uow-access-to-context.include.md
+++ b/nservicebus/uow-access-to-context.include.md
@@ -1,0 +1,1 @@
+NOTE: In NServiceBus Versions 6 `IManageUnitsOfWorks` doesn't have access to the incomming message context. If access to headers and/or message body is needed implemement a [unit of work using behaviors instead](samples/pipeline/unit-of-work).

--- a/nservicebus/upgrades/5to6/extension-seams.md
+++ b/nservicebus/upgrades/5to6/extension-seams.md
@@ -64,3 +64,8 @@ The `ConfigureTransport` class was deprecated. Custom transports are now configu
 ## Corrupted messages
 
 The core will now pass the error queue address to the transport to make it easier to handle corrupted messages. If a corrupted message is detected the transport is expected to move the message to the specified error queue.
+
+
+## Unit of Work
+
+include: uow-access-to-context

--- a/samples/unit-of-work/sample.md
+++ b/samples/unit-of-work/sample.md
@@ -11,7 +11,6 @@ This sample shows how to create a custom [Unit Of Work](/nservicebus/pipeline/un
 
 include: uow-access-to-context
 
-
  1. Run the solution.
  1. Press `s` to send a message that will succeed. Press `t` to send a message that will throw.
 

--- a/samples/unit-of-work/sample.md
+++ b/samples/unit-of-work/sample.md
@@ -9,6 +9,8 @@ related:
 
 This sample shows how to create a custom [Unit Of Work](/nservicebus/pipeline/unit-of-work.md).
 
+include: uow-access-to-context
+
 
  1. Run the solution.
  1. Press `s` to send a message that will succeed. Press `t` to send a message that will throw.


### PR DESCRIPTION
Unsure where in the upgrade guide to put a note?


@Particular/docs-maintainers can I use included in the samples like I do?