### PR TITLE
Move HardcodeReplyToAddressToLogicalAddress into a feature 

### DIFF
--- a/samples/azure/azure-service-fabric-routing/Core_6/Shared/EndpointPartitioning/EndpointPartitioningExtensions.cs
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Shared/EndpointPartitioning/EndpointPartitioningExtensions.cs
@@ -22,8 +22,6 @@ public static class EndpointPartitioningExtensions
         var endpointInstances = settings.GetOrCreate<EndpointInstances>();
         endpointInstances.AddOrReplaceInstances(endpointName, destinationEndpointInstances);
 
-        var pipeline = endpointConfiguration.Pipeline;
-        var addressToLogicalAddress = new HardcodeReplyToAddressToLogicalAddress(settings.InstanceSpecificQueue());
-        pipeline.Register(addressToLogicalAddress, "Hardcodes the ReplyToAddress to the instance specific address of this endpoint.");
+        endpointConfiguration.EnableFeature<HardcodeReplyToAddressToLogicalAddressFeature>();
     }
 }

--- a/samples/azure/azure-service-fabric-routing/Core_6/Shared/EndpointPartitioning/HardcodeReplyToAddressToLogicalAddressFeature.cs
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Shared/EndpointPartitioning/HardcodeReplyToAddressToLogicalAddressFeature.cs
@@ -1,0 +1,12 @@
+using NServiceBus;
+using NServiceBus.Features;
+
+class HardcodeReplyToAddressToLogicalAddressFeature : Feature
+{
+    protected override void Setup(FeatureConfigurationContext context)
+    {
+        var settings = context.Settings;
+        var addressToLogicalAddress = new HardcodeReplyToAddressToLogicalAddress(settings.InstanceSpecificQueue());
+        context.Pipeline.Register(addressToLogicalAddress, "Hardcodes the ReplyToAddress to the instance specific address of this endpoint.");
+    }
+}

--- a/samples/azure/azure-service-fabric-routing/Core_6/Shared/Shared.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Shared/Shared.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndpointPartitioning\EndpointPartitioningExtensions.cs" />
+    <Compile Include="EndpointPartitioning\HardcodeReplyToAddressToLogicalAddressFeature.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="ReceiverSideDistribution\Configuration\PartitionAwareReceiverSideDistributionConfiguration.cs" />
     <Compile Include="ReceiverSideDistribution\PartitionMappingFailedException.cs" />


### PR DESCRIPTION
Moved the `HardcodeReplyToAddressToLogicalAddress `behavior addition into a feature which gets enabled by `RegisterPartitionsForThisEndpoint`. The problem is we cannot do it in the endpoint configuration extension because that is too early for the instance specific queue to be read.