### PR TITLE
Only use a single saga property for correlation

### DIFF
--- a/nservicebus/sagas/message-correlation.md
+++ b/nservicebus/sagas/message-correlation.md
@@ -14,8 +14,7 @@ Correlation is needed in order to find existing saga instances based on data on 
 
 To declare this use the `ConfigureHowToFindSaga` method and use the `Mapper` to specify to which saga property each message maps to.
 
-NOTE: NServiceBus will only allows message mappings that all correlate to a single saga property and that all property types must match. Use a [custom saga finder](saga-finding.md). to correlate different properties and/or types.
-
+NOTE: NServiceBus  only allows message mappings where the message properties correlate to a single saga property and have the same type. 
 
 partial: note
 

--- a/nservicebus/sagas/message-correlation.md
+++ b/nservicebus/sagas/message-correlation.md
@@ -12,7 +12,9 @@ related:
 
 Correlation is needed in order to find existing saga instances based on data on the incoming message. In the example the `OrderId ` property of the `CompleteOrder` message is used to find the existing saga instance for that order.
 
-To declare this use the `ConfigureHowToFindSaga` method and use the `Mapper` to specify to which saga property each message maps to. Note that NServiceBus will only allow correlation on a single saga property and that the property types must match.
+To declare this use the `ConfigureHowToFindSaga` method and use the `Mapper` to specify to which saga property each message maps to.
+
+NOTE: NServiceBus will only allows message mappings that all correlate to a single saga property and that all property types must match. Use a [custom saga finder](saga-finding.md). to correlate different properties and/or types.
 
 
 partial: note
@@ -24,7 +26,7 @@ When `MyMessage` arrives, NServiceBus asks the saga persistence infrastructure t
 
 ## Message Property Expression
 
-If correlating on more than one property is necessary, or matched properties are of different types, use a [custom saga finder](saga-finding.md).
+If correlating on more than one saga property is necessary, or matched properties are of different types, use a [custom saga finder](saga-finding.md).
 
 
 partial: expression

--- a/nservicebus/sagas/message-correlation.md
+++ b/nservicebus/sagas/message-correlation.md
@@ -14,7 +14,7 @@ Correlation is needed in order to find existing saga instances based on data on 
 
 To declare this use the `ConfigureHowToFindSaga` method and use the `Mapper` to specify to which saga property each message maps to.
 
-NOTE: NServiceBus  only allows message mappings where the message properties correlate to a single saga property and have the same type. 
+NOTE: Message properties must correlate to a single saga property and have the same type.
 
 partial: note
 


### PR DESCRIPTION
Some changes that should make clear that:

- All messages mappings MUST map to the same saga property
- A saga can only have a single mapping property

If multiple saga properties need to be mapped or messages needed to be mapped to different saga data properties that a customer saga finder must be used.

/cc: @DavidBoike 