### PR TITLE
Separated the warning from script content. Resolves #2356

### DIFF
--- a/nservicebus/transports/queuecreation.md
+++ b/nservicebus/transports/queuecreation.md
@@ -12,4 +12,6 @@ tags:
 
 partial: warning
 
+partial: scripts
+
 partial: content

--- a/nservicebus/transports/queuecreation_scripts_core_[4,].partial.md
+++ b/nservicebus/transports/queuecreation_scripts_core_[4,].partial.md
@@ -1,0 +1,6 @@
+The scripting guidelines shows how to take full control over queue creation:
+
+ * [SqlServer](/nservicebus/sqlserver/operations-scripting.md#create-queues)
+ * [MSMQ](/nservicebus/msmq/operations-scripting.md#create-queues)
+ * [RabbitMQ](/nservicebus/rabbitmq/operations-scripting.md#create-queues)
+ * [Azure ServiceBus](/nservicebus/azure-service-bus/operational-scripting.md)

--- a/nservicebus/transports/queuecreation_warning_core_[4,5].partial.md
+++ b/nservicebus/transports/queuecreation_warning_core_[4,5].partial.md
@@ -1,9 +1,2 @@
 
 WARNING: NServiceBus will automatically request the transport to create queues needed if the [installers](/nservicebus/operations/installers.md) are enabled. This also includes queues needed by all declared [satellites](/nservicebus/satellites). Prefer the use of scripts to create custom queues instead of relying on the `IWantQueuesCreated` interface provided by NServiceBus.
-
-The scripting guidelines shows how to take full control over queue creation:
-
- * [SqlServer](/nservicebus/sqlserver/operations-scripting.md#create-queues)
- * [MSMQ](/nservicebus/msmq/operations-scripting.md#create-queues)
- * [RabbitMQ](/nservicebus/rabbitmq/operations-scripting.md#create-queues)
- * [Azure ServiceBus](/nservicebus/azure-service-bus/operational-scripting.md)

--- a/nservicebus/transports/queuecreation_warning_core_[4,5].partial.md
+++ b/nservicebus/transports/queuecreation_warning_core_[4,5].partial.md
@@ -1,2 +1,2 @@
 
-WARNING: NServiceBus will automatically request the transport to create queues needed if the [installers](/nservicebus/operations/installers.md) are enabled. This also includes queues needed by all declared [satellites](/nservicebus/satellites). Prefer the use of scripts to create custom queues instead of relying on the `IWantQueuesCreated` interface provided by NServiceBus.
+WARNING: NServiceBus will automatically request the transport to create queues needed if the [installers](/nservicebus/operations/installers.md) are enabled. This also includes queues needed by all declared [satellites](/nservicebus/satellites). Prefer the use of scripts to create custom queues instead of relying on interfaces provided by NServiceBus.


### PR DESCRIPTION
- Separated the script from warning.
- Warning won't show for v6 as the `IWantQueuesCreated` interface is obsoleted.

Resolves #2354 