### PR TITLE
Upgrade guide entry for the removal of RegisterStep.IsEnabled

### DIFF
--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -128,6 +128,9 @@ The `RemoveDeliveryConstaint` extension method has been renamed to `RemoveDelive
 
 The `GetMesssageIntent` extension method has been renamed to `GetMessageIntent`.
 
+## Pipeline configuration
+
+`RegisterStep.IsEnabled` has been removed. Instead of indicating steps as not enabled users should instead not register the steps in the pipeline at all.
 
 ## Assembly scanning
 

--- a/nservicebus/upgrades/6to7/index.md
+++ b/nservicebus/upgrades/6to7/index.md
@@ -130,7 +130,7 @@ The `GetMesssageIntent` extension method has been renamed to `GetMessageIntent`.
 
 ## Pipeline configuration
 
-`RegisterStep.IsEnabled` has been removed. Instead of indicating steps as not enabled users should instead not register the steps in the pipeline at all.
+`RegisterStep.IsEnabled` has been removed. Instead of overriding this method to disable registration, users should instead not register the steps in the pipeline at all.
 
 ## Assembly scanning
 


### PR DESCRIPTION
`RegisterStep.IsEnabled` was never documented and as far as we can tell never used so it was removed. This add this fact to the upgrade guide.

See https://github.com/Particular/NServiceBus/issues/4118 for details