### PR TITLE
Removes the heartbeat not support for send-only

### DIFF
--- a/servicecontrol/plugins/heartbeat.md
+++ b/servicecontrol/plugins/heartbeat.md
@@ -21,9 +21,6 @@ An inactive endpoint indicates that there is a failure in the communication path
 
 NOTE: It is essential to deploy this plugin to the endpoint in production for ServicePulse to be able to monitor the endpoint.
 
-WARNING: The Heartbeat plugin does not support [Send-Only endpoints](/nservicebus/hosting/#self-hosting-send-only-hosting).
-
-
 ### Deprecated NuGet
 
 The first release of the Heartbeat plugin the NuGet packages was named **ServiceControl.Plugin.Heartbeat**. **This packages is now obsolete and should be remove**. Replace it with the appropriate plugin based on the NServiceBus version. The new NServiceBus version specific packages are:

--- a/servicecontrol/plugins/heartbeat.md
+++ b/servicecontrol/plugins/heartbeat.md
@@ -1,7 +1,7 @@
 ---
 title: Heartbeat Plugin
 summary: Use the Heartbeat plugin to monitor the health of the endpoints
-reviewed: 2016-11-15
+reviewed: 2017-07-12
 component: Heartbeats
 related:
  - servicepulse/intro-endpoints-heartbeats


### PR DESCRIPTION
Heartbeat are supported both in V5 and V6 even for Send-Only endpoints.