### PR TITLE
Clarify SC/SP/SI Audit behavior

### DIFF
--- a/nservicebus/operations/auditing.md
+++ b/nservicebus/operations/auditing.md
@@ -13,7 +13,7 @@ redirects:
 
 The distributed nature of parallel, message-driven systems make them more difficult to debug than their sequential, synchronous and centralized counterparts. For these reasons, NServiceBus provides built-in message auditing for every endpoint. Configure NServiceBus to audit and it will capture a copy of every received message and forward it to a specified audit queue.
 
-NOTE: By default Auditing is not enabled and must be configured.
+NOTE: By default Auditing is not enabled and must be configured for each endpoint.
 
 It is recommended to specify a central auditing queue for all related endpoints (i.e. endpoints that belong to the same system). This gives an overview of the entire system in one place and see how messages correlate. One can look at the audit queue as a central record of everything that is happening in the system. A central audit queue is also required by the Particular Service Platform and especially [ServiceControl](/servicecontrol), which consumes messages from these auditing queues. For more information, see [ServicePulse documentation](/servicepulse/).
 

--- a/nservicebus/operations/auditing.md
+++ b/nservicebus/operations/auditing.md
@@ -13,6 +13,8 @@ redirects:
 
 The distributed nature of parallel, message-driven systems make them more difficult to debug than their sequential, synchronous and centralized counterparts. For these reasons, NServiceBus provides built-in message auditing for every endpoint. Configure NServiceBus to audit and it will capture a copy of every received message and forward it to a specified audit queue.
 
+NOTE: By default Auditing is not enabled and must be configured.
+
 It is recommended to specify a central auditing queue for all related endpoints (i.e. endpoints that belong to the same system). This gives an overview of the entire system in one place and see how messages correlate. One can look at the audit queue as a central record of everything that is happening in the system. A central audit queue is also required by the Particular Service Platform and especially [ServiceControl](/servicecontrol), which consumes messages from these auditing queues. For more information, see [ServicePulse documentation](/servicepulse/).
 
 

--- a/platform/servicecontrol.include.md
+++ b/platform/servicecontrol.include.md
@@ -10,6 +10,8 @@ To enable [ServiceControl](/servicecontrol) to gather this information, configur
  * configure [recoverability](/nservicebus/recoverability) to store information on messages failures;
  * [install plugins on the endpoints](/servicecontrol/plugins/) to monitor their health and sagas and use custom checks.
 
+NOTE: All endpoints should be configured to forward to the same audit, error, and ServiceControl plugin queues unless the system has been sharded between multiple ServiceControl instances.
+
 NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If you require a copy of those messages for your own processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwarderrormessages).
 
 By default ServiceControl stores information for 30 days, but it can be [customized](/servicecontrol/creating-config-file.md).

--- a/platform/servicecontrol.include.md
+++ b/platform/servicecontrol.include.md
@@ -12,7 +12,7 @@ To enable [ServiceControl](/servicecontrol) to gather this information, configur
 
 NOTE: All endpoints should be configured to forward to the same audit, error, and ServiceControl plugin queues unless the system has been sharded between multiple ServiceControl instances.
 
-NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If a copy of those messages is required for further processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwarderrormessages).
+NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If a copy of those messages is required for further processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwarderrormessages).
 
 By default ServiceControl stores information for 30 days, but it can be [customized](/servicecontrol/creating-config-file.md).
 

--- a/platform/servicecontrol.include.md
+++ b/platform/servicecontrol.include.md
@@ -12,7 +12,7 @@ To enable [ServiceControl](/servicecontrol) to gather this information, configur
 
 NOTE: All endpoints should be configured to forward to the same audit, error, and ServiceControl plugin queues unless the system has been sharded between multiple ServiceControl instances.
 
-NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If you require a copy of those messages for your own processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwarderrormessages).
+NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If a copy of those messages is required for further processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwarderrormessages).
 
 By default ServiceControl stores information for 30 days, but it can be [customized](/servicecontrol/creating-config-file.md).
 

--- a/platform/servicecontrol.include.md
+++ b/platform/servicecontrol.include.md
@@ -10,6 +10,8 @@ To enable [ServiceControl](/servicecontrol) to gather this information, configur
  * configure [recoverability](/nservicebus/recoverability) to store information on messages failures;
  * [install plugins on the endpoints](/servicecontrol/plugins/) to monitor their health and sagas and use custom checks.
 
+NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If you require a copy of those messages for your own processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#servicecontrolforwarderrormessages).
+
 By default ServiceControl stores information for 30 days, but it can be [customized](/servicecontrol/creating-config-file.md).
 
 Refer to the [Optimizing for use in different environments](/servicecontrol/servicecontrol-in-practice.md) article for more information about practical considerations.

--- a/platform/servicecontrol.include.md
+++ b/platform/servicecontrol.include.md
@@ -12,7 +12,7 @@ To enable [ServiceControl](/servicecontrol) to gather this information, configur
 
 NOTE: All endpoints should be configured to forward to the same audit, error, and ServiceControl plugin queues unless the system has been sharded between multiple ServiceControl instances.
 
-NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues. If a copy of those messages is required for further processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwarderrormessages).
+NOTE: ServiceControl _consumes_ messages that arrive in either the configured audit or error queues, i.e. it removes those messages from the queues. If a copy of those messages is required for further processing, configure [audit forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwardauditmessages) and/or [error queue forwarding](/servicecontrol/creating-config-file.md#transport-servicecontrolforwarderrormessages).
 
 By default ServiceControl stores information for 30 days, but it can be [customized](/servicecontrol/creating-config-file.md).
 

--- a/serviceinsight/index.md
+++ b/serviceinsight/index.md
@@ -58,6 +58,7 @@ The Endpoint Explorer indicates the connection to the ServiceControl instance pr
 
 Select endpoints to filter the message list. Select the root ServiceControl connection and the tree view to make the list expand to include all messages.
 
+NOTE: Endpoints will not appear unless messages are successfully completed and _audited_.
 
 ## Flow Diagram
 

--- a/serviceinsight/index.md
+++ b/serviceinsight/index.md
@@ -18,6 +18,7 @@ The flow diagram provides a detailed visual overview of the messages, collated b
 
 As endpoints are selected, the other views within ServiceInsight respond and filter the information to show only messages pertaining to that endpoint.
 
+NOTE: Endpoint lists, message information, and message flows will not be populated until messages have been successfully processed by ServiceControl.
 
 ## The Message Window
 

--- a/serviceinsight/index.md
+++ b/serviceinsight/index.md
@@ -59,8 +59,6 @@ The Endpoint Explorer indicates the connection to the ServiceControl instance pr
 
 Select endpoints to filter the message list. Select the root ServiceControl connection and the tree view to make the list expand to include all messages.
 
-NOTE: Endpoints will not appear unless messages are successfully completed and _audited_.
-
 ## Flow Diagram
 
 The flow diagram provides extensive message and system information. When messages are selected in the message list, the flow diagram illustrates the message and all related messages from the same conversation, along with the nature of the messages and the endpoints involved.

--- a/servicepulse/index.md
+++ b/servicepulse/index.md
@@ -25,6 +25,8 @@ The Dashboard provides a visual overview of the current state of the monitored N
 
 ServicePulse automatically detects what endpoints exist in the system by analyzing metadata from [audited messages](/nservicebus/operations/auditing.md). All detected endpoints will, by default, be listed in the Endpoints tab, but will not be automatically monitored.
 
+NOTE: Endpoints will not appear unless messages are successfully completed and _audited_.
+
 In order to monitor endpoints health and activity it is necessary to [configure them for monitoring](/servicepulse/how-to-configure-endpoints-for-monitoring.md).
 
 **Learn more:**

--- a/servicepulse/index.md
+++ b/servicepulse/index.md
@@ -25,7 +25,7 @@ The Dashboard provides a visual overview of the current state of the monitored N
 
 ServicePulse automatically detects what endpoints exist in the system by analyzing metadata from [audited messages](/nservicebus/operations/auditing.md). All detected endpoints will, by default, be listed in the Endpoints tab, but will not be automatically monitored.
 
-NOTE: Endpoints will not appear unless messages are successfully completed and _audited_.
+NOTE: Endpoints will not appear unless messages from the endpoint have been successfully processed by ServiceControl.
 
 In order to monitor endpoints health and activity it is necessary to [configure them for monitoring](/servicepulse/how-to-configure-endpoints-for-monitoring.md).
 


### PR DESCRIPTION
Completes #2531 

- [x] _If audits aren't enabled, SC will show no endpoints because it uses the contents of the queues to populate rather than the existence of the queues.So if the queues are empty, it looks like there are no endpoints._
   - [Note added to ServiceInsight index](https://github.com/Particular/docs.particular.net/pull/2653/files#diff-64f51c7ee0e998ad4611a1870370d25cR21)
   - [Note added to ServicePulse index](https://github.com/Particular/docs.particular.net/pull/2653/files#diff-5eea945ad2b91dc2b70ef1475ce4a5feR28)
- [x] _The docs say that every endpoint gets a built in audit log. Apparently that's not true, it's not per endpoint, and it's not by default._
   - [Note added to Audit feature doco](https://github.com/Particular/docs.particular.net/pull/2653/files#diff-13962c69f23c09efc3f7c439de6048f1R16)
- [x] _The docs say that a central audit log is 'also' required. Apparently, this is the same audit queue that every endpoint should be configured to use._
   - [Note added to ServiceControl index](https://github.com/Particular/docs.particular.net/pull/2653/files#diff-6fa3ad603af6bfeabca4ac626169b9d1R13)
- [x] The audit queue is actually 'consumed' by ServiceControl which means it will be removed from the audit queue and stored in service control in what seems to be a raven database, and deleted after so much time
   - [Note added to ServiceControl index](https://github.com/Particular/docs.particular.net/pull/2653/files#diff-6fa3ad603af6bfeabca4ac626169b9d1R15)