### PR TITLE
Add description to sample

### DIFF
--- a/samples/encryption/basic-encryption/sample.md
+++ b/samples/encryption/basic-encryption/sample.md
@@ -1,5 +1,6 @@
 ---
 title: Message Property Encryption
+summary: Encrypting specific parts of a message using the message property encryption feature.
 reviewed: 2017-02-08
 component: PropertyEncryption
 tags:


### PR DESCRIPTION
A description is missing e.g. when looking at the encryption samples page: https://docs.particular.net/samples/encryption/