### PR TITLE
Remove specific persistence support claims from TimeoutManager article

### DIFF
--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -21,7 +21,7 @@ When NServiceBus detects that an outgoing message should be delayed, it routes i
 
 The `[endpoint_queue_name].Timeouts` queue is monitored by NServiceBus [internal receiver](/nservicebus/satellites). The receiver picks up timeout messages and stores them using the selected NServiceBus persistence. 
 
-If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions then NServiceBus guarantees *exactly-once* semantics of the store operation, meaning that timeouts in the store will not get duplicated.
+If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions then *exactly-once* semantics of the store operation are guaranteed, meaning that timeouts in the store will not get duplicated.
 
 The delayed messages will be stored for the specified delay time, using persistance implementation specified in the configuration:
 

--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -19,9 +19,9 @@ The delayed-delivery feature uses a built-in persistent store and requires using
 
 When NServiceBus detects that an outgoing message should be delayed, it routes it to to the `[endpoint_queue_name].Timeouts` queue instead of directly to the destination queue. The ultimate destination address is preserved in a header. 
 
-The `[endpoint_queue_name].Timeouts` queue is monitored by NServiceBus [internal receiver](/nservicebus/satellites). The receiver picks up timeout messages and stores them using the selected NServiceBus persistence. NHibernate persistence stores timeout messages in a table called `TimeoutEntity`, RavenDB persistence stores them as documents of a type `TimeoutData`. 
+The `[endpoint_queue_name].Timeouts` queue is monitored by NServiceBus [internal receiver](/nservicebus/satellites). The receiver picks up timeout messages and stores them using the selected NServiceBus persistence. 
 
-If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions then NServiceBus guarantees *exactly-once* semantics of the store operation, meaning that timeouts in the store will not get duplicated. Both NHibernate and RavenDB support it.
+If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions then NServiceBus guarantees *exactly-once* semantics of the store operation, meaning that timeouts in the store will not get duplicated.
 
 The delayed messages will be stored for the specified delay time, using persistance implementation specified in the configuration:
 


### PR DESCRIPTION
Fixes #3176 

Taking out mentions of NH and RavenDB from this persistence article.

* Not really necessary. Details of each persistence are not really in scope on such a general article.
* Too difficult to keep these details up-to-date on this page. You wouldn't think to come here when updating doco for a specific persister.
* RavenDB no longer will support DTC transactions in latest major.
* Doesn't mention SQL Persistence, but if you did, you'd have to talk about the difference between each dialect, how it stores timeouts, and how it supports transactions.

Any objections?