### PR TITLE
Remove Configurations property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Configurations>Debug</Configurations>
     <WarningsAsErrors>IDE0018</WarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
Having the `Configurations` property in Directory.Build.props like this breaks Visual Studio's ability to add existing projects to a solution or create new projects. 

