### PR TITLE
Clarify that installers always run with debugger attached

### DIFF
--- a/nservicebus/operations/installers.md
+++ b/nservicebus/operations/installers.md
@@ -30,3 +30,5 @@ snippet:InstallersRunWhenNecessaryCommandLine
 or by a machine name convention like:
 
 snippet:InstallersRunWhenNecessaryMachineNameConvention
+
+NOTE: Installers are always run when the application is run with a debugger attached. This includes when the application is being debugged remotely.


### PR DESCRIPTION
Ping @Particular/nservicebus-maintainers.

In relation to a support case the customer was not aware of this behavior. This PR adds a quick note to explain that this occurs whenever the debugger is attached.