### PR TITLE
Update to the cloud show case

### DIFF
--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/App.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/App.config
@@ -1,14 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <section name="UnicastBusConfig" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
-  </configSections>
-  <UnicastBusConfig>
-    <MessageEndpointMappings>
-      <add Assembly="Store.Messages" Namespace="Store.Messages.Events" Endpoint="Store.Sales" />
-      <add Assembly="Store.Messages" Namespace="Store.Messages.RequestResponse" Endpoint="Store.Operations" />
-    </MessageEndpointMappings>
-  </UnicastBusConfig>
   <connectionStrings>
     <add name="AzureWebJobsDashboard" connectionString="UseDevelopmentStorage=true;" />
     <add name="AzureWebJobsStorage" connectionString="UseDevelopmentStorage=true;" />

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Program.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Program.cs
@@ -25,7 +25,13 @@ public class Program
     {
         Console.Title = "Samples.Store.ContentManagement";
         var endpointConfiguration = new EndpointConfiguration("Store.ContentManagement");
-        endpointConfiguration.ApplyCommonConfiguration();
+        endpointConfiguration.ApplyCommonConfiguration(transport =>
+        {
+            var routing = transport.Routing();
+            routing.RouteToEndpoint(typeof(Store.Messages.RequestResponse.ProvisionDownloadRequest), "Store.Operations");
+            routing.RegisterPublisher(typeof(Store.Messages.Events.OrderAccepted), "Store.Sales");
+        });
+
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Properties/webjob-publish-settings.json
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Properties/webjob-publish-settings.json
@@ -1,9 +1,5 @@
 ﻿{
   "$schema": "http://schemastore.org/schemas/json/webjob-publish-settings.json",
   "webJobName": "Store-ContentManagement",
-  "startTime": null,
-  "endTime": null,
-  "jobRecurrenceFrequency": null,
-  "interval": null,
   "runMode": "Continuous"
 }

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
@@ -115,4 +115,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
+  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
@@ -115,5 +115,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/Store.ContentManagement.csproj
@@ -71,6 +71,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.2.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.ContentManagement/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />
   <package id="NServiceBus.Encryption.MessageProperty" version="1.0.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/App.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/App.config
@@ -1,14 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <section name="UnicastBusConfig" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
-  </configSections>
-  <UnicastBusConfig>
-    <MessageEndpointMappings>
-      <add Assembly="Store.Messages" Namespace="Store.Messages.Events" Endpoint="Store.Sales" />
-      <add Assembly="Store.Messages" Type="Store.Messages.Events.ClientBecamePreferred" Endpoint="Store.CustomerRelations" />
-    </MessageEndpointMappings>
-  </UnicastBusConfig>
   <connectionStrings>
     <add name="AzureWebJobsDashboard" connectionString="UseDevelopmentStorage=true;" />
     <add name="AzureWebJobsStorage" connectionString="UseDevelopmentStorage=true;" />

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Program.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Program.cs
@@ -26,7 +26,14 @@ public class Program
     {
         Console.Title = "Samples.Store.CustomerRelations";
         var endpointConfiguration = new EndpointConfiguration("Store.CustomerRelations");
-        endpointConfiguration.ApplyCommonConfiguration();
+        endpointConfiguration.ApplyCommonConfiguration(transport =>
+        {
+            var routing = transport.Routing();
+            routing.RegisterPublisher(typeof(Store.Messages.Events.ClientBecamePreferred).Assembly, "Store.Messages.Events", "Store.Sales");
+            routing.RegisterPublisher(typeof(Store.Messages.Events.ClientBecamePreferred), "Store.CustomerRelations");
+        });
+
+
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
 

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Properties/webjob-publish-settings.json
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Properties/webjob-publish-settings.json
@@ -1,9 +1,5 @@
 ﻿{
   "$schema": "http://schemastore.org/schemas/json/webjob-publish-settings.json",
   "webJobName": "Store-CustomerRelations",
-  "startTime": null,
-  "endTime": null,
-  "jobRecurrenceFrequency": null,
-  "interval": null,
   "runMode": "Continuous"
 }

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -112,4 +112,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
+  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -69,6 +69,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.2.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -112,5 +112,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.CustomerRelations/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />
   <package id="NServiceBus.Encryption.MessageProperty" version="1.0.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Global.asax.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Global.asax.cs
@@ -23,7 +23,14 @@ public class MvcApplication :
     {
         var endpointConfiguration = new EndpointConfiguration("Store.ECommerce");
         endpointConfiguration.PurgeOnStartup(true);
-        endpointConfiguration.ApplyCommonConfiguration();
+        endpointConfiguration.ApplyCommonConfiguration(transport =>
+        {
+            var routing = transport.Routing();
+            routing.RouteToEndpoint(typeof(Store.Messages.Commands.SubmitOrder).Assembly, "Store.Messages.Commands", "Store.Sales");
+            routing.RegisterPublisher(typeof(Store.Messages.Events.DownloadIsReady), "Store.ContentManagement");
+            routing.RegisterPublisher(typeof(Store.Messages.Events.OrderCancelled), "Store.Sales");
+            routing.RegisterPublisher(typeof(Store.Messages.Events.OrderPlaced), "Store.Sales");
+        });
 
         EndpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Properties/webjobs-list.json
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Properties/webjobs-list.json
@@ -12,6 +12,21 @@
     },
     {
       "filePath": "../Store.ContentManagement/Store.ContentManagement.csproj"
+    },
+    {
+      "filePath": "../Store.CustomerRelations/Store.CustomerRelations.csproj"
+    },
+    {
+      "filePath": "../Store.Operations/Store.Operations.csproj"
+    },
+    {
+      "filePath": "../Store.Sales/Store.Sales.csproj"
+    },
+    {
+      "filePath": "../Store.CustomerRelations/Store.CustomerRelations.csproj"
+    },
+    {
+      "filePath": "../Store.ContentManagement/Store.ContentManagement.csproj"
     }
   ]
 }

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
@@ -183,6 +183,10 @@
   <ItemGroup>
     <Content Include="Properties\webjobs-list.json" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\PublishProfiles\WebJobs-DemoStore - FTP.pubxml" />
+    <None Include="Properties\PublishProfiles\WebJobs-DemoStore - Web Deploy.pubxml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -213,5 +217,6 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
@@ -218,5 +218,4 @@
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Store.ECommerce.csproj
@@ -44,7 +44,19 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.2.2\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Azure.KeyVault.Core.2.0.4\lib\net45\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -61,9 +73,15 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\WindowsAzure.Storage.8.1.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.2.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
@@ -78,6 +96,10 @@
       <HintPath>..\..\..\..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
@@ -184,7 +206,8 @@
           <IISUrl>http://localhost:50485/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl />
+          <CustomServerUrl>
+          </CustomServerUrl>
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Web.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/Web.config
@@ -1,16 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <section name="UnicastBusConfig" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
-  </configSections>
-  <UnicastBusConfig>
-    <MessageEndpointMappings>
-      <add Assembly="Store.Messages" Namespace="Store.Messages.Commands" Endpoint="Store.Sales" />
-      <add Assembly="Store.Messages" Type="Store.Messages.Events.DownloadIsReady" Endpoint="Store.ContentManagement" />
-      <add Assembly="Store.Messages" Type="Store.Messages.Events.OrderCancelled" Endpoint="Store.Sales" />
-      <add Assembly="Store.Messages" Type="Store.Messages.Events.OrderPlaced" Endpoint="Store.Sales" />
-    </MessageEndpointMappings>
-  </UnicastBusConfig>
   <system.web>
     <httpRuntime targetFramework="4.6.1" />
     <compilation debug="true" targetFramework="4.6.1" />

--- a/samples/show-case/cloud-azure/Core_6/Store.ECommerce/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.ECommerce/packages.config
@@ -5,6 +5,10 @@
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.2.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="2.0.4" targetFramework="net461" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
   <package id="Microsoft.Owin" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Security" version="3.1.0" targetFramework="net461" />
@@ -12,6 +16,13 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.13" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />
   <package id="NServiceBus.Encryption.MessageProperty" version="1.0.0" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Requests" version="4.3.0" targetFramework="net461" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="8.1.1" targetFramework="net461" />
 </packages>

--- a/samples/show-case/cloud-azure/Core_6/Store.Operations/Properties/webjob-publish-settings.json
+++ b/samples/show-case/cloud-azure/Core_6/Store.Operations/Properties/webjob-publish-settings.json
@@ -1,9 +1,5 @@
 ﻿{
   "$schema": "http://schemastore.org/schemas/json/webjob-publish-settings.json",
   "webJobName": "Store-Operations",
-  "startTime": null,
-  "endTime": null,
-  "jobRecurrenceFrequency": null,
-  "interval": null,
   "runMode": "Continuous"
 }

--- a/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
@@ -114,5 +114,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
@@ -114,4 +114,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
+  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Operations/Store.Operations.csproj
@@ -71,6 +71,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.2.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/show-case/cloud-azure/Core_6/Store.Operations/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.Operations/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />
   <package id="NServiceBus.Encryption.MessageProperty" version="1.0.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />

--- a/samples/show-case/cloud-azure/Core_6/Store.Sales/Properties/webjob-publish-settings.json
+++ b/samples/show-case/cloud-azure/Core_6/Store.Sales/Properties/webjob-publish-settings.json
@@ -1,9 +1,5 @@
 ﻿{
   "$schema": "http://schemastore.org/schemas/json/webjob-publish-settings.json",
   "webJobName": "Store-Sales",
-  "startTime": null,
-  "endTime": null,
-  "jobRecurrenceFrequency": null,
-  "interval": null,
   "runMode": "Continuous"
 }

--- a/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
@@ -117,5 +117,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
@@ -117,4 +117,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
+  <Import Project="..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.12\tools\webjobs.targets')" />
 </Project>

--- a/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Sales/Store.Sales.csproj
@@ -71,6 +71,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.2.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.0-rc0001\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/show-case/cloud-azure/Core_6/Store.Sales/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.Sales/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />
   <package id="NServiceBus.Encryption.MessageProperty" version="1.0.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />

--- a/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
@@ -1,14 +1,20 @@
 ﻿using System;
 using System.Text;
+using Microsoft.Azure;
 using NServiceBus;
 using NServiceBus.Encryption.MessageProperty;
 
 public static class CommonConfiguration
 {
     public static void ApplyCommonConfiguration(this EndpointConfiguration endpointConfiguration,  
-        Action<TransportExtensions<AzureStorageQueueTransport>> messageEndpointMappings = null,
-        string connectionString = "UseDevelopmentStorage=true")
+        Action<TransportExtensions<AzureStorageQueueTransport>> messageEndpointMappings = null)
     {
+        var connectionString = CloudConfigurationManager.GetSetting("NServiceBus.ConnectionString");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = "UseDevelopmentStorage=true";
+        }
+
         var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
         transport.ConnectionString(connectionString);
 

--- a/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
@@ -1,15 +1,19 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using NServiceBus;
 using NServiceBus.Encryption.MessageProperty;
 
 public static class CommonConfiguration
 {
-    public static void ApplyCommonConfiguration(this EndpointConfiguration endpointConfiguration)
+    public static void ApplyCommonConfiguration(this EndpointConfiguration endpointConfiguration, Action<TransportExtensions<AzureStorageQueueTransport>> messageEndpointMappings = null)
     {
         var connectionString = "UseDevelopmentStorage=true";
 
         var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
         transport.ConnectionString(connectionString);
+
+        messageEndpointMappings?.Invoke(transport);
+
         var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence>();
         persistence.ConnectionString(connectionString);
         var defaultKey = "2015-10";

--- a/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
+++ b/samples/show-case/cloud-azure/Core_6/Store.Shared/CommonConfiguration.cs
@@ -5,10 +5,10 @@ using NServiceBus.Encryption.MessageProperty;
 
 public static class CommonConfiguration
 {
-    public static void ApplyCommonConfiguration(this EndpointConfiguration endpointConfiguration, Action<TransportExtensions<AzureStorageQueueTransport>> messageEndpointMappings = null)
+    public static void ApplyCommonConfiguration(this EndpointConfiguration endpointConfiguration,  
+        Action<TransportExtensions<AzureStorageQueueTransport>> messageEndpointMappings = null,
+        string connectionString = "UseDevelopmentStorage=true")
     {
-        var connectionString = "UseDevelopmentStorage=true";
-
         var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
         transport.ConnectionString(connectionString);
 

--- a/samples/show-case/cloud-azure/Core_6/Store.Shared/Store.Shared.csproj
+++ b/samples/show-case/cloud-azure/Core_6/Store.Shared/Store.Shared.csproj
@@ -42,6 +42,9 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\WindowsAzure.Storage.8.1.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>

--- a/samples/show-case/cloud-azure/Core_6/Store.Shared/packages.config
+++ b/samples/show-case/cloud-azure/Core_6/Store.Shared/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net461" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net461" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.0-rc0001" targetFramework="net461" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.2.0" targetFramework="net461" />

--- a/samples/show-case/cloud-azure/sample.md
+++ b/samples/show-case/cloud-azure/sample.md
@@ -44,6 +44,7 @@ include: showcase-featureusage
 
 This sample has been designed to run in a development environment under the Azure Storage Emulator. In order to deploy the sample to the cloud the following should be considered:
 
+ 1. Application setting with the key `AzureWebJobsEnv` must be set to a value other than `Development`.
  1. An [Azure Storage account must be created](https://docs.microsoft.com/en-us/azure/storage/storage-create-storage-account#create-a-storage-account).
- 1. Each endpoint is hardcoded to use the development storage. The connection string passed into the Azure Storage Queues transport and the Azure Storage persistence in `CommonConfiguration.ApplyCommonConfiguration()` must be updated to point to the Storage Account configured in step 1.
+ 1. By default, each endpoint is using the development storage. Application setting with the key `NServiceBus.ConnectionString` must be defined and its value set to the Storage Account connection string configured in step 1.
  1. In order to support the elastic scale capabilities of the Azure platform, a [SignalR backplane](https://docs.microsoft.com/en-us/aspnet/signalr/overview/performance/scaleout-in-signalr) must be added to the `ECommerce` endpoint.

--- a/samples/show-case/cloud-azure/sample.md
+++ b/samples/show-case/cloud-azure/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Cloud Show Case
 summary: Implements a fictional store utilizing several features of NServiceBus.
-reviewed: 2017-02-10
+reviewed: 2017-05-18
 component: Core
 ---
 


### PR DESCRIPTION
**Changes**
- Replacing MEM with Routing API
- Replace hard-coded connection string with an argument to support real world usage
- Connect webjob projects to the webapp to be able to deploy all together
- The sample can be now deployed to Azure using updated deployment notes

With Core 6.3 MEM is obsoleted with warning.
Removing red scary messages from the show case by replacing MEM with Routing API.

Hard-coded connection string is not a good starting point for anyone who'd like to base their tryout (azure deployment) on this sample. Switched to a parameter which can be passed into `ApplyCommonConfiguration()` extension method.

Before the change, deploying webapp would not deploy the webjobs. Now with a publishing settings file, webdeploy pushes webapp and webjobs to Azure hosting plan.

@Particular/docs-maintainers please review