### PR TITLE
Remove redundant paragraph from 4.x callbacks page

### DIFF
--- a/nservicebus/rabbitmq/callbacks.md
+++ b/nservicebus/rabbitmq/callbacks.md
@@ -8,7 +8,4 @@ related:
  - nservicebus/messaging/callbacks
 ---
 
-When scaling out an endpoint, any of the endpoint instances can consume messages from the same shared broker queue. However, this behavior can cause problems when dealing with callback messages because the reply message for the callback needs to go to the specific instance that requested the callback.
-
-
 partial: queue

--- a/nservicebus/rabbitmq/callbacks_queue_rabbit_[,3].partial.md
+++ b/nservicebus/rabbitmq/callbacks_queue_rabbit_[,3].partial.md
@@ -1,3 +1,5 @@
+When scaling out an endpoint, any of the endpoint instances can consume messages from the same shared broker queue. However, this behavior can cause problems when dealing with callback messages because the reply message for the callback needs to go to the specific instance that requested the callback.
+
 Callbacks are enabled by default, and the transport will create a separate callback receiver queue, named `{endpointname}.{machinename}`, to which all callbacks are routed.
 
 


### PR DESCRIPTION
This moves the paragraph that is redundant for the 4.x page into the 3.x and older partial.