### PR TITLE
Clarify order of pipeline execution

### DIFF
--- a/nservicebus/pipeline/steps-stages-connectors_extra_core_[6.0,).partial.md
+++ b/nservicebus/pipeline/steps-stages-connectors_extra_core_[6.0,).partial.md
@@ -37,6 +37,7 @@ Forwarding[Forwarding]
 Audit[Audit]
 Dispatch
 end
+
 end
 
 AncillaryTransport[Transport]
@@ -46,10 +47,11 @@ RUC[Receiving<br>User Code]
 
 
 Transport --> TR
-IPM -.-> Forwarding
-IPM -.-> Audit
+IPM -- Step 1 --> ILM
+IPM -. Step 2 .-> Forwarding
+IPM -. Step 2 .-> Audit
 ILM --> IH
-IPM --> ILM
+
 TR --> IPM
 IH --> RUC
 


### PR DESCRIPTION
**Changes**:

1. `Ancillary Actions` moved to the bottom to show that message processing is taking the place first
1. Assigned step numbers to highlight the dependency on the message processing before auditing and forwarding can take place

The new rendering looks like the following

![image](https://cloud.githubusercontent.com/assets/1309622/24018993/d2932954-0a5b-11e7-85c3-3e2653d23428.png)

**Reason for the change**:

While reviewing the [Audit filter pipeline extension sample](https://docs.particular.net/samples/pipeline/audit-filtering/) it was not clear how it would work if `"AuditFilter.Rules"` is connected to the expected next execution of the `"AuditFilter.Filter"` behavior if they are not "connected" in any shape or form on the diagram.