### PR TITLE
Make handler output visible.

### DIFF
--- a/samples/errorhandling/Core_4/WithDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_4/WithDelayedRetries/MyMessageHandler.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using NServiceBus;
-using NServiceBus.Logging;
 
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger(typeof(MyMessageHandler));
     IBus bus;
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
@@ -18,7 +16,7 @@ public class MyMessageHandler :
     public void Handle(MyMessage message)
     {
         var context = bus.CurrentMessageContext;
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.Id}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
 
         string numOfRetries;
         if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
@@ -28,7 +26,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This is retry number {numOfRetries}");
+                Console.WriteLine($"This is retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
@@ -18,20 +18,6 @@ public class MyMessageHandler :
     {
         var context = bus.CurrentMessageContext;
         Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
-
-        string numOfRetries;
-        if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
-        {
-            string value;
-            Last.TryGetValue(message.Id, out value);
-
-            if (numOfRetries != value)
-            {
-                Console.WriteLine($"This is retry number {numOfRetries}");
-                Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
-            }
-        }
-
         throw new Exception("An exception occurred in the handler.");
     }
 }

--- a/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using NServiceBus;
-using NServiceBus.Logging;
 
 #region Handler
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger(typeof(MyMessageHandler));
     IBus bus;
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
@@ -19,7 +17,7 @@ public class MyMessageHandler :
     public void Handle(MyMessage message)
     {
         var context = bus.CurrentMessageContext;
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.Id}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
 
         string numOfRetries;
         if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
@@ -29,7 +27,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This is retry number {numOfRetries}");
+                Console.WriteLine($"This is retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_4/WithoutDelayedRetries/MyMessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using NServiceBus;
 
 #region Handler
@@ -7,7 +6,6 @@ public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
     IBus bus;
-    static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
     public MyMessageHandler(IBus bus)
     {

--- a/samples/errorhandling/Core_5/WithDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_5/WithDelayedRetries/MyMessageHandler.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using NServiceBus;
-using NServiceBus.Logging;
 
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger<MyMessageHandler>();
     IBus bus;
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
@@ -18,7 +16,7 @@ public class MyMessageHandler :
     public void Handle(MyMessage message)
     {
         var context = bus.CurrentMessageContext;
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.Id}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
 
         string numOfRetries;
         if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
@@ -28,7 +26,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This is retry number {numOfRetries}");
+                Console.WriteLine($"This is retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
@@ -18,20 +18,6 @@ public class MyMessageHandler :
     {
         var context = bus.CurrentMessageContext;
         Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
-
-        string numOfRetries;
-        if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
-        {
-            string value;
-            Last.TryGetValue(message.Id, out value);
-
-            if (numOfRetries != value)
-            {
-                Console.WriteLine($"This retry number {numOfRetries}");
-                Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
-            }
-        }
-
         throw new Exception("An exception occurred in the handler.");
     }
 }

--- a/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using NServiceBus;
-using NServiceBus.Logging;
 
 #region Handler
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger<MyMessageHandler>();
     IBus bus;
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
@@ -19,7 +17,7 @@ public class MyMessageHandler :
     public void Handle(MyMessage message)
     {
         var context = bus.CurrentMessageContext;
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.Id}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.Id}");
 
         string numOfRetries;
         if (context.Headers.TryGetValue(Headers.Retries, out numOfRetries))
@@ -29,7 +27,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This retry number {numOfRetries}");
+                Console.WriteLine($"This retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_5/WithoutDelayedRetries/MyMessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using NServiceBus;
 
 #region Handler
@@ -7,7 +6,6 @@ public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
     IBus bus;
-    static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
     public MyMessageHandler(IBus bus)
     {

--- a/samples/errorhandling/Core_6/WithDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_6/WithDelayedRetries/MyMessageHandler.cs
@@ -2,17 +2,15 @@
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Logging;
 
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger<MyMessageHandler>();
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.MessageId}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.MessageId}");
 
         string numOfRetries;
         if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out numOfRetries))
@@ -22,7 +20,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This is retry number {numOfRetries}");
+                Console.WriteLine($"This is retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
@@ -12,20 +12,6 @@ public class MyMessageHandler :
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
         Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.MessageId}");
-
-        string numOfRetries;
-        if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out numOfRetries))
-        {
-            string value;
-            Last.TryGetValue(message.Id, out value);
-
-            if (numOfRetries != value)
-            {
-                Console.WriteLine($"This is retry number {numOfRetries}");
-                Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
-            }
-        }
-
         throw new Exception("An exception occurred in the handler.");
     }
 

--- a/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
@@ -2,18 +2,16 @@
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Logging;
 
 #region Handler
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ILog log = LogManager.GetLogger<MyMessageHandler>();
     static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        log.Info($"ReplyToAddress: {context.ReplyToAddress} MessageId:{context.MessageId}");
+        Console.WriteLine($"Handling {nameof(MyMessage)} with MessageId:{context.MessageId}");
 
         string numOfRetries;
         if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out numOfRetries))
@@ -23,7 +21,7 @@ public class MyMessageHandler :
 
             if (numOfRetries != value)
             {
-                log.Info($"This is retry number {numOfRetries}");
+                Console.WriteLine($"This is retry number {numOfRetries}");
                 Last.AddOrUpdate(message.Id, numOfRetries, (key, oldValue) => numOfRetries);
             }
         }

--- a/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
+++ b/samples/errorhandling/Core_6/WithoutDelayedRetries/MyMessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using NServiceBus;
 
@@ -7,7 +6,6 @@ using NServiceBus;
 public class MyMessageHandler :
     IHandleMessages<MyMessage>
 {
-    static ConcurrentDictionary<Guid, string> Last = new ConcurrentDictionary<Guid, string>();
 
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {

--- a/samples/errorhandling/sample.md
+++ b/samples/errorhandling/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Automatic Retries
 summary: With Delayed Retries, the message causing the exception is instantly retried via a retries queue instead of an error queue.
-reviewed: 2016-03-21
+reviewed: 2016-12-15
 component: Core
 tags:
 - Delayed Retries
@@ -43,11 +43,8 @@ Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
 Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
 Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
 Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
-2016-12-14 13:27:41.232 ERROR NServiceBus.RecoverabilityExecutor Moving message
-'b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8' to the error queue 'error' because processing failed due to an exception:
+2016-12-14 13:27:41.232 ERROR NServiceBus.RecoverabilityExecutor Moving message 'b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8' to the error queue 'error' because processing failed due to an exception:
 System.Exception: An exception occurred in the handler.
-...
-
 ```
 
 
@@ -62,12 +59,9 @@ Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
-2016-12-14 13:33:18.790 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will 
-reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:20 because of an exception:
+2016-12-14 13:33:18.790 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:20 because of an exception: 
 System.Exception: An exception occurred in the handler.
-
 . . .
-
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 This is retry number 2
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
@@ -75,12 +69,9 @@ Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
-2016-12-14 13:33:40.886 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will
- reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:30 because of an exception:
+2016-12-14 13:33:40.886 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:30 because of an exception:
 System.Exception: An exception occurred in the handler.
-
 . . .
-
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 This is retry number 3
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
@@ -88,10 +79,7 @@ Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
-2016-12-14 13:34:15.750 ERROR NServiceBus.RecoverabilityExecutor Moving message
-'05b97154-04b9-405a-92d7-a6dc0163273f' to the error queue 'error' because proces
-sing failed due to an exception:
+2016-12-14 13:34:15.750 ERROR NServiceBus.RecoverabilityExecutor Moving message '05b97154-04b9-405a-92d7-a6dc0163273f' to the error queue 'error' because processing failed due to an exception:
 System.Exception: An exception occurred in the handler.
-
 . . .
 ```

--- a/samples/errorhandling/sample.md
+++ b/samples/errorhandling/sample.md
@@ -16,7 +16,7 @@ include: recoverability-rename
 
 Run the sample **without debugging**.
 
-Both endpoints execute the same code.
+The message handler in both endpoints is set to throw an exception.
 
 snippet: handler
 
@@ -30,34 +30,68 @@ snippet:Disable
 ## The output
 
 
+WARNING: This sample uses `Console.Writeline` instead of standard logging only for brevity and should not be used in actual projects. 
+
 ### Without Delayed Retries
 
+In this endpoint, the message is retried successively without any delay and then after the final failure it is forwarded to the configured error queue. 
+
 ```no-highlight
-ReplyToAddress: Samples.ErrorHandling.WithoutDelayedRetries MessageId:91cc7d3b-b763-4e01-9a3b-a42f0014f233
-ReplyToAddress: Samples.ErrorHandling.WithoutDelayedRetries MessageId:91cc7d3b-b763-4e01-9a3b-a42f0014f233
-ReplyToAddress: Samples.ErrorHandling.WithoutDelayedRetries MessageId:91cc7d3b-b763-4e01-9a3b-a42f0014f233
-ReplyToAddress: Samples.ErrorHandling.WithoutDelayedRetries MessageId:91cc7d3b-b763-4e01-9a3b-a42f0014f233
-ReplyToAddress: Samples.ErrorHandling.WithoutDelayedRetries MessageId:91cc7d3b-b763-4e01-9a3b-a42f0014f233
-2015-01-29 01:16:18.480 ERROR NServiceBus.Faults.Forwarder.FaultManager Message with '91cc7d3b-b763-4e01-9a3b-a42f0014f33' ID has failed Immediate Retries and will be moved to the configured error queue.
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+Handling MyMessage with MessageId:b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8
+2016-12-14 13:27:41.232 ERROR NServiceBus.RecoverabilityExecutor Moving message
+'b5d0ea24-63c7-4729-8fd3-a6dc0161a7f8' to the error queue 'error' because processing failed due to an exception:
+System.Exception: An exception occurred in the handler.
+...
+
 ```
 
 
 ### With Delayed Retries
 
+In this endpoint, the message is tried successively first and then delayed for the configured amount of time and then retried again. After the final configured retry the message is moved to the error queue. The sample displays the retry number for clarity. 
+
 ```no-highlight
-2015-01-29 01:13:57.517 WARN  NServiceBus.Faults.Forwarder.FaultManager Message with '24ea8afe-7610-41a0-b201-a42f00143fb4' ID has failed Immediate and will be handed over to Delayed Retries for retry attempt 2.
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
+This is retry number 1
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+2016-12-14 13:33:18.790 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will 
+reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:20 because of an exception:
+System.Exception: An exception occurred in the handler.
+
+. . .
+
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 This is retry number 2
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-2015-01-29 01:14:18.537 WARN  NServiceBus.Faults.Forwarder.FaultManager Message with '24ea8afe-7610-41a0-b201-a42f00143fb4' ID has failed Immediate Retries and will be handed over to Delayed Retries for retry attempt 3.
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+2016-12-14 13:33:40.886 WARN  NServiceBus.RecoverabilityExecutor Delayed Retry will
+ reschedule message '05b97154-04b9-405a-92d7-a6dc0163273f' after a delay of 00:00:30 because of an exception:
+System.Exception: An exception occurred in the handler.
+
+. . .
+
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
 This is retry number 3
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-ReplyToAddress: Samples.ErrorHandling.WithDelayedRetries MessageId:24ea8afe-7610-41a0-b201-a42f00143fb4
-2015-01-29 01:14:49.573 ERROR NServiceBus.Faults.Forwarder.FaultManager Delayed Retries has failed to resolve the issue with message 24ea8afe-7610-41a0-b201-a42f00143fb4 and will be forwarded to the error queue at error
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+Handling MyMessage with MessageId:05b97154-04b9-405a-92d7-a6dc0163273f
+2016-12-14 13:34:15.750 ERROR NServiceBus.RecoverabilityExecutor Moving message
+'05b97154-04b9-405a-92d7-a6dc0163273f' to the error queue 'error' because proces
+sing failed due to an exception:
+System.Exception: An exception occurred in the handler.
+
+. . .
 ```


### PR DESCRIPTION
This sample uses `log.Info` to write the output which is stated in the docs page but the program is configured to use log level `Warn` so it will actually never show the documented output as described here: https://docs.particular.net/samples/errorhandling/#the-output

I switched to use `Console.WriteLine` because it makes the output easily visible.
* changing to log level info will drown the input in logged exceptions from immediate retries
* changing the log statements to use warn instead of info will make the logged lines hardly visible as they are the same color as the warnings from delayed retries which dumps the full stacktrace.

thoughts @Particular/docs-maintainers ?