### PR TITLE
Critical time perf counter - confusing description

### DIFF
--- a/nservicebus/operations/performance-counters.md
+++ b/nservicebus/operations/performance-counters.md
@@ -33,7 +33,7 @@ Since all performance counters in Windows are exposed via Windows Management Ins
 
 **Added in:** Version 3
 
-Critical Time is the time from a message being sent until successfully processed. This metric is useful for monitoring message Service-level agreement similar to "All orders should be processed within X seconds/minutes/hours. Define an SLA for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
+Critical Time is the time from a message being sent until successfully processed. This metric is useful for monitoring message Service-level agreement. For example "All orders should be processed within X seconds/minutes/hours". Define an SLA for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
 
 **Versions 6 and above:** The value recorded in the TimeSent header is the time when the call to send the message is executed, not the actual time when the message was dispatched to the transport infrastructure. Since the outgoing messages in handlers are sent as a [batched](/nservicebus/messaging/batched-dispatch.md) operation, depending on how long the message handler takes to complete, the actual dispatch may happen later than the time recorded in the TimeSent header. For operations outside of handlers the recorded sent time is accurate.
 

--- a/nservicebus/operations/performance-counters.md
+++ b/nservicebus/operations/performance-counters.md
@@ -33,7 +33,7 @@ Since all performance counters in Windows are exposed via Windows Management Ins
 
 **Added in:** Version 3
 
-Monitors the age of the oldest message in the queue. This takes into account the whole chain, from the message being sent from the client machine until successfully processed by the server. Define an Service-level agreement (SLA) for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
+This takes into account the whole chain, from the message being sent from the client machine until successfully processed by the server. Define an Service-level agreement (SLA) for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
 
 **Versions 6 and above:** The value recorded in the TimeSent header is the time when the call to send the message is executed, not the actual time when the message was dispatched to the transport infrastructure. Since the outgoing messages in handlers are sent as a [batched](/nservicebus/messaging/batched-dispatch.md) operation, depending on how long the message handler takes to complete, the actual dispatch may happen later than the time recorded in the TimeSent header. For operations outside of handlers the recorded sent time is accurate.
 

--- a/nservicebus/operations/performance-counters.md
+++ b/nservicebus/operations/performance-counters.md
@@ -33,7 +33,7 @@ Since all performance counters in Windows are exposed via Windows Management Ins
 
 **Added in:** Version 3
 
-This takes into account the whole chain, from the message being sent from the client machine until successfully processed by the server. Define an Service-level agreement (SLA) for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
+Critical Time is the time from a message being sent until successfully processed. This metric is useful for monitoring message Service-level agreement similar to "All orders should be processed within X seconds/minutes/hours. Define an SLA for each endpoint and use the `CriticalTime` counter to ensure it is adhered to.
 
 **Versions 6 and above:** The value recorded in the TimeSent header is the time when the call to send the message is executed, not the actual time when the message was dispatched to the transport infrastructure. Since the outgoing messages in handlers are sent as a [batched](/nservicebus/messaging/batched-dispatch.md) operation, depending on how long the message handler takes to complete, the actual dispatch may happen later than the time recorded in the TimeSent header. For operations outside of handlers the recorded sent time is accurate.
 


### PR DESCRIPTION
Have removed the following sentence:
> Monitors the age of the oldest message in the queue. 

The entire paragraph now might need to be re-written.
Could someone with a bit more of b/g knowledge (or perhaps historical knowledge of how this perf counter used to be exercised) chime in?

@Particular/nservicebus-maintainers 

PS: I heard @andreasohlund ❤️  perf counters 😺 