### PR TITLE
Service Fabric hosting

### DIFF
--- a/Snippets/Core/Core_6/Core_6.csproj
+++ b/Snippets/Core/Core_6/Core_6.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Sagas\FindSagas\SynchronizedStorageSessionEx.cs" />
     <Compile Include="Serialization\AdditionalDeserializers.cs" />
     <Compile Include="Serialization\RegisterCustomSerializer.cs" />
+    <Compile Include="ServiceFabricHosting\EndpointCommunicationListener.cs" />
     <Compile Include="TransactionScopeUnitOfWork.cs" />
     <Compile Include="Features\FeatureConfiguration.cs" />
     <Compile Include="Features\MyFeatureWithStartupTasks.cs" />

--- a/Snippets/Core/Core_6/Core_6.csproj
+++ b/Snippets/Core/Core_6/Core_6.csproj
@@ -279,6 +279,9 @@
     <Content Include="Logging\OverrideInAppConfig.xml">
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="ServiceFabricHosting\Gateway.config.xml">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="UpgradeGuides\5to6\null.xml" />
     <None Include="project.json" />
   </ItemGroup>

--- a/Snippets/Core/Core_6/Core_6.csproj
+++ b/Snippets/Core/Core_6/Core_6.csproj
@@ -279,9 +279,6 @@
     <Content Include="Logging\OverrideInAppConfig.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="ServiceFabricHosting\Gateway.config.xml">
-      <SubType>Designer</SubType>
-    </Content>
     <Content Include="UpgradeGuides\5to6\null.xml" />
     <None Include="project.json" />
   </ItemGroup>

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -1,9 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Fabric;
-using System.Threading;
-using System.Threading.Tasks;
-using Core6.ServiceFabricHosting;
-using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace Core6.ServiceFabricHosting
@@ -19,11 +15,6 @@ namespace Core6.ServiceFabricHosting
     public class StatelessEndpointCommunicationListener : ICommunicationListener
     {
         IEndpointInstance endpointInstance;
-
-        public StatelessEndpointCommunicationListener(IReliableStateManager stateManager)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public async Task<string> OpenAsync(CancellationToken cancellationToken)
         {
@@ -62,7 +53,6 @@ namespace Core6.ServiceFabricHosting
         public StatefulEndpointCommunicationListener(IReliableStateManager stateManager)
         {
             this.stateManager = stateManager;
-            throw new System.NotImplementedException();
         }
 
         public async Task<string> OpenAsync(CancellationToken cancellationToken)
@@ -109,16 +99,14 @@ namespace Core6.ServiceFabricHosting
         {
             listener = new StatefulEndpointCommunicationListener(StateManager);
             return new List<ServiceReplicaListener>
-        {
-            new ServiceReplicaListener(context => listener)
-        };
+            {
+                new ServiceReplicaListener(context => listener)
+            };
         }
 
         protected override async Task RunAsync(CancellationToken cancellationToken)
         {
             await listener.RunAsync();
-
-            await base.RunAsync(cancellationToken);
         }
     }
 

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -1,0 +1,40 @@
+﻿namespace Core6.ServiceFabricHosting
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ServiceFabric.Services.Communication.Runtime;
+    using NServiceBus;
+
+    #region EndpointCommunicationListener
+
+    public class EndpointCommunicationListener : ICommunicationListener
+    {
+        IEndpointInstance endpointInstance;
+
+        public async Task<string> OpenAsync(CancellationToken cancellationToken)
+        {
+            var endpointName = "Sales";
+
+            var endpointConfiguration = new EndpointConfiguration(endpointName);
+            
+            // regular endpoint configuration
+
+            endpointInstance = await Endpoint.Start(endpointConfiguration)
+                .ConfigureAwait(false);
+
+            return endpointName;
+        }
+
+        public Task CloseAsync(CancellationToken cancellationToken)
+        {
+            return endpointInstance.Stop();
+        }
+
+        public void Abort()
+        {
+            CloseAsync(CancellationToken.None);
+        }
+    }
+
+    #endregion
+}

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -104,9 +104,9 @@ namespace Core6.ServiceFabricHosting
             };
         }
 
-        protected override async Task RunAsync(CancellationToken cancellationToken)
+        protected override Task RunAsync(CancellationToken cancellationToken)
         {
-            await listener.RunAsync();
+            return listener.RunAsync();
         }
     }
 

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -1,15 +1,29 @@
-﻿namespace Core6.ServiceFabricHosting
+﻿using System.Collections.Generic;
+using System.Fabric;
+using System.Threading;
+using System.Threading.Tasks;
+using Core6.ServiceFabricHosting;
+using Microsoft.ServiceFabric.Services.Communication.Runtime;
+using Microsoft.ServiceFabric.Services.Runtime;
+
+namespace Core6.ServiceFabricHosting
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.ServiceFabric.Data;
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
     using NServiceBus;
 
-    #region EndpointCommunicationListener
+    #region StatelessEndpointCommunicationListener
 
-    public class EndpointCommunicationListener : ICommunicationListener
+    public class StatelessEndpointCommunicationListener : ICommunicationListener
     {
         IEndpointInstance endpointInstance;
+
+        public StatelessEndpointCommunicationListener(IReliableStateManager stateManager)
+        {
+            throw new System.NotImplementedException();
+        }
 
         public async Task<string> OpenAsync(CancellationToken cancellationToken)
         {
@@ -18,7 +32,6 @@
             var endpointConfiguration = new EndpointConfiguration(endpointName);
 
             // endpoint configuration
-
             endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
 
@@ -37,4 +50,79 @@
     }
 
     #endregion
+
+    #region StatefulEndpointCommunicationListener
+
+    public class StatefulEndpointCommunicationListener : ICommunicationListener
+    {
+        readonly IReliableStateManager stateManager;
+        IEndpointInstance endpointInstance;
+        EndpointConfiguration endpointConfiguration;
+
+        public StatefulEndpointCommunicationListener(IReliableStateManager stateManager)
+        {
+            this.stateManager = stateManager;
+            throw new System.NotImplementedException();
+        }
+
+        public async Task<string> OpenAsync(CancellationToken cancellationToken)
+        {
+            var endpointName = "Sales";
+
+            endpointConfiguration = new EndpointConfiguration(endpointName);
+
+            // endpoint configuration with access to state manager
+            
+            return endpointName;
+        }
+
+        public async Task RunAsync()
+        {
+            endpointInstance = await Endpoint.Start(endpointConfiguration)
+                .ConfigureAwait(false);
+        }
+
+        public Task CloseAsync(CancellationToken cancellationToken)
+        {
+            return endpointInstance.Stop();
+        }
+
+        public void Abort()
+        {
+            CloseAsync(CancellationToken.None);
+        }
+    }
+
+    #endregion
+
+    #region StatefulService
+
+    class MyStatefulService : StatefulService
+    {
+        StatefulEndpointCommunicationListener listener;
+
+        public MyStatefulService(StatefulServiceContext context)
+            : base(context)
+        { }
+
+        protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
+        {
+            listener = new StatefulEndpointCommunicationListener(StateManager);
+            return new List<ServiceReplicaListener>
+        {
+            new ServiceReplicaListener(context => listener)
+        };
+        }
+
+        protected override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            await listener.RunAsync();
+
+            await base.RunAsync(cancellationToken);
+        }
+    }
+
+    #endregion
 }
+
+

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -16,8 +16,8 @@
             var endpointName = "Sales";
 
             var endpointConfiguration = new EndpointConfiguration(endpointName);
-            
-            // regular endpoint configuration
+
+            // endpoint configuration
 
             endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);

--- a/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/EndpointCommunicationListener.cs
@@ -61,8 +61,8 @@ namespace Core6.ServiceFabricHosting
 
             endpointConfiguration = new EndpointConfiguration(endpointName);
 
-            // endpoint configuration with access to state manager
-            
+            // configure endpoint with state manager dependency
+
             return endpointName;
         }
 

--- a/Snippets/Core/Core_6/ServiceFabricHosting/Gateway.config.xml
+++ b/Snippets/Core/Core_6/ServiceFabricHosting/Gateway.config.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--startcode configureGatewayChannel -->
+<configuration>
+  <configSections>
+    <section name="GatewayConfig"
+             type="NServiceBus.Config.GatewayConfig, NServiceBus.Gateway"/>
+  </configSections>
+  <GatewayConfig>
+    <Channels>
+      <Channel Address="http://+:25899/RemoteSite/"
+               ChannelType="Http"
+               Default="true"/>
+    </Channels>
+  </GatewayConfig>
+</configuration>
+<!--endcode-->

--- a/Snippets/Core/Core_6/project.json
+++ b/Snippets/Core/Core_6/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.ServiceFabric.Services": "2.*",
     "NServiceBus": "6.*",
     "NServiceBus.Autofac": "6.*",
     "NServiceBus.Callbacks": "1.*",

--- a/Snippets/Gateway/Gateway_2/Channels/Wildcard.config.xml
+++ b/Snippets/Gateway/Gateway_2/Channels/Wildcard.config.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<!--startcode configureGatewayChannel -->
+<!--startcode configureWildcardGatewayChannel -->
 <configuration>
   <configSections>
     <section name="GatewayConfig"

--- a/Snippets/Gateway/Gateway_2/Gateway_2.csproj
+++ b/Snippets/Gateway/Gateway_2/Gateway_2.csproj
@@ -45,6 +45,7 @@
     <Content Include="Channels\Channels.xml">
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="Channels\Wildcard.config.xml" />
     <Content Include="Sites\Sites.xml">
       <SubType>Designer</SubType>
     </Content>

--- a/Snippets/Gateway/Gateway_2/Gateway_2.csproj
+++ b/Snippets/Gateway/Gateway_2/Gateway_2.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Channels\ConfigurationSource\Usage.cs" />
     <Compile Include="Channels\ProvideConfiguration.cs" />
     <Compile Include="MyMessage.cs" />
+    <Compile Include="ServiceFabric.cs" />
     <Compile Include="Sites\ConfigurationSource\ConfigurationSource.cs" />
     <Compile Include="Sites\ConfigurationSource\Usage.cs" />
     <Compile Include="Sites\ProvideConfiguration.cs" />
@@ -46,6 +47,7 @@
       <SubType>Designer</SubType>
     </Content>
     <Content Include="Channels\Wildcard.config.xml" />
+    <Content Include="ServiceFabric\ServiceManifest.xml" />
     <Content Include="Sites\Sites.xml">
       <SubType>Designer</SubType>
     </Content>

--- a/Snippets/Gateway/Gateway_2/ServiceFabric.cs
+++ b/Snippets/Gateway/Gateway_2/ServiceFabric.cs
@@ -8,11 +8,11 @@
     #region GatewayCommunicationListener
     public class GatewayCommunicationListener : ICommunicationListener
     {
-        readonly StatelessServiceContext _serviceContext;
+        readonly StatelessServiceContext serviceContext;
 
         public GatewayCommunicationListener(StatelessServiceContext serviceContext)
         {
-            _serviceContext = serviceContext;
+            this.serviceContext = serviceContext;
         }
 
         public void Abort()
@@ -26,7 +26,7 @@
 
         public async Task<string> OpenAsync(CancellationToken cancellationToken)
         {
-            var endpoint = _serviceContext.CodePackageActivationContext.GetEndpoint("RemoteEndpoint");
+            var endpoint = serviceContext.CodePackageActivationContext.GetEndpoint("RemoteEndpoint");
 
             string uriPrefix = $"{endpoint.Protocol}://+:{endpoint.Port}/RemoteSite/";
 

--- a/Snippets/Gateway/Gateway_2/ServiceFabric.cs
+++ b/Snippets/Gateway/Gateway_2/ServiceFabric.cs
@@ -1,0 +1,37 @@
+﻿namespace Gateway_2
+{
+    using System.Threading.Tasks;
+    using System.Fabric;
+    using System.Threading;
+    using Microsoft.ServiceFabric.Services.Communication.Runtime;
+
+    #region GatewayCommunicationListener
+    public class GatewayCommunicationListener : ICommunicationListener
+    {
+        readonly StatelessServiceContext _serviceContext;
+
+        public GatewayCommunicationListener(StatelessServiceContext serviceContext)
+        {
+            _serviceContext = serviceContext;
+        }
+
+        public void Abort()
+        {
+        }
+
+        public Task CloseAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public async Task<string> OpenAsync(CancellationToken cancellationToken)
+        {
+            var endpoint = _serviceContext.CodePackageActivationContext.GetEndpoint("RemoteEndpoint");
+
+            string uriPrefix = $"{endpoint.Protocol}://+:{endpoint.Port}/RemoteSite/";
+
+            return uriPrefix.Replace("+", FabricRuntime.GetNodeContext().IPAddressOrFQDN);
+        }
+    }
+    #endregion
+}

--- a/Snippets/Gateway/Gateway_2/ServiceFabric/ServiceManifest.xml
+++ b/Snippets/Gateway/Gateway_2/ServiceFabric/ServiceManifest.xml
@@ -1,0 +1,7 @@
+﻿<!--startcode serviceManifestEndpoint -->
+<Resources>
+  <Endpoints>
+    <Endpoint Protocol="http" Name="RemoteEndpoint" Type="Input" Port="25899" />
+  </Endpoints>
+</Resources>
+<!--endcode -->

--- a/Snippets/Gateway/Gateway_2/Usage.cs
+++ b/Snippets/Gateway/Gateway_2/Usage.cs
@@ -92,4 +92,6 @@ class Usage
             throw new NotImplementedException();
         }
     }
+
+   
 }

--- a/Snippets/Gateway/Gateway_2/project.json
+++ b/Snippets/Gateway/Gateway_2/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.ServiceFabric.Services": "2.5.216",
     "NServiceBus.Gateway": "2.0.*"
   },
   "frameworks": {

--- a/Snippets/Gateway/Gateway_2/project.json
+++ b/Snippets/Gateway/Gateway_2/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.ServiceFabric.Services": "2.5.216",
+    "Microsoft.ServiceFabric.Services": "2.*",
     "NServiceBus.Gateway": "2.0.*"
   },
   "frameworks": {

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -269,6 +269,9 @@
       Title: Web Application
     - Url: nservicebus/hosting/service-fabric-hosting
       Title: Service Fabric
+      Articles:
+      - Url: nservicebus/hosting/service-fabric-hosting/hosting-gateway
+        Title: Hosting Gateway
     - Url: nservicebus/hosting/publishing-from-web-applications
       Title: Publishing from Web Applications
     - Url: nservicebus/wcf

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -267,6 +267,8 @@
       Title: Critical Errors
     - Url: nservicebus/hosting/web-application
       Title: Web Application
+    - Url: nservicebus/hosting/service-fabric-hosting
+      Title: Service Fabric
     - Url: nservicebus/hosting/publishing-from-web-applications
       Title: Publishing from Web Applications
     - Url: nservicebus/wcf

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -69,6 +69,11 @@ The only configuration when running in this mode is the destination when [Sendin
 NServiceBus can be hosted in any web technology that support .NET. See [Web Application Hosting](web-application.md).
 
 
+### Service Fabric Hosting
+
+[Service Fabric](https://docs.microsoft.com/en-us/azure/service-fabric/) can be used to host NServiceBus endpoints in several ways. See [Service Fabric Hosting](/nservicebus/hosting/service-fabric-hosting).
+
+
 ### Multi-Hosting
 
 "Multi-hosting" refers to hosing multiple NServiceBus endpoints in a single .NET process.

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -20,7 +20,7 @@ Snippet: configureWildcardGatewayChannel
 
 Snippet: serviceManifestEndpoint
 
-4. Add a second communication listener that returns the gateway address using the local FQDN instead of the + sign so that the service fabric instance is aware of the local address.
+4. Add a second communication listener that returns the gateway address using the local FQDN instead of the + sign, so that service fabric instance can set up the correct ACL on the host machine.
 
 Snippet: GatewayCommunicationListener
 

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -5,7 +5,7 @@ related:
 reviewed: 2017-03-30
 ---
 
-When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/nl-nl/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
+When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
 
 Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged as an intermediary to solve this problem. It provides reliable request reply semantics, with deduplication, between sites.
 

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -3,8 +3,9 @@ title: Hosting Gateway with Service Fabric
 related:
  - nservicebus/service-fabric
 reviewed: 2017-03-30
-hidden: true
 ---
+
+WARNING: [Gateway](/nservicebus/gateway) hosted in Service Fabric does not support forwarding messages containing [Databus](/nservicebus/messaging/databus/) properties.
 
 When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
 

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -9,7 +9,7 @@ When adopting Service Fabric, it's not uncommon that the Service Fabric hosted e
 
 Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged as an intermediary to solve this problem. It provides reliable request reply semantics, with deduplication, between sites.
 
-To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be taken into account:
+To host the NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be taken into account:
 
 1. Host the gateway as a [stateless service](/nservicebus/hosting/service-fabric/hosting/#stateful service), and use [partition aware routing](/samples/azure/azure-service-fabric-routing/) within to forward messages to other parts of the cluster.
 2. Make sure the endpoint is present on all service fabric cluster instances, by specifying -1 for the `InstanceCount` value.
@@ -17,10 +17,6 @@ To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the follo
 
 (Similar to https://github.com/adam3039/SampleNsbAsfProject/blob/master/WebApi/OwinCommunicationListener.cs#L95, just return the right address but don't open a port as the gateway is already doing that)
 
-4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that the HTTP communication listener is effectively listening on. (TODO: xml below should be a snippet)
+4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that the HTTP communication listener is effectively listening on. 
 
-```xml
-<Channel Address="http://+:25899/RemoteSite/"
-             ChannelType="Http"
-             Default="true"/>
-```
+Snippet: configureGatewayChannel

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -7,7 +7,7 @@ reviewed: 2017-03-30
 
 WARNING: [Gateway](/nservicebus/gateway) hosted in Service Fabric does not support forwarding messages containing [Databus](/nservicebus/messaging/databus/) properties.
 
-When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using sender side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
+When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using sender side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer.
 
 Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged as an intermediary to solve this problem. It provides reliable request reply semantics, with deduplication, between sites.
 

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -17,7 +17,7 @@ To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the follo
 
 (Similar to https://github.com/adam3039/SampleNsbAsfProject/blob/master/WebApi/OwinCommunicationListener.cs#L95, just return the right address but don't open a port as the gateway is already doing that)
 
-4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that hte HTTP communication listener is effectively listening on. (TODO: xml below should be a snippet)
+4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that the HTTP communication listener is effectively listening on. (TODO: xml below should be a snippet)
 
 ```xml
 <Channel Address="http://+:25899/RemoteSite/"

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -1,0 +1,18 @@
+---
+title: Hosting Gateway with Service Fabric
+related:
+ - nservicebus/service-fabric
+reviewed: 2017-03-30
+---
+
+To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be done:
+
+1. Channel address should use URL with wildcards (TODO: xml below should be a snippet)
+1. HTTP communication listener defined (TODO: code snippet, or better, point to an existing SF doco)  
+
+
+```xml
+<Channel Address="http://+:25899/RemoteSite/"
+             ChannelType="Http"
+             Default="true"/>
+```

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -7,7 +7,7 @@ reviewed: 2017-03-30
 
 WARNING: [Gateway](/nservicebus/gateway) hosted in Service Fabric does not support forwarding messages containing [Databus](/nservicebus/messaging/databus/) properties.
 
-When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
+When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using sender side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
 
 Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged as an intermediary to solve this problem. It provides reliable request reply semantics, with deduplication, between sites.
 

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -19,4 +19,4 @@ To host the NServiceBus Gateway in an endpoint deployed to Service Fabric, the f
 
 4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that the HTTP communication listener is effectively listening on. 
 
-Snippet: configureGatewayChannel
+Snippet: configureWildcardGatewayChannel

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -3,6 +3,7 @@ title: Hosting Gateway with Service Fabric
 related:
  - nservicebus/service-fabric
 reviewed: 2017-03-30
+hidden: true
 ---
 
 When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -5,11 +5,19 @@ related:
 reviewed: 2017-03-30
 ---
 
-To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be done:
+When adopting Service Fabric, it's not uncommon that the Service Fabric hosted endpoints need to interact with endpoints outside of the cluster. This can get tricky especially when the endpoints inside Service Fabric are stateful. When integrating using client side distribution, or when using the Service Fabric built in [reverse proxy](https://docs.microsoft.com/nl-nl/azure/service-fabric/service-fabric-reverseproxy) to expose the endpoints as web services, then the partition information needs to be provided by the consumer, which is often not desired.
 
-1. Channel address should use URL with wildcards (TODO: xml below should be a snippet)
-1. HTTP communication listener defined (TODO: code snippet, or better, point to an existing SF doco)  
+Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged as an intermediary to solve this problem. It provides reliable request reply semantics, with deduplication, between sites.
 
+To host NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be taken into account:
+
+1. Host the gateway as a [stateless service](/nservicebus/hosting/service-fabric/hosting/#stateful service), and use [partition aware routing](/samples/azure/azure-service-fabric-routing/) within to forward messages to other parts of the cluster.
+2. Make sure the endpoint is present on all service fabric cluster instances, by specifying -1 for the `InstanceCount` value.
+3. Add a second communication listener that opens up communication on the gateway address using the local FQDN
+
+(Similar to https://github.com/adam3039/SampleNsbAsfProject/blob/master/WebApi/OwinCommunicationListener.cs#L95, just return the right address but don't open a port as the gateway is already doing that)
+
+4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that hte HTTP communication listener is effectively listening on. (TODO: xml below should be a snippet)
 
 ```xml
 <Channel Address="http://+:25899/RemoteSite/"

--- a/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
+++ b/nservicebus/hosting/service-fabric-hosting/hosting-gateway.md
@@ -12,11 +12,16 @@ Alternatively the [nservicebus gateway](/nservicebus/gateway/) can be leveraged 
 To host the NServiceBus Gateway in an endpoint deployed to Service Fabric, the following has to be taken into account:
 
 1. Host the gateway as a [stateless service](/nservicebus/hosting/service-fabric/hosting/#stateful service), and use [partition aware routing](/samples/azure/azure-service-fabric-routing/) within to forward messages to other parts of the cluster.
-2. Make sure the endpoint is present on all service fabric cluster instances, by specifying -1 for the `InstanceCount` value.
-3. Add a second communication listener that opens up communication on the gateway address using the local FQDN
-
-(Similar to https://github.com/adam3039/SampleNsbAsfProject/blob/master/WebApi/OwinCommunicationListener.cs#L95, just return the right address but don't open a port as the gateway is already doing that)
-
-4. Configure the gateway channel address to use a URL with wildcard as the public IP address will differ from the one that the HTTP communication listener is effectively listening on. 
+2. Because the service instance are hosted behind a load balancer, it is required to configure the gateway channel address to use a URL with wildcard. The reason is that the public IP address is the one from the cluster load balancer and will therefore differ from the one that the gateway communication listener will effectively be listening on. 
 
 Snippet: configureWildcardGatewayChannel
+
+3. Open the correct port for the gateway on the cluster load balancer by specifying an `Endpoint` entry in the service manifest.
+
+Snippet: serviceManifestEndpoint
+
+4. Add a second communication listener that returns the gateway address using the local FQDN instead of the + sign so that the service fabric instance is aware of the local address.
+
+Snippet: GatewayCommunicationListener
+
+5. Make sure the host service is present on all service fabric cluster instances, by specifying -1 for the `InstanceCount` value.

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -36,7 +36,7 @@ Due to characteristics of Stateful Services i.e. data partitioning and local dat
 
 - Service partitioning schema must be well defined before the first deployment occurs (repartitioning requires all data to be deleted)
 - Messages must be routed among the shards according to the partitioning schema
-- A single instance of NServiceBus endpoint will be running on the primary replica for each partition
+- A single instance of an NServiceBus endpoint will be running on the primary replica for each partition
 
 See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) for more information on how to host NServiceBus with stateful services and to learn how to configure routing between service partitions and persist data in reliable collections.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -18,7 +18,7 @@ Note: The Actor model is another Service Fabric programming model that is curren
 
 ### Stateless service
 
-Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out) at the transport level.
+Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out.md#broker-transports) at the transport level.
 
 With stateless services, the number of instances of a service can range from one to the number of nodes in a cluster (-1). Endpoints are self hosted and should be started using a custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -3,48 +3,46 @@ title: Service Fabric Hosting
 related:
  - nservicebus/service-fabric
  - samples/azure/azure-service-fabric-routing
-reviewed: 2017-03-29
+reviewed: 2017-03-30
 ---
 
-NServiceBus endpoints can be hosted with Service Fabric using Reliable Services using, using any of the three options:
+NServiceBus endpoints can be hosted with Service Fabric using Reliable Services, using any of the three options:
 
 1. Stateless services
 1. Stateful services
-1. Guest executables
+1. Guest executable 
 
-To choose the right option, see [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview) for details on each of the options.
+To decide what option to use, refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview) for details, followed by this document.
+
+Note: Actor model is another Service Fabric programming model that is not suitable for hosting NServiceBus endpoints.
   
 
 ### Stateless service
 
-Hosting with Stateless service is very similar to a any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with Azure App Plan). Endpoints are stateless and use external persistence to store and data or state for its operation.
+Hosting with Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use external persistence to store and data or state for its operation. Endpoints can be scaled out, leveraging competing consumer on the transport level.
 
-TODO:
-- Elaborate on scale-out with # of instances
-- Communication listener (general, outside of this block)
-- Code snippet(s) if needed
+With stateless services, number of instance of a service can be between one and number of nodes in a cluster. Endpoints are self hosted and require Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) to be implemented.
+
+snippet: EndpointCommunicationListener
+
 
 ### Stateful service
 
-Whenever data sharding is required and data must be close to the processing, stateful service offer reliable collections to solve the problem. This does pose certain constrains on the endpoints.
+Unlike with stateless service, whenever data sharding is required and data must be close to the processing, stateful service option offers reliable collections to solve the problem. This poses certain constrains that need to be taken into consideration:
 
-- Messages must be routed among shards according to the partitioning schema
-- There cannot be more than one instance (`replica`) of an endpoint per shard actively processing messages
-- Partitioning schema must be well defined
+- Service partitioning schema must be well defined upfront
+- Messages must be routed among the shards according to the partitioning schema
+- There cannot be more than one actively processing instance (`replica`) of an endpoint per shard
 
-TODO:
-- do more to emphasize how different it is from the stateless model
-- point to the sample for routing
-- elaborate on the SF persitence package
-- snippets if needed    
+See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) on how to host NServiceBus with stateful services.
+
+NServiceBus provides native implementation for Sagas and the Outbox feature to support endpoints hosted as stateful services. See [Service Fabric persistence](/nservicebus/service-fabric) for details.
 
 
 ### Guest Executable
 
-[Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-deploy-existing-app) option allows packaging and deployment of an an existing endpoint into service fabric with a minimal or no change at all.
+[Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-deploy-existing-app) option allows packaging and deployment of an an existing endpoint into service fabric with a minimal or no change at all. Service Fabric treats guest executable as Stateless services.
+
+This option can be used as an interim solution for the endpoints that need to be eventually converted to Service Fabric services, but cannot be converted right away.
 
 WARNING: MSMQ transport should not be used. Replace it with any other transport.
-
-TODO:
-- elaborate on some details of guest executables (similar to stateless)
-- sample scenario 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -1,4 +1,3 @@
-
 ---
 title: Service Fabric Hosting
 related:

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -12,7 +12,7 @@ NServiceBus endpoints can be hosted with Service Fabric using Reliable Services,
 1. Stateful services
 1. Guest executable 
 
-To decide what option to use, please refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview).
+To decide what option to use, refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview).
 
 Note: Actor model is another Service Fabric programming model that is currently not supported by NServiceBus.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -18,7 +18,7 @@ Note: The Actor model is another Service Fabric programming model that is curren
 
 ### Stateless service
 
-Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out#broker-transports/) at the transport level.
+Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out#broker-transports) at the transport level.
 
 With stateless services, the number of instances of a service can range from one to the number of nodes in a cluster (-1). Endpoints are self hosted and should be started using a custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -18,7 +18,7 @@ Note: The Actor model is another Service Fabric programming model that is curren
 
 ### Stateless service
 
-Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out#broker-transports) at the transport level.
+Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out) at the transport level.
 
 With stateless services, the number of instances of a service can range from one to the number of nodes in a cluster (-1). Endpoints are self hosted and should be started using a custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -1,3 +1,4 @@
+
 ---
 title: Service Fabric Hosting
 related:
@@ -6,7 +7,7 @@ related:
 reviewed: 2017-03-30
 ---
 
-NServiceBus endpoints can be hosted with Service Fabric using Reliable Services, using any of the three options:
+NServiceBus endpoints can be hosted in Service Fabric using any of these three options:
 
 1. Stateless services
 1. Stateful services
@@ -14,33 +15,39 @@ NServiceBus endpoints can be hosted with Service Fabric using Reliable Services,
 
 To decide what option to use, refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview).
 
-Note: Actor model is another Service Fabric programming model that is currently not supported by NServiceBus.
+Note: The Actor model is another Service Fabric programming model that is currently not supported by NServiceBus.
 
 ### Stateless service
 
-Hosting with Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to SF for managing data needed for their operation. Endpoints can be scaled out, leveraging competing consumer at the transport level.
+Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging competing consumer at the transport level.
 
-With stateless services, number of instances of a service can range from one to number of nodes in a cluster. Endpoints are self hosted and should be started using custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
+With stateless services, the number of instances of a service can range from one to the number of nodes in a cluster (-1). Endpoints are self hosted and should be started using a custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 
-snippet: EndpointCommunicationListener
+snippet: StatelessEndpointCommunicationListener
 
 ### Stateful service
 
-The process of configuring and starting an endpoint hosted in stateful service is similar to stateless service hosting approach. However due to characteristics of Stateful Services i.e. data partitioning and local data storage, additional configuration aspects have to be taken into consideration: 
+The process of configuring and starting an endpoint hosted in a stateful service is very similar to stateless service hosting approach. The main difference is that the endpoint cannot be started until after the `OpenAsync` method has returned as the `StateManager` instance has not been fully configured yet. This is fairly trivial to solve by calling the `Endpoint.Start` operation from the `RunAsync` operation instead.
 
-- Service partitioning schema must be well defined before first deployment
+snippet: StatefulEndpointCommunicationListener
+
+snippet: StatefulService
+
+Due to characteristics of Stateful Services i.e. data partitioning and local data storage, additional configuration aspects have to be taken into consideration: 
+
+- Service partitioning schema must be well defined before the first deployment occurs (repartitioning requires all data to be deleted)
 - Messages must be routed among the shards according to the partitioning schema
-- There can only be one NServiceBus endpoint running per service partition
+- There can only be one NServiceBus endpoint running per service partition (in the master instance)
 
-See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) on how to host NServiceBus with stateful services, configure routing between service partitions and persist data in reliable collections.
+See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) for more information on how to host NServiceBus with stateful services and to learn how to configure routing between service partitions and persist data in reliable collections.
 
 NServiceBus provides persistence based on reliable collections for Sagas and Outbox data. See [Service Fabric persistence](/nservicebus/service-fabric) for details.
 
 
 ### Guest Executable
 
-[Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-deploy-existing-app) option allows packaging and deployment of an an existing endpoint into service fabric with a minimal or no change at all. Service Fabric treats guest executable as Stateless services.
+The [Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-deploy-existing-app) option allows packaging and deployment of an an existing endpoint into service fabric with minimal or no change at all. Service Fabric treats guest executable as Stateless services.
 
 This option can be used as an interim solution for the endpoints that need to be eventually converted to Service Fabric services, but cannot be converted right away.
 
-WARNING: While executables can be packaged and deployed to Service Fabric without much effort, SF hosting environment might not provide all external dependencies e.g. endpoints running on MSMQ transport should be migrated to other transport.
+WARNING: While executables can be packaged and deployed to Service Fabric without much effort, SF hosting environment might not support all local dependencies e.g. endpoints running on MSMQ transport should be migrated to other transport. The reason for this is that Service Fabric reallocates processes to different machines based on metrics such as CPU load. But these local dependencies will not move along with it.

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -1,0 +1,15 @@
+---
+title: Service Fabric Hosting
+related:
+ - nservicebus/service-fabric
+ - samples/azure/azure-service-fabric-routing
+reviewed: 2017-03-29
+---
+
+Hosting with Reliable Services general info.
+
+### Stateless services
+
+### Stateful service
+
+### Guest Executable

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -6,10 +6,45 @@ related:
 reviewed: 2017-03-29
 ---
 
-Hosting with Reliable Services general info.
+NServiceBus endpoints can be hosted with Service Fabric using Reliable Services using, using any of the three options:
 
-### Stateless services
+1. Stateless services
+1. Stateful services
+1. Guest executables
+
+To choose the right option, see [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview) for details on each of the options.
+  
+
+### Stateless service
+
+Hosting with Stateless service is very similar to a any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with Azure App Plan). Endpoints are stateless and use external persistence to store and data or state for its operation.
+
+TODO:
+- Elaborate on scale-out with # of instances
+- Communication listener (general, outside of this block)
+- Code snippet(s) if needed
 
 ### Stateful service
 
+Whenever data sharding is required and data must be close to the processing, stateful service offer reliable collections to solve the problem. This does pose certain constrains on the endpoints.
+
+- Messages must be routed among shards according to the partitioning schema
+- There cannot be more than one instance (`replica`) of an endpoint per shard actively processing messages
+- Partitioning schema must be well defined
+
+TODO:
+- do more to emphasize how different it is from the stateless model
+- point to the sample for routing
+- elaborate on the SF persitence package
+- snippets if needed    
+
+
 ### Guest Executable
+
+[Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-deploy-existing-app) option allows packaging and deployment of an an existing endpoint into service fabric with a minimal or no change at all.
+
+WARNING: MSMQ transport should not be used. Replace it with any other transport.
+
+TODO:
+- elaborate on some details of guest executables (similar to stateless)
+- sample scenario 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -36,7 +36,7 @@ Due to characteristics of Stateful Services i.e. data partitioning and local dat
 
 - Service partitioning schema must be well defined before the first deployment occurs (repartitioning requires all data to be deleted)
 - Messages must be routed among the shards according to the partitioning schema
-- NServiceBus endpoint should be running only on primary replicas
+- A single instance of NServiceBus endpoint will be running on the primary replica for each partition
 
 See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) for more information on how to host NServiceBus with stateful services and to learn how to configure routing between service partitions and persist data in reliable collections.
 

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -57,6 +57,4 @@ WARNING: While executables can be packaged and deployed to Service Fabric withou
 
 Service Fabric can be deployed to run in any environment that contains a set of interconnected Windows Server machines. See [official documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-for-windows-server) for details.
 
-Service Fabric standalone cluster can also be [deployed in Linux](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-get-started-linux).
-
 On Azure, Service Fabric can be hosted with [Azure Service Fabric service](https://azure.microsoft.com/en-us/services/service-fabric/).

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -12,31 +12,29 @@ NServiceBus endpoints can be hosted with Service Fabric using Reliable Services,
 1. Stateful services
 1. Guest executable 
 
-To decide what option to use, refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview) for details, followed by this document.
+To decide what option to use, please refer to [Service Fabric documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-overview).
 
-Note: Actor model is another Service Fabric programming model that is not suitable for hosting NServiceBus endpoints.
-  
+Note: Actor model is another Service Fabric programming model that is currently not supported by NServiceBus.
 
 ### Stateless service
 
-Hosting with Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use external persistence to store and data or state for its operation. Endpoints can be scaled out, leveraging competing consumer on the transport level.
+Hosting with Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to SF for managing data needed for their operation. Endpoints can be scaled out, leveraging competing consumer at the transport level.
 
-With stateless services, number of instance of a service can be between one and number of nodes in a cluster. Endpoints are self hosted and require Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) to be implemented.
+With stateless services, number of instances of a service can range from one to number of nodes in a cluster. Endpoints are self hosted and should be started using custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 
 snippet: EndpointCommunicationListener
 
-
 ### Stateful service
 
-Unlike with stateless service, whenever data sharding is required and data must be close to the processing, stateful service option offers reliable collections to solve the problem. This poses certain constrains that need to be taken into consideration:
+The process of configuring and starting an endpoint hosted in stateful service is similar to stateless service hosting approach. However due to characteristics of Stateful Services i.e. data partitioning and local data storage, additional configuration aspects have to be taken into consideration: 
 
-- Service partitioning schema must be well defined upfront
+- Service partitioning schema must be well defined before first deployment
 - Messages must be routed among the shards according to the partitioning schema
-- There cannot be more than one actively processing instance (`replica`) of an endpoint per shard
+- There can only be one NServiceBus endpoint running per service partition
 
-See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) on how to host NServiceBus with stateful services.
+See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) on how to host NServiceBus with stateful services, configure routing between service partitions and persist data in reliable collections.
 
-NServiceBus provides native implementation for Sagas and the Outbox feature to support endpoints hosted as stateful services. See [Service Fabric persistence](/nservicebus/service-fabric) for details.
+NServiceBus provides persistence based on reliable collections for Sagas and Outbox data. See [Service Fabric persistence](/nservicebus/service-fabric) for details.
 
 
 ### Guest Executable
@@ -45,4 +43,4 @@ NServiceBus provides native implementation for Sagas and the Outbox feature to s
 
 This option can be used as an interim solution for the endpoints that need to be eventually converted to Service Fabric services, but cannot be converted right away.
 
-WARNING: MSMQ transport should not be used. Replace it with any other transport.
+WARNING: While executables can be packaged and deployed to Service Fabric without much effort, SF hosting environment might not provide all external dependencies e.g. endpoints running on MSMQ transport should be migrated to other transport.

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -51,3 +51,12 @@ The [Guest executable](https://docs.microsoft.com/en-us/azure/service-fabric/ser
 This option can be used as an interim solution for the endpoints that need to be eventually converted to Service Fabric services, but cannot be converted right away.
 
 WARNING: While executables can be packaged and deployed to Service Fabric without much effort, SF hosting environment might not support all local dependencies e.g. endpoints running on MSMQ transport should be migrated to other transport. The reason for this is that Service Fabric reallocates processes to different machines based on metrics such as CPU load. But these local dependencies will not move along with it.
+
+
+## Hosting NServiceBus in a standalone cluster
+
+Service Fabric can be deployed to run in any environment that contains a set of interconnected Windows Server machines. See [official documentation](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-for-windows-server) for details.
+
+Service Fabric standalone cluster can also be [deployed in Linux](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-get-started-linux).
+
+On Azure, Service Fabric can be hosted with [Azure Service Fabric service](https://azure.microsoft.com/en-us/services/service-fabric/).

--- a/nservicebus/hosting/service-fabric-hosting/index.md
+++ b/nservicebus/hosting/service-fabric-hosting/index.md
@@ -18,7 +18,7 @@ Note: The Actor model is another Service Fabric programming model that is curren
 
 ### Stateless service
 
-Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging competing consumer at the transport level.
+Hosting with a Stateless service is very similar to any other Azure-based hosting (using [Cloud services](/nservicebus/hosting/cloud-services-host) or [self-hosting](/nservicebus/hosting/#self-hosting) with [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)). Endpoints are stateless and use storage external to Service Fabric for managing data needed for their operation. Endpoints can be scaled out, leveraging [competing consumer](/nservicebus/transports/scale-out#broker-transports/) at the transport level.
 
 With stateless services, the number of instances of a service can range from one to the number of nodes in a cluster (-1). Endpoints are self hosted and should be started using a custom Service Fabric [`ICommunicationListener`](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-communication) implementation.
 
@@ -36,7 +36,7 @@ Due to characteristics of Stateful Services i.e. data partitioning and local dat
 
 - Service partitioning schema must be well defined before the first deployment occurs (repartitioning requires all data to be deleted)
 - Messages must be routed among the shards according to the partitioning schema
-- There can only be one NServiceBus endpoint running per service partition (in the master instance)
+- NServiceBus endpoint should be running only on primary replicas
 
 See [Service Fabric Partition Aware Routing](/samples/azure/azure-service-fabric-routing) for more information on how to host NServiceBus with stateful services and to learn how to configure routing between service partitions and persist data in reliable collections.
 

--- a/samples/azure/azure-service-fabric-routing/sample.md
+++ b/samples/azure/azure-service-fabric-routing/sample.md
@@ -1,5 +1,5 @@
 ---
-title: Azure Service Fabric Partition Aware Routing
+title: Service Fabric Partition Aware Routing
 summary: Implementing partition aware routing for services hosted inside Service Fabric cluster.
 reviewed: 2017-03-03
 component: Core


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1112

SF hosting options (replaces PR #2594)

**TODO:**
- [x] Stateless service
- [x] Stateful service
- [x] Guest executable
- [x] Update [Azure index page](https://docs.particular.net/nservicebus/azure/) with self hosting option for SF
- [x] Hosting [NSB Gateway](https://github.com/Particular/NServiceBus.Gateway/pull/66)