### PR TITLE
Add registry based config options to list deprecated options

### DIFF
--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -24,6 +24,8 @@ Configuring Audit via the following APIs have been deprecated:
  * `IProvideConfiguration<AuditConfig>`
  * `AuditConfig` in an app.config `configSections`
  * Returning a `AuditConfig` from a `IConfigurationSource`
+ * `HKEY_LOCAL_MACHINE\SOFTWARE\ParticularSoftware\ServiceBus\AuditQueue` registry key
+ 
 
 Instead use one of the following:
 
@@ -70,6 +72,7 @@ Configuring the error queue via the following APIs have been deprecated:
  * `IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>`
  * `MessageForwardingInCaseOfFaultConfig` in an app.config `configSections`
  * Returning a `MessageForwardingInCaseOfFaultConfig` from a `IConfigurationSource`
+ * `HKEY_LOCAL_MACHINE\SOFTWARE\ParticularSoftware\ServiceBus\ErrorQueue` registry key
 
 Instead use one of the following:
 


### PR DESCRIPTION
Registry based config options for the error and audit queue are no longer supported. (see https://github.com/Particular/NServiceBus/pull/4741)