### PR TITLE
Mention critical error in self-hosting sample

### DIFF
--- a/samples/hosting/self-hosting/sample.md
+++ b/samples/hosting/self-hosting/sample.md
@@ -14,3 +14,5 @@ related:
 This sample shows how to host an in-process instance of NServiceBus.
 
 snippet: self-hosting
+
+WARNING: Although not shown in this sample, when self-hosting NServiceBus the [critical error action](/nservicebus/hosting/critical-errors.md) should always be overridden. If a critical error occurs, NServiceBus will stop the endpoint but will not shut down the process. By specifying a critical error action, the host application can elect to terminate in order to be respawned, or take action to notify system administrators of the failure.

--- a/samples/hosting/self-hosting/sample.md
+++ b/samples/hosting/self-hosting/sample.md
@@ -15,4 +15,4 @@ This sample shows how to host an in-process instance of NServiceBus.
 
 snippet: self-hosting
 
-WARNING: Although not shown in this sample, when self-hosting NServiceBus the [critical error action](/nservicebus/hosting/critical-errors.md) should always be overridden. If a critical error occurs, NServiceBus will stop the endpoint but will not shut down the process. By specifying a critical error action, the host application can elect to terminate in order to be respawned, or take action to notify system administrators of the failure.
+WARNING: Although not shown in this sample, when self-hosting NServiceBus, the [critical error action](/nservicebus/hosting/critical-errors.md) should always be overridden. If a critical error occurs, NServiceBus will stop the endpoint but will not shut down the process. By specifying a critical error action, the host application can elect to terminate in order to be respawned, or take action to notify system administrators of the failure.


### PR DESCRIPTION
Suggested by a support case, as they were working off the self-hosting sample but didn't ever find out about the critical error guidance.

Decided actually implementing critical error in the sample (both V5/V6) would be distracting and instead added a WARNING to the markdown. Open to suggestions on better wording.

@Particular/docs-maintainers please review.