### PR TITLE
Pass PushRuntimeSettings.Default.MaxConcurrency

### DIFF
--- a/samples/scaleout/senderside-and-distributor/Core_6/Worker1/Program.cs
+++ b/samples/scaleout/senderside-and-distributor/Core_6/Worker1/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Routing.Legacy;
+using NServiceBus.Transport;
 
 class Program
 {
@@ -20,7 +21,7 @@ class Program
         endpointConfiguration.EnlistWithLegacyMSMQDistributor(
             masterNodeAddress: appSettings["DistributorAddress"],
             masterNodeControlAddress: appSettings["DistributorControlAddress"],
-            capacity: 1);
+            capacity: PushRuntimeSettings.Default.MaxConcurrency);
 
         #endregion
 

--- a/samples/scaleout/senderside-and-distributor/Core_6/Worker2/Program.cs
+++ b/samples/scaleout/senderside-and-distributor/Core_6/Worker2/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Routing.Legacy;
+using NServiceBus.Transport;
 
 class Program
 {
@@ -17,7 +18,7 @@ class Program
         endpointConfiguration.EnlistWithLegacyMSMQDistributor(
             masterNodeAddress: appSettings["DistributorAddress"],
             masterNodeControlAddress: appSettings["DistributorControlAddress"],
-            capacity: 1);
+            capacity: PushRuntimeSettings.Default.MaxConcurrency);
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");
         var recoverability = endpointConfiguration.Recoverability();


### PR DESCRIPTION
Pass PushRuntimeSettings.Default.MaxConcurrency to align capacity with the default maximum concurrency instead of using 1.