### PR TITLE
Remove the documentation about custom conversation ids

### DIFF
--- a/nservicebus/messaging/headers.md
+++ b/nservicebus/messaging/headers.md
@@ -84,8 +84,6 @@ Identifier of the conversation that this message is part of. It enables the trac
 
 The first message that is sent in a new flow is automatically assigned a unique `Conversation Id` that is then propagated to all the messages that are subsequently sent, thus forming a _conversation_. Each message that is sent within a conversation also has a `RelatedTo` value that identifies the originating message that caused it to be sent. 
 
-The `Conversation Id` header can be manipulated to create custom conversations which are meaningful from the domain perspective (e.g. using Order Id as the `Conversation Id` to track the life cycle of the order).
-
 
 ### NServiceBus.RelatedTo
 


### PR DESCRIPTION
A custom conversation id can only be set when a new message flow is started (messages sent from `IMessageSession`). When the header is set in a message handler it would overwrite an existing conversation id and throw instead.

We currently don't offer a proper API to set a custom conversation id and the removed statement is also not backed by any snippet code so I propose to remove it entirely. If we really think this is a case we should support, we should provide an option on `SendOptions` (which can't differentiate between sends from the message session or the handler context)

@andreasohlund @indualagarsamy thoughts?