### PR TITLE
Fixing Raven samples broken by Raven 3.5

### DIFF
--- a/samples/ravendb/simple/Raven_4/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_4/Server/Server.csproj
@@ -30,6 +30,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/ravendb/simple/Raven_4/Server/packages.config
+++ b/samples/ravendb/simple/Raven_4/Server/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.1.0-rc0001" targetFramework="net461" />
   <package id="NServiceBus.RavenDB" version="4.1.0" targetFramework="net461" />
   <package id="RavenDB.Client" version="3.5.1" targetFramework="net461" />

--- a/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/RavenHost.cs
+++ b/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/RavenHost.cs
@@ -19,12 +19,17 @@ class RavenHost :
             Configuration =
             {
                 Port = 32076,
-                PluginsDirectory = Environment.CurrentDirectory,
-                HostName = "localhost"
-            }
+                PluginsDirectory = "Plugins",
+                HostName = "localhost",
+                Settings =
+                {
+                    { "Raven/ActiveBundles", "Unique Constraints" }
+                }
+            },
         };
         documentStore.RegisterListener(new UniqueConstraintsStoreListener());
         documentStore.Initialize();
+
         // since hosting a fake raven server in process need to remove it from the logging pipeline
         Trace.Listeners.Clear();
         Trace.Listeners.Add(new DefaultTraceListener());

--- a/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/Sample.csproj
+++ b/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/Sample.csproj
@@ -30,6 +30,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/packages.config
+++ b/samples/saga/ravendb-custom-sagafinder/Raven_4/Sample/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.1.0-rc0001" targetFramework="net461" />
   <package id="NServiceBus.RavenDB" version="4.1.0" targetFramework="net461" />
   <package id="RavenDB.Bundles.UniqueConstraints" version="3.5.1" targetFramework="net461" />


### PR DESCRIPTION
* Raven 3.5 server package requires Microsoft.Owin.Host.HttpListener NuGet package, but not included in NuGet dependency list
* Raven 3.5 requires magic string to allow bundles (unique constraints) to work server-side