### PR TITLE
Switch storage persistence sample to ASQ transport

### DIFF
--- a/samples/azure/storage-persistence/ASP_1/Client/Client.csproj
+++ b/samples/azure/storage-persistence/ASP_1/Client/Client.csproj
@@ -55,6 +55,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.4.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/azure/storage-persistence/ASP_1/Client/Program.cs
+++ b/samples/azure/storage-persistence/ASP_1/Client/Program.cs
@@ -18,7 +18,8 @@ class Program
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");
-        var transport = endpointConfiguration.UseTransport<LearningTransport>();
+        var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
+        transport.ConnectionString("UseDevelopmentStorage=true");
         var routing = transport.Routing();
         routing.RouteToEndpoint(typeof(StartOrder), "Samples.Azure.StoragePersistence.Server");
 

--- a/samples/azure/storage-persistence/ASP_1/Client/app.config
+++ b/samples/azure/storage-persistence/ASP_1/Client/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.2.1.0" newVersion="8.2.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/samples/azure/storage-persistence/ASP_1/Client/packages.config
+++ b/samples/azure/storage-persistence/ASP_1/Client/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.4.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net461" />

--- a/samples/azure/storage-persistence/ASP_1/Server/Program.cs
+++ b/samples/azure/storage-persistence/ASP_1/Server/Program.cs
@@ -29,7 +29,8 @@ class Program
         endpointConfiguration.UseSerialization<JsonSerializer>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");
-        endpointConfiguration.UseTransport<LearningTransport>();
+        endpointConfiguration.UseTransport<AzureStorageQueueTransport>()
+            .ConnectionString("UseDevelopmentStorage=true");
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/azure/storage-persistence/ASP_1/Server/Server.csproj
+++ b/samples/azure/storage-persistence/ASP_1/Server/Server.csproj
@@ -51,6 +51,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.7.4.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.6.3.4\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/azure/storage-persistence/ASP_1/Server/packages.config
+++ b/samples/azure/storage-persistence/ASP_1/Server/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NServiceBus" version="6.3.4" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="7.4.0" targetFramework="net461" />
   <package id="NServiceBus.Persistence.AzureStorage" version="1.4.0" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />

--- a/samples/azure/storage-persistence/Azure_6/Client/Client.csproj
+++ b/samples/azure/storage-persistence/Azure_6/Client/Client.csproj
@@ -50,6 +50,9 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.6.2.2\lib\net45\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.5.2.22\lib\net45\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/azure/storage-persistence/Azure_6/Client/Program.cs
+++ b/samples/azure/storage-persistence/Azure_6/Client/Program.cs
@@ -12,6 +12,8 @@ class Program
         busConfiguration.UseSerialization<JsonSerializer>();
         busConfiguration.EnableInstallers();
         busConfiguration.UsePersistence<InMemoryPersistence>();
+        busConfiguration.UseTransport<AzureStorageQueueTransport>()
+            .ConnectionString("UseDevelopmentStorage=true");
 
         using (var bus = Bus.Create(busConfiguration).Start())
         {

--- a/samples/azure/storage-persistence/Azure_6/Client/packages.config
+++ b/samples/azure/storage-persistence/Azure_6/Client/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net451" />
   <package id="NServiceBus" version="5.2.22" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net461" />

--- a/samples/azure/storage-persistence/Azure_6/Server/Program.cs
+++ b/samples/azure/storage-persistence/Azure_6/Server/Program.cs
@@ -8,12 +8,16 @@ class Program
     {
         Console.Title = "Samples.Azure.StoragePersistence.Server";
         var busConfiguration = new BusConfiguration();
+        
         #region config
 
         busConfiguration.EndpointName("Samples.Azure.StoragePersistence.Server");
         busConfiguration.UsePersistence<AzureStoragePersistence>();
 
         #endregion
+
+        busConfiguration.UseTransport<AzureStorageQueueTransport>()
+            .ConnectionString("UseDevelopmentStorage=true");
         busConfiguration.UseSerialization<JsonSerializer>();
         busConfiguration.EnableInstallers();
 

--- a/samples/azure/storage-persistence/Azure_6/Server/Server.csproj
+++ b/samples/azure/storage-persistence/Azure_6/Server/Server.csproj
@@ -54,6 +54,9 @@
       <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.6.2.7\lib\net45\NServiceBus.Azure.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.6.2.2\lib\net45\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c">
       <HintPath>..\..\..\..\..\packages\NServiceBus.5.2.22\lib\net45\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/samples/azure/storage-persistence/Azure_6/Server/packages.config
+++ b/samples/azure/storage-persistence/Azure_6/Server/packages.config
@@ -7,6 +7,7 @@
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="NServiceBus" version="5.2.22" targetFramework="net461" />
   <package id="NServiceBus.Azure" version="6.2.7" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net461" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
@Particular/docs-maintainers I've decided to switch from Learning transport to ASQ.
Learning transport has native pub/sub and in a way breaks the sample by now exercising persistence to store subscriptions.

In addition to that, I've switched the previous major version of the sample to also use ASQ transport. It allows easier testing/verification of an upgrade when needed (/cc @ramonsmits).

/cc @Particular/azure-maintainers 