### PR TITLE
Upgrade guide updates

### DIFF
--- a/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6,7).partial.md
+++ b/nservicebus/recoverability/configure-delayed-retries_legacy_core_[6,7).partial.md
@@ -9,4 +9,4 @@ The `.Retries` receiver can be disabled via code using:
 
 snippet: DisableLegacyRetriesSatellite
 
-INFO: This API will be obsoleted in Version 7 and removed afterwards.
+INFO: This .Retries message receiver and the API to disable it will be removed in Version 7.

--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -106,14 +106,28 @@ snippet: 6to7endpoint-mapping-Routing-Logical
 snippet: 6to7endpoint-mapping-Routing-RegisterPublisher
 
 
-## Access to settings
+## Renamed APIs
 
-The `.GetSettings()` extension method has been moved from `NServiceBus.Configuration.AdvanceExtensibility` to the `NServiceBus.Configuration.AdvancedExtensibility` namespace. More details on advanced access to settings can be found [here](/nservicebus/pipeline/features.md#feature-settings-endpointconfiguration).
+
+### Access to settings
+
+The `GetSettings` extension method has been moved from `NServiceBus.Configuration.AdvanceExtensibility` to the `NServiceBus.Configuration.AdvancedExtensibility` namespace. More details on advanced access to settings can be found [here](/nservicebus/pipeline/features.md#feature-settings-endpointconfiguration).
+
+
+###  ContextBag extensions
+
+The `RemoveDeliveryConstaint` extension method has been renamed to `RemoveDeliveryConstraint`.
+
+
+### IncomingMessage extensions
+
+The `GetMesssageIntent` extension method has been renamed to `GetMessageIntent`.
 
 
 ## Assembly scanning
 
 64-bit assemblies are no longer silently excluded from scanning when running in a x86 process. Instead startup will fail with a `System.BadImageFormatException`. Use the [exclude API](/nservicebus/hosting/assembly-scanning.md#assemblies-to-scan) to exclude the assembly and avoid the exception. 
+
 
 ## Legacy .Retries message receiver
 

--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -114,3 +114,7 @@ The `.GetSettings()` extension method has been moved from `NServiceBus.Configura
 ## Assembly scanning
 
 64-bit assemblies are no longer silently excluded from scanning when running in a x86 process. Instead startup will fail with a `System.BadImageFormatException`. Use the [exclude API](/nservicebus/hosting/assembly-scanning.md#assemblies-to-scan) to exclude the assembly and avoid the exception. 
+
+## Legacy .Retries message receiver
+
+The [.Retries message receiver](/nservicebus/recoverability/configure-delayed-retries.md?version=core_6#custom-retry-policy-legacy-retries-message-receiver) added to assist in migrating from Version 5 to Version 6 has been removed. The API to disable it has also been removed.

--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -106,11 +106,9 @@ snippet: 6to7endpoint-mapping-Routing-Logical
 snippet: 6to7endpoint-mapping-Routing-RegisterPublisher
 
 
-include: dependencies
+## Access to settings
 
-### Access to settings
-
-The `.GetSettings()` extension metod has been moved from `NServiceBus.Configuration.AdvanceExtensibility` to the `NServiceBus.Configuration.AdvancedExtensibility` namespace. More details on advanced access to settings [here](/nservicebus/pipeline/features.md#feature-settings-endpointconfiguration).
+The `.GetSettings()` extension method has been moved from `NServiceBus.Configuration.AdvanceExtensibility` to the `NServiceBus.Configuration.AdvancedExtensibility` namespace. More details on advanced access to settings can be found [here](/nservicebus/pipeline/features.md#feature-settings-endpointconfiguration).
 
 
 ## Assembly scanning


### PR DESCRIPTION
Updates for the 6 to 7 upgrade guide.

Adds entries for https://github.com/Particular/NServiceBus/pull/4745 and https://github.com/Particular/NServiceBus/pull/4768.


CC: @Particular/nservicebus-maintainers 