### PR TITLE
splitting version specific settings into partials

### DIFF
--- a/transports/azure-service-bus/configuration/full.md
+++ b/transports/azure-service-bus/configuration/full.md
@@ -8,7 +8,7 @@ tags:
 redirects:
  - nservicebus/azure-service-bus/configuration/configuration
  - nservicebus/azure-service-bus/configuration/full
-reviewed: 2017-06-08
+reviewed: 2017-10-05
 ---
 
 
@@ -53,15 +53,13 @@ The following settings are available to define how queues should be created:
  * `ForwardDeadLetteredMessagesTo(Func<string, bool>, string)`: Forward all dead lettered messages to the specified entity if the given condition equals to `true` (e.g. it allows to exclude forwarding dead lettered messages on the error queue). This setting is off by default.
  * `DefaultMessageTimeToLive(TimeSpan)`: The maximum age of a message, defaults to `TimeSpan.MaxValue`.
  * `EnableDeadLetteringOnMessageExpiration(bool)`: Messages that expire will be dead lettered, defaults to `false`.
- * `EnableExpress(bool)`: Enables express mode, defaults to `false`. For more information refer to [MSDN](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.queuedescription#Microsoft_ServiceBus_Messaging_QueueDescription_EnableExpress)
- * `EnableExpress(Func<string, bool>, string)`: Enables express mode when the given condition is `true`.
  * `AutoDeleteOnIdle(TimeSpan)`: Automatically deletes the queue if it hasn't been used for the specified time period. By default the queue will not be automatically deleted.
  * `EnablePartitioning(bool)`: Enables partitioning, defaults to `false`. For more information on partitioning refer to the [Partitioned messaging entities](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) article on MSDN.
  * `EnableBatchedOperations(bool)`: Enables server side batched operations, defaults to `true`.
  * `RequiresDuplicateDetection(bool)`: Specifies whether the queue should perform native broker duplicate detection, defaults to `false`.
  * `DuplicateDetectionHistoryTimeWindow(TimeSpan)`: The time period in which native broker duplicate detection should occur.
  * `SupportOrdering(bool)`: Best effort message ordering on the queue, defaults to `false`.
- * `DescriptionCustomizer(Action<QueueDescription>)`: A factory method that allows to modify a `QueueDescription` object created by the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Queues API.
+partial: queues
 
 
 ### Topics
@@ -72,14 +70,12 @@ The following settings are available to define how topics should be created:
  * `DefaultMessageTimeToLive(TimeSpan)`: The maximum age of a message, defaults to `TimeSpan.MaxValue`.
  * `AutoDeleteOnIdle(TimeSpan)`: Automatically deletes the topic if it hasn't been used for the specified time period. By default the topic will not be automatically deleted.
  * `EnableBatchedOperations(bool)`: Enables server side batched operations, defaults to `true`.
- * `EnableExpress(bool)`: Enables express mode, defaults to `false`. For more information refer to  the [TopicDescription.EnableExpress Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.topicdescription#Microsoft_ServiceBus_Messaging_TopicDescription_EnableExpress) documentation on MSDN.
- * `EnableExpress(Func<string, bool>, bool)`: Enables express mode when the given condition is `true`.
  * `EnableFilteringMessagesBeforePublishing(bool)`: Enables filtering messages before they are published, which validates that subscribers exist before a message is published. Defaults to `false`.
  * `EnablePartitioning(bool)`: Enables partitioning, defaults to `false`. For more information on partitioning refer to the [Partitioned messaging entities](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) article on MSDN.
  * `RequiresDuplicateDetection(bool)`: Specifies whether the topic should perform native broker duplicate detection, defaults to `false`.
  * `DuplicateDetectionHistoryTimeWindow(TimeSpan)`: The time period in which native broker duplicate detection should occur.
  * `SupportOrdering(bool)`: Best effort message ordering on the topic, defaults to `false`.
- * `DescriptionCustomizer(Action<TopicDescription>)`: A factory method that allows to modify a `TopicDescription` object created for the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Topics API.
+partial: topics
 
 
 ### Subscriptions

--- a/transports/azure-service-bus/configuration/full_queues_asb_[,8).partial.md
+++ b/transports/azure-service-bus/configuration/full_queues_asb_[,8).partial.md
@@ -1,0 +1,3 @@
+ * `EnableExpress(bool)`: Enables express mode, defaults to `false`. For more information refer to [MSDN](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.queuedescription#Microsoft_ServiceBus_Messaging_QueueDescription_EnableExpress)
+ * `EnableExpress(Func<string, bool>, string)`: Enables express mode when the given condition is `true`.
+ * `DescriptionFactory(Func<string, string, ReadOnlySettings, QueueDescription> factory)`: A factory method that allows to modify a `QueueDescription` object created for the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Topics API.

--- a/transports/azure-service-bus/configuration/full_queues_asb_[8,).partial.md
+++ b/transports/azure-service-bus/configuration/full_queues_asb_[8,).partial.md
@@ -1,0 +1,1 @@
+ * `DescriptionCustomizer(Action<QueueDescription>)`: A factory method that allows to modify a `QueueDescription` object created by the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Queues API.

--- a/transports/azure-service-bus/configuration/full_topics_asb_[,8).partial.md
+++ b/transports/azure-service-bus/configuration/full_topics_asb_[,8).partial.md
@@ -1,0 +1,3 @@
+ * `EnableExpress(bool)`: Enables express mode, defaults to `false`. For more information refer to  the [TopicDescription.EnableExpress Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.topicdescription#Microsoft_ServiceBus_Messaging_TopicDescription_EnableExpress) documentation on MSDN.
+ * `EnableExpress(Func<string, bool>, bool)`: Enables express mode when the given condition is `true`.
+  * `DescriptionFactory(Func<string, string, ReadOnlySettings, TopicDescription> factory)`: A factory method that allows to modify a `TopicDescription` object created for the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Topics API.

--- a/transports/azure-service-bus/configuration/full_topics_asb_[8,).partial.md
+++ b/transports/azure-service-bus/configuration/full_topics_asb_[8,).partial.md
@@ -1,0 +1,1 @@
+ * `DescriptionCustomizer(Action<TopicDescription>)`: A factory method that allows to modify a `TopicDescription` object created for the Azure Service Bus SDK. Use this factory method to override any (future) settings that are not supported by the Topics API.


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.AzureServiceBus/pull/646

@Particular/azure-maintainers looks like DescriptionFactory was replaced when we needed to split it into the old doco.