### PR TITLE
add named params to metrics

### DIFF
--- a/Snippets/Metrics/Metrics_1.1/Configuration.cs
+++ b/Snippets/Metrics/Metrics_1.1/Configuration.cs
@@ -18,19 +18,21 @@ namespace Metrics_1
 
             #region Metrics-Log
 
-            metricsOptions.EnableLogTracing(TimeSpan.FromMinutes(5));
+            metricsOptions.EnableLogTracing(interval: TimeSpan.FromMinutes(5));
 
             #endregion
 
             #region Metrics-Log-Info
 
-            metricsOptions.EnableLogTracing(TimeSpan.FromMinutes(5), LogLevel.Info);
+            metricsOptions.EnableLogTracing(
+                interval: TimeSpan.FromMinutes(5),
+                logLevel: LogLevel.Info);
 
             #endregion
 
             #region Metrics-Tracing
 
-            metricsOptions.EnableMetricTracing(TimeSpan.FromSeconds(5));
+            metricsOptions.EnableMetricTracing(interval: TimeSpan.FromSeconds(5));
 
             #endregion
 
@@ -48,16 +50,16 @@ namespace Metrics_1
 
             #region Metrics-Observers
 
-            metricsOptions.RegisterObservers(ctx =>
+            metricsOptions.RegisterObservers(context =>
             {
-                foreach (var duration in ctx.Durations)
+                foreach (var duration in context.Durations)
                 {
                     duration.Register(durationLength =>
                     {
                         Console.WriteLine($"Duration '{duration.Name}' value observed: '{durationLength}'");
                     });
                 }
-                foreach (var signal in ctx.Signals)
+                foreach (var signal in context.Signals)
                 {
                     signal.Register(() =>
                     {

--- a/Snippets/Metrics/Metrics_1/Configuration.cs
+++ b/Snippets/Metrics/Metrics_1/Configuration.cs
@@ -18,19 +18,21 @@ namespace Metrics_1
 
             #region Metrics-Log
 
-            metricsOptions.EnableLogTracing(TimeSpan.FromMinutes(5));
+            metricsOptions.EnableLogTracing(interval: TimeSpan.FromMinutes(5));
 
             #endregion
 
             #region Metrics-Log-Info
 
-            metricsOptions.EnableLogTracing(TimeSpan.FromMinutes(5), LogLevel.Info);
+            metricsOptions.EnableLogTracing(
+                interval: TimeSpan.FromMinutes(5),
+                logLevel: LogLevel.Info);
 
             #endregion
 
             #region Metrics-Tracing
 
-            metricsOptions.EnableMetricTracing(TimeSpan.FromSeconds(5));
+            metricsOptions.EnableMetricTracing(interval: TimeSpan.FromSeconds(5));
 
             #endregion
 


### PR DESCRIPTION
i think this makes the snippets more readable. since without the param names the timespan is ambiguous 