### PR TITLE
Adjust for new error queue default

### DIFF
--- a/nservicebus/msmq/index.md
+++ b/nservicebus/msmq/index.md
@@ -59,7 +59,7 @@ Remote queues are not supported for MSMQ as this conflicts with the [Distributed
 
 ## Error queue configuration
 
-The transport requires all endpoints to configure the error queue address and a centralized error queue is recommended setup for production scenarios.
+The transport requires all endpoints to configure the error queue address. The centralized error queue is a recommended setup for production scenarios.
 
 See the [recoverability documentation](/nservicebus/recoverability/configure-error-handling.md) for details on how to configure the error queue address.
 

--- a/nservicebus/msmq/index.md
+++ b/nservicebus/msmq/index.md
@@ -57,6 +57,11 @@ So downtime is proportional to the time taken for the MSMQ service to restart on
 
 Remote queues are not supported for MSMQ as this conflicts with the [Distributed Bus architectural style](/nservicebus/architecture/) that is predicated on concepts of durability, autonomy and avoiding a single point of failure. For scenarios where a [Broker style architecture](/nservicebus/architecture/) is required use transports like [Sql Server](/nservicebus/sqlserver/) and [RabbitMQ](/nservicebus/rabbitmq/).
 
+## Error queue configuration
+
+The transport requires all endpoints to configure the error queue address and a centralized error queue is recommended setup for production scenarios.
+
+See the [recoverability documentation](/nservicebus/recoverability/configure-error-handling.md) for details on how to configure the error queue address.
 
 ## Public Queues
 

--- a/nservicebus/recoverability/configure-error-handling.md
+++ b/nservicebus/recoverability/configure-error-handling.md
@@ -22,9 +22,7 @@ WARNING: When running with [transport transactions disabled](/nservicebus/transp
 
 WARNING: When running with [transport transactions disabled](/nservicebus/transports/transactions.md#transactions-unreliable-transactions-disabled). Both [Immediate Retries](/nservicebus/recoverability/#immediate-retries) and [Delayed Retries](/nservicebus/recoverability/#delayed-retries) will be automatically disabled when transactions are turned off.
 
-The default error queue name is `error` but some transports reqires it to be explicitly be configured.
-
-This can be done in several ways.
+partial: ErrorQueueDefault
 
 partial: ErrorWithCode
 

--- a/nservicebus/recoverability/configure-error-handling.md
+++ b/nservicebus/recoverability/configure-error-handling.md
@@ -22,7 +22,9 @@ WARNING: When running with [transport transactions disabled](/nservicebus/transp
 
 WARNING: When running with [transport transactions disabled](/nservicebus/transports/transactions.md#transactions-unreliable-transactions-disabled). Both [Immediate Retries](/nservicebus/recoverability/#immediate-retries) and [Delayed Retries](/nservicebus/recoverability/#delayed-retries) will be automatically disabled when transactions are turned off.
 
-Error queue address can be configured in several ways.
+The default error queue name is `error` but some transports reqires it to be explicitly be configured.
+
+This can be done in several ways.
 
 partial: ErrorWithCode
 

--- a/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[3.0,6.2).partial.md
+++ b/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[3.0,6.2).partial.md
@@ -1,1 +1,1 @@
-Error queue address is mandatory can be configured in several ways.
+Error queue address is mandatory. It can be configured in several ways:

--- a/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[3.0,6.2).partial.md
+++ b/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[3.0,6.2).partial.md
@@ -1,0 +1,1 @@
+Error queue address is mandatory can be configured in several ways.

--- a/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[6.3,).partial.md
+++ b/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[6.3,).partial.md
@@ -1,3 +1,3 @@
-The default error queue name is `error` but some transports reqires it to be explicitly be configured.
+The default error queue name is `error` but some transports reqire it to be explicitly be configured.
 
-This can be done in several ways.
+This can be done in several ways:

--- a/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[6.3,).partial.md
+++ b/nservicebus/recoverability/configure-error-handling_errorqueuedefault_core_[6.3,).partial.md
@@ -1,0 +1,3 @@
+The default error queue name is `error` but some transports reqires it to be explicitly be configured.
+
+This can be done in several ways.


### PR DESCRIPTION
As of 6.3 most transports won't need a error queue defined

## WIP

- [x] Add partial
- [x] Update relevant samples