### PR TITLE
Tidy up MVC Send sample

### DIFF
--- a/samples/web/send-from-mvc-controller/Core_6/WebApplication/Global.asax.cs
+++ b/samples/web/send-from-mvc-controller/Core_6/WebApplication/Global.asax.cs
@@ -34,15 +34,15 @@ public class MvcApplication :
 
         endpoint = Endpoint.Start(endpointConfiguration).GetAwaiter().GetResult();
 
-        var updater = new ContainerBuilder();
-        updater.RegisterInstance(endpoint);
+        var mvcContainerBuilder = new ContainerBuilder();
+        mvcContainerBuilder.RegisterInstance(endpoint);
 
         // Register MVC controllers.
-        updater.RegisterControllers(typeof(MvcApplication).Assembly);
+        mvcContainerBuilder.RegisterControllers(typeof(MvcApplication).Assembly);
 
-        var updated = updater.Build();
+        var mvcContainer = mvcContainerBuilder.Build();
 
-        DependencyResolver.SetResolver(new AutofacDependencyResolver(updated));
+        DependencyResolver.SetResolver(new AutofacDependencyResolver(mvcContainer));
 
         AreaRegistration.RegisterAllAreas();
         RegisterRoutes(RouteTable.Routes);

--- a/samples/web/send-from-mvc-controller/Core_6/WebApplication/Global.asax.cs
+++ b/samples/web/send-from-mvc-controller/Core_6/WebApplication/Global.asax.cs
@@ -15,18 +15,8 @@ public class MvcApplication :
     {
         #region ApplicationStart
 
-        var builder = new ContainerBuilder();
-
-        // Set the dependency resolver to be Autofac.
-        var container = builder.Build();
-
         var endpointConfiguration = new EndpointConfiguration("Samples.MvcInjection.WebApplication");
-        // instruct NServiceBus to use a custom AutoFac configuration
-        endpointConfiguration.UseContainer<AutofacBuilder>(
-            customizations: customizations =>
-            {
-                customizations.ExistingLifetimeScope(container);
-            });
+
         endpointConfiguration.UseSerialization<JsonSerializer>();
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();


### PR DESCRIPTION
The endpoint no longer needs a custom container because we aren't updating it.

The MVC application container was still called updated based on when we were updating the Endpoint container. If we are no longer doing that, it should be called something else.