### PR TITLE
Native MySQL requires at least Server 5.7

### DIFF
--- a/nservicebus/sql-persistence/index.md
+++ b/nservicebus/sql-persistence/index.md
@@ -14,7 +14,7 @@ The SQL Persistence uses [Json.NET](http://www.newtonsoft.com/json) to serialize
 ## Supported SQL Implementations
 
  * [SQL Server](https://www.microsoft.com/en-au/sql-server/)
- * [MySql](https://www.mysql.com/)
+ * [MySql](https://www.mysql.com/) (5.7 or greater)
 
 
 ## Usage


### PR DESCRIPTION
Discovered that native SQL persister won't work with 5.6 or lower (which is default version right now for an RDS instance, by the way) because the json datatype wasn't added until 5.7.

@SimonCropp is there a better way to call this out in doco?