### PR TITLE
Fixes typo in documentation.

### DIFF
--- a/transports/rabbitmq/transactions-and-delivery-guarantees.md
+++ b/transports/rabbitmq/transactions-and-delivery-guarantees.md
@@ -17,7 +17,7 @@ The RabbitMQ transport supports the following [Transport Transaction Modes](/tra
 
 ## Transport transaction - Receive Only
 
-When running in `ReceiveOnly` mode, the RabbitMQ transport consumes messages from the broker in manual acknowledgment mode. After a message is successfully processed, it is acknowledged via the AMQP [basic.ack](http://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.ack) method, which allows the broker know that the message can be removed from the queue. If a message is not successfully processed and needs to be retried, it is re-queued via the AMQP [basic.reject](http://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.reject) method.
+When running in `ReceiveOnly` mode, the RabbitMQ transport consumes messages from the broker in manual acknowledgment mode. After a message is successfully processed, it is acknowledged via the AMQP [basic.ack](http://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.ack) method, which allows the broker to know that the message can be removed from the queue. If a message is not successfully processed and needs to be retried, it is re-queued via the AMQP [basic.reject](http://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.reject) method.
 
 WARNING: If the connection to the broker is lost for any reason before a message can be acknowledged, even if the message was successfully processed, the message will automatically be re-queued by the broker. This will result in the endpoint processing the same message multiple times.
 


### PR DESCRIPTION
While reading through the docs for RabbitMQ, I noticed that there was a missing word. It read "which allows the broker know" so I updated it to "which allows the broker *to* know".

I'm not sure the bottom paragraph is being marked as edited. I made no changes to it whatsoever.