### PR TITLE
Updating SQL Persistence doco/samples/snippets

### DIFF
--- a/Snippets/SqlPersistence/SqlPersistence_3/Usage.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_3/Usage.cs
@@ -19,7 +19,7 @@ class Usage
 
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
         var connection = @"Data Source=.\SqlExpress;Initial Catalog=dbname;Integrated Security=True";
-        persistence.SqlVariant(SqlVariant.MsSqlServer);
+        persistence.SqlDialect<SqlDialect.MsSqlServer>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {
@@ -62,7 +62,7 @@ class Usage
 
         var connection = "server=localhost;user=root;database=dbname;port=3306;password=pass;AllowUserVariables=True;AutoEnlist=false";
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-        persistence.SqlVariant(SqlVariant.MySql);
+        persistence.SqlDialect<SqlDialect.MySql>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {
@@ -78,7 +78,7 @@ class Usage
 
         var connection = "Data Source=localhost;User Id=username;Password=pass;Enlist=false;";
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-        persistence.SqlVariant(SqlVariant.Oracle);
+        persistence.SqlDialect<SqlDialect.Oracle>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {
@@ -189,7 +189,8 @@ class Usage
         #region Schema
 
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-        persistence.Schema("MySchema");
+        var dialect = persistence.SqlDialect<SqlDialect.MsSqlServer>();
+        dialect.Schema("MySchema");
 
         #endregion
     }

--- a/persistence/sql/index.md
+++ b/persistence/sql/index.md
@@ -90,7 +90,7 @@ WARNING: Projects using `project.json` are **not** supported. The `project.json`
 
 SQL installation scripts are created at compile time by the `NServiceBus.Persistence.Sql.MsBuild` NuGet package.
 
-Scripts will be created in the directory format of `[CurrentProjectDebugDir]\NServiceBus.Persistence.Sql\[SqlVariant]`.
+partial: scriptlocation
 
 For example for a project named `ClassLibrary` build in Debug mode the following directories will be created.
 
@@ -149,7 +149,7 @@ snippet: TablePrefix
 
 #### Database Schema
 
-A database schema can be defined in the configuration API as follows:
+When using Microsoft SQL Server, a database schema other than the default `dbo` can be defined in the configuration API as follows:
 
 snippet: Schema
 

--- a/persistence/sql/index_scriptlocation_sqlpersistence_[1.3).partial.md
+++ b/persistence/sql/index_scriptlocation_sqlpersistence_[1.3).partial.md
@@ -1,0 +1,1 @@
+Scripts will be created in the directory format of `[CurrentProjectDebugDir]\NServiceBus.Persistence.Sql\[SqlVariant]`.

--- a/persistence/sql/index_scriptlocation_sqlpersistence_[3,).partial.md
+++ b/persistence/sql/index_scriptlocation_sqlpersistence_[3,).partial.md
@@ -1,0 +1,1 @@
+Scripts will be created in the directory format of `[CurrentProjectDebugDir]\NServiceBus.Persistence.Sql\[SqlDialect]`.

--- a/samples/sql-persistence/saga-rename/SqlPersistence_2/EndpointVersion2/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_2/EndpointVersion2/Program.cs
@@ -24,7 +24,7 @@ class Program
 
         #region renameTables
 
-        var connectionString = @"Data Source=.\SqlExpress;Initial Catalog=Samples.SqlPersistence.RenameSaga;Integrated Security=True";
+        var connectionString = @"Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlPersistenceRenameSaga;Integrated Security=True";
         using (var connection = new SqlConnection(connectionString))
         {
             await connection.OpenAsync()

--- a/samples/sql-persistence/saga-rename/SqlPersistence_3/EndpointVersion2/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_3/EndpointVersion2/Program.cs
@@ -24,7 +24,7 @@ class Program
 
         #region renameTables
 
-        var connectionString = @"Data Source=.\SqlExpress;Initial Catalog=Samples.SqlPersistence.RenameSaga;Integrated Security=True";
+        var connectionString = @"Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlPersistenceRenameSaga;Integrated Security=True";
         using (var connection = new SqlConnection(connectionString))
         {
             await connection.OpenAsync()

--- a/samples/sql-persistence/saga-rename/SqlPersistence_3/Shared/SharedConfiguration.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_3/Shared/SharedConfiguration.cs
@@ -11,7 +11,7 @@ public static class SharedConfiguration
         #region endpointConfig
 
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-        persistence.SqlVariant(SqlVariant.MsSqlServer);
+        persistence.SqlDialect<SqlDialect.MsSqlServer>();
         var subscriptions = persistence.SubscriptionSettings();
         subscriptions.CacheFor(TimeSpan.FromMinutes(1));
         var connection = @"Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlPersistenceRenameSaga;Integrated Security=True";

--- a/samples/sql-persistence/simple/SqlPersistence_3/EndpointMySql/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_3/EndpointMySql/Program.cs
@@ -35,7 +35,7 @@ class Program
             throw new Exception("Could not extract 'MySqlUserName' from Environment variables.");
         }
         var connection = $"server=localhost;user={username};database=sqlpersistencesample;port=3306;password={password};AllowUserVariables=True;AutoEnlist=false";
-        persistence.SqlVariant(SqlVariant.MySql);
+        persistence.SqlDialect<SqlDialect.MySql>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {

--- a/samples/sql-persistence/simple/SqlPersistence_3/EndpointOracle/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_3/EndpointOracle/Program.cs
@@ -31,7 +31,7 @@ internal class Program
             throw new Exception("Could not extract 'OracleUserName' from Environment variables.");
         }
         var connection = $"Data Source=localhost;User Id={username}; Password={password}; Enlist=false";
-        persistence.SqlVariant(SqlVariant.Oracle);
+        persistence.SqlDialect < SqlDialect.Oracle>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {

--- a/samples/sql-persistence/simple/SqlPersistence_3/EndpointSqlServer/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_3/EndpointSqlServer/Program.cs
@@ -21,7 +21,7 @@ class Program
 
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
         var connection = @"Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlPersistence;Integrated Security=True";
-        persistence.SqlVariant(SqlVariant.MsSqlServer);
+        persistence.SqlDialect<SqlDialect.MsSqlServer>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointMySql/Program.cs
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointMySql/Program.cs
@@ -31,7 +31,7 @@ partial class Program
             throw new Exception("Could not extract 'MySqlUserName' from Environment variables.");
         }
         var connection = $"server=localhost;user={username};database=sqlpersistencesample;port=3306;password={password};AllowUserVariables=True;AutoEnlist=false";
-        persistence.SqlVariant(SqlVariant.MySql);
+        persistence.SqlDialect<SqlDialect.MySql>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointOracle/Program.cs
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointOracle/Program.cs
@@ -31,7 +31,7 @@ partial class Program
             throw new Exception("Could not extract 'OracleUserName' from Environment variables.");
         }
         var connection = $"Data Source=localhost;User Id={username}; Password={password}; Enlist=false";
-        persistence.SqlVariant(SqlVariant.Oracle);
+        persistence.SqlDialect<SqlDialect.Oracle>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointSqlServer/Program.cs
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointSqlServer/Program.cs
@@ -23,7 +23,7 @@ partial class Program
         var connection = @"Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlPersistenceTransition;Integrated Security=True";
         SqlHelper.EnsureDatabaseExists(connection);
         var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-        persistence.SqlVariant(SqlVariant.MsSqlServer);
+        persistence.SqlDialect<SqlDialect.MsSqlServer>();
         persistence.ConnectionBuilder(
             connectionBuilder: () =>
             {


### PR DESCRIPTION
Didn't have time to get to started on an upgrade guide, which doesn't exist yet. I'm concerned that because a breaking changes alpha is on MyGet, it can get picked up by version wildcards, and that could be breaking docs in various ways. So I think this should get merged first anyway.

While updating samples I smoke tested them. Caught an unrelated error in the saga rename sample caused by having 2 non-matching connection strings with different catalog names. Fixed that in the V2 and V3 versions.

I punted a little bit on the doco for Schema, and just specified that it was MSSQL-specific, which I think is technically true for all versions, which let me get away without doing a partial in that case.

@Particular/sqlpersistence-maintainers please have a look.