### PR TITLE
Enable installer

### DIFF
--- a/samples/nhibernate/simple/NHibernate_8/Server/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Program.cs
@@ -30,6 +30,7 @@ class Program
         #endregion
 
         endpointConfiguration.UseTransport<LearningTransport>();
+        endpointConfiguration.EnableInstallers();
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);


### PR DESCRIPTION
the sample needs installers to be explicitly enabled so the saga table is created when running the sample.