### PR TITLE
Fix to ASQ shortening/sanitization backwards compatible code

### DIFF
--- a/Snippets/ASQ/ASQ_8/Sanitization.cs
+++ b/Snippets/ASQ/ASQ_8/Sanitization.cs
@@ -1,0 +1,118 @@
+﻿// ReSharper disable SuggestVarOrType_Elsewhere
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using NServiceBus;
+
+[SuppressMessage("ReSharper", "UnusedMember.Local")]
+public class Sanitization
+{
+    void CustomSanitization(EndpointConfiguration endpointConfiguration)
+    {
+        #region azure-storage-queue-sanitization
+
+        var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
+        transport.SanitizeQueueNamesWith(queueName => queueName.Replace('.', '-'));
+
+        #endregion
+    }
+
+    void SanitizeWithMd5BackwardsCompatible(EndpointConfiguration endpointConfiguration)
+    {
+        #region azure-storage-queue-backwards-compatible-sanitization-with-md5
+
+        var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
+        transport.SanitizeQueueNamesWith(BackwardsCompatibleQueueNameSanitizer.WithMd5Shortener);
+
+        #endregion
+    }
+
+    #region azure-storage-queue-backwards-compatible-sanitization
+
+    public static class BackwardsCompatibleQueueNameSanitizer
+    {
+        public static string WithMd5Shortener(string queueName)
+        {
+            return Sanitize(queueName, useMd5Hashing: true);
+        }
+
+        public static string WithSha1Shortener(string queueName)
+        {
+            return Sanitize(queueName, useMd5Hashing: false);
+        }
+
+        static string Sanitize(string queueName, bool useMd5Hashing = true)
+        {
+            var queueNameInLowerCase = queueName.ToLowerInvariant();
+            return ShortenQueueNameIfNecessary(SanitizeQueueName(queueNameInLowerCase), useMd5Hashing);
+        }
+
+        static string ShortenQueueNameIfNecessary(string sanitizedQueueName, bool useMd5Hashing)
+        {
+            if (sanitizedQueueName.Length <= 63)
+            {
+                return sanitizedQueueName;
+            }
+
+            var shortenedName = useMd5Hashing ? ShortenWithMd5(sanitizedQueueName) : ShortenWithSha1(sanitizedQueueName);
+
+            return $"{sanitizedQueueName.Substring(0, 63 - shortenedName.Length - 1).Trim('-')}-{shortenedName}";
+        }
+
+        static string SanitizeQueueName(string queueName)
+        {
+            // this can lead to multiple '-' occurrences in a row
+            var sanitized = invalidCharacters.Replace(queueName, "-");
+            return multipleDashes.Replace(sanitized, "-");
+        }
+
+        static string ShortenWithMd5(string test)
+        {
+            //use MD5 hash to get a 16-byte hash of the string
+            using (var provider = MD5.Create())
+            {
+                var inputBytes = Encoding.Default.GetBytes(test);
+                var hashBytes = provider.ComputeHash(inputBytes);
+                //generate a GUID from the hash:
+                return new Guid(hashBytes).ToString();
+            }
+        }
+
+        static string ShortenWithSha1(string queueName)
+        {
+            using (var provider = SHA1.Create())
+            {
+                var inputBytes = Encoding.Default.GetBytes(queueName);
+                var hashBytes = provider.ComputeHash(inputBytes);
+
+                return ToChars(hashBytes);
+            }
+        }
+
+        static string ToChars(byte[] hashBytes)
+        {
+            var chars = new char[hashBytes.Length * 2];
+            for (var i = 0; i < chars.Length; i += 2)
+            {
+                var byteIndex = i / 2;
+                chars[i] = HexToChar((byte)(hashBytes[byteIndex] >> 4));
+                chars[i + 1] = HexToChar(hashBytes[byteIndex]);
+            }
+
+            return new string(chars);
+        }
+
+        static char HexToChar(byte a)
+        {
+            a &= 15;
+            return a > 9 ? (char)(a - 10 + 97) : (char)(a + 48);
+        }
+
+        static Regex invalidCharacters = new Regex(@"[^a-z0-9\-]", RegexOptions.Compiled);
+        static Regex multipleDashes = new Regex(@"\-+", RegexOptions.Compiled);
+    }
+    #endregion
+}

--- a/Snippets/ASQ/ASQ_8/Usage.cs
+++ b/Snippets/ASQ/ASQ_8/Usage.cs
@@ -119,16 +119,6 @@ class Usage
         #endregion
     }
 
-    void UseSha1(EndpointConfiguration endpointConfiguration)
-    {
-        #region AzureStorageQueueSanitization
-
-        var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
-        transport.SanitizeQueueNamesWith(queueName => queueName.Replace('.', '-'));
-
-        #endregion
-    }
-
     void SetSerialization(EndpointConfiguration endpointConfiguration)
     {
         #region AzureStorageQueueSerialization

--- a/samples/azure/storage-queues/ASQ_8/Shared/BackwardsCompatibleQueueNameSanitizer.cs
+++ b/samples/azure/storage-queues/ASQ_8/Shared/BackwardsCompatibleQueueNameSanitizer.cs
@@ -20,19 +20,19 @@ public static class BackwardsCompatibleQueueNameSanitizer
     static string Sanitize(string queueName, bool useMd5Hashing = true)
     {
         var queueNameInLowerCase = queueName.ToLowerInvariant();
-        return ShortenQueueNameIfNecessary(queueNameInLowerCase, SanitizeQueueName(queueNameInLowerCase), useMd5Hashing);
+        return ShortenQueueNameIfNecessary(SanitizeQueueName(queueNameInLowerCase), useMd5Hashing);
     }
 
-    static string ShortenQueueNameIfNecessary(string queueName, string hashedQueueName, bool useMd5Hashing)
+    static string ShortenQueueNameIfNecessary(string sanitizedQueueName, bool useMd5Hashing)
     {
-        if (hashedQueueName.Length <= 63)
+        if (sanitizedQueueName.Length <= 63)
         {
-            return hashedQueueName;
+            return sanitizedQueueName;
         }
 
-        var shortenedName = useMd5Hashing ? ShortenWithMd5(queueName) : ShortenWithSha1(queueName);
+        var shortenedName = useMd5Hashing ? ShortenWithMd5(sanitizedQueueName) : ShortenWithSha1(sanitizedQueueName);
 
-        return $"{hashedQueueName.Substring(0, 63 - shortenedName.Length - 1).Trim('-')}-{shortenedName}";
+        return $"{sanitizedQueueName.Substring(0, 63 - shortenedName.Length - 1).Trim('-')}-{shortenedName}";
     }
 
     static string SanitizeQueueName(string queueName)

--- a/transports/azure-storage-queues/sanitization.md
+++ b/transports/azure-storage-queues/sanitization.md
@@ -7,7 +7,7 @@ tags:
 related:
 - transports/azure-storage-queues/configuration
 - samples/azure/storage-queues
-reviewed: 2017-10-06
+reviewed: 2017-10-24
 ---
 
 
@@ -28,11 +28,28 @@ In Versions 8.0 and above, the Azure Storage Queues transport no longer sanitize
 
 To sanitize queue names, a sanitization function containing the required logic can be registered.
 
-snippet: AzureStorageQueueSanitization
+snippet: azure-storage-queue-sanitization
 
 When an endpoint is started, the sanitizer function will be invoked for each queue the transport creates.
 
 
-## Backwards compatibility
+## Backward compatibility with versions 7 and below
 
-To obtain sanitizing logic backwards compatible with the transport versions below 8.0, refer to the Azure Storage Queues sample.
+To remain backward compatible with endpoints versions 7 and below, endpoints version 8 and above should be configured to perform sanitization based on version 7 and below rules. The following custom code will ensure queues are sanitized in a backwards compatible manner.
+
+snippet: azure-storage-queue-backwards-compatible-sanitization-with-md5
+
+Sanitization code for MD5 and SHA1:
+
+snippet: azure-storage-queue-backwards-compatible-sanitization
+
+
+## Future consideration prior to using sanitization
+
+When implementing custom sanitization, consider factors such as readability and discover-ability. Things to consider:
+
+ * Truncated long queue names could conflict.
+ * Hashed queue names could lead to difficult names to use during production troubleshooting or debugging.
+ * Sanitized queue names stay in the system and cannot be replaced until no longer used.
+
+Possible way to avoid sanitization is to define endpoint name as short and meaningful.

--- a/transports/azure-storage-queues/sanitization.md
+++ b/transports/azure-storage-queues/sanitization.md
@@ -52,4 +52,4 @@ When implementing custom sanitization, consider factors such as readability and 
  * Hashed queue names could lead to difficult names to use during production troubleshooting or debugging.
  * Sanitized queue names stay in the system and cannot be replaced until no longer used.
 
-Possible way to avoid sanitization is to define endpoint name as short and meaningful.
+Possible way to avoid sanitization is to define endpoint name short and meaningful.

--- a/transports/upgrades/asq-7to8.md
+++ b/transports/upgrades/asq-7to8.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Storage Queues Transport Upgrade Version 7 to 8
 summary: Instructions on how to upgrade Azure Storage Queues Transport Version 7 to 8.
-reviewed: 2017-10-18
+reviewed: 2017-10-24
 component: ASQ
 related:
 - transports/azure-storage-queues
@@ -23,7 +23,7 @@ In previous versions, the transport was responsible for sanitization of the queu
 
 In Versions 8 and above, the transport is no longer performing sanitization by default. Instead, sanitization logic can be [registered](/transports/azure-storage-queues/sanitization.md).
 
-snippet: AzureStorageQueueSanitization
+snippet: azure-storage-queue-sanitization
 
 
 ## Serialization is mandatory


### PR DESCRIPTION
Fixes #3255 
Connects to https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/282
Closes https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/282

Have verified the results for v6/7/8 of the transport.

**v8**
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters
`samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc`

**v7**
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters
`samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc`
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters-retries
`samples-azure-storagequeue-bdb4edc7-74cc-65c2-5f65-a49ed3032070`

**v6**
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters
`samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc`
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters-retries
`samples-azure-storagequeue-bdb4edc7-74cc-65c2-5f65-a49ed3032070`
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters-timeouts
`samples-azure-storagequeue-b8a43bfc-91b1-b74e-508b-f25faf13070a`
Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters-timeoutsdispatcher
`samples-azure-storagequeue-69ef360b-8499-1e4f-c514-6d4830df20e6`