### PR TITLE
Revise RabbitMQ delayed delivery backwards compatibility section

### DIFF
--- a/Snippets/Rabbit/Rabbit_4/Usage.cs
+++ b/Snippets/Rabbit/Rabbit_4/Usage.cs
@@ -161,15 +161,4 @@ class Usage
 
         #endregion
     }
-
-    void AllEndpointsSupportDelayedDelivery(EndpointConfiguration endpointConfiguration)
-    {
-        #region rabbitmq-delay-all-endpoints-support-delayed-delivery 4.3
-
-        var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
-        var delayedDelivery = transport.DelayedDelivery();
-        delayedDelivery.AllEndpointsSupportDelayedDelivery();
-
-        #endregion
-    }
 }

--- a/nservicebus/rabbitmq/delayed-delivery.md
+++ b/nservicebus/rabbitmq/delayed-delivery.md
@@ -112,20 +112,17 @@ end
 
 ## Backwards compatibility
 
-When using a version of the transport that supports delayed delivery natively, the endpoint continues to operate in a backwards-compatible manner by default. The timeout manager will continue to be enabled, so any delayed messages already stored in the endpoint's persistence database will be sent when their timeouts expire. New delayed messages will be sent through the delay infrastructure, but the endpoint cannot assume that other endpoints have also been upgraded, so it will incur some additional overhead when sending delayed messages to ensure that they can be delivered successfully.
+When upgrading to a version of the transport that supports delayed delivery natively, it is safe to operate a combination of native-delay and non-native-delay endpoints at the same time. Native endpoints can send delayed messages to endpoints that are not yet aware of the native delay infrastructure. Native endpoints can continue to receive delayed messages from non-native endpoints as well.
 
 
 ### Disabling the timeout manager
+
+To assist with the upgrade process, the timeout manager is still enabled by default, so any delayed messages already stored in the endpoint's persistence database before the upgrade will be sent when their timeouts expire. Any delayed messages sent after the upgrade will be sent through the delay infrastructure even though the timeout manager is enabled.
 
 Once an endpoint has no more delayed messages in its persistence database, there is no more need for the timeout manager. It can be disabled by calling:
 
 snippet: rabbitmq-delay-disable-timeout-manager
 
-At this point, the `.Timeouts` and `.TimeoutsDispatcher` exchanges and queues for the endpoint can be deleted from the broker. In addition, the endpoint no longer requires timeout persistence.
+At this point, the `.Timeouts` and `.TimeoutsDispatcher` exchanges and queues for the endpoint can be deleted from the broker. In addition, the endpoint no longer requires timeout persistence, so those storage entities can be removed from the persistence database as well.
 
-
-### Removing the sending overhead
-
-Once all endpoints have been upgraded to a version of the transport that supports delayed delivery natively, the extra overheard in sending a delayed message in a backwards-compatible manner can be removed by calling the following on each endpoint:
-
-snippet: rabbitmq-delay-all-endpoints-support-delayed-delivery
+NOTE: Newly created endpoints that have never been deployed without native delayed delivery should also set this value to prevent the timeout manager from running.


### PR DESCRIPTION
This removes the references to the deprecated `AllEndpointsSupportDelayedDelivery` setting and revises the backwards compatibility section in light of this change.

@Particular/rabbitmq-transport-maintainers 