### PR TITLE
[Core 6.2] Remove double-opt-in doc for v6

### DIFF
--- a/Snippets/Core/Core_6/Core_6.csproj
+++ b/Snippets/Core/Core_6/Core_6.csproj
@@ -272,9 +272,6 @@
     <Content Include="Logging\OverrideInAppConfig.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Outbox\EnablingInConfig.xml">
-      <SubType>Designer</SubType>
-    </Content>
     <Content Include="UpgradeGuides\5to6\null.xml" />
     <None Include="project.json" />
   </ItemGroup>

--- a/Snippets/Core/Core_6/Outbox/EnablingInConfig.xml
+++ b/Snippets/Core/Core_6/Outbox/EnablingInConfig.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <!--startcode OutboxEnablingInAppConfig-->
-  <appSettings>
-    <add key="NServiceBus/Outbox" 
-         value="true" />
-  </appSettings>
-  <!--endcode -->
-</configuration>

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -19,7 +19,7 @@ Using Outbox allows for running endpoints with similar reliability to DTC while 
 
 The Outbox feature has been implemented using the [Outbox](http://gistlabs.com/2014/05/the-outbox/) and the [Deduplication](https://en.wikipedia.org/wiki/Data_deduplication#In-line_deduplication) patterns.
 
-Every time a message is processed, the copy of that message is stored in the persistent _Outbox storage_. Whenever a new message is received, the framework verifies if that message has been processed already by checking if it's present in the Outbox storage. 
+Every time a message is processed, a copy of that message is stored in the persistent _Outbox storage_. Whenever a new message is received, the framework verifies if that message has been processed already by checking if it's present in the Outbox storage. 
 
 If the message is not found in the Outbox storage, then it is processed in a regular way 
 as shown in the following diagram:
@@ -48,17 +48,7 @@ Note: On the wire level the Outbox guarantees `at-least-once` message delivery, 
 
 ## Enabling the Outbox
 
-In order to enable the Outbox for transports that don't support distributed transactions, e.g. RabbitMQ transport, use the following code API:
-
-snippet: OutboxEnablineInCode
-
-In order to enable the Outbox for transports that support distributed transactions, e.g. MSMQ or SQL Server transport, it is additionally required to add the following `app.config` setting:
-
-snippet: OutboxEnablingInAppConfig
-
-Note: When Outbox is enabled then NServiceBus automatically lowers the default delivery guarantee level to `ReceiveOnly`. A different level can be explicitly [specified in configuration](/nservicebus/transports/transactions.md).
-
-Warning: The double opt-in configuration for transports supporting DTC is ensuring that Outbox is not accidentally used in combination with DTC. If endpoints using Outbox send messages to endpoints using DTC, then messages might get duplicated. As a result, the same messages might be processed multiple times. 
+partial:enable-outbox
 
 
 ## Persistence

--- a/nservicebus/outbox/index_enable-outbox_core_[5, 5].partial.md
+++ b/nservicebus/outbox/index_enable-outbox_core_[5, 5].partial.md
@@ -1,0 +1,11 @@
+In order to enable the Outbox for transports that don't support distributed transactions, e.g. RabbitMQ transport, use the following code API:
+
+snippet: OutboxEnablineInCode
+
+In order to enable the Outbox for transports that support distributed transactions, e.g. MSMQ or SQL Server transport, it is additionally required to add the following `app.config` setting:
+
+snippet: OutboxEnablingInAppConfig
+
+Note: When Outbox is enabled then NServiceBus automatically lowers the default delivery guarantee level to `ReceiveOnly`. A different level can be explicitly [specified in configuration](/nservicebus/transports/transactions.md).
+
+Warning: The double opt-in configuration for transports supporting DTC is ensuring that Outbox is not accidentally used in combination with DTC. If endpoints using Outbox send messages to endpoints using DTC, then messages might get duplicated. As a result, the same messages might be processed multiple times. 

--- a/nservicebus/outbox/index_enable-outbox_core_[6,).partial.md
+++ b/nservicebus/outbox/index_enable-outbox_core_[6,).partial.md
@@ -1,0 +1,5 @@
+In order to enable the Outbox, use the following code API:
+
+snippet: OutboxEnablineInCode
+
+Note: When Outbox is enabled then NServiceBus automatically lowers the default delivery guarantee level to `ReceiveOnly`. A different level can be explicitly [specified in configuration](/nservicebus/transports/transactions.md).


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/pull/4440

Is the partial version [5,5] correct?