### PR TITLE
A sample showing how to gradually migrate saga persistence

### DIFF
--- a/samples/saga/migration/Core_6/Client/Client.csproj
+++ b/samples/saga/migration/Core_6/Client/Client.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B8A5C24-DD5E-4983-8CA1-8FFCE8626CE0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Client</RootNamespace>
+    <AssemblyName>Client</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>6</LangVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="ReplyHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{605CD4EC-065C-48AA-90CC-EBA935249240}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/saga/migration/Core_6/Client/Program.cs
+++ b/samples/saga/migration/Core_6/Client/Program.cs
@@ -21,11 +21,11 @@ class Program
 
         while (true)
         {
-            Console.WriteLine("Type 'start <SagaId>' or 'ping <SagaId>'.");
+            Console.WriteLine("Type 'start <SagaId>', 'complete <SagaId>' or hit enter to exit.");
             var line = Console.ReadLine();
-            if (line == null)
+            if (string.IsNullOrEmpty(line))
             {
-                continue;
+                break;
             }
             var parts = line.Split(' ');
             if (parts.Length != 2)
@@ -43,7 +43,7 @@ class Program
                     .ConfigureAwait(false);
                 Console.WriteLine($"Sent a starting message to {sagaId}");
             }
-            else if (string.Equals(parts[0], "ping", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(parts[0], "complete", StringComparison.OrdinalIgnoreCase))
             {
                 var correlatedMessage = new CorrelatedMessage
                 {

--- a/samples/saga/migration/Core_6/Client/Program.cs
+++ b/samples/saga/migration/Core_6/Client/Program.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class Program
+{
+    static void Main()
+    {
+        Start().GetAwaiter().GetResult();
+    }
+
+    static async Task Start()
+    {
+        Console.Title = "Samples.SagaMigration.Client";
+
+        var config = new EndpointConfiguration("Samples.SagaMigration.Client");
+        config.UsePersistence<InMemoryPersistence>();
+        config.SendFailedMessagesTo("error");
+
+        var endpoint = await Endpoint.Start(config).ConfigureAwait(false);
+
+        while (true)
+        {
+            Console.WriteLine("Type 'start <SagaId>' or 'ping <SagaId>'.");
+            var line = Console.ReadLine();
+            if (line == null)
+            {
+                continue;
+            }
+            var parts = line.Split(' ');
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+            var sagaId = parts[1];
+            if (string.Equals(parts[0], "start", StringComparison.OrdinalIgnoreCase))
+            {
+                var startingMessage = new StartingMessage
+                {
+                    SomeId = sagaId
+                };
+                await endpoint.Send("Samples.SagaMigration.Server", startingMessage)
+                    .ConfigureAwait(false);
+                Console.WriteLine($"Sent a starting message to {sagaId}");
+            }
+            else if (string.Equals(parts[0], "ping", StringComparison.OrdinalIgnoreCase))
+            {
+                var correlatedMessage = new CorrelatedMessage
+                {
+                    SomeId = sagaId
+                };
+                await endpoint.Send("Samples.SagaMigration.Server", correlatedMessage)
+                    .ConfigureAwait(false);
+                Console.WriteLine($"Sent a correlated message to {sagaId}");
+            }
+        }
+    }
+}

--- a/samples/saga/migration/Core_6/Client/Program.cs
+++ b/samples/saga/migration/Core_6/Client/Program.cs
@@ -27,13 +27,13 @@ class Program
             {
                 break;
             }
-            var parts = line.Split(' ');
+            var parts = line.ToLowerInvariant().Split(' ');
             if (parts.Length != 2)
             {
                 continue;
             }
             var sagaId = parts[1];
-            if (string.Equals(parts[0], "start", StringComparison.OrdinalIgnoreCase))
+            if (parts[0] == "start")
             {
                 var startingMessage = new StartingMessage
                 {
@@ -43,7 +43,7 @@ class Program
                     .ConfigureAwait(false);
                 Console.WriteLine($"Sent a starting message to {sagaId}");
             }
-            else if (string.Equals(parts[0], "complete", StringComparison.OrdinalIgnoreCase))
+            else if (parts[0] == "complete")
             {
                 var correlatedMessage = new CorrelatedMessage
                 {

--- a/samples/saga/migration/Core_6/Client/ReplyHandler.cs
+++ b/samples/saga/migration/Core_6/Client/ReplyHandler.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class ReplyHandler :
+    IHandleMessages<ReplyMessage>
+{
+    public Task Handle(ReplyMessage message, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"Got reply from {message.SomeId}");
+        return context.Reply(new ReplyFollowUpMessage());
+    }
+}

--- a/samples/saga/migration/Core_6/Client/packages.config
+++ b/samples/saga/migration/Core_6/Client/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="6.1.1" targetFramework="net452" />
+</packages>

--- a/samples/saga/migration/Core_6/Contracts/Contracts.csproj
+++ b/samples/saga/migration/Core_6/Contracts/Contracts.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{605CD4EC-065C-48AA-90CC-EBA935249240}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contracts</RootNamespace>
+    <AssemblyName>Contracts</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>6</LangVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CorrelatedMessage.cs" />
+    <Compile Include="ReplyFollowUpMessage.cs" />
+    <Compile Include="ReplyMessage.cs" />
+    <Compile Include="StartingMessage.cs" />
+    <Compile Include="TestTimeout.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/saga/migration/Core_6/Contracts/CorrelatedMessage.cs
+++ b/samples/saga/migration/Core_6/Contracts/CorrelatedMessage.cs
@@ -1,0 +1,7 @@
+﻿using NServiceBus;
+
+public class CorrelatedMessage :
+    IMessage
+{
+    public string SomeId { get; set; }
+}

--- a/samples/saga/migration/Core_6/Contracts/ReplyFollowUpMessage.cs
+++ b/samples/saga/migration/Core_6/Contracts/ReplyFollowUpMessage.cs
@@ -1,0 +1,6 @@
+using NServiceBus;
+
+public class ReplyFollowUpMessage :
+    IMessage
+{
+}

--- a/samples/saga/migration/Core_6/Contracts/ReplyMessage.cs
+++ b/samples/saga/migration/Core_6/Contracts/ReplyMessage.cs
@@ -1,0 +1,7 @@
+﻿using NServiceBus;
+
+public class ReplyMessage :
+    IMessage
+{
+    public string SomeId { get; set; }
+}

--- a/samples/saga/migration/Core_6/Contracts/StartingMessage.cs
+++ b/samples/saga/migration/Core_6/Contracts/StartingMessage.cs
@@ -1,0 +1,7 @@
+﻿using NServiceBus;
+
+public class StartingMessage :
+    IMessage
+{
+    public string SomeId { get; set; }
+}

--- a/samples/saga/migration/Core_6/Contracts/TestTimeout.cs
+++ b/samples/saga/migration/Core_6/Contracts/TestTimeout.cs
@@ -1,0 +1,3 @@
+﻿public class TestTimeout
+{
+}

--- a/samples/saga/migration/Core_6/Contracts/packages.config
+++ b/samples/saga/migration/Core_6/Contracts/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="6.1.1" targetFramework="net452" />
+</packages>

--- a/samples/saga/migration/Core_6/PersistenceMigration.sln
+++ b/samples/saga/migration/Core_6/PersistenceMigration.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{1B8A5C24-DD5E-4983-8CA1-8FFCE8626CE0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Server\Server.csproj", "{6F62A054-2D0F-49EF-8B40-D25E656120DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server.New", "Server.New\Server.New.csproj", "{A2E83036-39F0-4F67-A6C8-CE2D303D54D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts", "Contracts\Contracts.csproj", "{605CD4EC-065C-48AA-90CC-EBA935249240}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1B8A5C24-DD5E-4983-8CA1-8FFCE8626CE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B8A5C24-DD5E-4983-8CA1-8FFCE8626CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F62A054-2D0F-49EF-8B40-D25E656120DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F62A054-2D0F-49EF-8B40-D25E656120DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2E83036-39F0-4F67-A6C8-CE2D303D54D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2E83036-39F0-4F67-A6C8-CE2D303D54D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{605CD4EC-065C-48AA-90CC-EBA935249240}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{605CD4EC-065C-48AA-90CC-EBA935249240}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/saga/migration/Core_6/PersistenceMigration.sln.DotSettings
+++ b/samples/saga/migration/Core_6/PersistenceMigration.sln.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>

--- a/samples/saga/migration/Core_6/Server.New/Program.cs
+++ b/samples/saga/migration/Core_6/Server.New/Program.cs
@@ -1,0 +1,92 @@
+﻿//#define POST_MIGRATION
+
+using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Persistence.Sql;
+// ReSharper disable RedundantUsingDirective
+using NServiceBus.Features;
+using NServiceBus.Routing;
+using NServiceBus.Transport;
+// ReSharper restore RedundantUsingDirective
+
+class Program
+{
+    static void Main()
+    {
+        Start().GetAwaiter().GetResult();
+    }
+
+    static async Task Start()
+    {
+        Console.Title = "Samples.SagaMigration.Server.New";
+        var endpointConfiguration = new EndpointConfiguration("Samples.SagaMigration.Server");
+
+#if !POST_MIGRATION
+        endpointConfiguration.OverrideLocalAddress("Samples.SagaMigration.Server.New");
+#endif
+
+        var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
+        persistence.ConnectionBuilder(
+            connectionBuilder: () =>
+        {
+            return new SqlConnection(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;");
+        });
+        persistence.TablePrefix("New");
+        endpointConfiguration.SendFailedMessagesTo("error");
+
+        var endpoint = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        Console.WriteLine("Press <enter> to exit.");
+        Console.ReadLine();
+
+        await endpoint.Stop().ConfigureAwait(false);
+    }
+}
+
+#if POST_MIGRATION
+public class DrainTempQueueSatelliteFeature :
+    Feature
+{
+    public DrainTempQueueSatelliteFeature()
+    {
+        EnableByDefault();
+    }
+
+    protected override void Setup(FeatureConfigurationContext context)
+    {
+        #region DrainTempQueueSatellite
+
+        var settings = context.Settings;
+        var qualifiedAddress = settings.LogicalAddress().CreateQualifiedAddress("New");
+        var tempQueue = settings.GetTransportAddress(qualifiedAddress);
+        var mainQueue = settings.LocalAddress();
+
+        context.AddSatelliteReceiver(
+            name: "DrainTempQueueSatellite",
+            transportAddress: tempQueue,
+            runtimeSettings: new PushRuntimeSettings(maxConcurrency: 1),
+            recoverabilityPolicy: (config, errorContext) =>
+            {
+                return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);
+            },
+            onMessage: (builder, messageContext) =>
+            {
+                var messageDispatcher = builder.Build<IDispatchMessages>();
+                var outgoingHeaders = messageContext.Headers;
+
+                var outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
+                var outgoingOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(mainQueue));
+
+                Console.WriteLine($"Moving message from {tempQueue} to {mainQueue}");
+
+                var transportOperations = new TransportOperations(outgoingOperation);
+                return messageDispatcher.Dispatch(transportOperations, messageContext.TransportTransaction, messageContext.Context);
+            });
+
+        #endregion
+    }
+}
+#endif

--- a/samples/saga/migration/Core_6/Server.New/Program.cs
+++ b/samples/saga/migration/Core_6/Server.New/Program.cs
@@ -30,9 +30,9 @@ class Program
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
-        {
-            return new SqlConnection(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;");
-        });
+            {
+                return new SqlConnection(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;");
+            });
         persistence.TablePrefix("New");
         endpointConfiguration.SendFailedMessagesTo("error");
 

--- a/samples/saga/migration/Core_6/Server.New/Server.New.csproj
+++ b/samples/saga/migration/Core_6/Server.New/Server.New.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A2E83036-39F0-4F67-A6C8-CE2D303D54D6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Server</RootNamespace>
+    <AssemblyName>Server.New</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NEW</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>6</LangVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.2-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Persistence.Sql, Version=1.0.0.0, Culture=neutral, PublicKeyToken=affc41380e1a1478, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Persistence.Sql.1.0.0-beta0010\lib\net452\NServiceBus.Persistence.Sql.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Server\TestSaga.cs">
+      <Link>TestSaga.cs</Link>
+    </Compile>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{605CD4EC-065C-48AA-90CC-EBA935249240}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\..\..\packages\NServiceBus.Persistence.Sql.MsBuild.1.0.0-beta0010\build\NServiceBus.Persistence.Sql.MsBuild.targets" Condition="Exists('..\..\..\..\..\packages\NServiceBus.Persistence.Sql.MsBuild.1.0.0-beta0010\build\NServiceBus.Persistence.Sql.MsBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\..\packages\NServiceBus.Persistence.Sql.MsBuild.1.0.0-beta0010\build\NServiceBus.Persistence.Sql.MsBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\NServiceBus.Persistence.Sql.MsBuild.1.0.0-beta0010\build\NServiceBus.Persistence.Sql.MsBuild.targets'))" />
+  </Target>
+</Project>

--- a/samples/saga/migration/Core_6/Server.New/Server.New.csproj
+++ b/samples/saga/migration/Core_6/Server.New/Server.New.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NEW</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SERVER_NEW</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/saga/migration/Core_6/Server.New/packages.config
+++ b/samples/saga/migration/Core_6/Server.New/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.2-beta1" targetFramework="net452" />
+  <package id="NServiceBus" version="6.1.1" targetFramework="net452" />
+  <package id="NServiceBus.Persistence.Sql" version="1.0.0-beta0010" targetFramework="net452" />
+  <package id="NServiceBus.Persistence.Sql.MsBuild" version="1.0.0-beta0010" targetFramework="net452" />
+</packages>

--- a/samples/saga/migration/Core_6/Server/App.config
+++ b/samples/saga/migration/Core_6/Server/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/samples/saga/migration/Core_6/Server/DummyMessage.cs
+++ b/samples/saga/migration/Core_6/Server/DummyMessage.cs
@@ -1,0 +1,7 @@
+﻿using NServiceBus;
+
+public class DummyMessage :
+    IMessage
+{
+    public string SomeId { get; set; }
+}

--- a/samples/saga/migration/Core_6/Server/NotFoundHandler.cs
+++ b/samples/saga/migration/Core_6/Server/NotFoundHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Sagas;
+
+#region Forwarder
+class NotFoundHandler :
+    IHandleSagaNotFound
+{
+    public Task Handle(object message, IMessageProcessingContext context)
+    {
+        return context.ForwardCurrentMessageTo("Samples.SagaMigration.Server.New");
+    }
+}
+#endregion

--- a/samples/saga/migration/Core_6/Server/Program.cs
+++ b/samples/saga/migration/Core_6/Server/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Persistence;
+
+class Program
+{
+    static void Main()
+    {
+        Start().GetAwaiter().GetResult();
+    }
+
+    static async Task Start()
+    {
+        Console.Title = "Samples.SagaMigration.Server";
+
+        var endpointConfiguration = new EndpointConfiguration("Samples.SagaMigration.Server");
+        var persistence = endpointConfiguration.UsePersistence<NHibernatePersistence>();
+        persistence.ConnectionString(@"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;");
+        endpointConfiguration.SendFailedMessagesTo("error");
+
+        var endpoint = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        Console.WriteLine("Press <enter> to exit.");
+        Console.ReadLine();
+
+        await endpoint.Stop()
+            .ConfigureAwait(false);
+    }
+}

--- a/samples/saga/migration/Core_6/Server/Server.csproj
+++ b/samples/saga/migration/Core_6/Server/Server.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6F62A054-2D0F-49EF-8B40-D25E656120DF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Server</RootNamespace>
+    <AssemblyName>Server</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>6</LangVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHibernate, Version=4.1.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NHibernate.4.1.0.4000\lib\net40\NHibernate.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.6.1.1\lib\net452\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.NHibernate, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.NHibernate.7.0.2\lib\net452\NServiceBus.NHibernate.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DummyMessage.cs" />
+    <Compile Include="NotFoundHandler.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="TestSaga.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{605CD4EC-065C-48AA-90CC-EBA935249240}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/saga/migration/Core_6/Server/TestSaga.cs
+++ b/samples/saga/migration/Core_6/Server/TestSaga.cs
@@ -47,7 +47,8 @@ public class TestSaga :
         mapper.ConfigureMapping<CorrelatedMessage>(m => m.SomeId)
             .ToSaga(s => s.SomeId);
 #if MIGRATION && !SERVER_NEW
-        mapper.ConfigureMapping<DummyMessage>(m => m.SomeId).ToSaga(s => s.SomeId);
+        mapper.ConfigureMapping<DummyMessage>(m => m.SomeId)
+            .ToSaga(s => s.SomeId);
 #endif
 
         #endregion

--- a/samples/saga/migration/Core_6/Server/TestSaga.cs
+++ b/samples/saga/migration/Core_6/Server/TestSaga.cs
@@ -1,0 +1,92 @@
+﻿#region Toggle
+
+//#define MIGRATION
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+#region Header
+
+#if NEW
+[NServiceBus.Persistence.Sql.SqlSaga(correlationProperty: "SomeId")]
+#endif
+
+public class TestSaga :
+        Saga<TestSaga.TestSagaData>,
+        IHandleMessages<ReplyFollowUpMessage>,
+        IHandleMessages<CorrelatedMessage>,
+        IHandleTimeouts<TestTimeout>,
+#if MIGRATION && !NEW
+    IHandleMessages<StartingMessage>,
+    IAmStartedByMessages<DummyMessage>
+#else
+        IAmStartedByMessages<StartingMessage>
+#endif
+
+    #endregion
+
+{
+#if MIGRATION && !NEW
+    public Task Handle(DummyMessage message, IMessageHandlerContext context)
+    {
+        throw new Exception("Dummy");
+    }
+#endif
+
+    protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+    {
+        #region Mappings
+
+        mapper.ConfigureMapping<StartingMessage>(m => m.SomeId)
+            .ToSaga(s => s.SomeId);
+        mapper.ConfigureMapping<CorrelatedMessage>(m => m.SomeId)
+            .ToSaga(s => s.SomeId);
+#if MIGRATION && !NEW
+        mapper.ConfigureMapping<DummyMessage>(m => m.SomeId).ToSaga(s => s.SomeId);
+#endif
+
+        #endregion
+    }
+
+    #region Handlers
+
+    public Task Handle(StartingMessage message, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"{Data.SomeId}: Created new saga instance.");
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(ReplyFollowUpMessage message, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"{Data.SomeId}: Got a follow-up message.");
+        return RequestTimeout<TestTimeout>(context, DateTime.UtcNow.AddSeconds(10));
+    }
+
+    public Task Handle(CorrelatedMessage message, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"{Data.SomeId}: Got a correlated message {message.SomeId}. Replying back.");
+        var replyMessage = new ReplyMessage
+        {
+            SomeId = Data.SomeId
+        };
+        return context.Reply(replyMessage);
+    }
+
+    public Task Timeout(TestTimeout state, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"{Data.SomeId}: Got timeout. Completing.");
+        MarkAsComplete();
+        return Task.CompletedTask;
+    }
+
+    #endregion
+
+    public class TestSagaData :
+        ContainSagaData
+    {
+        public virtual string SomeId { get; set; }
+    }
+}

--- a/samples/saga/migration/Core_6/Server/TestSaga.cs
+++ b/samples/saga/migration/Core_6/Server/TestSaga.cs
@@ -10,7 +10,8 @@ using NServiceBus;
 
 #region Header
 
-#if NEW
+//SERVER_NEW is defined in Server.New project settings
+#if SERVER_NEW
 [NServiceBus.Persistence.Sql.SqlSaga(correlationProperty: "SomeId")]
 #endif
 
@@ -19,7 +20,7 @@ public class TestSaga :
         IHandleMessages<ReplyFollowUpMessage>,
         IHandleMessages<CorrelatedMessage>,
         IHandleTimeouts<TestTimeout>,
-#if MIGRATION && !NEW
+#if MIGRATION && !SERVER_NEW
     IHandleMessages<StartingMessage>,
     IAmStartedByMessages<DummyMessage>
 #else
@@ -29,7 +30,8 @@ public class TestSaga :
     #endregion
 
 {
-#if MIGRATION && !NEW
+#if MIGRATION && !SERVER_NEW
+    //Required to satisfy NServiceBus validation
     public Task Handle(DummyMessage message, IMessageHandlerContext context)
     {
         throw new Exception("Dummy");
@@ -44,7 +46,7 @@ public class TestSaga :
             .ToSaga(s => s.SomeId);
         mapper.ConfigureMapping<CorrelatedMessage>(m => m.SomeId)
             .ToSaga(s => s.SomeId);
-#if MIGRATION && !NEW
+#if MIGRATION && !SERVER_NEW
         mapper.ConfigureMapping<DummyMessage>(m => m.SomeId).ToSaga(s => s.SomeId);
 #endif
 

--- a/samples/saga/migration/Core_6/Server/packages.config
+++ b/samples/saga/migration/Core_6/Server/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net452" />
+  <package id="NHibernate" version="4.1.0.4000" targetFramework="net452" />
+  <package id="NServiceBus" version="6.1.1" targetFramework="net452" />
+  <package id="NServiceBus.NHibernate" version="7.0.2" targetFramework="net452" />
+</packages>

--- a/samples/saga/migration/sample.md
+++ b/samples/saga/migration/sample.md
@@ -24,27 +24,26 @@ related:
 ## Running the project
 
  1. Start the solution
- 1. Wait until `Type 'start <SagaId>' or 'ping <SagaId>'` is shown in the "Client" console window.
+ 1. Wait until `Type 'start <SagaId>' or 'complete <SagaId>'` is shown in the "Client" console window.
  1. Start a couple of sagas with easy to remember IDs (e.g. `start 1`, `start 2` and `start 3`)
  1. Verify sagas are started by running `SELECT * FROM [nservicebus].[dbo].[TestSaga]`
  1. Verify that the messages were handled by "Server" endpoint.
- 1. Ping one of the sagas (e.g. `ping 1`). Observe the message flow. It can take up to 10 seconds to complete as the flow involves a saga timeout. The result should be completion of a saga (verify by checking that a corresponding row is removed from the saga table by running again the previous query)
+ 1. Complete one of the sagas (e.g. `complete 1`). Observe the message flow. It can take up to 10 seconds to complete as the flow involves a saga timeout. The result should be completion of a saga (verify by checking that a corresponding row is removed from the saga table by running again the previous query)
  1. Stop the solution
  1. Uncomment the `#define MIGRATION` line in `TestSaga.cs`
  1. Start the solution
- 1. Start and ping some new sagas (e.g. `start A`, `start B` and `start C`)
+ 1. Start and complete some new sagas (e.g. `start A`, `start B` and `start C`)
  1. Verify sagas are started by running `SELECT * FROM [nservicebus].[dbo].[NewTestSaga]`
  1. Verify that the messages were handled by "Server.New" endpoint.
  1. Notice that "Server" console shows information indicating that the not-found handler has been used
- 1. Ping the previously created sagas (`ping 2` or `ping 3`) to drain the saga store
+ 1. Complete the previously created sagas (`complete 2` or `complete 3`) to drain the saga store
  1. Verify the messages are handled by the old "Server" endpoint, not the "Server.New"
- 1. Ping one of the new sagas (e.g. `ping A`) to verify it is handled properly "Server.New"
- 1. Notice that the timeout message that completes the saga does not go through "Server". The destination as stored in the timeout store is set to "Server.New"
- 1. Ping another saga (e.g. `ping B`) and stop the solution as soon as `Got a follow-up message.` is shown in the console
+ 1. Complete one of the new sagas (e.g. `complete A`) to verify it is handled properly by "Server.New"
+ 1. Complete another saga (e.g. `complete B`) and stop the solution as soon as `Got a follow-up message.` is shown in the console
  1. Run `SELECT [Destination], [SagaId] FROM [nservicebus].[dbo].[NewTimeoutData]` to verify the timeout is stored in the database and the destination is the "Server.New" queue
  1. Uncomment the `#define POST_MIGRATION` in `Program.cs` of "Server.New". This changes the input queue of "Server.New" back to the well-known `Samples.SagaMigration.Server` and enables an additional receiver that drains the temporary queue. 
  1. Start only the "Server.New" project by right-clicking the project in Solution Explorer and selecting "Debug -> Start new instance"
- 1. Notice "Server.New" prints `Moving message from Samples.SagaMigration.Server.New@<machine> to Samples.SagaMigration.Server@<machine>` and then `Got timeout. Completing.` which means the timeout has been successfully redirected from the temporary queue.
+ 1. Notice "Server.New" prints `Moving message from Samples.SagaMigration.Server.New@<machine> to Samples.SagaMigration.Server@<machine>` and then `Got timeout. Completing.` which means the timeout has been successfully redirected from the temporary queue. This happens only if there were outstanding timeout messages present when new version of the endpoint replaced the old one.
 
 
 ## Code walk-through
@@ -63,13 +62,13 @@ The sample shows how to gradually migrate from one saga persister to another wit
 
 The message flow is designed to demonstrate the correctness of migration logic:
  * The `StartingMessage` (sent via `start` command) starts the saga and assigns the correlation property.
- * The `CorrelatedMessage` (sent via `ping` command) contains the correlation property value of an already started saga. Handling of this message results in sending back a `ReplyMessage`
+ * The `CorrelatedMessage` (sent via `complete` command) contains the correlation property value of an already started saga. Handling of this message results in sending back a `ReplyMessage`
  * The `ReplyMessage` sent by the saga contains the saga ID header containing the storage ID (not the correlation property) of the saga instance that sent it
  * The `ReplyFollowUpMessage` send as a response to `ReplyMessage` contains the mentioned saga ID header by which the target saga is being looked up
 
 snippet:Handlers
 
-To summarise, sagas can be either looked up by their correlation property value or the storage ID.
+To summarize, sagas can be either looked up by their correlation property value or the storage ID.
 
 
 ### How it works

--- a/samples/saga/migration/sample.md
+++ b/samples/saga/migration/sample.md
@@ -103,7 +103,7 @@ snippet:Mappings
 
 When there are no sagas left in the old persistence, the old version of the endpoint can be decommissioned. In order to not lose any messages, the new version has to include, for a certain period of time, a redirection satellite that receives any remaining messages from the temporary queue and moves it to the regular queue.
 
-snippet:DrainTempQueueSatellite 
+snippet:DrainTempQueueSatellite
 
 
 #### Decommissioning the old endpoint
@@ -111,8 +111,7 @@ snippet:DrainTempQueueSatellite
 Once all the sagas stored in the old persister are complete, the old endpoint can be decommissioned.
 
  1. Ensure the saga table is empty by running a command similar to `SELECT * FROM [nservicebus].[dbo].[TestSaga]`
- 2. Stop the old endpoint ("Server")
- 3. Update the binaries and/or config of the old endpoint with the binaries and config of the new endpoint. Enable the redirection of the temporary queue.
- 4. Start the endpoint
- 5. The redirection of temporary queue can be removed when there are no timeout messages for the temporary queue (e.g. by running a query like `SELECT [Destination], [SagaId] FROM [nservicebus].[dbo].[NewTimeoutData] WHERE [Destination] = <address of temp queue>`
-  
+ 1. Stop the old endpoint ("Server")
+ 1. Update the binaries and/or config of the old endpoint with the binaries and config of the new endpoint. Enable the redirection of the temporary queue.
+ 1. Start the endpoint
+ 1. The redirection of temporary queue can be removed when there are no timeout messages for the temporary queue (e.g. by running a query like `SELECT [Destination], [SagaId] FROM [nservicebus].[dbo].[NewTimeoutData] WHERE [Destination] = <address of temp queue>`

--- a/samples/saga/migration/sample.md
+++ b/samples/saga/migration/sample.md
@@ -1,0 +1,119 @@
+---
+title: Migrating saga persistence
+summary: How to migrate from one type of saga persistence to another without an off-line migration procedure
+component: Core
+reviewed: 2017-01-04
+tags:
+- Saga
+- NHibernate
+- SQL
+- Migration
+related:
+- nservicebus/sagas
+- nservicebus/nhibernate
+- nservicebus/sql-persistence
+---
+
+## Prerequisites
+
+ 1. Make sure MSMQ is set up as described in the [MSMQ Transport - NServiceBus Configuration](/nservicebus/msmq/#nservicebus-configuration) section.
+ 1. Make sure SQL Server Express is installed and accessible as `.\SQLEXPRESS`.
+ 1. Create database called `nservicebus`.
+
+ 
+## Running the project
+
+ 1. Start the solution
+ 1. Wait until `Type 'start <SagaId>' or 'ping <SagaId>'` is shown in the "Client" console window.
+ 1. Start a couple of sagas with easy to remember IDs (e.g. `start 1`, `start 2` and `start 3`)
+ 1. Verify sagas are started by running `SELECT * FROM [nservicebus].[dbo].[TestSaga]`
+ 1. Verify that the messages were handled by "Server" endpoint.
+ 1. Ping one of the sagas (e.g. `ping 1`). Observe the message flow. It can take up to 10 seconds to complete as the flow involves a saga timeout. The result should be completion of a saga (verify by checking that a corresponding row is removed from the saga table by running again the previous query)
+ 1. Stop the solution
+ 1. Uncomment the `#define MIGRATION` line in `TestSaga.cs`
+ 1. Start the solution
+ 1. Start and ping some new sagas (e.g. `start A`, `start B` and `start C`)
+ 1. Verify sagas are started by running `SELECT * FROM [nservicebus].[dbo].[NewTestSaga]`
+ 1. Verify that the messages were handled by "Server.New" endpoint.
+ 1. Notice that "Server" console shows information indicating that the not-found handler has been used
+ 1. Ping the previously created sagas (`ping 2` or `ping 3`) to drain the saga store
+ 1. Verify the messages are handled by the old "Server" endpoint, not the "Server.New"
+ 1. Ping one of the new sagas (e.g. `ping A`) to verify it is handled properly "Server.New"
+ 1. Notice that the timeout message that completes the saga does not go through "Server". The destination as stored in the timeout store is set to "Server.New"
+ 1. Ping another saga (e.g. `ping B`) and stop the solution as soon as `Got a follow-up message.` is shown in the console
+ 1. Run `SELECT [Destination], [SagaId] FROM [nservicebus].[dbo].[NewTimeoutData]` to verify the timeout is stored in the database and the destination is the "Server.New" queue
+ 1. Uncomment the `#define POST_MIGRATION` in `Program.cs` of "Server.New". This changes the input queue of "Server.New" back to the well-known `Samples.SagaMigration.Server` and enables an additional receiver that drains the temporary queue. 
+ 1. Start only the "Server.New" project by right-clicking the project in Solution Explorer and selecting "Debug -> Start new instance"
+ 1. Notice "Server.New" prints `Moving message from Samples.SagaMigration.Server.New@<machine> to Samples.SagaMigration.Server@<machine>` and then `Got timeout. Completing.` which means the timeout has been successfully redirected from the temporary queue.
+
+
+## Code walk-through
+
+This sample contains four projects:
+
+ * Contracts - contains definitions of messages exchanged between the Client and the Server.
+ * Client - initiates a multi-message conversation with the server.
+ * Server - implements a long running process via the Saga feature. Uses [NHibernate-based](/nservicebus/nhibernate) saga persister.
+ * Server.New - implements the same functionality as Server but uses [SQL-based](/nservicebus/sql-persistence) saga persister.
+
+The sample shows how to gradually migrate from one saga persister to another without requiring an off-line migration procedure/script. In this example NHibernate and SQL persisters as source and target respectively but any persister can be used in any role i.e. the same method can be used to migrate e.g. from RavenDB to NHibernate persister.
+
+
+### Message flow
+
+The message flow is designed to demonstrate the correctness of migration logic:
+ * The `StartingMessage` (sent via `start` command) starts the saga and assigns the correlation property.
+ * The `CorrelatedMessage` (sent via `ping` command) contains the correlation property value of an already started saga. Handling of this message results in sending back a `ReplyMessage`
+ * The `ReplyMessage` sent by the saga contains the saga ID header containing the storage ID (not the correlation property) of the saga instance that sent it
+ * The `ReplyFollowUpMessage` send as a response to `ReplyMessage` contains the mentioned saga ID header by which the target saga is being looked up
+
+snippet:Handlers
+
+To summarise, sagas can be either looked up by their correlation property value or the storage ID.
+
+
+### How it works
+
+The migration procedure require that the new version of a given endpoint is deployed alongside the old one. In this sample "Server.New" represents the new version that uses SQL persistence. Before the migration is complete the new version is not visible to the outside world because it uses a different queue name.
+
+The new version has to be deployed and started before the migration process can begin. Only then the old version has to be modified to enable the migration. This requires a couple of code changes. In this sample both versions share the same source code file for the saga definition and the changes are done via pre-processor instructions. Enabling the migration happens by un-commenting this statement:
+
+snippet:Toggle
+
+
+#### Handling not found sagas
+
+In order to eventually migrate to the new persistence, all new saga instances need to be created by the "Server.New" endpoint. To ensure this, the old "Server" endpoint has to include a handler for not found sagas that forwards the messages to the new endpoint:
+
+snippet:Forwarder
+
+The messages are forwarded as-is, without any side effects and handled normally by the destination.
+
+This handler is only invoked for messages that target an existing saga (either by correlation or by having a saga ID header). It is never invoked for a message that can start a saga so the saga code has to be modified to not treat `StartingMessage` as a saga started in the old endpoint.
+
+snippet:Header
+
+Notice `DummyMessage` is necessary as a saga starter. NServiceBus validation logic does not allow sagas without any starter messages. `DummyMessage` is never sent. It is only there so satisfy the validation.
+
+The correlation property mappings also need to include `DummyMessage`
+
+snippet:Mappings
+
+
+#### Forwarding messages from temporary queue
+
+When there are no sagas left in the old persistence, the old version of the endpoint can be decommissioned. In order to not lose any messages, the new version has to include, for a certain period of time, a redirection satellite that receives any remaining messages from the temporary queue and moves it to the regular queue.
+
+snippet:DrainTempQueueSatellite 
+
+
+#### Decommissioning the old endpoint
+
+Once all the sagas stored in the old persister are complete, the old endpoint can be decommissioned.
+
+ 1. Ensure the saga table is empty by running a command similar to `SELECT * FROM [nservicebus].[dbo].[TestSaga]`
+ 2. Stop the old endpoint ("Server")
+ 3. Update the binaries and/or config of the old endpoint with the binaries and config of the new endpoint. Enable the redirection of the temporary queue.
+ 4. Start the endpoint
+ 5. The redirection of temporary queue can be removed when there are no timeout messages for the temporary queue (e.g. by running a query like `SELECT [Destination], [SagaId] FROM [nservicebus].[dbo].[NewTimeoutData] WHERE [Destination] = <address of temp queue>`
+  


### PR DESCRIPTION
Shows how to migrate saga persistences without an off-line migration procedure/script by using a pair of endpoints where existing sagas are continued to be handled by an "old" version of the endpoint while new sagas are started in the "new" version of the endpoint, using the new persistence.

It covers:
 * Routing of messages with correlation property value
 * Routing of messages with saga ID header
 * Re-routing of timeouts after the temp endpoint is decomissioned