### PR TITLE
clarifications for endpoint tuning defaults

### DIFF
--- a/nservicebus/operations/tuning_throttling_core_[,5].partial.md
+++ b/nservicebus/operations/tuning_throttling_core_[,5].partial.md
@@ -1,4 +1,4 @@
-NOTE: by default endpoing is not throttled.
+NOTE: By default endpoints are not throttled.
 
 Define a maximum value for the number of messages per second that the endpoint will process at any given time. This will help avoiding the endpoint from overloading sensitive resources that it's using like web-services, databases, other endpoints etc. Some examples would include
 

--- a/nservicebus/operations/tuning_throttling_core_[,5].partial.md
+++ b/nservicebus/operations/tuning_throttling_core_[,5].partial.md
@@ -1,3 +1,5 @@
+NOTE: by default endpoing is not throttled.
+
 Define a maximum value for the number of messages per second that the endpoint will process at any given time. This will help avoiding the endpoint from overloading sensitive resources that it's using like web-services, databases, other endpoints etc. Some examples would include
 
  * An integration endpoint calling a web API, like `api.github.com`, that have restrictions on the number or requests per unit of time allowed.


### PR DESCRIPTION
The default is not spelled out, which leave questions.
After looking at the override, it might feel that max throughput needs to be overridden as well when changing settings.

With this change it states clearly that throughput is **not** throttled.

@Particular/nservicebus-maintainers please review