### PR TITLE
Remove sanitization to simplify ASP sample

### DIFF
--- a/samples/azure/storage-persistence/ASP_2/Client/Program.cs
+++ b/samples/azure/storage-persistence/ASP_2/Client/Program.cs
@@ -12,8 +12,8 @@ class Program
         Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
         Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
-        Console.Title = "Samples.Azure.StoragePersistence.Client";
-        var endpointConfiguration = new EndpointConfiguration("Samples.Azure.StoragePersistence.Client");
+        Console.Title = "Samples-Azure-StoragePersistence-Client";
+        var endpointConfiguration = new EndpointConfiguration("Samples-Azure-StoragePersistence-Client");
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
@@ -21,10 +21,9 @@ class Program
         var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
         transport.ConnectionString("UseDevelopmentStorage=true");
         transport.DelayedDelivery().DisableTimeoutManager();
-        transport.SanitizeQueueNamesWith(name => name.Replace(".", "-"));
         var routing = transport.Routing();
-        routing.RouteToEndpoint(typeof(StartOrder), "Samples.Azure.StoragePersistence.Server");
-        routing.RegisterPublisher(typeof(OrderCompleted), "Samples.Azure.StoragePersistence.Server");
+        routing.RouteToEndpoint(typeof(StartOrder), "Samples-Azure-StoragePersistence-Server");
+        routing.RegisterPublisher(typeof(OrderCompleted), "Samples-Azure-StoragePersistence-Server");
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/azure/storage-persistence/ASP_2/Server/Program.cs
+++ b/samples/azure/storage-persistence/ASP_2/Server/Program.cs
@@ -13,11 +13,11 @@ class Program
         Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
         Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
-        Console.Title = "Samples.Azure.StoragePersistence.Server";
+        Console.Title = "Samples-Azure-StoragePersistence-Server";
 
         #region config
 
-        var endpointConfiguration = new EndpointConfiguration("Samples.Azure.StoragePersistence.Server");
+        var endpointConfiguration = new EndpointConfiguration("Samples-Azure-StoragePersistence-Server");
         var persistence = endpointConfiguration.UsePersistence<AzureStoragePersistence>();
         persistence.ConnectionString("UseDevelopmentStorage=true");
 
@@ -32,7 +32,6 @@ class Program
         var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
         transport.ConnectionString("UseDevelopmentStorage=true");
         transport.DelayedDelivery().DisableTimeoutManager();
-        transport.SanitizeQueueNamesWith(name => name.Replace(".", "-"));
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);


### PR DESCRIPTION
The sample is already packed with persistence configuration. No need to add to the complexity with ASQ transport sanitization.

@yvesgoeleven please review