### PR TITLE
Updating delayed retries

### DIFF
--- a/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6.1,7].partial.md
+++ b/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6.1,7].partial.md
@@ -2,8 +2,7 @@
 
 In Versions 5 and below, the [Delayed Retries](/nservicebus/recoverability/#delayed-retries) used the `[endpoint_name].Retries` queue for persistent storage of messages to be retried. To prevent message loss when upgrading to Version 6, a dedicated `.Retries` queue receiver is started if not explicitly disabled. It serves a purpose of forwarding messages from the `.Retries` queue to the endpoint's main queue to be retried appropriately.
 
-NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to: [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
-
+NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to the [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue). 
 Letting the receiver continue to run might have negative performance implications depending on the transport being used. For example, for endpoints using either [SQL Server](/nservicebus/sqlserver/) or [Msmq](/nservicebus/msmq/) as its transport, endpoint will periodically poll the `.Retries` queue to check for messages.
 
 The `.Retries` receiver can be disabled via code using:

--- a/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6.1,7].partial.md
+++ b/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6.1,7].partial.md
@@ -2,7 +2,7 @@
 
 In Versions 5 and below, the [Delayed Retries](/nservicebus/recoverability/#delayed-retries) used the `[endpoint_name].Retries` queue for persistent storage of messages to be retried. To prevent message loss when upgrading to Version 6, a dedicated `.Retries` queue receiver is started if not explicitly disabled. It serves a purpose of forwarding messages from the `.Retries` queue to the endpoint's main queue to be retried appropriately.
 
-NOTE: The receiver is needed only during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to: [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
+NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to: [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
 
 Letting the receiver continue to run might have negative performance implications depending on the transport being used. For example, for endpoints using either [SQL Server](/nservicebus/sqlserver/) or [Msmq](/nservicebus/msmq/) as its transport, endpoint will periodically poll the `.Retries` queue to check for messages.
 
@@ -10,4 +10,4 @@ The `.Retries` receiver can be disabled via code using:
 
 snippet: 5to6-DisableLegacyRetriesSatellite
 
-INFO: This API will be obsoleted and removed in Version 7.
+INFO: This API will be obsoleted in Version 7 and removed afterwards.

--- a/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6].partial.md
+++ b/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6].partial.md
@@ -2,7 +2,7 @@
 
 In Versions 5 and below, the [Delayed Retries](/nservicebus/recoverability/#delayed-retries) used the `[endpoint_name].Retries` queue for persistent storage of messages to be retried. To prevent message loss when upgrading to Version 6, a dedicated `.Retries` queue receiver is started if not explicitly disabled. It serves a purpose of forwarding messages from the `.Retries` queue to the endpoint's main queue to be retried appropriately.
 
-NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to: [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
+NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to the [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
 
 Letting the receiver continue to run might have negative performance implications depending on the transport being used. For example, for endpoints using either [SQL Server](/nservicebus/sqlserver/) or [Msmq](/nservicebus/msmq/) as its transport, endpoint will periodically poll the `.Retries` queue to check for messages.
 

--- a/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6].partial.md
+++ b/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6].partial.md
@@ -1,0 +1,13 @@
+### Legacy .Retries message receiver
+
+In Versions 5 and below, the [Delayed Retries](/nservicebus/recoverability/#delayed-retries) used the `[endpoint_name].Retries` queue for persistent storage of messages to be retried. To prevent message loss when upgrading to Version 6, a dedicated `.Retries` queue receiver is started if not explicitly disabled. It serves a purpose of forwarding messages from the `.Retries` queue to the endpoint's main queue to be retried appropriately.
+
+NOTE: The receiver is only needed during the upgrade from Versions 5 and below and is not needed for new endpoints using Version 6. For details on upgrade process and how to safely disable the receiver refer to: [Version 6 Upgrade Guide](/nservicebus/upgrades/5to6/recoverability.md#legacy-retries-queue).
+
+Letting the receiver continue to run might have negative performance implications depending on the transport being used. For example, for endpoints using either [SQL Server](/nservicebus/sqlserver/) or [Msmq](/nservicebus/msmq/) as its transport, endpoint will periodically poll the `.Retries` queue to check for messages.
+
+The `.Retries` receiver can be disabled via code using:
+
+snippet: 5to6-DisableLegacyRetriesSatellite
+
+INFO: This API is obsoleted in Version 6 and to use it you either have to use [pragma warning](https://msdn.microsoft.com/en-us/library/441722ys.aspx) to disable it or upgrade to Version 6.1.

--- a/nservicebus/upgrades/5to6/recoverability.md
+++ b/nservicebus/upgrades/5to6/recoverability.md
@@ -100,7 +100,7 @@ Once the upgrade is done the receiver can be safely [disabled](/nservicebus/reco
 
 ### When Creating New Endpoints using Version 6
 
-In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoints that are written purely using Version 6, can safely use the following configuration API to [disable](/nservicebus/recoverability/configure-delayed-retries.md#custom-retry-policy-legacy-retries-message-receiver) the satellite from even starting.
+In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoint that is written using Version 6, can safely use the following configuration API to [disable](/nservicebus/recoverability/configure-delayed-retries.md#custom-retry-policy-legacy-retries-message-receiver) the satellite from even starting.
 
 
 ## IManageMessageFailures is now obsolete.

--- a/nservicebus/upgrades/5to6/recoverability.md
+++ b/nservicebus/upgrades/5to6/recoverability.md
@@ -100,7 +100,7 @@ Once the upgrade is done the receiver can be safely [disabled](/nservicebus/reco
 
 ### When Creating New Endpoints using Version 6
 
-In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoint that is written using Version 6, can safely use the following configuration API to [disable](/nservicebus/recoverability/configure-delayed-retries.md#custom-retry-policy-legacy-retries-message-receiver) the satellite from even starting.
+In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoint that is written using Version 6, can safely use the following configuration API to [disable the satellite](/nservicebus/recoverability/configure-delayed-retries.md#custom-retry-policy-legacy-retries-message-receiver).
 
 
 ## IManageMessageFailures is now obsolete.

--- a/nservicebus/upgrades/5to6/recoverability.md
+++ b/nservicebus/upgrades/5to6/recoverability.md
@@ -100,7 +100,7 @@ Once the upgrade is done the receiver can be safely [disabled](/nservicebus/reco
 
 ### When Creating New Endpoints using Version 6
 
-In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoints that are written purely using Version 6, can safely use the following configuration API to disable the satellite from even starting.
+In Version 6, the only reason that the `.retries` queue exists is so that Version 5 endpoints can be migrated to Version 6 without any message loss. Any endpoints that are written purely using Version 6, can safely use the following configuration API to [disable](/nservicebus/recoverability/configure-delayed-retries.md#custom-retry-policy-legacy-retries-message-receiver) the satellite from even starting.
 
 
 ## IManageMessageFailures is now obsolete.


### PR DESCRIPTION
Updated the notes for DisableLegacyRetriesSatellite obsoleted method. Resolves #2272

@Particular/docs-maintainers Please review. Wasn't sure if I should extract the notes into its own partial or leave it as is.