### PR TITLE
Small typo for ASB transport

### DIFF
--- a/nservicebus/azure-service-bus/configuration/full.md
+++ b/nservicebus/azure-service-bus/configuration/full.md
@@ -47,7 +47,7 @@ The topology will create entities it needs, based on the following settings:
 
  * `Queues()`: Settings for queues.
  * `Topics()`: Settings for topics.
- * `()`: Settings for subscriptions.
+ * `Subscriptions()`: Settings for subscriptions.
 
 
 ### Queues


### PR DESCRIPTION
Small typo (missing `Subscriptions` before configuration method call)