### PR TITLE
Rework custom audit sample doc

### DIFF
--- a/samples/pipeline/audit-filtering/sample.md
+++ b/samples/pipeline/audit-filtering/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Audit filter pipeline extension
 summary: Extending the pipeline to stop certain messages from being audited.
-reviewed: 2016-06-01
+reviewed: 2017-02-21
 component: Core
 tags:
  - Pipeline
@@ -21,31 +21,11 @@ This sample shows how to extend the pipeline with custom behaviors to add filter
 
 The solution contains a single endpoint with auditing enabled. The endpoint sends one `AuditThisMessage` and one `DoNotAuditThisMessage` to itself on startup. Both messages are handled by message handlers but `DoNotAuditThisMessage` should not be moved to the audit queue.
 
-Three behaviors are added to the message processing pipeline to implement the desired filtering logic:
+partial:filtering
+
+The filtering logic then needs to be registered in the pipeline:
 
 snippet:addFilterBehaviors
-
-
-
-### AuditFilterContextBehavior
-
-This behavior adds a class to the pipeline contexts `Extensions` bag. This class can later be accessed by the other behaviors to share state across behaviors. The state needs to be added early in the pipeline because anything added to the `Extensions` after the `IIncomingPhysicalMessageContext` is invisible to the `IAuditContext`.
-
-snippet:auditFilterContextBehavior
-
-
-### AuditRulesBehavior
-
-The `AuditRulesBehavior` uses the `IIncomingLogicalMessageContext` to inspect the incoming message type and applies its rules to determine whether that message should be audited or not. If the message should not be audited, it retrieves the shared state from the context's `Extensions` and marks the message.
-
-snippet:auditRulesBehavior
-
-
-### AuditFilterBehavior
-
-This behavior is invoked for every message which is sent to the audit queue. By retrieving the shared state and checking its value, this behavior can stop the auditing pipeline by not invoking the next step.
-
-snippet:auditFilterBehavior
 
 
 ## Running the Code

--- a/samples/pipeline/audit-filtering/sample_filtering_core[6.0,).partial.md
+++ b/samples/pipeline/audit-filtering/sample_filtering_core[6.0,).partial.md
@@ -1,0 +1,22 @@
+Three behaviors are added to the message processing pipeline to implement the desired filtering logic:
+
+
+### AuditFilterContextBehavior
+
+This behavior adds a class to the pipeline contexts `Extensions` bag. This class can later be accessed by the other behaviors to share state across behaviors. The state needs to be added early in the pipeline because anything added to the `Extensions` after the `IIncomingPhysicalMessageContext` is invisible to the `IAuditContext`.
+
+snippet:auditFilterContextBehavior
+
+
+### AuditRulesBehavior
+
+The `AuditRulesBehavior` uses the `IIncomingLogicalMessageContext` to inspect the incoming message type and applies its rules to determine whether that message should be audited or not. If the message should not be audited, it retrieves the shared state from the context's `Extensions` and marks the message.
+
+snippet:auditRulesBehavior
+
+
+### AuditFilterBehavior
+
+This behavior is invoked for every message which is sent to the audit queue. By retrieving the shared state and checking its value, this behavior can stop the auditing pipeline by not invoking the next step.
+
+snippet:auditFilterBehavior

--- a/samples/pipeline/audit-filtering/sample_filtering_core_[5.0,6.0).partial.md
+++ b/samples/pipeline/audit-filtering/sample_filtering_core_[5.0,6.0).partial.md
@@ -1,0 +1,5 @@
+To implement the desired filtering logic, a custom audit behavior is required:
+
+snippet:auditRulesBehavior
+
+NOTE: Since the behavior is going to replace the existing audit behavior, it is necessary to ensure the audit logic is handled completely by the new behavior. This is done by copying the logic from the core's `AuditBehavior` to the custom behavior.


### PR DESCRIPTION
Adjust the samples docs to work better with the v5 sample provided by @indualagarsamy in the target branch which replaces the complete audit behavior instead of registering additional pipeline behaviors.

@Particular/docs-maintainers thoughts?