### PR TITLE
Switching to closure access in lambda to avoid deadlocks in lifetime scope

### DIFF
--- a/samples/containers/autofac/Autofac_6/Sample/Program.cs
+++ b/samples/containers/autofac/Autofac_6/Sample/Program.cs
@@ -20,10 +20,8 @@ static class Program
 
         var builder = new ContainerBuilder();
 
-        builder.Register(x =>
-            {
-                return Endpoint.Start(endpointConfiguration).GetAwaiter().GetResult();
-            })
+        IEndpointInstance endpoint = null;
+        builder.Register(x => endpoint)
             .As<IEndpointInstance>()
             .SingleInstance();
 
@@ -42,6 +40,11 @@ static class Program
         endpointConfiguration.UseSerialization<JsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();
+
+        #region EndpointAssignment
+        endpoint = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+        #endregion
 
         var endpointInstance = container.Resolve<IEndpointInstance>();
         var myMessage = new MyMessage();

--- a/samples/containers/autofac/sample.md
+++ b/samples/containers/autofac/sample.md
@@ -13,6 +13,7 @@ related:
 
 snippet: ContainerConfiguration
 
+partial: assignment
 
 ### Injecting the dependency in the handler
 

--- a/samples/containers/autofac/sample_assignment_autofac_[6,).partial.md
+++ b/samples/containers/autofac/sample_assignment_autofac_[6,).partial.md
@@ -1,0 +1,3 @@
+Assign the local variable endpoint as shown below
+
+snippet: EndpointAssignment


### PR DESCRIPTION
The current recomended approach that we have on our autofac sample can lead to a deadlock.  Example

```
builder.Register(x =>
            {
                return Endpoint.Start(endpointConfiguration).GetAwaiter().GetResult();
            }).As<IEndpointInstance>().SingleInstance();
```

The code above registers as a lambda the endpoint start. Endpoint start returns a task. You use `GetAwaiter().GetResult()` to execute the task in a blocking manner. The lambda itself is lazy evaluated when the first resolve on `IEndpointInstance` happens. 

```
 Timeout.Execute(() =>
            {                
               IEndpointInstance endpoint = container.Resolve<IEndpointInstance>();

               var msg = new StartTestSaga() { MsgId = 1 };
                endpoint.Publish(msg);
            }, 2000);
```

The timer execute enters on a background thread the lambda which then calls into resolve. Resolve internally uses the lifetime scope of autofac. Autofacs lifetime scope acquires a lock. https://github.com/autofac/Autofac/blob/ea21e5fd7076cb10383c339ab00dbd0fa5def4a2/src/Autofac/Core/Lifetime/LifetimeScope.cs#L268 While holding the lock we enter the lambda defined above when then starts the endpoint synchronously. When NServiceBus starts it also uses the container provided by you which is already holding a lock. It then wants to resolve other instances from the container, tries to acquire the lock which is already taken by the very same thread and you are deadlocked. See the picture below

![image](https://user-images.githubusercontent.com/174258/27434604-849ed43c-5759-11e7-8de2-ce69bc057eae.png)

## Workaround

```
            IMessageSession messageSession = null;
            // Register endpoint instance
            builder.Register(ctx => messageSession).As<IMessageSession>().SingleInstance();

            // Build container
            var container = builder.Build();

            endpointConfiguration.UseContainer<AutofacBuilder>(customizations =>
            {
                customizations.ExistingLifetimeScope(container);
            });

            var endpoint = await Endpoint.Start(endpointConfiguration).ConfigureAwait(false);
            messageSession = endpoint;

```