### PR TITLE
namespace hierarchy added to the list

### DIFF
--- a/servicecontrol/transport-adapter/incompatible-features.md
+++ b/servicecontrol/transport-adapter/incompatible-features.md
@@ -22,6 +22,7 @@ Neither [direct topology](/transports/rabbitmq/routing-topology.md#direct-routin
  * Using [aliases](/transports/azure-service-bus/securing-connection-strings.md) instead of connection string will make it impossible to retry messages from ServiceControl.
  * Leveraging [multiple namespaces in a topology](/transports/azure-service-bus/multiple-namespaces-support.md) will require a setup of multiple ServiceControl instances.
  * Customizing [brokered message creation](/transports/azure-service-bus/brokered-message-creation.md) may lead to incompatible wire formats and deserialization errors.
+ * Customizing entity paths by using [Namespace hierarchy](/transports/azure-service-bus/namespace-hierarchy.md).
 
 
 ## Azure Storage Queues


### PR DESCRIPTION
4th feature of ASB incompatible with the "classic" SC and addressed by SC adapter.

A [sample PR](https://github.com/Particular/docs.particular.net/pull/3028) is also added

@Particular/servicecontrol-maintainers please review