### PR TITLE
azure/index.md hidden

### DIFF
--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -4,4 +4,5 @@ summary: Using Azure for endpoint hosting and to provide Transports and Persiste
 tags:
 - Azure
 reviewed: 2016-09-21
+hidden: true
 ---


### PR DESCRIPTION
Hide the index file that because of the packages being separated now, provides no value as there's no one `Azure` thing.