### PR TITLE
Updated reference to updated API

### DIFF
--- a/transports/sql/concurrency_content_sqltransport_2.partial.md
+++ b/transports/sql/concurrency_content_sqltransport_2.partial.md
@@ -1,0 +1,12 @@
+## Versions 2.0.x
+
+Each endpoint running SQL Server transport spins up a fixed number of threads (controlled by `MaximumConcurrencyLevel` property of `TransportConfig` section) for each input queue. Each thread runs in a loop, polling the database for messages awaiting processing.
+
+By default, there are 5 input queues created for every endpoint (apart from the main one, there are two for handling timeouts, one for the retries and another one for callbacks). As a consequence, if `MaximumConcurrencyLevel` is set to 10, there are 41 threads running and constantly polling the database. The callback queue has a separate concurrency settings which default to 1 polling thread.
+
+
+## Versions 2.1 and above
+
+SQL Server transport uses an adaptive concurrency model. The transport adapts the number of polling threads based on the rate of messages coming in. A separate instance of the algorithm is executed by each polling thread. The algorithm counts consecutive successful and failed poll attempts (the attempt succeeds if it finds a message waiting in a queue).
+
+If the number of consecutive successful polls is greater than an internal threshold, a new polling thread is started (provided the `MaximumConcurrencyLevel` is not exceeded). On the other hand, if the number of consecutive failed polls is greater than a threshold, the thread dies.

--- a/transports/sql/concurrency_content_sqltransport_[,2).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[,2).partial.md
@@ -2,4 +2,4 @@ Each endpoint running SQL Server transport spins up a fixed number of threads (c
 
 By default, there are 4 input queues created for every endpoint (apart from the main one, there are two for handling timeouts and one for the retries). As a consequence, if `MaximumConcurrencyLevel` is set to 10, there are 40 threads running and constantly polling the database.
 
-Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning?version=core_4).
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md?version=core_4).

--- a/transports/sql/concurrency_content_sqltransport_[,2).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[,2).partial.md
@@ -1,3 +1,5 @@
 Each endpoint running SQL Server transport spins up a fixed number of threads (controlled by `MaximumConcurrencyLevel` property of `TransportConfig` section) for each input queue. Each thread runs in a loop, polling the database for messages awaiting processing.
 
 By default, there are 4 input queues created for every endpoint (apart from the main one, there are two for handling timeouts and one for the retries). As a consequence, if `MaximumConcurrencyLevel` is set to 10, there are 40 threads running and constantly polling the database.
+
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning?version=core_4).

--- a/transports/sql/concurrency_content_sqltransport_[,2).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[,2).partial.md
@@ -2,4 +2,4 @@ Each endpoint running SQL Server transport spins up a fixed number of threads (c
 
 By default, there are 4 input queues created for every endpoint (apart from the main one, there are two for handling timeouts and one for the retries). As a consequence, if `MaximumConcurrencyLevel` is set to 10, there are 40 threads running and constantly polling the database.
 
-Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md?version=core_4).
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md).

--- a/transports/sql/concurrency_content_sqltransport_[2,3).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[2,3).partial.md
@@ -10,3 +10,5 @@ By default, there are 5 input queues created for every endpoint (apart from the 
 SQL Server transport uses an adaptive concurrency model. The transport adapts the number of polling threads based on the rate of messages coming in. A separate instance of the algorithm is executed by each polling thread. The algorithm counts consecutive successful and failed poll attempts (the attempt succeeds if it finds a message waiting in a queue).
 
 If the number of consecutive successful polls is greater than an internal threshold, a new polling thread is started (provided the `MaximumConcurrencyLevel` is not exceeded). On the other hand, if the number of consecutive failed polls is greater than a threshold, the thread dies.
+
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning?version=core_5).

--- a/transports/sql/concurrency_content_sqltransport_[2].partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[2].partial.md
@@ -11,4 +11,4 @@ SQL Server transport uses an adaptive concurrency model. The transport adapts th
 
 If the number of consecutive successful polls is greater than an internal threshold, a new polling thread is started (provided the `MaximumConcurrencyLevel` is not exceeded). On the other hand, if the number of consecutive failed polls is greater than a threshold, the thread dies.
 
-Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md?version=core_5).
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md).

--- a/transports/sql/concurrency_content_sqltransport_[2].partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[2].partial.md
@@ -11,4 +11,4 @@ SQL Server transport uses an adaptive concurrency model. The transport adapts th
 
 If the number of consecutive successful polls is greater than an internal threshold, a new polling thread is started (provided the `MaximumConcurrencyLevel` is not exceeded). On the other hand, if the number of consecutive failed polls is greater than a threshold, the thread dies.
 
-Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning?version=core_5).
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md?version=core_5).

--- a/transports/sql/concurrency_content_sqltransport_[3,).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[3,).partial.md
@@ -1,3 +1,5 @@
 SQL Server transport maintains a dedicated monitoring thread for each input queue. It is responsible for detecting the number of messages waiting for delivery and creating receive tasks - one for each pending message.
 
-The maximum number of concurrent tasks will never exceed `MaximumConcurrencyLevel`. The number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms.
+The maximum number of concurrent tasks will never exceed the value set by `LimitMessageProcessingConcurrencyTo`. The number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms.
+
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning).

--- a/transports/sql/concurrency_content_sqltransport_[3,).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[3,).partial.md
@@ -2,4 +2,4 @@ SQL Server transport maintains a dedicated monitoring thread for each input queu
 
 The maximum number of concurrent tasks will never exceed the value set by `LimitMessageProcessingConcurrencyTo`. The number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms.
 
-Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning).
+Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md).


### PR DESCRIPTION
## Issue 

SQL Transport [3,) concurrency documentation was referring to old API. Result was that customer on NSBv6 and SQL Transport v3 was unable to find how to change concurrency with current documentation.

## Solution

Change API reference and added link to documentation on how to change concurrency.