### PR TITLE
netcore sample proposal

### DIFF
--- a/samples/serializers/bond/Bond_1.3/BondSample.NetCore.sln
+++ b/samples/serializers/bond/Bond_1.3/BondSample.NetCore.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+MinimumVisualStudioVersion = 15.0.26430.04
+MinimumVisualStudioVersion = 15.0.26430.04
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.NetCore.csproj", "{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/serializers/bond/Bond_1.3/Sample/Sample.NetCore.csproj
+++ b/samples/serializers/bond/Bond_1.3/Sample/Sample.NetCore.csproj
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="Sample.csproj" />
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/samples/serializers/bond/Bond_1.3/Sample/Sample.csproj
+++ b/samples/serializers/bond/Bond_1.3/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
So we cant use `<TargetFrameworks>` to muti-target both 461 and netcoreapp2.0. since that means people would need the netcore2.0 sdk installed to compile, and hence run, 461. i think it is too early to force that. So this is a temporary solution until a time we can say "you have to have netcoreapp installed"

 * create a new `ProjectName.NetCore.csproj` that includes the main project but overwrites the `<targetframeworks>` to `netcoreapp2.0`
 * duplicate the sample sln and include the new project instead of the old

note the above steps could be initially scripted. will also need to verify it works on VS 2017 update 2