### PR TITLE
SC monitoring instances (take 2)

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -897,6 +897,8 @@
 
 - Name: ServiceControl
   Topics:
+  - Title: Powershell
+    Url: servicecontrol/powershell
   - Title: ServiceControl instances
     Url: servicecontrol/servicecontrol-instances
     Articles:

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -897,6 +897,8 @@
 
 - Name: ServiceControl
   Topics:
+  - Title: Licensing
+    Url: servicecontrol/license
   - Title: Powershell
     Url: servicecontrol/powershell
   - Title: ServiceControl instances
@@ -920,8 +922,6 @@
         Url: servicecontrol/installation-powershell
       - Title: Cluster Deployment
         Url: servicecontrol/deploying-servicecontrol-in-a-cluster
-      - Title: Licensing
-        Url: servicecontrol/license
       - Title: Settings
         Url: servicecontrol/creating-config-file
       - Title: Overriding the host identifier

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -1,59 +1,32 @@
 ---
-title: Managing Instances via PowerShell
-reviewed: 2016-11-09
+title: Managing ServiceControl instances via PowerShell
+reviewed: 2017-07-26
 tags:
  - Installation
  - PowerShell
 ---
 
+NOTE: For general information about ServiceControl Powershell, including troubleshooting and licensing guidance, see [Managing ServiceControl via PowerShell](/servicecontrol/powershell.md).
 
-## ServiceControl PowerShell
+## ServiceControl instance Cmdlets and Aliases
 
-ServiceControl 1.7 introduced a new graphical management utility to add, remove, update and delete instances of the ServiceControl service. These actions and some additional tools have also exposed via PowerShell module called `ServiceControlMgmt`.
-
-
-## Prerequisites
-
-The ServiceControlMgmt module requires:
-
- * Microsoft PowerShell 3.0
-
-
-## Loading and Running the PowerShell Module
-
-The majority of the ServiceControlMgmt PowerShell module cmdlets will only work if the PowerShell session is running under administrator privileges. The ServiceControl installer creates a shortcut in the Windows start menu to launch an administrative PowerShell Session with the module automatically loaded. Alternatively the module can be loaded directly into an an existing PowerShell session by loading `ServiceControlMgmt.psd1` using the `Import-Module` cmdlet as show below:
-
-```ps
-Import-Module "C:\Program Files (x86)\Particular Software\ServiceControl Management\ServiceControlMgmt.psd1"
-```
-
-
-## Cmdlets and Aliases
-
-The following cmdlets and aliases are provided by the ServiceControl Management PowerShell module.
+The following cmdlets and aliases are provided by the ServiceControl Management PowerShell module for the management of ServiceControl instances.
 
 | Alias                  | Cmdlet                                        |
 | ---------------------- | --------------------------------------------- |
 | sc-add                 | New-ServiceControlInstance                    |
 | sc-addfromunattendfile | New-ServiceControlInstanceFromUnattendedFile  |
-| sc-addlicense          | Import-ServiceControlLicense                  |
 | sc-delete              | Remove-ServiceControlInstance                 |
-| sc-findlicense         | Get-ServiceControlLicense                     |
-| sc-help                | Get-ServiceControlMgmtCommands                |
 | sc-instances           | Get-ServiceControlInstances                   |
 | sc-makeunattendfile    | New-ServiceControlUnattendedFile              |
 | sc-transportsinfo      | Get-ServiceControlTransportTypes              |
 | sc-upgrade             | Invoke-ServiceControlInstanceUpgrade          |
-| urlacl-add             | Add-UrlAcl                                    |
-| urlacl-delete          | Remove-UrlAcl                                 |
-| urlacl-list            | Get-UrlAcls                                   |
-| port-check             | Test-IfPortIsAvailable                        |
-| user-sid               | Get-SecurityIdentifier                        |
 
 
-### Examples
 
-To following commands show some uses of some of the cmdlets provided in the module. All of the cmdlets have local help which can be accessed via the standard PowerShell help command
+### Help
+
+All of the cmdlets have local help which can be accessed via the standard PowerShell help command
 
 ```ps
 Get-Help Get-ServiceControlInstances
@@ -105,17 +78,6 @@ Invoke-ServiceControlInstanceUpgrade -Name <Instance To upgrade>
 The upgrade will stop the service if it is running. Additional parameters for `Invoke-ServiceControlInstanceUpgrade` may be required. The configuration file of the existing version is examined prior to deter,in e if all the required settings are present. If a configuration setting is missing  then the cmdlet will throw an error indicating the required additional parameter.
 
 
-### Licensing
-
-Add the license file to the registry by running the following cmdlet.
-
-```ps
-Import-ServiceControlLicense <License-File>
-```
-
-The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to all instances of ServiceControl installed on the machine.
-
-
 ### Building an unattended install file
 
 Since ServiceControl 1.7 the installation executable has a MSI command line argument to enable the installation of a ServiceControl service instance during installation. This is intended to assist with [unattended installation](installation-silent.md)
@@ -160,49 +122,3 @@ New-ServiceControlInstanceFromUnattendedFile -UnattendFile c:\temp\unattended.xm
 ```
 
 Note: Neither the unattended file method or the `New-ServiceControlInstance` cover all the configuration settings that are available to ServiceControl. To set additonal options refer to [Customizing ServiceControl configuration](creating-config-file.md). A scripted method of adding additional settings is detailed in [Installing ServiceControl Silently](installation-silent.md).
-
-
-## Troubleshooting via PowerShell
-
-The ServiceControl Management PowerShell offers some cmdlets to assist with troubleshooting the install of ServiceControl instances.
-
-
-### Check if a Port is already in use
-
-Before adding an instance of ServiceControl test if the port to use is currently in use.
-
-```ps
-Test-IfPortIsAvailable -Port 33333
-```
-
-This example shows the available ports out of a range of ports
-
-```ps
-33330..33339 | Test-IfPortIsAvailable | ? Available
-```
-
-
-### Checking and manipulating UrlAcls
-
-The Window HTTPServer API is used by underlying components in ServiceControl. This API uses a permissions system to limit what accounts can add a HTTP listener to a specific URI.
-The standard mechanism for viewing and manipulating these ports in via the [netsh.exe](https://technet.microsoft.com/en-us/library/Cc725882.aspx) command line tool.
-
-For example `netsh.exe http show urlacl` will list all of the available. This output is detailed but not very friendly to query. The ServiceControl Management PowerShell provides simplified PowerShell equivalents for listing, add and removing UrlAcls and makes the output easier to query.
-
-For example the following command lists all of the UrlAcls assigned to any URI for port 33333.
-
-```ps
-Get-UrlAcls | ? Port -eq 33333
-```
-
-In this example any UrlAcl on port 33335 is remove
-
-```ps
-Get-UrlAcls | ? Port -eq 33335 | Remove-UrlAcl
-```
-
-The following example shows how to add UrlAcl for a ServiceControl service that should only respond to a specific DNS name. This would require an update of the ServiceControl configuration file as well. Refer to [setting a custom host name and port number](setting-custom-hostname.md)
-
-```ps
-Add-UrlAcl -Url http://servicecontrol.mycompany.com:33333/api/ -Users Users
-```

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -1,5 +1,5 @@
 ---
-title: Managing ServiceControl instances via PowerShell
+title: Manage ServiceControl instances via PowerShell
 reviewed: 2017-07-26
 tags:
  - Installation
@@ -75,7 +75,7 @@ To upgrade and instance to the latest version of the binaries run.
 Invoke-ServiceControlInstanceUpgrade -Name <Instance To upgrade>
 ```
 
-The upgrade will stop the service if it is running. Additional parameters for `Invoke-ServiceControlInstanceUpgrade` may be required. The configuration file of the existing version is examined prior to deter,in e if all the required settings are present. If a configuration setting is missing  then the cmdlet will throw an error indicating the required additional parameter.
+The upgrade will stop the service if it is running. Additional parameters for `Invoke-ServiceControlInstanceUpgrade` may be required. The configuration file of the existing version is examined prior to determine if all the required settings are present. If a configuration setting is missing then the cmdlet will throw an error indicating the required additional parameter.
 
 
 ### Building an unattended install file
@@ -88,11 +88,13 @@ The MSI command line argument requires an XML file which detail the instance opt
 New-ServiceControlUnattendedFile -OutputFile c:\temp\unattended.xml -Name Test -InstallPath c:\servicecontrol\test\bin -DBPath c:\servicecontrol\test\db -LogPath c:\servicecontrol\test\logs -Port 33335 -ErrorQueue error-test -AuditQueue audit-test -ErrorLogQueue errorlog-test -AuditLogQueue auditlog-test -Transport MSMQ -ForwardAuditMessages $false -ForwardErrorMessages $false
 ```
 
-This sample produces the following Files
+This sample produces the following file
 
 ```xml
 <?xml version="1.0"?>
-<ServiceControlInstanceMetadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<ServiceControlInstanceMetadata
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <LogPath>C:\servicecontrol\test\db</LogPath>
   <DBPath>C:\servicecontrol\test\logs</DBPath>
   <HostName>localhost</HostName>

--- a/servicecontrol/monitoring-instances/index.md
+++ b/servicecontrol/monitoring-instances/index.md
@@ -1,0 +1,29 @@
+---
+title: Monitoring instances
+reviewed: 2017-07-25
+component: ServiceControl
+---
+
+Monitoring instances collect and analyze metric data collected by the [metrics plugin](/nservicebus/operations/metrics.md) installed in NServiceBus endpoints. This data is exposed to [ServicePulse](/servicepulse/) via an HTTP API.
+
+NOTE: The ServiceControl HTTP API is designed for use by ServicePulse only and may change at any time. Use of this HTTP API for other purposes is discouraged.
+
+```mermaid
+graph LR
+  subgraph Endpoints
+    Audit
+    Error
+    Plugin[Metrics<br>Plugin]
+  end
+
+  Plugin -- Metric<br>Data --> IQ
+	
+  IQ[Monitoring<br>Input Queue] --> MI[Monitoring<br>Instance]
+  ServicePulse -.-> MI
+```
+
+Each endpoint in the system should be [configured to send metric data](/nservicebus/operations/metrics.md). A Monitoring instance consumes this data makes it available for visualization in ServicePulse. 
+
+NOTE: Monitoring instances store data about each endpoint in memory for 10 minutes. Monitoring instances do not store persistent data. Restarting the monitoring instance will clear the in-memory cache.
+
+Each environment should have a single Monitoring instance that all endpoints are configured to use.

--- a/servicecontrol/monitoring-instances/installation/creating-config-file.md
+++ b/servicecontrol/monitoring-instances/installation/creating-config-file.md
@@ -25,6 +25,7 @@ Default: `localhost`
 
 NOTE: This setting must have a value in order for the Monitoring instance API to be available from remote machines. 
 
+
 ### Monitoring/HttpPort
 
 The port to bind the embedded HTTP server.
@@ -33,7 +34,9 @@ Type: int
 
 Default: `33633`.
 
+
 ## Logging
+
 
 ### Monitoring/LogPath
 

--- a/servicecontrol/monitoring-instances/installation/creating-config-file.md
+++ b/servicecontrol/monitoring-instances/installation/creating-config-file.md
@@ -1,0 +1,85 @@
+---
+title: Monitoring Instance Configuration Settings
+summary: Categorized list of ServiceControl Monitoring instance configuration settings.
+reviewed: 2017-07-26
+---
+
+
+## Configuration Settings
+
+The configuration of a Monitoring instance can be adjusted via ServiceControl Management or by directly modifying the `ServiceControl.Monitoring.exe.config` file. The settings listed are applicable to the app settings section of the configuration file unless otherwise specified.
+
+
+## Host Settings
+
+Please review [Setting a Custom Hostname](setting-custom-hostname.md) prior to modifying configuration settings:
+
+
+### Monitoring/HttpHostname
+
+The hostname to bind the embedded HTTP server to, modify to bind to a specific hostname, eg. `monitoring.mydomain.com`.
+
+Type: string
+
+Default: `localhost`
+
+NOTE: This setting must have a value in order for the Monitoring instance API to be available from remote machines. 
+
+### Monitoring/HttpPort
+
+The port to bind the embedded HTTP server.
+
+Type: int
+
+Default: `33633`.
+
+## Logging
+
+### Monitoring/LogPath
+
+The path for the Monitoring instance logs.
+
+Type: string
+
+Default: The folder that contains the Monitoring instance executable.
+
+
+### Monitoring/LogLevel
+
+Controls the LogLevel of the Monitoring instance logs.
+
+Type: string
+
+Default: `Warn`
+
+Valid settings are: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`.
+
+This setting will default to `Warn` if an invalid value is assigned.
+
+
+## Transport
+
+
+### Monitoring/TransportType
+
+The transport type to run ServiceControl Monitor with.
+
+Type: string
+
+Default: `NServiceBus.MsmqTransport, NServiceBus.Core`
+
+
+### NServiceBus/Transport
+
+The connection string for the transport. This setting should be placed in `connectionStrings` section of configuration file.
+
+Type: string
+
+
+### Monitoring/ErrorQueue
+
+The error queue name.
+
+Type: string
+
+Default: `error`

--- a/servicecontrol/monitoring-instances/installation/creating-config-file.md
+++ b/servicecontrol/monitoring-instances/installation/creating-config-file.md
@@ -12,7 +12,7 @@ The configuration of a Monitoring instance can be adjusted via ServiceControl Ma
 
 ## Host Settings
 
-Please review [Setting a Custom Hostname](setting-custom-hostname.md) prior to modifying configuration settings:
+Prior to modifying these configuration settings review [Setting a Custom Hostname](setting-custom-hostname.md):
 
 
 ### Monitoring/HttpHostname

--- a/servicecontrol/monitoring-instances/installation/creating-config-file.md
+++ b/servicecontrol/monitoring-instances/installation/creating-config-file.md
@@ -32,7 +32,7 @@ The port to bind the embedded HTTP server.
 
 Type: int
 
-Default: `33633`.
+Default: `33633`
 
 
 ## Logging

--- a/servicecontrol/monitoring-instances/installation/index.md
+++ b/servicecontrol/monitoring-instances/installation/index.md
@@ -1,0 +1,69 @@
+---
+title: Installing Monitoring Instances
+reviewed: 2017-07-26
+tags:
+ - Installation
+---
+
+The ServiceControl installation file consists of an embedded MSI bootstrapper EXE and an embedded MSI. This installation can be executed standalone or via the [Platform Installer](/platform/installer/). The installation package include a utility to manage the installation, upgrade and remove of ServiceControl services, including Monitoring instances. This utility is launched as the final step in the installation process and is also available via the Windows Start Menu.
+
+
+## Prerequisites
+
+The ServiceControl Installation has the following prerequisites:
+
+ * [Microsoft .NET 4.5.2 Runtime](https://www.microsoft.com/en-us/download/details.aspx?id=42643)
+
+If ServiceControl is installed via the Platform Installer then the installation and configuration of these prerequisites are managed by the installer.
+
+NOTE: Each environment should contain a single [ServiceControl instance](/servicecontrol/servicecontrol-instances/) and a single [Monitoring instance](/servicecontrol/monitoring-instances/). In high-throughput scenarios it is recommended that these instances each run on a separate dedicated machine.
+
+
+## Transport Support
+
+Monitoring instances can be configured to use one of the supported [transports](/transports/) listed below using the ServiceControl Management application:
+
+ * [Microsoft Message Queuing (MSMQ)](/transports/msmq/)
+ * [Azure Storage Queues](/transports/azure-storage-queues/)
+ * [Azure Service Bus](/transports/azure-service-bus/)
+ * [SQL Server](/transports/sql/)
+ * [RabbitMQ](/transports/rabbitmq/)
+
+Adding third party transports via the Management Utility is not supported at this stage. If MSMQ is the selected transport then ensure the service has been installed and configured as outlined in [Installing The Platform Components Manually](/platform/installer/offline.md#platform-installer-components-nservicebus-prerequisites).
+
+Installing MSMQ is optional in the Platform Installer. See [Platform Installer - MSMQ](/platform/installer/#select-items-to-install-configure-microsoft-message-queuing).
+
+
+## Using ServiceControl Management to upgrade Monitoring instances
+
+ServiceControl Management provides a simple means of setting up one or more Monitoring instances
+
+WARNING: The ability to add multiple instances is primarily intended to assist development and test environments.
+
+ServiceControl Management can be launched automatically at the end of the installation process to enable adding or upgrading ServiceControl or Monitoring instances.
+
+ServiceControl Management will display the list of installed ServiceControl and Monitoring instances. If the version of the binaries used by an instance are older that those shipped with ServiceControl Management an upgrade link will be shown against the version label.
+
+![](managementutil-upgradelink.png 'width=500')
+
+To upgrade the service just click the upgrade link next to the Service name
+
+Clicking the upgrade link will
+
+ * Prompt for any additional information that is required such as values for new mandatory settings introduced in the newer version.
+ * Stop the Service.
+ * Remove the old binaries.
+ * Run the new binaries to create any required queues.
+ * Start the Service.
+
+
+## Using ServiceControl Management to add Monitoring instances
+
+Click on the `+ NEW` link at the top of the screen and select "Monitoring instance" to launch the "New instance form". Complete the form to register a new Monitoring instance service.
+
+
+## Service Name and Plugins
+
+When adding the first Monitoring instance service the default service name is "Particular.Monitoring". It is possible to change this name to a custom service name. In doing so this is also changing the queue name associated with this Monitoring instance.
+
+The metrics endpoint plugin will need the Monitoring instance name in order to send metric data to the Monitoring instance.

--- a/servicecontrol/monitoring-instances/installation/index.md
+++ b/servicecontrol/monitoring-instances/installation/index.md
@@ -44,7 +44,7 @@ ServiceControl Management can be launched automatically at the end of the instal
 
 ServiceControl Management will display the list of installed ServiceControl and Monitoring instances. If the version of the binaries used by an instance are older that those shipped with ServiceControl Management an upgrade link will be shown against the version label.
 
-![](managementutil-upgradelink.png 'width=500')
+![](/servicecontrol/managementutil-upgradelink.png 'width=500')
 
 To upgrade the service just click the upgrade link next to the Service name
 

--- a/servicecontrol/monitoring-instances/installation/index.md
+++ b/servicecontrol/monitoring-instances/installation/index.md
@@ -36,7 +36,7 @@ Installing MSMQ is optional in the Platform Installer. See [Platform Installer -
 
 ## Using ServiceControl Management to upgrade Monitoring instances
 
-ServiceControl Management provides a simple means of setting up one or more Monitoring instances
+ServiceControl Management provides a simple means of setting up one or more Monitoring instances.
 
 WARNING: The ability to add multiple instances is primarily intended to assist development and test environments.
 
@@ -64,6 +64,6 @@ Click on the `+ NEW` link at the top of the screen and select "Monitoring instan
 
 ## Service Name and Plugins
 
-When adding the first Monitoring instance service the default service name is "Particular.Monitoring". It is possible to change this name to a custom service name. In doing so this is also changing the queue name associated with this Monitoring instance.
+When adding the first Monitoring instance service the default service name is `Particular.Monitoring`. It is possible to change this name to a custom service name. In doing so this is also changing the queue name associated with this Monitoring instance.
 
 The metrics endpoint plugin will need the Monitoring instance name in order to send metric data to the Monitoring instance.

--- a/servicecontrol/monitoring-instances/installation/installation-powershell.md
+++ b/servicecontrol/monitoring-instances/installation/installation-powershell.md
@@ -8,6 +8,7 @@ tags:
 
 NOTE: For general information about ServiceControl Powershell, including troubleshooting and licensing guidance, see [Managing ServiceControl via PowerShell](/servicecontrol/powershell.md).
 
+
 ## Monitoring instance Cmdlets and Aliases
 
 The following cmdlets and aliases are provided by the ServiceControl Management PowerShell module for managing Monitoring instances.
@@ -20,7 +21,6 @@ The following cmdlets and aliases are provided by the ServiceControl Management 
 | mon-upgrade            | Invoke-MonitoringInstanceUpgrade              |
 | sc-help                | Get-ServiceControlMgmtCommands                |
 | sc-transportsinfo      | Get-ServiceControlTransportTypes              |
-
 
 
 ### Help

--- a/servicecontrol/monitoring-instances/installation/installation-powershell.md
+++ b/servicecontrol/monitoring-instances/installation/installation-powershell.md
@@ -1,0 +1,69 @@
+---
+title: Managing Monitoring instances via PowerShell
+reviewed: 2017-07-26
+tags:
+ - Installation
+ - PowerShell
+---
+
+NOTE: For general information about ServiceControl Powershell, including troubleshooting and licensing guidance, see [Managing ServiceControl via PowerShell](/servicecontrol/powershell.md).
+
+## Monitoring instance Cmdlets and Aliases
+
+The following cmdlets and aliases are provided by the ServiceControl Management PowerShell module for managing Monitoring instances.
+
+| Alias                  | Cmdlet                                        |
+| ---------------------- | --------------------------------------------- |
+| mon-add                | New-MonitoringInstance                        |
+| mon-delete             | Remove-MonitoringInstance                     |
+| mon-instances          | Get-MonitoringInstances                       |
+| mon-upgrade            | Invoke-MonitoringInstanceUpgrade              |
+| sc-help                | Get-ServiceControlMgmtCommands                |
+| sc-transportsinfo      | Get-ServiceControlTransportTypes              |
+
+
+
+### Help
+
+All of the cmdlets have local help which can be accessed via the standard PowerShell help command
+
+```ps
+Get-Help Get-MonitoringInstances
+```
+
+
+### Adding an instance
+
+```ps
+New-MonitoringInstance -Name Test.Monitoring -InstallPath C:\ServiceControlMonitor\Bin -LogPath C:\ServiceMonitor\Logs -Port 33335 -Transport MSMQ
+```
+
+There are additional parameters available to set additional configuration options such as hostname, transport connection string, and error queue.
+
+
+### Removing an instance
+
+Remove the instance that was created in the Add sample and delete the logs:
+
+```ps
+Remove-MonitoringInstance -Name Test.Monitoring -RemoveLogs
+```
+
+To List existing instances of the ServiceControl Monitoring service use `Get-MonitoringInstances`.
+
+
+### Upgrading an instance
+
+The following command will list the ServiceControl Monitoring instances current installed and their version number.
+
+```ps
+Get-MonitoringInstances | Select Name, Version
+```
+
+To upgrade and instance to the latest version of the binaries run.
+
+```ps
+Invoke-MonitoringInstanceUpgrade -Name <Instance To upgrade>
+```
+
+The upgrade will stop the service if it is running. Additional parameters for `Invoke-MonitoringInstanceUpgrade` may be required. The configuration file of the existing version is examined prior to determine if all the required settings are present. If a configuration setting is missing  then the cmdlet will throw an error indicating the required additional parameter.

--- a/servicecontrol/monitoring-instances/installation/setting-custom-hostname.md
+++ b/servicecontrol/monitoring-instances/installation/setting-custom-hostname.md
@@ -1,0 +1,28 @@
+---
+title: Configure the URI
+summary: How to configure a Monitoring instance to be exposed through a custom hostname and IP port
+reviewed: 2016-11-09
+---
+
+
+## Changing the Monitoring instance URI
+
+To set a custom hostname and IP port for an instance of the Monitoring instance HTTP API:
+
+NOTE: Anyone who can access the Monitoring instance URL has complete access to the endpoint data stored by the Monitoring instance. This is  why the default is to only respond to the localhost. Consider carefully the implications of exposing a Monitoring instance via a custom or wildcard URI.
+
+
+### Using ServiceControl Management
+
+ 1. Click the Configuration Icon for for the Service Instance to modify.
+ 1. Change the Host and Port number fields to the desired values.
+ 1. Click Save.
+
+ServiceControl Management will then validate the settings changes and restart the service to apply the changes.
+
+
+### Updating ServicePulse Configuration to Monitoring instance Custom Hostname
+
+ 1. Update the ServicePulse configuration file to access the updated Monitoring instance hostname & port number. By default, the ServicePulse configuration file is located in `[Program Files]\Particular Software\ServicePulse\app\config.js`.
+ 1. Update the value of the `monitoring_urls` parameter to the specified Monitoring instance hostname and IP port number.
+ 1. When next accessing ServicePulse, make sure to refresh the browser cache to allow ServicePulse to access the updated configuration settings.

--- a/servicecontrol/monitoring-instances/installation/setting-custom-hostname.md
+++ b/servicecontrol/monitoring-instances/installation/setting-custom-hostname.md
@@ -1,7 +1,7 @@
 ---
 title: Configure the URI
 summary: How to configure a Monitoring instance to be exposed through a custom hostname and IP port
-reviewed: 2016-11-09
+reviewed: 2017-07-29
 ---
 
 

--- a/servicecontrol/powershell.md
+++ b/servicecontrol/powershell.md
@@ -45,6 +45,7 @@ The following general cmdlets and aliases are provided by the ServiceControl Man
 
 For information about managing ServiceControl instances with powershell, see [Managing ServiceControl instance via PowerShell](/servicecontrol/installation-powershell.md).
 
+
 ### Help
 
 All of the cmdlets have local help which can be accessed via the standard PowerShell help command
@@ -87,8 +88,7 @@ This example shows the available ports out of a range of ports
 
 ### Checking and manipulating UrlAcls
 
-The Window HTTPServer API is used by underlying components in ServiceControl. This API uses a permissions system to limit what accounts can add a HTTP listener to a specific URI.
-The standard mechanism for viewing and manipulating these ports in via the [netsh.exe](https://technet.microsoft.com/en-us/library/Cc725882.aspx) command line tool.
+The Window HTTPServer API is used by underlying components in ServiceControl. This API uses a permissions system to limit what accounts can add a HTTP listener to a specific URI. The standard mechanism for viewing and manipulating these ports in via the [netsh.exe](https://technet.microsoft.com/en-us/library/Cc725882.aspx) command line tool.
 
 For example `netsh.exe http show urlacl` will list all of the available. This output is detailed but not very friendly to query. The ServiceControl Management PowerShell provides simplified PowerShell equivalents for listing, add and removing UrlAcls and makes the output easier to query.
 

--- a/servicecontrol/powershell.md
+++ b/servicecontrol/powershell.md
@@ -1,0 +1,111 @@
+---
+title: Managing ServiceControl via PowerShell
+reviewed: 2017-07-26
+tags:
+ - Installation
+ - PowerShell
+---
+
+
+## ServiceControl PowerShell
+
+ServiceControl 1.7 introduced a new graphical management utility to add, remove, update and delete instances of the ServiceControl service. These actions and some additional tools have also exposed via PowerShell module called `ServiceControlMgmt`.
+
+
+## Prerequisites
+
+The ServiceControlMgmt module requires:
+
+ * Microsoft PowerShell 3.0
+
+
+## Loading and Running the PowerShell Module
+
+The majority of the ServiceControlMgmt PowerShell module cmdlets will only work if the PowerShell session is running under administrator privileges. The ServiceControl installer creates a shortcut in the Windows start menu to launch an administrative PowerShell Session with the module automatically loaded. Alternatively the module can be loaded directly into an an existing PowerShell session by loading `ServiceControlMgmt.psd1` using the `Import-Module` cmdlet as show below:
+
+```ps
+Import-Module "C:\Program Files (x86)\Particular Software\ServiceControl Management\ServiceControlMgmt.psd1"
+```
+
+
+## General Cmdlets and Aliases
+
+The following general cmdlets and aliases are provided by the ServiceControl Management PowerShell module.
+
+| Alias                  | Cmdlet                                        |
+| ---------------------- | --------------------------------------------- |
+| sc-addlicense          | Import-ServiceControlLicense                  |
+| sc-findlicense         | Get-ServiceControlLicense                     |
+| sc-help                | Get-ServiceControlMgmtCommands                |
+| urlacl-add             | Add-UrlAcl                                    |
+| urlacl-delete          | Remove-UrlAcl                                 |
+| urlacl-list            | Get-UrlAcls                                   |
+| port-check             | Test-IfPortIsAvailable                        |
+| user-sid               | Get-SecurityIdentifier                        |
+
+For information about managing ServiceControl instances with powershell, see [Managing ServiceControl instance via PowerShell](/servicecontrol/installation-powershell.md).
+
+### Help
+
+All of the cmdlets have local help which can be accessed via the standard PowerShell help command
+
+```ps
+Get-Help Get-ServiceControlLicense
+```
+
+
+### Licensing
+
+Add the license file to the registry by running the following cmdlet.
+
+```ps
+Import-ServiceControlLicense <License-File>
+```
+
+The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it available to all instances of ServiceControl installed on the machine.
+
+
+## Troubleshooting via PowerShell
+
+The ServiceControl Management PowerShell offers some cmdlets to assist with troubleshooting the install of ServiceControl instances.
+
+
+### Check if a Port is already in use
+
+Before adding an instance of ServiceControl test if the port to use is currently in use.
+
+```ps
+Test-IfPortIsAvailable -Port 33333
+```
+
+This example shows the available ports out of a range of ports
+
+```ps
+33330..33339 | Test-IfPortIsAvailable | ? Available
+```
+
+
+### Checking and manipulating UrlAcls
+
+The Window HTTPServer API is used by underlying components in ServiceControl. This API uses a permissions system to limit what accounts can add a HTTP listener to a specific URI.
+The standard mechanism for viewing and manipulating these ports in via the [netsh.exe](https://technet.microsoft.com/en-us/library/Cc725882.aspx) command line tool.
+
+For example `netsh.exe http show urlacl` will list all of the available. This output is detailed but not very friendly to query. The ServiceControl Management PowerShell provides simplified PowerShell equivalents for listing, add and removing UrlAcls and makes the output easier to query.
+
+For example the following command lists all of the UrlAcls assigned to any URI for port 33333.
+
+```ps
+Get-UrlAcls | ? Port -eq 33333
+```
+
+In this example any UrlAcl on port 33335 is remove
+
+```ps
+Get-UrlAcls | ? Port -eq 33335 | Remove-UrlAcl
+```
+
+The following example shows how to add UrlAcl for a ServiceControl service that should only respond to a specific DNS name. This would require an update of the ServiceControl configuration file as well. Refer to [setting a custom host name and port number](setting-custom-hostname.md)
+
+```ps
+Add-UrlAcl -Url http://servicecontrol.mycompany.com:33333/api/ -Users Users
+```


### PR DESCRIPTION
Replaces https://github.com/Particular/docs.particular.net/pull/2835 and builds on top of https://github.com/Particular/docs.particular.net/pull/2936

The idea was to split the SC doco into SC instance doco and Monitoring instance doco. This allows us to add the Monitoring instance doco as new doco that can be merged before we're ready to put it in the menu and officially publish it.