### PR TITLE
Slight restructuring of custom recoverability policy

### DIFF
--- a/nservicebus/recoverability/custom-recoverability-policy.md
+++ b/nservicebus/recoverability/custom-recoverability-policy.md
@@ -65,19 +65,17 @@ NOTE: In cases when Immediate and/or Delayed Retry capabilities have been turned
 
 ### Partial customization
 
-Sometimes only a partial customization of the default Recoverability Policy is desired. In order to achieve partial customization the `DefaultRecoverabilityPolicy` needs to be called in the customized Recoverability Policy delegate.
+Sometimes only a partial customization of the default Recoverability Policy is desired. In order to achieve partial customization the `DefaultRecoverabilityPolicy` needs to be called in the customized Recoverability Policy delegate. If when certain exceptions like `MyBusinessException` happen messages that triggered such an exception should be moved to error queue then a policy might look like:
+
+snippet: CustomExceptionPolicyHandler
 
 In the following example the default Recoverability Policy is tweaked to do three Immediate Retries and three Delayed Retries with a time increase of two seconds. The configuration looks like the following:
 
 snippet: PartiallyCustomizedPolicyRecoverabilityConfiguration
 
-If when certain exceptions like `MyBusinessException` happen messages that triggered such an exception should be moved to error queue. And if for exceptions like `MyOtherBusinessException` the default Delayed Retries time increase should be always five seconds but for all other cases the Default Recoverability Policy should be applied then the code can look like the following:
+And if for exceptions like `MyOtherBusinessException`, in addition to moving `MyBusinessException` directly to the error queue, the default Delayed Retries time increase should be always five seconds but for all other cases the Default Recoverability Policy should be applied then the code can look like the following:
 
 snippet: PartiallyCustomizedPolicy
-
-If the Default Recoverability Policy just needs to be tweaked for `MyBusinessException` then a policy might look like:
-
-snippet: CustomExceptionPolicyHandler
 
 If more control over Recoverability is desired the Recoverability delegate can be overridden completely.
 

--- a/nservicebus/recoverability/custom-recoverability-policy.md
+++ b/nservicebus/recoverability/custom-recoverability-policy.md
@@ -65,7 +65,7 @@ NOTE: In cases when Immediate and/or Delayed Retry capabilities have been turned
 
 ### Partial customization
 
-Sometimes only a partial customization of the default Recoverability Policy is desired. In order to achieve partial customization the `DefaultRecoverabilityPolicy` needs to be called in the customized Recoverability Policy delegate. If when certain exceptions like `MyBusinessException` happen messages that triggered such an exception should be moved to error queue then a policy might look like:
+Sometimes only a partial customization of the default Recoverability Policy is desired. In order to achieve partial customization the `DefaultRecoverabilityPolicy` needs to be called in the customized Recoverability Policy delegate. If, when certain exceptions like `MyBusinessException` happen messages that triggered, such an exception should be moved to error queue then a policy might look like:
 
 snippet: CustomExceptionPolicyHandler
 
@@ -88,8 +88,9 @@ snippet: FullyCustomizedPolicyRecoverabilityConfiguration
 The configuration will be passed into the custom policy. 
 
 The following custom policy:
-- for unrecoverable exceptions such as `MyBusinessException` immediately moves failed messages to a custom error queue 
-- for `MyOtherBusinessException` does Delayed Retries with a constant time increase of five seconds 
-- for all other cases immediately moves failed messages to the configured standard error queue.
+
+ * for unrecoverable exceptions such as `MyBusinessException` immediately moves failed messages to a custom error queue 
+ * for `MyOtherBusinessException` does Delayed Retries with a constant time increase of five seconds 
+ * for all other cases immediately moves failed messages to the configured standard error queue.
 
 snippet: FullyCustomizedPolicy


### PR DESCRIPTION
@SimonCropp I checked the `recoverability.AddUnrecoverableException<MyBusinessException>();` part and it makes sense. If you look closer the 6.2 snippet custom policy is only dealing with the delayed case because of that line.

fixes #2541 