### PR TITLE
Add NH timeout index resolution guide to menu

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -120,6 +120,8 @@
       Articles:
       - Url: nservicebus/upgrades/nhibernate-6to7
         Title: Version 6 to 7
+      - Url: nservicebus/upgrades/nhibernate-timeouts-index
+        Title: Resolving incorrect timeout table indexes
     - Title: RabbitMQ Transport
       Articles:
       - Url: nservicebus/upgrades/rabbitmq-3to4


### PR DESCRIPTION
It seems like an omission from yesterday's release.

@ramonsmits @Particular/docs-maintainers Can you have a look and merge when green?