### PR TITLE
Custom routing refresh exception handling

### DIFF
--- a/samples/routing/custom/Core_6/Shared/AutomaticRouting/AutomaticRoutingFeature.cs
+++ b/samples/routing/custom/Core_6/Shared/AutomaticRouting/AutomaticRoutingFeature.cs
@@ -31,7 +31,9 @@ class AutomaticRoutingFeature :
         // Create the infrastructure
         var dataAccess = new SqlDataAccess(uniqueKey, connectionString);
 
-        context.RegisterStartupTask(builder => new RoutingInfoCommunicator(dataAccess, builder.Build<CriticalError>()));
+        context.Container.ConfigureComponent(builder => new RoutingInfoCommunicator(dataAccess, builder.Build<CriticalError>()), DependencyLifecycle.SingleInstance);
+
+        context.RegisterStartupTask(builder => builder.Build<RoutingInfoCommunicator>());
 
         // Register the routing info publisher
         context.RegisterStartupTask(builder =>

--- a/samples/routing/custom/Core_6/Shared/AutomaticRouting/AutomaticRoutingFeature.cs
+++ b/samples/routing/custom/Core_6/Shared/AutomaticRouting/AutomaticRoutingFeature.cs
@@ -30,8 +30,8 @@ class AutomaticRoutingFeature :
 
         // Create the infrastructure
         var dataAccess = new SqlDataAccess(uniqueKey, connectionString);
-        var communicator = new RoutingInfoCommunicator(dataAccess);
-        context.RegisterStartupTask(communicator);
+
+        context.RegisterStartupTask(builder => new RoutingInfoCommunicator(dataAccess, builder.Build<CriticalError>()));
 
         // Register the routing info publisher
         context.RegisterStartupTask(builder =>
@@ -39,7 +39,7 @@ class AutomaticRoutingFeature :
             var handlerRegistry = builder.Build<MessageHandlerRegistry>();
             var messageTypesHandled = GetHandledCommands(handlerRegistry, conventions);
             return new RoutingInfoPublisher(
-                dataBackplane: communicator,
+                dataBackplane: builder.Build<RoutingInfoCommunicator>(),
                 hanledMessageTypes: messageTypesHandled,
                 publishedMessageTypes: messageTypesPublished,
                 settings: settings,
@@ -58,6 +58,7 @@ class AutomaticRoutingFeature :
                 publishers: publishers,
                 sweepPeriod: TimeSpan.FromSeconds(5),
                 heartbeatTimeout: TimeSpan.FromSeconds(20));
+            var communicator = builder.Build<RoutingInfoCommunicator>();
             communicator.Changed = subscriber.OnChanged;
             communicator.Removed = subscriber.OnRemoved;
             return subscriber;

--- a/samples/routing/custom/Core_6/Shared/ICircuitBreaker.cs
+++ b/samples/routing/custom/Core_6/Shared/ICircuitBreaker.cs
@@ -1,0 +1,8 @@
+using System;
+using System.Threading.Tasks;
+
+interface ICircuitBreaker
+{
+    void Success();
+    Task Failure(Exception exception);
+}

--- a/samples/routing/custom/Core_6/Shared/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/samples/routing/custom/Core_6/Shared/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.Logging;
+
+class RepeatedFailuresOverTimeCircuitBreaker : IDisposable, ICircuitBreaker
+{
+    public RepeatedFailuresOverTimeCircuitBreaker(string name, TimeSpan timeToWaitBeforeTriggering, Action<Exception> triggerAction)
+    {
+        this.name = name;
+        this.triggerAction = triggerAction;
+        this.timeToWaitBeforeTriggering = timeToWaitBeforeTriggering;
+
+        timer = new Timer(CircuitBreakerTriggered);
+    }
+
+    public void Success()
+    {
+        var oldValue = Interlocked.Exchange(ref failureCount, 0);
+
+        if (oldValue == 0)
+        {
+            return;
+        }
+
+        timer.Change(Timeout.Infinite, Timeout.Infinite);
+        Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+    }
+
+    public Task Failure(Exception exception)
+    {
+        lastException = exception;
+        var newValue = Interlocked.Increment(ref failureCount);
+
+        if (newValue == 1)
+        {
+            timer.Change(timeToWaitBeforeTriggering, NoPeriodicTriggering);
+            Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+        }
+
+        return Task.Delay(TimeSpan.FromSeconds(1));
+    }
+
+    public void Dispose()
+    {
+        //Injected
+    }
+
+    void CircuitBreakerTriggered(object state)
+    {
+        if (Interlocked.Read(ref failureCount) > 0)
+        {
+            Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+            triggerAction(lastException);
+        }
+    }
+
+    long failureCount;
+    Exception lastException;
+
+    string name;
+    Timer timer;
+    TimeSpan timeToWaitBeforeTriggering;
+    Action<Exception> triggerAction;
+
+    static TimeSpan NoPeriodicTriggering = TimeSpan.FromMilliseconds(-1);
+    static ILog Logger = LogManager.GetLogger<RepeatedFailuresOverTimeCircuitBreaker>();
+}

--- a/samples/routing/custom/Core_6/Shared/Shared.csproj
+++ b/samples/routing/custom/Core_6/Shared/Shared.csproj
@@ -45,7 +45,9 @@
     <Compile Include="AutomaticRoutingConst.cs" />
     <Compile Include="AutomaticRouting\AdvertisePublishingSettings.cs" />
     <Compile Include="AutomaticRouting\AutomaticRoutingFeature.cs" />
+    <Compile Include="ICircuitBreaker.cs" />
     <Compile Include="AutomaticRouting\Installer.cs" />
+    <Compile Include="RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="AutomaticRouting\RoutingInfoCommunicator.cs" />
     <Compile Include="AutomaticRouting\AutomaticRoutingConfigExtensions.cs" />
     <Compile Include="AutomaticRouting\EndpointInstanceInfo.cs" />


### PR DESCRIPTION
Current implementation crashed when there is a temporary error on the database. Also have execution overlap protection added in case the refresh operation duration is larger then the timer interval period.