### PR TITLE
Add HandleCurrentMessageLater changes to v6 upgrade guide

### DIFF
--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -52,6 +52,11 @@ The signature for the mutators now passes context arguments that give access to 
 See [header manipulation](/nservicebus/messaging/header-manipulation.md) for one example on how this might look.
 
 
+### HandleCurrentMessageLater and the Outbox
+
+The `HandleCurrentMessageLater` API can no longer be used in conjuction with the Outbox. Use the [recoverability](/nservicebus/recoverability) or [delayed delivery](/nservicebus/messaging/delayed-delivery.md) APIs instead when using the Outbox.
+
+
 ## Migration
 
 

--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -54,7 +54,7 @@ See [header manipulation](/nservicebus/messaging/header-manipulation.md) for one
 
 ### HandleCurrentMessageLater and the Outbox
 
-The `HandleCurrentMessageLater` API can no longer be used in conjuction with the Outbox. Use the [recoverability](/nservicebus/recoverability) or [delayed delivery](/nservicebus/messaging/delayed-delivery.md) APIs instead when using the Outbox.
+The `HandleCurrentMessageLater` method can no longer be used in conjuction with the Outbox. Use the [recoverability](/nservicebus/recoverability) or [delayed delivery](/nservicebus/messaging/delayed-delivery.md) APIs instead when using the Outbox.
 
 
 ## Migration

--- a/nservicebus/upgrades/5to6/handlers-and-sagas.md
+++ b/nservicebus/upgrades/5to6/handlers-and-sagas.md
@@ -54,7 +54,13 @@ See [header manipulation](/nservicebus/messaging/header-manipulation.md) for one
 
 ### HandleCurrentMessageLater and the Outbox
 
-The `HandleCurrentMessageLater` method can no longer be used in conjuction with the Outbox. Use the [recoverability](/nservicebus/recoverability) or [delayed delivery](/nservicebus/messaging/delayed-delivery.md) APIs instead when using the Outbox.
+The `HandleCurrentMessageLater` method can no longer be used in conjunction with the [Outbox](/nservicebus/outbox/). 
+
+When this scenario is detected an exception with the following message will be throw:
+
+> HandleCurrentMessageLater cannot be used in conjunction with the Outbox. Use the recoverability mechanisms or delayed delivery instead.
+
+Use the [recoverability](/nservicebus/recoverability) or [delayed delivery](/nservicebus/messaging/delayed-delivery.md) APIs instead when using the Outbox. 
 
 
 ## Migration


### PR DESCRIPTION
as this was supported in v5 and we're patching v6 to throw an exception when HandleCurrentMessageLater is used in conjunction with the Outbox (as this would cause a message loss in v6), we concluded that we should add this to the v6 upgrade guide as well.

related issue: https://github.com/Particular/NServiceBus/issues/4993