### PR TITLE
Improvements on critical error callback

### DIFF
--- a/Snippets/Core/Core_3/CriticalErrors.cs
+++ b/Snippets/Core/Core_3/CriticalErrors.cs
@@ -26,16 +26,20 @@ namespace Core3.Host
 
         void OnCriticalError()
         {
-            // Write log entry in version 3 since this is not done by default.
-            log.Fatal("CRITICAL Error");
-
-            // To leave the process active, dispose the bus.
-            // When the bus is disposed sending messages will throw an ObjectDisposedException.
-            ((IDisposable)bus).Dispose();
-
-            // To kill the process, raise a fail fast error as shown below.
-            // var failMessage = "Critical error shutting.";
-            // Environment.FailFast(failMessage);
+            try
+            {
+                // To leave the process active, dispose the bus.
+                // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
+                ((IDisposable)bus).Dispose();
+                // Perform custom actions here, e.g.
+                // NLog.LogManager.Shutdown();
+            }
+            finally
+            {
+                // Write log entry in version 3 since this is not done by default.
+                log.Fatal("CRITICAL Error");
+                Environment.FailFast("Critical error shutting down.");
+            }
         }
 
         #endregion

--- a/Snippets/Core/Core_3/CriticalErrors.cs
+++ b/Snippets/Core/Core_3/CriticalErrors.cs
@@ -28,6 +28,8 @@ namespace Core3.Host
         {
             try
             {
+                // Write log entry in version 3 since this is not done by default.
+                log.Fatal("CRITICAL Error");
                 // To leave the process active, dispose the bus.
                 // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
                 ((IDisposable)bus).Dispose();
@@ -36,8 +38,6 @@ namespace Core3.Host
             }
             finally
             {
-                // Write log entry in version 3 since this is not done by default.
-                log.Fatal("CRITICAL Error");
                 Environment.FailFast("Critical error shutting down.");
             }
         }

--- a/Snippets/Core/Core_4/CriticalErrors.cs
+++ b/Snippets/Core/Core_4/CriticalErrors.cs
@@ -23,13 +23,19 @@ namespace Core4
 
         void OnCriticalError(string errorMessage, Exception exception)
         {
-            // To leave the process active, dispose the bus.
-            // When the bus is disposed sending messages will throw an ObjectDisposedException.
-            bus.Dispose();
-
-            // To kill the process, raise a fail fast error as shown below.
-            // var failMessage = $"Critical error shutting down:'{errorMessage}'.";
-            // Environment.FailFast(failMessage, exception);
+            try
+            {
+                // To leave the process active, dispose the bus.
+                // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
+                bus.Dispose();
+                // Perform custom actions here, e.g.
+                // NLog.LogManager.Shutdown();
+            }
+            finally
+            {
+                var failMessage = $"Critical error shutting down:'{errorMessage}'.";
+                Environment.FailFast(failMessage, exception);
+            }
         }
 
         #endregion

--- a/Snippets/Core/Core_5/CriticalErrors.cs
+++ b/Snippets/Core/Core_5/CriticalErrors.cs
@@ -24,13 +24,19 @@ namespace Core5
 
         void OnCriticalError(string errorMessage, Exception exception)
         {
-            // To leave the process active, dispose the bus.
-            // When the bus is disposed sending messages will throw an ObjectDisposedException.
-            bus.Dispose();
-
-            // To kill the process, raise a fail fast error as shown below.
-            // var failMessage = $"Critical error shutting down:'{errorMessage}'.";
-            // Environment.FailFast(failMessage, exception);
+            try
+            {
+                // To leave the process active, dispose the bus.
+                // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
+                bus.Dispose();
+                // Perform custom actions here, e.g.
+                // NLog.LogManager.Shutdown();
+            }
+            finally
+            {
+                var failMessage = $"Critical error shutting down:'{errorMessage}'.";
+                Environment.FailFast(failMessage, exception);
+            }
         }
 
         #endregion

--- a/Snippets/Core/Core_6/CriticalErrors.cs
+++ b/Snippets/Core/Core_6/CriticalErrors.cs
@@ -20,15 +20,21 @@ namespace Core6
 
         #region CustomHostErrorHandlingAction
 
-        Task OnCriticalError(ICriticalErrorContext context)
+        async Task OnCriticalError(ICriticalErrorContext context)
         {
-            // To leave the process active, stop the endpoint.
-            return context.Stop();
-
-            // To kill the process, await the above,
-            // then raise a fail fast error as shown below.
-            // var failMessage = $"Critical error shutting down:'{context.Error}'.";
-            // Environment.FailFast(failMessage, context.Exception);
+            try
+            {
+                // To leave the process active, dispose the bus.
+                // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
+                await context.Stop();
+                // Perform custom actions here, e.g.
+                // NLog.LogManager.Shutdown();
+            }
+            finally
+            {
+                var failMessage = $"Critical error shutting down:'{context.Error}'.";
+                Environment.FailFast(failMessage, context.Exception);
+            }
         }
 
         #endregion

--- a/Snippets/Core/Core_6/CriticalErrors.cs
+++ b/Snippets/Core/Core_6/CriticalErrors.cs
@@ -26,7 +26,7 @@ namespace Core6
             {
                 // To leave the process active, dispose the bus.
                 // When the bus is disposed, the attempt to send message will cause an ObjectDisposedException.
-                await context.Stop();
+                await context.Stop().ConfigureAwait(false);
                 // Perform custom actions here, e.g.
                 // NLog.LogManager.Shutdown();
             }

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -52,7 +52,7 @@ Consider the following things when implementing a critical error callback:
 - Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
  - Flush NLog or log4net state by calling `LogManager.Shutdown();`, this still isn't 100% guaranteed to not loose any log entries. Check each logging framework its document.
-- Flush any state/caches used if you normally would flush such data structure in a certain interval.
+- Flush any state/caches used if normally such data structures are would persisted in a certain interval or at graceful shutdown.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 
 Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -58,7 +58,7 @@ When implementing a custom critical error callback:
 
 - To exit the process use the [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) method. In case the environment has threads running that should be completed before shutdown (e.g. non transactional operations), one may also use the [Environment.Exit](https://msdn.microsoft.com/en-us/library/system.environment.exit(v=vs.110).aspx) method.
 - The code should be wrapped in a `try...finally` clause. In the `try` block perform any custom operations, in the `finally` block call the method that exits the process.
-- The custom operations should include flushing any in-memory state and cached data, if normally its persisted at a certain interval or during graceful shutdown. For example, flush appenders if you are using buffering or asynchrounous appanders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
+- The custom operations should include flushing any in-memory state and cached data, if normally its persisted at a certain interval or during graceful shutdown. For example, flush appenders when using buffering or asynchrounous appanders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 
 Whenever possible rely on the environment hosting the endpoint process to automatically restart it:
 - IIS: The IIS host will automatically spawn a new instance.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -55,7 +55,7 @@ Consider the following when implementing a critical error callback:
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
  - Flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 - Flush any state/caches used if such data structures would be written/persisted at a certain interval or regular graceful shutdown.
-- It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
+- It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) or [Environment.Exit](https://msdn.microsoft.com/en-us/library/system.environment.exit(v=vs.110).aspx).
 
 Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -45,7 +45,11 @@ snippet:CustomHostErrorHandlingAction
 
 ## When to override the default action
 
-When self hosting the should be overriden in order to exit the current process unless you are using the [NServiceBus Host](/nservicebus/hosting/nservicebus-host) which already has a implementation that exits the process.
+When self hosting the critical error callback must be overriden in order to exit the current process. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
+
+NOTE: If not killing the process and just disposing the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
+
+When the [NServiceBus Host](/nservicebus/hosting/nservicebus-host) is used it is not required to override this callback as the host has a default implementation that exits the process. However, if it is required to execute tasks just before shutdown then it can be overriden in the same way as when self hosting.
 
 Consider the following things when implementing a critical error callback:
 
@@ -57,7 +61,6 @@ Consider the following things when implementing a critical error callback:
 
 Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
 
-NOTE: If not killing the process and just dispose the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 
 
 ## Raising Critical error

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -45,10 +45,16 @@ snippet:CustomHostErrorHandlingAction
 
 ## When to override the default action
 
-The default action should be overridden whenever that default does not meet the specific hosting requirements. For example
+When self hosting the should be overriden in order to exit the current process unless you are using the [NServiceBus Host](/nservicebus/hosting/nservicebus-host) which already has a implementation that exits the process.
 
- * If using [NServiceBus Host](/nservicebus/hosting/nservicebus-host), and wish to take a custom action before the endpoint process is killed.
- * If self hosting the process can be shut down the process via [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) and re-start the process once the root cause has been diagnosed.
+Consider the following things when implementing a critical error callback:
+
+- Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
+- Flush any loggers used which makes sure any unwritten tail of the log is persisted as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process
+- Flush any state/caches used if you normally would flush such data structure in a certain interval.
+- It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
+
+Rely on the environemnt that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
 
 NOTE: If not killing the process and just dispose the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -57,7 +57,11 @@ Consider the following when implementing a critical error callback:
 - Flush any state/caches used if such data structures would be written/persisted at a certain interval or regular graceful shutdown.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) or [Environment.Exit](https://msdn.microsoft.com/en-us/library/system.environment.exit(v=vs.110).aspx).
 
-Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
+
+Rely on the environment hosting the endpoint process for it to be automatically restarted.
+
+- IIS: When hosting in IIS the IIS host will automatically spawn a new instance
+- Windows Service: The OS can restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
 
 
 WARNING: It is important to consider the effect these defaults will have on other things hosted in the same process. For example if co-hosting NServiceBus with a web-service or website.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -49,7 +49,7 @@ When self hosting the critical error callback must be overriden in order to exit
 
 NOTE: If not killing the process and just disposing the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 
-Consider the following things when implementing a critical error callback:
+Consider the following when implementing a critical error callback:
 
 - If calling any code wrap it in a `try..finally`, making sure the process will invoke exit code in the `finally` like `Environment.FailFast` if any code fails.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -51,7 +51,7 @@ NOTE: If not killing the process and just disposing the bus, be aware that any `
 
 Consider the following things when implementing a critical error callback:
 
-- Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
+- Wrap any code in a `try..finally`, making sure the process will exit if any tasks fail.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
  - Flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 - Flush any state/caches used if such data structures would be written/persisted at a certain interval or regular graceful shutdown.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -56,9 +56,9 @@ NOTE: If the endpoint is stopped without exiting the process, then any `Send` op
 
 When implementing a custom critical error callback:
 
-- To exit the process use the [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) method. In case of send-only endpoints, also [Environment.Exit](https://msdn.microsoft.com/en-us/library/system.environment.exit(v=vs.110).aspx) may be used.
+- To exit the process use the [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) method. In case the environment has threads running that should be completed before shutdown (e.g. non transactional operations), one may also use the [Environment.Exit](https://msdn.microsoft.com/en-us/library/system.environment.exit(v=vs.110).aspx) method.
 - The code should be wrapped in a `try...finally` clause. In the `try` block perform any custom operations, in the `finally` block call the method that exits the process.
-- The custom operations should include flushing any in-memory state and cached data, if normally its persisted at a certain interval or during graceful shutdown. For example, flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
+- The custom operations should include flushing any in-memory state and cached data, if normally its persisted at a certain interval or during graceful shutdown. For example, flush appenders if you are using buffering or asynchrounous appanders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 
 Whenever possible rely on the environment hosting the endpoint process to automatically restart it:
 - IIS: The IIS host will automatically spawn a new instance.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -43,13 +43,11 @@ Next define what action to take when this scenario occurs:
 snippet:CustomHostErrorHandlingAction
 
 
-## When to override the default action
+## When to override the default critical error action
 
 When self hosting the critical error callback must be overriden in order to exit the current process. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
 
 NOTE: If not killing the process and just disposing the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
-
-When the [NServiceBus Host](/nservicebus/hosting/nservicebus-host) is used it is not required to override this callback as the host has a default implementation that exits the process. However, if it is required to execute tasks just before shutdown then it can be overriden in the same way as when self hosting.
 
 Consider the following things when implementing a critical error callback:
 
@@ -60,6 +58,9 @@ Consider the following things when implementing a critical error callback:
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 
 Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
+
+
+WARNING: It is important to consider the effect these defaults will have on other things hosted in the same process. For example if co-hosting NServiceBus with a web-service or website.
 
 
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -51,7 +51,7 @@ NOTE: If not killing the process and just disposing the bus, be aware that any `
 
 Consider the following things when implementing a critical error callback:
 
-- Wrap any code in a `try..finally`, making sure the process will exit if any tasks fail.
+- If calling any code wrap it in a `try..finally`, making sure the process will invoke exit code in the `finally` like `Environment.FailFast` if any code fails.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
  - Flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 - Flush any state/caches used if such data structures would be written/persisted at a certain interval or regular graceful shutdown.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -53,7 +53,7 @@ Consider the following things when implementing a critical error callback:
 
 - Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
- - Flush NLog or log4net state by calling `LogManager.Shutdown();`, this still isn't 100% guaranteed to not loose any log entries. Check each logging framework its document.
+ - Flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
 - Flush any state/caches used if normally such data structures are would persisted in a certain interval or at graceful shutdown.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -45,7 +45,7 @@ snippet:CustomHostErrorHandlingAction
 
 ## When to override the default critical error action
 
-When self hosting the critical error callback must be overriden in order to exit the current process. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
+When self hosting the critical error callback must be overridden in order to exit the current process. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
 
 NOTE: If not killing the process and just disposing the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -50,11 +50,11 @@ When self hosting the should be overriden in order to exit the current process u
 Consider the following things when implementing a critical error callback:
 
 - Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
-- Flush any loggers used which makes sure any unwritten tail of the log is persisted as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process
+- Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
 - Flush any state/caches used if you normally would flush such data structure in a certain interval.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 
-Rely on the environemnt that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
+Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.
 
 NOTE: If not killing the process and just dispose the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -54,7 +54,7 @@ Consider the following things when implementing a critical error callback:
 - Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
  - Flush appenders for [NLog](http://nlog-project.org/documentation/v4.3.0/html/M_NLog_LogManager_Shutdown.htm) or [log4net](https://logging.apache.org/log4net/log4net-1.2.11/release/sdk/log4net.LogManager.Shutdown.html) state by calling `LogManager.Shutdown();`.
-- Flush any state/caches used if normally such data structures are would persisted in a certain interval or at graceful shutdown.
+- Flush any state/caches used if such data structures would be written/persisted at a certain interval or regular graceful shutdown.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 
 Rely on the environment that the process will be automatically restarted. When hosting in IIS the IIS host will automatically spawn a new instance and when hosting as a Windows Service the OS will restart the service after 1 minute if [Windows Service Recovery](/nservicebus/hosting/windows-service.md#installation-restart-recovery) is enabled.

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -51,6 +51,7 @@ Consider the following things when implementing a critical error callback:
 
 - Wrap any tasks in a `try..finally`, making sure the process will exit if any tasks fail.
 - Flush any loggers used which makes sure any unwritten log state is written/pushed to its target(s) making sure the tail of the log is not lost as [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx) will immediately exit the process.
+ - Flush NLog or log4net state by calling `LogManager.Shutdown();`, this still isn't 100% guaranteed to not loose any log entries. Check each logging framework its document.
 - Flush any state/caches used if you normally would flush such data structure in a certain interval.
 - It is easiest to call [Environment.FailFast](https://msdn.microsoft.com/en-us/library/dd289240.aspx)
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -45,7 +45,7 @@ snippet:CustomHostErrorHandlingAction
 
 ## When to override the default critical error action
 
-When self hosting the critical error callback must be overridden in order to exit the current process. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
+The default behavior is to stop the endpoint and not the process. It is recommended to exit the process when a critical error occurs. Not overriding the critical error callback will result in the endpoint instance to stop processing messages without the ability to recover from this state.
 
 NOTE: If not killing the process and just disposing the bus, be aware that any `Send` operations will result in [ObjectDisposedException](https://msdn.microsoft.com/en-us/library/system.objectdisposedexception.aspx) being thrown.
 

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -27,6 +27,8 @@ There are several approaches to hosting.
  * [Endpoint Lifecycle](/nservicebus/lifecycle/)
  * [Critical Error handling](critical-errors.md)
 
+NOTE: Be aware of critical errors, not configuring a critical error callback makes your endpoints unresponsive without terminating the process.
+
 Related:
 
  * [Self-Hosting Sample](/samples/hosting/self-hosting/) for more details.

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -27,7 +27,7 @@ There are several approaches to hosting.
  * [Endpoint Lifecycle](/nservicebus/lifecycle/)
  * [Critical Error handling](critical-errors.md)
 
-NOTE: Be aware of critical errors, not configuring a critical error callback makes your endpoints unresponsive without terminating the process.
+NOTE: Be aware of critical errors, not configuring a critical error callback makes an endpoints unresponsive after a critical error without terminating the process.
 
 Related:
 

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -27,7 +27,7 @@ There are several approaches to hosting.
  * [Endpoint Lifecycle](/nservicebus/lifecycle/)
  * [Critical Error handling](critical-errors.md)
 
-NOTE: Be aware of critical errors, not configuring a critical error callback makes an endpoints unresponsive after a critical error without terminating the process.
+Note: Override the default critical error callback when self-hosting NServiceBus. By default NServiceBus will stop the endpoint without exiting the process. Refer to the [Critical Errors](/nservicebus/hosting/critical-errors.md) article for more information.
 
 Related:
 

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -27,7 +27,7 @@ There are several approaches to hosting.
  * [Endpoint Lifecycle](/nservicebus/lifecycle/)
  * [Critical Error handling](critical-errors.md)
 
-Note: Override the default critical error callback when self-hosting NServiceBus. By default NServiceBus will stop the endpoint without exiting the process. Refer to the [Critical Errors](/nservicebus/hosting/critical-errors.md) article for more information.
+Note: Override the default critical error callback when self-hosting NServiceBus. By default NServiceBus will stop the endpoint instance without exiting the process. Refer to the [Critical Errors](/nservicebus/hosting/critical-errors.md) article for more information.
 
 Related:
 

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -93,7 +93,7 @@ The default [Critical Error Action](/nservicebus/hosting/critical-errors.md) for
 
 snippet:DefaultHostCriticalErrorAction
 
-It is not required to override this callback. However, if it is required to execute tasks just before shutdown then it can be overridden in the same way as when self hosting. See [When to override the default critical error action](/nservicebus/hosting/critical-errors.md#when-to-override-the-default-critical-error-action) for guidance.
+It is not required to override this callback. However, if it is required to execute code just before shutdown then it can be overridden in the same way as when self hosting. See [When to override the default critical error action](/nservicebus/hosting/critical-errors.md#when-to-override-the-default-critical-error-action) for guidance.
 
 
 ## Performance Counters

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -93,7 +93,7 @@ The default [Critical Error Action](/nservicebus/hosting/critical-errors.md) for
 
 snippet:DefaultHostCriticalErrorAction
 
-WARNING: It is important to consider the effect these defaults will have on other things hosted in the same process. For example if co-hosting NServiceBus with a web-service or website.
+It is not required to override this callback. However, if it is required to execute tasks just before shutdown then it can be overridden in the same way as when self hosting. See [When to override the default critical error action](/nservicebus/hosting/critical-errors.md#when-to-override-the-default-critical-error-action) for guidance.
 
 
 ## Performance Counters

--- a/nservicebus/hosting/nservicebus-host/index.md
+++ b/nservicebus/hosting/nservicebus-host/index.md
@@ -93,7 +93,7 @@ The default [Critical Error Action](/nservicebus/hosting/critical-errors.md) for
 
 snippet:DefaultHostCriticalErrorAction
 
-It is not required to override this callback. However, if it is required to execute code just before shutdown then it can be overridden in the same way as when self hosting. See [When to override the default critical error action](/nservicebus/hosting/critical-errors.md#when-to-override-the-default-critical-error-action) for guidance.
+The default callback should be overriden, if some custom code should be executed before exiting the process, such as persisting some in-memory data, flushing the loggers, etc. Refer to the [Critical Errors](/nservicebus/hosting/critical-errors.md) article for more information.
 
 
 ## Performance Counters


### PR DESCRIPTION
Based on https://particularsoftware.slack.com/files/ramon/F3ZJCG747/double_finaly_on_critical_error_to_flush_configured_custom_logger_before_failfast.md