### PR TITLE
Translate MSMQ transport message to SQL transport message

### DIFF
--- a/samples/msmq/sql-bridge/Core_5/SqlBridge/MsmqReceiver.cs
+++ b/samples/msmq/sql-bridge/Core_5/SqlBridge/MsmqReceiver.cs
@@ -90,6 +90,13 @@ class MsmqReceiver :
         return new TransportMessage(sqlId, headers)
         {
             Body = msmqMessage.Body,
+            // MSMQ and SQL Server transports signal lack of TimeToBeReceived differently.
+            // MSMQ uses Message.InfiniteTimeout value to indicate that a message should
+            // never be discarded. SQL Server transport expects TimeSpan.MaxValue to
+            // indicate the same behaviour. This would normally be handled by NServiceBus
+            // pipeline when transforming a transport message into a logical message.
+            // This sample skips the pipeline and deals with transport messages directly,
+            // thus making this translation required.
             TimeToBeReceived = (msmqMessage.TimeToBeReceived < Message.InfiniteTimeout) ? msmqMessage.TimeToBeReceived : TimeSpan.MaxValue
         };
     }

--- a/samples/msmq/sql-bridge/Core_5/SqlBridge/SqlBridge.csproj
+++ b/samples/msmq/sql-bridge/Core_5/SqlBridge/SqlBridge.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Messaging" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GuidBuilder.cs" />

--- a/samples/msmq/sql-bridge/sample.md
+++ b/samples/msmq/sql-bridge/sample.md
@@ -95,6 +95,8 @@ snippet: satellite
 
 Note: Since `SqlBridge` is not using the native MSMQ transport manually creating `SqlMsmqTransportBridge` queue will be required.
 
+Note: `TransportMessage` objects for different transports may use certain properties in an incompatible way (e.g. `TimeToBeReceived`) and values of such properties need to be translated before use on another transport.
+
 
 ## How does the advanced satellite work
 


### PR DESCRIPTION
Also, add a note that in general this might be required when using `TransportMessage` objects coming from different transports.