### PR TITLE
Removed sentence from opening

### DIFF
--- a/samples/servicecontrol/adapter-sqlserver/sample.md
+++ b/samples/servicecontrol/adapter-sqlserver/sample.md
@@ -12,7 +12,7 @@ related:
 
 This sample shows how to configure ServiceControl to monitor endpoints and retry messages when using SQL Server transport in a multi-database mode.
 
-The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance) mode). 
+The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance.md) mode). 
 
 
 ## Prerequisistes

--- a/samples/servicecontrol/adapter-sqlserver/sample.md
+++ b/samples/servicecontrol/adapter-sqlserver/sample.md
@@ -12,7 +12,7 @@ related:
 
 This sample shows how to configure ServiceControl to monitor endpoints and retry messages when using SQL Server transport in a multi-database mode.
 
-The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance.md) mode). 
+The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [SQL Server multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance.md) mode). 
 
 
 ## Prerequisistes

--- a/samples/servicecontrol/adapter-sqlserver/sample.md
+++ b/samples/servicecontrol/adapter-sqlserver/sample.md
@@ -12,7 +12,7 @@ related:
 
 This sample shows how to configure ServiceControl to monitor endpoints and retry messages when using SQL Server transport in a multi-database mode.
 
-The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance) mode). In order to do so, the adapter provides a ServiceControl interface to the business endpoints. 
+The purpose of the adapter is to isolate ServiceControl from the specifics of the physical deployment topology of the business endpoints (such as [multi-instance](/nservicebus/sqlserver/deployment-options.md#modes-overview-multi-instance) mode). 
 
 
 ## Prerequisistes


### PR DESCRIPTION
Removed this:

> In order to do so, the adapter provides a ServiceControl interface to the business endpoints. 

It isn't clear to me what this means or how this would help me, as a user, understand the sample. Could be just me, though. I'm not as technical as I used to be.