### PR TITLE
Improve pipeline events page

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -374,6 +374,8 @@
       Title: Unit of Work
     - Url: nservicebus/pipeline/aborting
       Title: Abort execution
+    - Url: nservicebus/pipeline/events
+      Title: Subscribing to notification events
     - Url: nservicebus/pipeline/features
       Title: Features
     - Url: nservicebus/pipeline/customizing-error-handling

--- a/nservicebus/pipeline/events.md
+++ b/nservicebus/pipeline/events.md
@@ -11,19 +11,19 @@ related:
 - nservicebus/recoverability
 ---
 
-The pipeline exposed the following events.
+The pipeline raises the following notification events:
 
 
-## Receive Pipeline completed
+## Receive pipeline completed
 
-Every time a receive pipeline is completed a `ReceivePipelineCompleted` event will be raised. This event will occur even if the message fails to be processed.
+Every time a receive pipeline is completed, a `ReceivePipelineCompleted` event will be raised. This event will occur even if the message fails to be processed.
 
 Use the following configuration code to subscribe to this event:
 
 snippet: ReceivePipelineCompletedSubscriptionFromEndpointConfig
 
-Subscribing from a [feature](/nservicebus/pipeline/features.md) is show below:
+Subscribing from a [feature](/nservicebus/pipeline/features.md) is shown below:
 
 snippet: ReceivePipelineCompletedSubscriptionFromFeature
 
-NOTE: A completed receive pipeline is not the same as the message being removed from the incoming queue. Infrastructure exceptions can still cause the message to be rolled back and reprocessed.
+NOTE: A `ReceivePipelineCompleted` event being raised does not guarantee that the message has been removed from the incoming queue. Infrastructure exceptions can still cause the message to be rolled back and reprocessed.


### PR DESCRIPTION
This adds the new pipeline events pages to the menu, and I also made some changes to the text of the page.

As I was adding a title to the menu, I released that "subscribing to events" is a phrase that already has a lot of meaning, so I added "notification events" in a couple places to help distinguish what's being talked about here.

CC: @Particular/nservicebus-maintainers 