### PR TITLE
Add default number of retries for Immediate retries

### DIFF
--- a/nservicebus/recoverability/configure-immediate-retries_config_core_[3.0,4.0).partial.md
+++ b/nservicebus/recoverability/configure-immediate-retries_config_core_[3.0,4.0).partial.md
@@ -1,5 +1,6 @@
 ## Configuring
 
+ * `MaxRetries`: Number of times Immediate Retries are performed. Default: 5.
 
 ### Using app.config
 

--- a/nservicebus/recoverability/configure-immediate-retries_config_core_[4.0,6.0).partial.md
+++ b/nservicebus/recoverability/configure-immediate-retries_config_core_[4.0,6.0).partial.md
@@ -1,5 +1,6 @@
 ## Configuring
 
+ * `MaxRetries`: Number of times Immediate Retries are performed. Default: 5.
 
 ### Using app.config
 

--- a/nservicebus/recoverability/configure-immediate-retries_config_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/configure-immediate-retries_config_core_[6.0,).partial.md
@@ -1,12 +1,11 @@
 ## Configuring
 
+ * `NumberOfRetries`: Number of times Immediate Retries are performed. Default: 5.
 
 snippet: ImmediateRetriesConfiguration
 
 
-
 ## Disabling
-
 
 snippet: DisablingImmediateRetriesConfiguration
 


### PR DESCRIPTION
The general [recoverability documentation](https://docs.particular.net/nservicebus/recoverability/) speaks about retries and the default maximum number, but the default number of retries is not stated in the specific page for [immediate retries](https://docs.particular.net/nservicebus/recoverability/configure-immediate-retries) the way it's done for [delayed retries](https://docs.particular.net/nservicebus/recoverability/configure-delayed-retries?#configuring-delayed-retries).

This PR adds that info.

@Particular/nservicebus-maintainers please review