### PR TITLE
[DO NOT MERGE] Tutorial inline download buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Tutorials are similar to samples but optimized for new users to follow in a step
 * Focus on only the most recent version
 * Rendered without button toolbar and component information at the top
 * By default, solution download button is rendered at the end
+  * An inline download button can be created instead using a `downloadbutton` directive on its own line within the tutorial markdown.
 * Utilizes two collections of snippets, from the solution and also from an optional Snippets solution, allowing more granular or multi-phase snippets
 * Allows use of personal voice (you/your/we/etc.) within `/tutorials` directory to foster collaborative tone with user
 
@@ -518,22 +519,6 @@ An example directory structure for a tutorial might look like this:
 ```
 
 Tutorials can be grouped together in a parent directory with a normal article serving as a table of contents.
-
-
-### Metadata options
-
-These YAML metadata options affect rendering for tutorials only.
-
-
-#### Download at top
-
-By default a tutorial assumes the user will build their own solution from scratch, and only offers the completed download at the bottom. If the tutorial requires a "starter" solution, a banner can be placed at the top of the page notifying the user and providing the download link.
-
-```
-extensions:
-- !!tutorial
-  downloadAtTop: true
-```
 
 
 ### Multi-lesson tutorials

--- a/tutorials/message-replay/tutorial.md
+++ b/tutorials/message-replay/tutorial.md
@@ -2,18 +2,17 @@
 title: Message replay tutorial
 reviewed: 2017-06-09
 summary: In this tutorial, you'll learn how to replay a failed message using the Particular Service Platform tools.
-extensions:
-- !!tutorial
-  downloadAtTop: true
 ---
 
 One of the most powerful features of NServiceBus is the ability to replay a message that has failed. By the time a message reaches the error queue, it will have already progressed through multiple retries via the [immediate retries](/nservicebus/recoverability/#immediate-retries) and [delayed retries](/nservicebus/recoverability/#delayed-retries) process, so you can be sure that the exception is systemic.
 
 Often, this type of failure can be introduced by a bug that isn't found until the code is deployed. When this happens, many errors can flood into the error queue all at once. At these times, it's incredibly valuable to be able to roll back to the old version of the endpoint, and then replay the failed messages through proven code. Then you can take the time to properly troubleshoot and fix the issue before attempting a new deployment.
 
-In this tutorial, which is based on the code developed in the [Introduction to NServiceBus tutorial](/tutorials/intro-to-nservicebus/), we'll see how to use ServiceControl to monitor an NServiceBus system, and ServicePulse to replay a failed message.
+In this tutorial, we'll see how to use ServiceControl to monitor an NServiceBus system, and ServicePulse to replay a failed message.
 
-To get started, download the solution above, extract the archive, and then open the **RetailDemo.sln** file with Visual Studio 2015 or later.
+To get started, download the solution, extract the archive, and then open the **RetailDemo.sln** file with Visual Studio 2015 or later.
+
+downloadbutton
 
 
 ## Project Structure

--- a/tutorials/quickstart/tutorial.md
+++ b/tutorials/quickstart/tutorial.md
@@ -4,7 +4,6 @@ reviewed: 2017-06-05
 summary: See why software systems built on asynchronous messaging using NServiceBus are superior to traditional synchronous HTTP-based web services.
 extensions:
 - !!tutorial
-  downloadAtTop: true
   nextText: "Next: NServiceBus from the ground up"
   nextUrl: tutorials/intro-to-nservicebus/1-getting-started
 ---
@@ -13,7 +12,9 @@ include: quickstart-tutorial-intro-paragraph
 
 This tutorial skips over some concepts and implementation details in order to get up and running quickly. If you'd prefer to go more in-depth, check out our [Introduction to NServiceBus](/tutorials/intro-to-nservicebus/) tutorial. It will teach you the NServiceBus API and important concepts you need to learn to build successful message-based software systems.
 
-To get started download the solution above, extract the archive, and then open the **RetailDemo.sln** file with Visual Studio 2015 or later.
+To get started download the solution, extract the archive, and then open the **RetailDemo.sln** file with Visual Studio 2015 or later.
+
+downloadbutton
 
 
 ## Project structure


### PR DESCRIPTION
**DO NOT MERGE**: Requires https://github.com/Particular/DocsEngine/pull/327 to be deployed first.

Adds the markup to place the inline download buttons in the Quick Start and Message Replay tutorials, removing the downloadAtTop metadata used previously.

Also removes deprecated downloadAtTop info from README.