### PR TITLE
Changed "Go straight to runnable code" to "Samples"

### DIFF
--- a/get-started.md
+++ b/get-started.md
@@ -22,7 +22,7 @@ These articles are recommended to gain an understanding of the key concepts and 
 The [Messaging Basics Tutorial](/tutorials/nservicebus-101/) gives a guided walk through of building an NServiceBus system and introduces the basic concepts of messaging. Each lesson includes a downloadable solution with the completed exercise.
 
 
-## Go straight to runnable code
+## Samples
 
 Samples are fully functional solutions that can be run from Visual Studio. The samples allow to learn by exploring code. Each includes an explanation of the scenario, technology or concept that it illustrates.
 

--- a/get-started.md
+++ b/get-started.md
@@ -24,7 +24,7 @@ The [Messaging Basics Tutorial](/tutorials/nservicebus-101/) gives a guided walk
 
 ## Samples
 
-Samples are fully functional solutions that can be run from Visual Studio. The samples allow to learn by exploring code. Each includes an explanation of the scenario, technology or concept that it illustrates.
+Samples are a great way to learn and explore NServiceBus by looking at runnable code. They are fully functional solutions that can be run from Visual Studio. Learn by exploring code. Each sample includes an explanation of the scenario and the technology or concept that it illustrates.
 
 Go to [Introduction to Sample](/samples/) or [Skip to the list of samples](/samples/#related-samples).
 


### PR DESCRIPTION
The purpose of this PR is to put "Samples" on the same level as "Tutorials".

The "Go straight to runnable code" language pushes the reader much more strongly to the samples than to the tutorials.