### PR TITLE
Removed "using in a saga"

### DIFF
--- a/nservicebus/sql-persistence/index.md
+++ b/nservicebus/sql-persistence/index.md
@@ -112,7 +112,3 @@ The current [DbConnection](https://msdn.microsoft.com/en-us/library/system.data.
 
 snippet: handler-sqlPersistenceSession
 
-
-### Using in a Saga
-
-snippet: saga-sqlPersistenceSession


### PR DESCRIPTION
Sagas shouldn't be talking to databases - only managing their own state. As such, showing people how to use it in a saga is guiding them down the wrong path.