### PR TITLE
Clarify changes to assembly scanning in 6.2

### DIFF
--- a/Snippets/Core/Core_6/Lifecycle/INeedInitialization.cs
+++ b/Snippets/Core/Core_6/Lifecycle/INeedInitialization.cs
@@ -12,9 +12,7 @@
             // Perform initialization
             // This is after Type Scanning.
             // Do NOT call the following here:
-            // endpointConfiguration.ExcludeAssemblies();
-            // endpointConfiguration.ExcludeTypes();
-            // endpointConfiguration.ScanAssembliesInNestedDirectories();
+            // endpointConfiguration.AssemblyScanner();
         }
     }
 

--- a/Snippets/Core/Core_6/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Core/Core_6/Scanning/ScanningPublicApi.cs
@@ -73,7 +73,7 @@ namespace Core6.Scanning
         {
             #region 5to6ScanningUpgrade
 
-            endpointConfiguration.ExcludeAssemblies(
+            endpointConfiguration.AssemblyScanner().ExcludeAssemblies(
                 "BadAssembly1.dll",
                 "BadAssembly2.dll");
 

--- a/Snippets/Core/Core_6/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Core/Core_6/Scanning/ScanningPublicApi.cs
@@ -32,7 +32,9 @@ namespace Core6.Scanning
 
         void ScanningExcludeByWildcard(EndpointConfiguration endpointConfiguration)
         {
-            #region ScanningAssebliesWildcard
+            #region ScanningAssembliesWildcard
+
+            var assemblyScanner = endpointConfiguration.AssemblyScanner();
 
             var excludeRegexs = new List<string>
             {
@@ -48,7 +50,7 @@ namespace Core6.Scanning
                 {
                     if (Regex.IsMatch(fileName, pattern, RegexOptions.IgnoreCase))
                     {
-                        endpointConfiguration.ExcludeAssemblies(fileName);
+                        assemblyScanner.ExcludeAssemblies(fileName);
                         break;
                     }
                 }

--- a/nservicebus/hosting/assembly-scanning_wildcard_core_[6,].partial.md
+++ b/nservicebus/hosting/assembly-scanning_wildcard_core_[6,].partial.md
@@ -3,4 +3,4 @@
 
 Multiple assemblies can be excluded by wildcard using the following:
 
-snippet: ScanningAssebliesWildcard
+snippet: ScanningAssembliesWildcard

--- a/nservicebus/upgrades/6to6.2.md
+++ b/nservicebus/upgrades/6to6.2.md
@@ -46,3 +46,9 @@ snippet: 6to6-2register-mutator
 See also [Registering message mutators](/nservicebus/pipeline/message-mutators.md#registering-a-mutator).
 
 Note that, for backward compatibility, registering mutators directly via the container API will continue to work in all Version 6 releases but will be removed in a future major version.
+
+## Assembly Scanning API
+
+The API to control assembly scanning has been moved from `EndpointConfiguration` to a dedicated API. The `ExcludeAssemblies`, `ExcludeTypes`, and `ScanAssembliesInNestedDirectories` methods on `EndpointConfiguration` are now marked as obsolete and will be removed in Version 7.
+
+See [Assembly Scanning](/nservicebus/hosting/assembly-scanning.md) for details on how to control assembly scanning with NServiceBus 6.2.


### PR DESCRIPTION
Fixes #2627 

Addresses feedback around changes to the assembly scanning API introduced in NServiceBus 6.2

- [x] Update 6 to 6.2 upgrade guide to mention API has been moved and old API marked as obsolete
- [x] Rename and update `ScanningAssebliesWildcard` snippet.
- [x] Update 5 to 6 upgrade guide to newer API
- [x] Update `lifecycle-ineedinitialization` snippet