### PR TITLE
Use correct output path

### DIFF
--- a/samples/hosting/windows-service/sample_netcore_core_[7.0,).partial.md
+++ b/samples/hosting/windows-service/sample_netcore_core_[7.0,).partial.md
@@ -22,7 +22,7 @@ To use the installation approach described above, a self contained exe is requir
 dotnet publish WindowsServiceHosting.Core.sln --framework netcoreapp2.0 --runtime win10-x64
 ```
 
-`Sample.Core.exe` will then exist in `Sample\bin\Debug\netcoreapp2.0\win10-x64`.
+`Sample.Core.exe` will then exist in `Sample\bin\Debug\netcoreapp2.0\win10-x64\publish`.
 
 
 ### Via dotnet.exe


### PR DESCRIPTION
@SimonCropp got feedback from a customer that the path is incorrect. Can you confirm?