### PR TITLE
Added note about default saga not found behavior

### DIFF
--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -21,7 +21,18 @@ Design processes with more than one remote call to use sagas.
 
 While it may seem excessive at first, the business implications of the system getting out of sync with the other systems it interacts with can be substantial. It's not just about exceptions that end up in the logs.
 
-NOTE: If a message is received while there is no saga instance, then by default this message is discarded and succesfully processed. If the received message must not be discarded and throw an error so that it gets moved to the error queue then it is required to override saga not found behavior by implementing `IHandleSagaNotFound` and throw an exception. 
+## No saga instance available
+
+If a message is received while there is no saga instance, then by default this message gets discarded and succesfully processed. When you have a saga instance that is already completed then it makes sense to discard other messages.
+
+This can also happen for saga instance creation. A message is received that expects a saga instance to be there but that message is not received yet. In this case the message should not be discarded. There are two options to resolve this:
+
+- Let the saga instance be created for message B
+- Override the saga not found behavior and throw an exception
+
+By getting the saga instance created for message B that is received before message A we now have to make sure that the behavior of the saga will remain correct. For example, when a message is send when B is received then maybe state from message A needs to be included that is added to the saga instance when A is received. This state is not yet stored in the saga thus the message cannot be send yet. We now need to check that when message A is received if message B is already processed and then have the message send. This can make the saga much more complex!
+
+A simpler solution is to throw an error when the saga instance does not exist so that it gets moved to the error queue then it is required to override saga not found behavior by implementing `IHandleSagaNotFound` and throw an exception. 
 
 ## A simple Saga
 

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -21,7 +21,7 @@ Design processes with more than one remote call to use sagas.
 
 While it may seem excessive at first, the business implications of the system getting out of sync with the other systems it interacts with can be substantial. It's not just about exceptions that end up in the logs.
 
-NOTE: If a message is received while there is not saga instance then by default this message is discarded and succesfully processed. If the received message must not be discarded and throw an error so that it gets moved to the error queue then it is required to override saga not found behavior by implementing `IHandleSagaNotFound` and throw an exception. 
+NOTE: If a message is received while there is no saga instance, then by default this message is discarded and succesfully processed. If the received message must not be discarded and throw an error so that it gets moved to the error queue then it is required to override saga not found behavior by implementing `IHandleSagaNotFound` and throw an exception. 
 
 ## A simple Saga
 

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -21,6 +21,7 @@ Design processes with more than one remote call to use sagas.
 
 While it may seem excessive at first, the business implications of the system getting out of sync with the other systems it interacts with can be substantial. It's not just about exceptions that end up in the logs.
 
+NOTE: If a message is received while there is not saga instance then by default this message is discarded and succesfully processed. If the received message must not be discarded and throw an error so that it gets moved to the error queue then it is required to override saga not found behavior by implementing `IHandleSagaNotFound` and throw an exception. 
 
 ## A simple Saga
 

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -91,7 +91,7 @@ Correlation is needed in order to find existing saga instances based on data on 
 
 ## Message discard behavior when saga not found
 
-If a message handled by a saga is received, but no related saga instance is found, then by default that message is discarded. Usually that happens when the saga had been already completed when further messages arrive and indeed such messages should be discarded. If a different behavior is expected for specific scenarios, the default behavior [can be modified](nservicebus/sagas/saga-not-found.md).
+If a message handled by a saga is received, but no related saga instance is found, then by default that message is discarded. Usually that happens when the saga had been already completed when further messages arrive and indeed such messages should be discarded. If a different behavior is expected for specific scenarios, the default behavior [can be modified](saga-not-found.md).
 
 
 ## Ending a long-running process

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -22,11 +22,15 @@ Design processes with more than one remote call to use sagas.
 While it may seem excessive at first, the business implications of the system getting out of sync with the other systems it interacts with can be substantial. It's not just about exceptions that end up in the logs.
 
 
-## No saga instance available
+## Saga design considerations
+
+### Message discard behavior when saga not found
 
 If a message that is handled by a saga is received, but no related saga instance is found, then by default that message is discarded, i.e. it is possible that a saga instance had been already completed when further messages arrive and such messages should be discarded.
 
 NOTE: Always assume that messages can be delivered out of order, e.g. due to invoking the error recovery mechanism, network latency, and/or concurrent message processing.
+
+### Dealing with out of order delivery
 
 A similar message discarding behavior can also be invoked in case of saga instance creation. When a message is received that expects a saga instance to be there but that message that would create the saga instance has not yet been received or completed processing.
 
@@ -35,7 +39,11 @@ To ensure messages are not discarded when they arrive out of order:
 - Let the saga instance be created for all the messages that previously assumed the saga instance would already exist using `IAmStartedBy<T>`
 - Override the saga not found behavior and throw an exception using `IHandleSagaNotFound` and rely on error recovery to resolve out of order issues.
 
+#### Saga state machine
+
 By letting the saga instance also be created for a message that previously relied on another message that would have create the saga instance we now have to make sure that the behavior of the saga will remain correct. Lets assume that we relied on message A to be processed before B but we now also have the saga instance created when B is received then maybe state from message A needs to be included that is added to the saga instance when A is received. This state is not yet stored in the saga if message B is processed before message A thus the message cannot be send yet. We now need to check that when message A is received if message B is already processed and then have the message send. This can make the saga much more complex!
+
+#### Not to discard on saga not found and rely on recovery 
 
 A simpler solution is to throw an error when the saga instance does not exist so that it eventually gets moved to the error queue after all immediate and delayed retries attempts are done. Override saga not found behavior by [implementing `IHandleSagaNotFound` and throw an exception](saga-not-found.md). 
 


### PR DESCRIPTION
In the main saga guidance it is not really clear that the default behavior is that message are discarded if the message does not start a saga, but a saga instance does not exist. A lot of customers might not expect this behavior and can cause message/data loss.