### PR TITLE
Update InstancePerUnitOfWorkRegistration to use InstancePerUnitOfWork lifecycle

### DIFF
--- a/Snippets/Core/Core_3/InstancePerUnitOfWorkRegistration.cs
+++ b/Snippets/Core/Core_3/InstancePerUnitOfWorkRegistration.cs
@@ -11,7 +11,7 @@
             #region InstancePerUnitOfWorkRegistration
 
             var configureComponents = configuration.Configurer;
-            configureComponents.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerCall);
+            configureComponents.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerUnitOfWork);
 
             #endregion
         }

--- a/Snippets/Core/Core_4/InstancePerUnitOfWorkRegistration.cs
+++ b/Snippets/Core/Core_4/InstancePerUnitOfWorkRegistration.cs
@@ -11,7 +11,7 @@
             #region InstancePerUnitOfWorkRegistration
 
             var configureComponents = configuration.Configurer;
-            configureComponents.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerCall);
+            configureComponents.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerUnitOfWork);
 
             #endregion
         }

--- a/Snippets/Core/Core_5/InstancePerUnitOfWorkRegistration.cs
+++ b/Snippets/Core/Core_5/InstancePerUnitOfWorkRegistration.cs
@@ -13,7 +13,7 @@
             busConfiguration.RegisterComponents(
                 registration: components =>
                 {
-                    components.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerCall);
+                    components.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerUnitOfWork);
                 });
 
             #endregion

--- a/Snippets/Core/Core_6/InstancePerUnitOfWorkRegistration.cs
+++ b/Snippets/Core/Core_6/InstancePerUnitOfWorkRegistration.cs
@@ -14,7 +14,7 @@
             endpointConfiguration.RegisterComponents(
                 registration: components =>
                 {
-                    components.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerCall);
+                    components.ConfigureComponent<MyUnitOfWork>(DependencyLifecycle.InstancePerUnitOfWork);
                 });
 
             #endregion


### PR DESCRIPTION
Update the snippets to show `InstancePerUnitOfWork` instead of `InstancePerCall`.