### PR TITLE
Removed notion of non-existing thread

### DIFF
--- a/transports/sql/concurrency_content_sqltransport_[3,).partial.md
+++ b/transports/sql/concurrency_content_sqltransport_[3,).partial.md
@@ -1,4 +1,4 @@
-SQL Server transport maintains a dedicated monitoring thread for each input queue. It is responsible for detecting the number of messages waiting for delivery and creating receive tasks - one for each pending message.
+SQL Server transport monitors each input queue separately. The monitoring task is responsible for detecting the number of messages waiting for delivery and creating receive tasks - one for each pending message.
 
 The maximum number of concurrent tasks will never exceed the value set by `LimitMessageProcessingConcurrencyTo`. The number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms.
 


### PR DESCRIPTION
This PR slightly changes the phrasing of a description for sql transport concurrency. It removes the notion of a thread replacing it with a task