### PR TITLE
Highlights method order invocation is importat

### DIFF
--- a/nservicebus/testing/index_teststructure_testing_[4,6).partial.md
+++ b/nservicebus/testing/index_teststructure_testing_[4,6).partial.md
@@ -3,7 +3,7 @@ The tests have to follow a well-defined structure, otherwise a subtle issues mig
 
 Before executing any test method, it is necessary to call the `Test.Initialize()` method (or any of its overloads).
 
-The tests are written using fluent API, but expectations should be generally specified before invoking the tested behaviour (the exception is testing saga timeouts).
+NOTE: The tests are written using fluent API, but expectations should be generally specified before invoking the tested behaviour (the exception is testing saga timeouts).
 
 If [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md) is used, the conventions must be configured in the `Test.Initialize()` method:
 


### PR DESCRIPTION
Had a couple of cases where people complained about Test Fluent API in V5 being susceptible to method invocation order. In our doco it is specified https://docs.particular.net/nservicebus/testing/?version=testing_5#structure that order is important, but probably it is not enough highlighted.

Adding a `NOTE: ` to make it bolder.

@Particular/docs-maintainers please review.