### PR TITLE
Switch to native ADO transactions

### DIFF
--- a/samples/sqltransport-sqlpersistence/Core_6/Receiver/EntityFramework/SubmittedOrderDbContext.cs
+++ b/samples/sqltransport-sqlpersistence/Core_6/Receiver/EntityFramework/SubmittedOrderDbContext.cs
@@ -19,11 +19,6 @@ namespace EntityFramework
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            options.ConfigureWarnings(
-                warnings =>
-                {
-                    warnings.Ignore(RelationalEventId.AmbientTransactionWarning);
-                });
             options.UseSqlServer(connection);
         }
     }

--- a/samples/sqltransport-sqlpersistence/Core_6/Receiver/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_6/Receiver/Program.cs
@@ -33,6 +33,9 @@ public static class Program
         transport.UseSchemaForQueue("error", "dbo");
         transport.UseSchemaForQueue("audit", "dbo");
         transport.UseSchemaForQueue("Samples.Sql.Sender", "sender");
+
+        transport.Transactions(TransportTransactionMode.SendsAtomicWithReceive);
+
         var routing = transport.Routing();
         routing.RouteToEndpoint(typeof(OrderAccepted), "Samples.Sql.Sender");
         routing.RegisterPublisher(typeof(OrderSubmitted).Assembly, "Samples.Sql.Sender");

--- a/samples/sqltransport-sqlpersistence/sample.md
+++ b/samples/sqltransport-sqlpersistence/sample.md
@@ -10,6 +10,7 @@ related:
 
 In this sample, the [SQL Server Transport](/transports/sql/) is used in conjunction with [SQL Persistence](/persistence/sql/). The sample shows how to use the same database connection for both transport and persistence operations, and how to access (using multiple [ORMs](https://en.wikipedia.org/wiki/Object-relational_mapping)) the current SQL connection and transaction from within a message handler to persist business objects to the database.
 
+NOTE: Because SQL Persistence is able to reuse the connection and transaction managed by SQL Server transport the endpoints can run in the `TransportTransactionMode.SendsAtomicWithReceive` while ensuring exactly once message processing guarantees, as long as SQL Persistence session APIs are used to access connection and transaction. 
 
 ## Prerequisites
 

--- a/samples/sqltransport-sqlpersistence/sample.md
+++ b/samples/sqltransport-sqlpersistence/sample.md
@@ -134,8 +134,6 @@ snippet: SubmittedOrderEF
 
 Entity Framework required an implementation of [DBContext](https://docs.microsoft.com/en-us/ef/core/miscellaneous/configuring-dbcontext) to persist data.
 
-Since, in the context of handlers, there is an ambient transaction, the `AmbientTransactionWarning` needs to be suppressed.
-
 snippet: SubmittedOrderDbContext
 
 


### PR DESCRIPTION
It allows to remove the warning override in EF while maintaining the same guarantees.