### PR TITLE
WIP: fix RowVersion usage

### DIFF
--- a/Snippets/NHibernate/NHibernate_6/Concurrency/SagaDataWithRowVersion.cs
+++ b/Snippets/NHibernate/NHibernate_6/Concurrency/SagaDataWithRowVersion.cs
@@ -3,9 +3,13 @@ using NServiceBus.SagaPersisters.NHibernate;
 
 #region NHibernateConcurrencyRowVersion
 public class SagaDataWithRowVersion :
-    ContainSagaData
+    IContainSagaData
 {
     [RowVersion]
-    public int MyVersion { get; set; }
+    public virtual int MyVersion { get; set; }
+    
+    public virtual string OriginalMessageId { get; set; }
+    public virtual string Originator { get; set; }
+    public virtual Guid Id { get; set; }
 }
 #endregion

--- a/Snippets/NHibernate/NHibernate_6/Concurrency/SagaDataWithRowVersion.cs
+++ b/Snippets/NHibernate/NHibernate_6/Concurrency/SagaDataWithRowVersion.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus.Saga;
+﻿using System;
+using NServiceBus.Saga;
 using NServiceBus.SagaPersisters.NHibernate;
 
 #region NHibernateConcurrencyRowVersion

--- a/Snippets/NHibernate/NHibernate_7/Concurrency/SagaDataWithRowVersion.cs
+++ b/Snippets/NHibernate/NHibernate_7/Concurrency/SagaDataWithRowVersion.cs
@@ -3,9 +3,13 @@ using NServiceBus.SagaPersisters.NHibernate;
 
 #region NHibernateConcurrencyRowVersion
 public class SagaDataWithRowVersion :
-    ContainSagaData
+    IContainSagaData
 {
     [RowVersion]
-    public int MyVersion { get; set; }
+    public virtual int MyVersion { get; set; }
+    
+    public virtual string OriginalMessageId { get; set; }
+    public virtual string Originator { get; set; }
+    public virtual Guid Id { get; set; }
 }
 #endregion

--- a/Snippets/NHibernate/NHibernate_7/Concurrency/SagaDataWithRowVersion.cs
+++ b/Snippets/NHibernate/NHibernate_7/Concurrency/SagaDataWithRowVersion.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System;
+using NServiceBus;
 using NServiceBus.SagaPersisters.NHibernate;
 
 #region NHibernateConcurrencyRowVersion

--- a/nservicebus/nhibernate/saga-concurrency.md
+++ b/nservicebus/nhibernate/saga-concurrency.md
@@ -30,7 +30,7 @@ That property will be included by NHibernate in the `SELECT` and `UPDATE` SQL st
 
 NOTE: Marking a property with `RowVersion` **does not** disable the pessimistic locking optimization. All it does is replacing the default optimistic concurrency validation that depends on values of all columns with one that is based on that single explicit version column. To switch to pure optimistic concurrency adjust the locking strategy to `Read`.
 
-NOTE: NHibernate doesn't support `RowVersion` attribute when used on derived classes. Instead of inheriting saga data from the `ContainSagaData` class, directly implement the `IContainSagaData` interface.
+NOTE: `RowVersion` attribute is not supported when used on derived classes. To specify a custom row version property don't inherit saga data from the `ContainSagaData` class, instead directly implement the `IContainSagaData` interface.
 
 In most cases where the saga data table is only ever accessed by the saga persister it is advisable to use an explicit version because the `UPDATE` SQL statement is much simpler and faster. The downside is that it does not detect concurrency violations if the data is updated by some external party that does not conform to the protocol i.e. does not bump the version field when doing updates. If such an external modification is possible, e.g. when different business process touches the same set of data, it is better to use the default optimistic concurrency validation strategy.
 

--- a/nservicebus/nhibernate/saga-concurrency.md
+++ b/nservicebus/nhibernate/saga-concurrency.md
@@ -30,6 +30,8 @@ That property will be included by NHibernate in the `SELECT` and `UPDATE` SQL st
 
 NOTE: Marking a property with `RowVersion` **does not** disable the pessimistic locking optimization. All it does is replacing the default optimistic concurrency validation that depends on values of all columns with one that is based on that single explicit version column. To switch to pure optimistic concurrency adjust the locking strategy to `Read`.
 
+NOTE: NHibernate doesn't support `RowVersion` attribute when used on derived classes. Instead of inheriting saga data from the `ContainSagaData` class, directly implement the `IContainSagaData` interface.
+
 In most cases where the saga data table is only ever accessed by the saga persister it is advisable to use an explicit version because the `UPDATE` SQL statement is much simpler and faster. The downside is that it does not detect concurrency violations if the data is updated by some external party that does not conform to the protocol i.e. does not bump the version field when doing updates. If such an external modification is possible, e.g. when different business process touches the same set of data, it is better to use the default optimistic concurrency validation strategy.
 
 ## Adjusting the locking strategy


### PR DESCRIPTION
NHibernate saga concurrency can be implemented using the `RowVersion` attribute, `RowVersion` is not supported when used on derived classes. The only option is to implement the `IContainSagaData` interface directly.

@Particular/nhibernate-persistence-maintainers @Particular/docs-maintainers please review