### PR TITLE
ASP sample storage data fixes

### DIFF
--- a/samples/azure/storage-persistence/ASP_2/Server/Program.cs
+++ b/samples/azure/storage-persistence/ASP_2/Server/Program.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Persistence;
 
 class Program
 {

--- a/samples/azure/storage-persistence/sample.md
+++ b/samples/azure/storage-persistence/sample.md
@@ -2,7 +2,7 @@
 title: Azure Storage Persistence
 summary: Using Azure Storage to store Sagas, Timeouts and Subscriptions.
 component: ASP
-reviewed: 2017-08-01
+reviewed: 2017-10-03
 tags:
 - Saga
 - Timeout
@@ -88,47 +88,16 @@ snippet: UsingHelpers
 
 The saga data from the 'OrderSagaData' table contents
 
-```
-PartitionKey:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
-  RowKey:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
-  Id:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
-  Originator:= Samples.Azure.StoragePersistence.Client@RETINA
-  OriginalMessageId:= 0d574aa7-0d39-4e93-8233-a50e00ea764f
-  OrderId:= 79cc2072-c724-4cc0-9202-b6c4918a3de2
-  OrderDescription:= The saga for order 79cc2072-c724-4cc0-9202-b6c4918...
-```
+partial: sagadata
 
 
 ### The Timeouts
 
-The timeout data from the `TimeoutDataTableName` table
-
-```
-  PartitionKey:= 2015090918
-    RowKey:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
-    Destination:= Samples.Azure.StoragePersistence.Server@RETINA
-    Headers:= {"NServiceBus.MessageId":"06800d44-9fc4-49b5-a9e9-...
-    OwningTimeoutManager:= Samples.Azure.StoragePersistence.Server
-    SagaId:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
-    StateAddress:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
-    Time:= 9/09/2015 6:06:59 PM
-```
-
-The timeout serialized message from the `timeoutstate` blob container.
-
-```
-'timeoutstate' container contents
-  Blob:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
-    ﻿{"OrderDescription":"The saga for order 79cc2072-c724-4cc0-9202-b6c4918a3de2"}
-```
+partial: timeouts
 
 
 ### The Subscriptions
 
 The Client endpoint registered in the `Subscription` table contents
 
-```
-PartitionKey:= OrderCompleted, Version=0.0.0.0
-  RowKey:= U2FtcGxlcy5BenVyZS5TdG9yYWdlUGVyc2lzdGVuY2UuQ2xpZW50QFJFVElOQQ==
-  DecodedRowKey:= Samples.Azure.StoragePersistence.Client@RETINA
-```
+partial: subscriptions

--- a/samples/azure/storage-persistence/sample_sagadata_asp_[1,).partial.md
+++ b/samples/azure/storage-persistence/sample_sagadata_asp_[1,).partial.md
@@ -1,0 +1,13 @@
+```
+PartitionKey:= 0145ddc6-5aa5-4a84-8b40-a8020044e9fb
+  RowKey:= 0145ddc6-5aa5-4a84-8b40-a8020044e9fb
+  OrderId:= 696788ff-97a0-4721-b6dc-71cf1ad4a4ba
+  Id:= 0145ddc6-5aa5-4a84-8b40-a8020044e9fb
+  Originator:= samples-azure-storagepersistence-client
+  OriginalMessageId:= 14c900c2-1188-49a6-8238-a8020044e91a
+  OrderDescription:= The saga for order 696788ff-97a0-4721-b6dc-71cf1ad...
+  NServiceBus_2ndIndexKey:= Index_OrderSagaData_OrderId_"696788ff-97a0-4721-b6...
+PartitionKey:= Index_OrderSagaData_OrderId_"696788ff-97a0-4721-b6dc-71cf1ad4a4ba"
+  RowKey:= 
+  SagaId:= 0145ddc6-5aa5-4a84-8b40-a8020044e9fb
+```

--- a/samples/azure/storage-persistence/sample_sagadata_azure_6.partial.md
+++ b/samples/azure/storage-persistence/sample_sagadata_azure_6.partial.md
@@ -1,0 +1,9 @@
+```
+PartitionKey:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
+  RowKey:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
+  Id:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
+  Originator:= Samples.Azure.StoragePersistence.Client@RETINA
+  OriginalMessageId:= 0d574aa7-0d39-4e93-8233-a50e00ea764f
+  OrderId:= 79cc2072-c724-4cc0-9202-b6c4918a3de2
+  OrderDescription:= The saga for order 79cc2072-c724-4cc0-9202-b6c4918...
+```

--- a/samples/azure/storage-persistence/sample_subscriptions_asp_[1,).partial.md
+++ b/samples/azure/storage-persistence/sample_subscriptions_asp_[1,).partial.md
@@ -1,0 +1,6 @@
+```
+PartitionKey:= Shared.OrderCompleted, Version=1.0.0.0
+  RowKey:= c2FtcGxlcy1henVyZS1zdG9yYWdlcGVyc2lzdGVuY2UtY2xpZW50
+  DecodedRowKey:= samples-azure-storagepersistence-client
+  EndpointName:= Samples-Azure-StoragePersistence-Client
+```

--- a/samples/azure/storage-persistence/sample_subscriptions_azure_6.partial.md
+++ b/samples/azure/storage-persistence/sample_subscriptions_azure_6.partial.md
@@ -1,0 +1,5 @@
+```
+PartitionKey:= OrderCompleted, Version=0.0.0.0
+  RowKey:= U2FtcGxlcy5BenVyZS5TdG9yYWdlUGVyc2lzdGVuY2UuQ2xpZW50QFJFVElOQQ==
+  DecodedRowKey:= Samples.Azure.StoragePersistence.Client@RETINA
+```

--- a/samples/azure/storage-persistence/sample_timeouts_asp_[1,).partial.md
+++ b/samples/azure/storage-persistence/sample_timeouts_asp_[1,).partial.md
@@ -1,0 +1,1 @@
+The sample is using Azure Storage Queues transport. From version 7.4 and above, the transport is using native delayed delivery and does not rely on the Azure Storage persistence for timeouts.

--- a/samples/azure/storage-persistence/sample_timeouts_azure_6.partial.md
+++ b/samples/azure/storage-persistence/sample_timeouts_azure_6.partial.md
@@ -1,0 +1,20 @@
+The timeout data from the `TimeoutDataTableName` table
+
+```
+  PartitionKey:= 2015090918
+    RowKey:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
+    Destination:= Samples.Azure.StoragePersistence.Server@RETINA
+    Headers:= {"NServiceBus.MessageId":"06800d44-9fc4-49b5-a9e9-...
+    OwningTimeoutManager:= Samples.Azure.StoragePersistence.Server
+    SagaId:= 21a6f7ed-65d2-42ff-a4d3-a50e00ea76ba
+    StateAddress:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
+    Time:= 9/09/2015 6:06:59 PM
+```
+
+The timeout serialized message from the `timeoutstate` blob container.
+
+```
+'timeoutstate' container contents
+  Blob:= 06800d44-9fc4-49b5-a9e9-a50e00ea76c0
+    ﻿{"OrderDescription":"The saga for order 79cc2072-c724-4cc0-9202-b6c4918a3de2"}
+```


### PR DESCRIPTION
Depends on #3308 

Markdown needed to be updates as we no longer produce the data as it shows.
- For timeouts, ASQ has native delayed delivery infrastructure and persistence is not used in v1,v2 of ASP
- Saga data is different in v1,2
- Subscriptions data is different in v1,2