### PR TITLE
Azure landing page with a short intro and links

### DIFF
--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -3,7 +3,7 @@ title: NServiceBus and Azure
 summary: Using Azure for endpoint hosting and to provide Transports and Persistence
 tags:
 - Azure
-reviewed: 2017-03-28
+reviewed: 2017-03-30
 ---
 
 NServiceBus helps create distributed .NET systems not only on premises but also in the Microsoft Azure cloud. It provides a variety of capabilities built for Microsoft Azure such as hosting, Azure specific transports and persistence.
@@ -12,6 +12,11 @@ NServiceBus helps create distributed .NET systems not only on premises but also 
 
  * [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
  * [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
+
+### Self hosting
+
+ * [Azure App Service](/samples/show-case/cloud-azure/) using WebApps and WebJobs
+ * Service Fabric
 
 
 ## Transports

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -6,8 +6,7 @@ tags:
 reviewed: 2017-03-28
 ---
 
-NServiceBus helps create distributed .NET systems not only on premises but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, the cloud closest to .NET. This covers hosting, Azure specific transports and persistence.
-
+NServiceBus helps create distributed .NET systems not only on premises but also in the Microsoft Azure cloud. It provides a variety of capabilities built for Microsoft Azure such as hosting, Azure specific transports and persistence.
 
 ## Hosting
 

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -6,7 +6,7 @@ tags:
 reviewed: 2017-03-28
 ---
 
-NServiceBus helps create distributed systems not only on premise but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, covering hosting, Azure specific transports and persistence.
+NServiceBus helps create distributed .NET systems not only on premises but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, the cloud closest to .NET. This covers hosting, Azure specific transports and persistence.
 
 Hosting:
 - [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -6,14 +6,14 @@ tags:
 reviewed: 2017-03-30
 ---
 
-NServiceBus helps create distributed .NET systems not only on premises but also in the Microsoft Azure cloud. It provides a variety of capabilities built for Microsoft Azure such as hosting, Azure specific transports and persistence.
+NServiceBus helps create distributed .NET systems not only on premises but also in the Microsoft Azure cloud. It provides a variety of capabilities built for Microsoft Azure such as hosting, Azure specific transports, and persistence.
 
 ## Hosting
 
  * [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
  * [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
 
-### Self hosting
+### Self-hosting
 
  * [Azure App Service](/samples/show-case/cloud-azure/) using WebApps and WebJobs
  * Service Fabric

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -8,18 +8,22 @@ reviewed: 2017-03-28
 
 NServiceBus helps create distributed .NET systems not only on premises but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, the cloud closest to .NET. This covers hosting, Azure specific transports and persistence.
 
-Hosting:
-- [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
-- [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
+## Hosting
 
-Transports:
-- [Azure Service Bus Transport](/nservicebus/azure-service-bus/)
-- [Azure Storage Queues](/nservicebus/azure-storage-queues/)
+ * [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
+ * [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
 
-Persistence:
-- [Azure Storage Persistence](/nservicebus/azure-storage-persistence/)
-- [Service Fabric Persistence](/nservicebus/service-fabric/)
+## Transports
 
-Cloud native extensions and samples:
-- [Azure Blob Storage DataBus](/samples/azure/blob-storage-databus/)
-- [Azure Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing/)
+ *[Azure Service Bus Transport](/nservicebus/azure-service-bus/)
+ * [Azure Storage Queues](/nservicebus/azure-storage-queues/)
+
+## Persistence
+
+ * [Azure Storage Persistence](/nservicebus/azure-storage-persistence/)
+ * [Service Fabric Persistence](/nservicebus/service-fabric/)
+
+## Cloud native extensions and samples
+
+ * [Azure Blob Storage DataBus](/samples/azure/blob-storage-databus/)
+ * [Azure Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing/)

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -6,7 +6,7 @@ tags:
 reviewed: 2017-03-28
 ---
 
-With lots of customers moving to the cloud, embracing the public cloud sector is a must have. That is why NServiceBus provides a variety of capabilities built specially for Microsoft Azure, covering hosting, Azure specific transports and persistence.
+NServiceBus helps create distributed systems not only on premise but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, covering hosting, Azure specific transports and persistence.
 
 Hosting:
 - [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -8,10 +8,12 @@ reviewed: 2017-03-30
 
 NServiceBus helps create distributed .NET systems not only on premises but also in the Microsoft Azure cloud. It provides a variety of capabilities built for Microsoft Azure such as hosting, Azure specific transports, and persistence.
 
+
 ## Hosting
 
  * [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
  * [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
+
 
 ### Self-hosting
 

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -8,20 +8,24 @@ reviewed: 2017-03-28
 
 NServiceBus helps create distributed .NET systems not only on premises but also in a public cloud environment. That is why it provides a variety of capabilities built for Microsoft Azure, the cloud closest to .NET. This covers hosting, Azure specific transports and persistence.
 
+
 ## Hosting
 
  * [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
  * [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
 
+
 ## Transports
 
- *[Azure Service Bus Transport](/nservicebus/azure-service-bus/)
+ * [Azure Service Bus Transport](/nservicebus/azure-service-bus/)
  * [Azure Storage Queues](/nservicebus/azure-storage-queues/)
+
 
 ## Persistence
 
  * [Azure Storage Persistence](/nservicebus/azure-storage-persistence/)
  * [Service Fabric Persistence](/nservicebus/service-fabric/)
+
 
 ## Cloud native extensions and samples
 

--- a/nservicebus/azure/index.md
+++ b/nservicebus/azure/index.md
@@ -3,5 +3,23 @@ title: NServiceBus and Azure
 summary: Using Azure for endpoint hosting and to provide Transports and Persistence
 tags:
 - Azure
-reviewed: 2016-09-21
+reviewed: 2017-03-28
 ---
+
+With lots of customers moving to the cloud, embracing the public cloud sector is a must have. That is why NServiceBus provides a variety of capabilities built specially for Microsoft Azure, covering hosting, Azure specific transports and persistence.
+
+Hosting:
+- [Hosting in Azure Cloud Services](/nservicebus/hosting/cloud-services-host/)
+- [Shared Hosting in Azure Cloud Services](/samples/azure/shared-host/)
+
+Transports:
+- [Azure Service Bus Transport](/nservicebus/azure-service-bus/)
+- [Azure Storage Queues](/nservicebus/azure-storage-queues/)
+
+Persistence:
+- [Azure Storage Persistence](/nservicebus/azure-storage-persistence/)
+- [Service Fabric Persistence](/nservicebus/service-fabric/)
+
+Cloud native extensions and samples:
+- [Azure Blob Storage DataBus](/samples/azure/blob-storage-databus/)
+- [Azure Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing/)


### PR DESCRIPTION
PR provides a landing content page for Azure that currently is displayed in multiple places like:
- referenced articles under https://docs.particular.net/nservicebus/
- google search for [NServiceBus Azure](https://www.google.pl/?q=NServiceBus+Azure)

Previous version was empty, but still visible. After discussing it under PR hiding this page #2583 it was  agreed to deliver some content in there.