### PR TITLE
Update FileBasedRouting sample

### DIFF
--- a/samples/routing/file-based-routing/FileBasedRouting_1/Billing/Billing.csproj
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Billing/Billing.csproj
@@ -31,9 +31,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.FileBasedRouting, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.0.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NServiceBus.FileBasedRouting, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.2.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Billing/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Billing/Program.cs
@@ -15,8 +15,9 @@ class Program
     {
         Console.Title = "Samples.FileBasedRouting.Billing";
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Billing");
-        endpointConfiguration.UsePersistence<LearningPersistence>();
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
+        endpointConfiguration.UsePersistence<InMemoryPersistence>();
+        endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
+        var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();
         routing.UseFileBasedRouting(@"..\..\..\endpoints.xml");
 

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Billing/packages.config
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Billing/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
-  <package id="NServiceBus.FileBasedRouting" version="1.0.0" targetFramework="net461" />
+  <package id="NServiceBus.FileBasedRouting" version="1.2.0" targetFramework="net461" />
 </packages>

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Client/Client.csproj
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Client/Client.csproj
@@ -35,9 +35,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.FileBasedRouting, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.0.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NServiceBus.FileBasedRouting, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.2.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Client/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Client/Program.cs
@@ -19,11 +19,12 @@ class Program
         var random = new Random();
 
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Client");
-        endpointConfiguration.UsePersistence<LearningPersistence>();
+        endpointConfiguration.UsePersistence<InMemoryPersistence>();
+        endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
 
         #region FileBasedRouting
 
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
+        var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();
         routing.UseFileBasedRouting(@"..\..\..\endpoints.xml");
 

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Client/packages.config
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Client/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
-  <package id="NServiceBus.FileBasedRouting" version="1.0.0" targetFramework="net461" />
+  <package id="NServiceBus.FileBasedRouting" version="1.2.0" targetFramework="net461" />
 </packages>

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Sales/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Sales/Program.cs
@@ -14,9 +14,10 @@ class Program
     {
         Console.Title = "Samples.FileBasedRouting.Sales";
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Sales");
-        endpointConfiguration.UsePersistence<LearningPersistence>();
+        endpointConfiguration.UsePersistence<InMemoryPersistence>();
+        endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
 
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
+        var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();
         routing.UseFileBasedRouting(@"..\..\..\endpoints.xml");
 

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Sales/Sales.csproj
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Sales/Sales.csproj
@@ -31,9 +31,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.FileBasedRouting, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.0.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NServiceBus.FileBasedRouting, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.2.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Sales/packages.config
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Sales/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
-  <package id="NServiceBus.FileBasedRouting" version="1.0.0" targetFramework="net461" />
+  <package id="NServiceBus.FileBasedRouting" version="1.2.0" targetFramework="net461" />
 </packages>

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/Program.cs
@@ -15,9 +15,10 @@ class Program
     {
         Console.Title = "Samples.FileBasedRouting.Shipping";
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Shipping");
-        endpointConfiguration.UsePersistence<LearningPersistence>();
+        endpointConfiguration.UsePersistence<InMemoryPersistence>();
+        endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
 
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
+        var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();
         routing.UseFileBasedRouting(@"..\..\..\endpoints.xml");
 

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/Shipping.csproj
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/Shipping.csproj
@@ -31,9 +31,8 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NServiceBus.FileBasedRouting, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.0.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NServiceBus.FileBasedRouting, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.FileBasedRouting.1.2.0\lib\net46\NServiceBus.FileBasedRouting.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/packages.config
+++ b/samples/routing/file-based-routing/FileBasedRouting_1/Shipping/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
-  <package id="NServiceBus.FileBasedRouting" version="1.0.0" targetFramework="net461" />
+  <package id="NServiceBus.FileBasedRouting" version="1.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
* Updated to NServiceBus.FileBasedRouting 1.2
* Switched back transport to MSMQ: Learning transport doesn't make much sense in here as the sample demonstrates routing config of commands and events, whereas the "event routes" will be ignored as the learning transport provides native pub/sub.
* Switched back to InMemoryPersistence, as MSMQ requires a persistence which provides a timeout storage.