### PR TITLE
Add note about context parameter

### DIFF
--- a/Snippets/Core/Core_6/Scheduling/Scheduling.cs
+++ b/Snippets/Core/Core_6/Scheduling/Scheduling.cs
@@ -18,6 +18,7 @@
                     timeSpan: TimeSpan.FromMinutes(5),
                     task: pipelineContext =>
                     {
+                        // use the pipelineContext parameter to send messages
                         var message = new CallLegacySystem();
                         return pipelineContext.Send(message);
                     })

--- a/Snippets/Core/Core_7/Scheduling/Scheduling.cs
+++ b/Snippets/Core/Core_7/Scheduling/Scheduling.cs
@@ -18,6 +18,7 @@
                     timeSpan: TimeSpan.FromMinutes(5),
                     task: pipelineContext =>
                     {
+                        // use the pipelineContext parameter to send messages
                         var message = new CallLegacySystem();
                         return pipelineContext.Send(message);
                     })


### PR DESCRIPTION
fixes https://github.com/Particular/docs.particular.net/issues/2931 by adding a comment to underline that you should use the context parameter to send messages instead of using the endpointInstance.