### PR TITLE
Update the ASB SC adapter sample to use namespace hierarchy

### DIFF
--- a/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Adapter/Program.cs
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Adapter/Program.cs
@@ -43,6 +43,9 @@ class Program
                 namespacePartitioning.AddNamespace("shipping", shippingConnectionString);
                 namespacePartitioning.UseStrategy<RoundRobinNamespacePartitioning>();
                 transport.UseForwardingTopology();
+                var composition = transport.Composition();
+                composition.UseStrategy<HierarchyComposition>()
+                    .PathGenerator(path => "scadapter/");
             });
 
         #endregion

--- a/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Sales/Program.cs
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Sales/Program.cs
@@ -39,6 +39,9 @@ class Program
         routing.AddNamespace("shipping", shippingConnectionString);
         transport.UseForwardingTopology();
         transport.BrokeredMessageBodyType(SupportedBrokeredMessageBodyTypes.Stream);
+        var composition = transport.Composition();
+        composition.UseStrategy<HierarchyComposition>()
+            .PathGenerator(path => "scadapter/");
 
         #endregion
 

--- a/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Shipping/Program.cs
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/SCTransportAdapter_1/Shipping/Program.cs
@@ -34,6 +34,7 @@ class Program
         routing.AddNamespace("sales", salesConnectionString);
         transport.UseForwardingTopology();
         transport.BrokeredMessageBodyType(SupportedBrokeredMessageBodyTypes.Stream);
+        transport.Composition().UseStrategy<HierarchyComposition>().PathGenerator(path => "scadapter/");
 
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
 

--- a/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
@@ -112,7 +112,7 @@ The following code configures the adapter to match advanced transport features e
  * [Secure connection strings](/transports/azure-service-bus/securing-connection-strings.md).
  * [Customized brokered message creation](/transports/azure-service-bus/brokered-message-creation.md) using `Stream`.
  * [Multiple namespace](/transports/azure-service-bus/multiple-namespaces-support.md#round-robin-namespace-partitioning).
-  * [Namespace hierary](/transports/azure-service-bus/namespace-hierarchy.md)
+ * [Namespace hierary](/transports/azure-service-bus/namespace-hierarchy.md)
 
 snippet: EndpointSideConfig
 

--- a/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
@@ -2,7 +2,7 @@
 title: Monitor Azure Service Bus endpoints with the ServiceControl adapter
 summary: Centralized monitoring of Azure Service Bus endpoints with the ServiceControl adapter
 component: SCTransportAdapter
-reviewed: 2017-07-17
+reviewed: 2017-08-03
 related:
  - servicecontrol
  - servicecontrol/transport-adapter

--- a/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
+++ b/samples/servicecontrol/adapter-asb-multi-namespace/sample.md
@@ -91,6 +91,7 @@ Both endpoints are configured to use:
  * [Secure connection strings](/transports/azure-service-bus/securing-connection-strings.md).
  * [Customized brokered message creation](/transports/azure-service-bus/brokered-message-creation.md) using `Stream`.
  * Different namespaces with [cross-namespace routing](/transports/azure-service-bus/multiple-namespaces-support.md#cross-namespace-routing) enabled.
+ * [Namespace hierary](/transports/azure-service-bus/namespace-hierarchy.md) to prefix all entities with `scadapter/`.
 
 snippet: featuresunsuportedbysc
 
@@ -111,6 +112,7 @@ The following code configures the adapter to match advanced transport features e
  * [Secure connection strings](/transports/azure-service-bus/securing-connection-strings.md).
  * [Customized brokered message creation](/transports/azure-service-bus/brokered-message-creation.md) using `Stream`.
  * [Multiple namespace](/transports/azure-service-bus/multiple-namespaces-support.md#round-robin-namespace-partitioning).
+  * [Namespace hierary](/transports/azure-service-bus/namespace-hierarchy.md)
 
 snippet: EndpointSideConfig
 


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.AzureServiceBus/issues/593

Namespace hierarchy is the 4th SC unsupported transport feature.
Adding it to the sample to show that adapter can handle it as well.
Documentation for SC Adapter will be updated separately.