### PR TITLE
[Core 6.2] Disable obsoletion warnings for config sections

### DIFF
--- a/Snippets/Core/Core_6/Audit/ProvideConfiguration.cs
+++ b/Snippets/Core/Core_6/Audit/ProvideConfiguration.cs
@@ -4,6 +4,7 @@
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
 
+    #pragma warning disable CS0618
     #region AuditProvideConfiguration
 
     class ProvideConfiguration :
@@ -20,4 +21,5 @@
     }
 
     #endregion
+    #pragma warning restore CS0618
 }

--- a/Snippets/Core/Core_6/Headers/Writers/HeaderWriterDefer.cs
+++ b/Snippets/Core/Core_6/Headers/Writers/HeaderWriterDefer.cs
@@ -6,8 +6,6 @@
     using Common;
     using CoreAll.Msmq.QueueDeletion;
     using NServiceBus;
-    using NServiceBus.Config;
-    using NServiceBus.Config.ConfigurationSource;
     using NServiceBus.MessageMutator;
     using NUnit.Framework;
 
@@ -39,6 +37,8 @@
                 {
                     components.ConfigureComponent<Mutator>(DependencyLifecycle.InstancePerCall);
                 });
+            var routing = endpointConfiguration.UseTransport<MsmqTransport>().Routing();
+            routing.RouteToEndpoint(GetType().Assembly, EndpointName);
 
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
@@ -66,21 +66,6 @@
             }
         }
 
-        class ConfigUnicastBus :
-            IProvideConfiguration<UnicastBusConfig>
-        {
-            public UnicastBusConfig GetConfiguration()
-            {
-                var unicastBusConfig = new UnicastBusConfig();
-                var endpointMapping = new MessageEndpointMapping
-                {
-                    AssemblyName = GetType().Assembly.GetName().Name,
-                    Endpoint = $"{EndpointName}@{Environment.MachineName}"
-                };
-                unicastBusConfig.MessageEndpointMappings.Add(endpointMapping);
-                return unicastBusConfig;
-            }
-        }
         class Mutator :
             IMutateIncomingTransportMessages
         {

--- a/Snippets/Core/Core_6/Headers/Writers/HeaderWriterPublish.cs
+++ b/Snippets/Core/Core_6/Headers/Writers/HeaderWriterPublish.cs
@@ -5,8 +5,6 @@
     using Common;
     using CoreAll.Msmq.QueueDeletion;
     using NServiceBus;
-    using NServiceBus.Config;
-    using NServiceBus.Config.ConfigurationSource;
     using NServiceBus.MessageMutator;
     using NUnit.Framework;
 
@@ -38,6 +36,9 @@
                 {
                     components.ConfigureComponent<Mutator>(DependencyLifecycle.InstancePerCall);
                 });
+            var routing = endpointConfiguration.UseTransport<MsmqTransport>().Routing();
+            routing.RouteToEndpoint(GetType().Assembly, EndpointName);
+
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
 
@@ -62,22 +63,6 @@
             public Task Handle(MessageToPublish message, IMessageHandlerContext context)
             {
                 return Task.CompletedTask;
-            }
-        }
-
-        class ConfigUnicastBus :
-            IProvideConfiguration<UnicastBusConfig>
-        {
-            public UnicastBusConfig GetConfiguration()
-            {
-                var unicastBusConfig = new UnicastBusConfig();
-                var endpointMapping = new MessageEndpointMapping
-                {
-                    AssemblyName = GetType().Assembly.GetName().Name,
-                    Endpoint = EndpointName
-                };
-                unicastBusConfig.MessageEndpointMappings.Add(endpointMapping);
-                return unicastBusConfig;
             }
         }
 

--- a/Snippets/Core/Core_6/Logging/ProvideConfiguration.cs
+++ b/Snippets/Core/Core_6/Logging/ProvideConfiguration.cs
@@ -3,6 +3,7 @@
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
 
+    #pragma warning disable CS0618
     #region LoggingThresholdFromIProvideConfiguration
 
     public class ProvideConfiguration :
@@ -18,4 +19,5 @@
     }
 
     #endregion
+    #pragma warning restore CS0618
 }

--- a/Snippets/Core/Core_6/Recoverability/ErrorHandling/ConfigurationSource/ConfigurationSource.cs
+++ b/Snippets/Core/Core_6/Recoverability/ErrorHandling/ConfigurationSource/ConfigurationSource.cs
@@ -4,6 +4,7 @@
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
 
+    #pragma warning disable CS0618
     #region ErrorQueueConfigurationSource
     public class ConfigurationSource :
         IConfigurationSource
@@ -25,4 +26,5 @@
         }
     }
     #endregion
+    #pragma warning restore CS0618
 }

--- a/Snippets/Core/Core_6/Recoverability/ErrorHandling/ProvideConfiguration.cs
+++ b/Snippets/Core/Core_6/Recoverability/ErrorHandling/ProvideConfiguration.cs
@@ -3,6 +3,7 @@
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
 
+    #pragma warning disable CS0618
     #region ErrorQueueConfigurationProvider
 
     class ProvideConfiguration :
@@ -18,6 +19,7 @@
     }
 
     #endregion
+    #pragma warning restore CS0618
 }
 
 

--- a/Snippets/Core/Core_6/Routing/EndpointMapping/ConfigurationSource/ConfigurationSource.cs
+++ b/Snippets/Core/Core_6/Routing/EndpointMapping/ConfigurationSource/ConfigurationSource.cs
@@ -3,7 +3,7 @@
     using System.Configuration;
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
-
+    #pragma warning disable CS0618
     #region endpoint-mapping-configurationsource
     public class ConfigurationSource :
         IConfigurationSource
@@ -37,4 +37,5 @@
         }
     }
     #endregion
+    #pragma warning restore CS0618
 }

--- a/Snippets/Core/Core_6/Routing/EndpointMapping/ProvideConfiguration.cs
+++ b/Snippets/Core/Core_6/Routing/EndpointMapping/ProvideConfiguration.cs
@@ -4,6 +4,7 @@
     using NServiceBus.Config;
     using NServiceBus.Config.ConfigurationSource;
 
+    #pragma warning disable CS0618
     #region endpoint-mapping-configurationprovider
     public class ProvideConfiguration :
         IProvideConfiguration<UnicastBusConfig>
@@ -32,4 +33,5 @@
         }
     }
     #endregion
+    #pragma warning restore CS0618
 }

--- a/Snippets/Core/Core_6/project.json
+++ b/Snippets/Core/Core_6/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NServiceBus": "6.2.0-alpha0219",
+    "NServiceBus": "6.2.0-alpha0282",
     "NServiceBus.Autofac": "6.*",
     "NServiceBus.Callbacks": "1.*",
     "NServiceBus.NHibernate": "7.*",


### PR DESCRIPTION
@Particular/docs-maintainers I think it might make sense to pull this in before the 6.2 release (removing the package update of course).