### PR TITLE
Clarify callbacks and unique queues

### DIFF
--- a/nservicebus/messaging/callbacks_route_callbacks_[1,).partial.md
+++ b/nservicebus/messaging/callbacks_route_callbacks_[1,).partial.md
@@ -1,12 +1,16 @@
 
-Callback responses are routed based on the `ReplyTo` header of the request. To use callbacks, a unique instance Id needs to be specified in the requester endpoint configuration:
+Callbacks are tied to the endpoint instance making the request so all responses needs to be routed back to the specific instance making the request. This means that callbacks requires the endpoint to configure a unique instance Id:
 
 snippet: Callbacks-InstanceId
 
-This will make each instance of the endpoint uniquely addressable by creating an additional queue using the instance Id in the name of the queue. Each instance needs to use a different instance Id to guarantee they each get their own queue.
+This will make each instance of the endpoint uniquely addressable by creating an additional queue using the instance Id in the name of the queue. 
 
-Uniquely addressable endpoints will consume messages from both the shared and unique queues. Replies will automatically be sent to the instance-specific queue.
+Selecting the Id depends on the transport used and how the endpoint is [scaled out](/transports/scale-out.md#when-to-scale-out).
 
-This approach makes it possible to deploy multiple callback-enabled instances of a given endpoint even to the same machine.
+For broker transports like Azure SeviceBus, RabbitMQ etc the instance Id needs to be selected unique across all instances since they all connect to the same broker.
 
-WARNING: This Id needs to be stable, and it should never be hardcoded. An example approach might be reading it from the configuration file or from the environment (e.g. role Id in Azure).
+For federated transports like MSMQ it might be enough to use a "hardcoded" Id like `replies`, `callbacks` etc if you are running each instance on a separate machine. 
+
+Uniquely addressable endpoints will consume messages from both the shared and unique queue. Replies will automatically be routed to the instance-specific queue.
+
+WARNING: To avoid creating excessive amounts of queues the Id needs to be keept stable. An example approach might be reading it from the configuration file or from the environment (e.g. role Id in Azure or machine name for on-premise deployments).

--- a/nservicebus/messaging/callbacks_route_callbacks_[1,).partial.md
+++ b/nservicebus/messaging/callbacks_route_callbacks_[1,).partial.md
@@ -1,16 +1,14 @@
 
-Callbacks are tied to the endpoint instance making the request so all responses needs to be routed back to the specific instance making the request. This means that callbacks requires the endpoint to configure a unique instance Id:
+Callbacks are tied to the endpoint instance making the request, so all responses need to be routed back to the specific instance making the request. This means that callbacks requires the endpoint to configure a unique instance Id:
 
 snippet: Callbacks-InstanceId
 
-This will make each instance of the endpoint uniquely addressable by creating an additional queue using the instance Id in the name of the queue. 
+This will make each instance of the endpoint uniquely addressable, an additional queue will be created that has the instance Id in the name. 
 
-Selecting the Id depends on the transport used and how the endpoint is [scaled out](/transports/scale-out.md#when-to-scale-out).
+Selecting the Id depends on the transport used and how the endpoint is [scaled out](/transports/scale-out.md#when-to-scale-out):
+- For broker transports like Azure SeviceBus, RabbitMQ, etc. the instance Id needs to be unique across all instances since they all connect to the same broker.
+- For federated transports like MSMQ, when every instance is running on a seprate machine, then it is enough to use a "hardcoded" Id like `replies`, `callbacks`, etc.. 
 
-For broker transports like Azure SeviceBus, RabbitMQ etc the instance Id needs to be selected unique across all instances since they all connect to the same broker.
+Uniquely addressable endpoints will consume messages from both the shared and their dedicated, instance-specific queues. Replies will automatically be routed to the correct instance-specific queue.
 
-For federated transports like MSMQ it might be enough to use a "hardcoded" Id like `replies`, `callbacks` etc if you are running each instance on a separate machine. 
-
-Uniquely addressable endpoints will consume messages from both the shared and unique queue. Replies will automatically be routed to the instance-specific queue.
-
-WARNING: To avoid creating excessive amounts of queues the Id needs to be keept stable. An example approach might be reading it from the configuration file or from the environment (e.g. role Id in Azure or machine name for on-premise deployments).
+WARNING: To avoid creating excessive number of queues, the Id needs to be kept stable. For example, it may be retrieved from a configuration file or from the environment (e.g. role Id in Azure or machine name for on-premise deployments).


### PR DESCRIPTION
As part of https://discuss.particular.net/t/how-do-i-configure-iis-for-use-with-callbacks/131 we realized that our guidance for callbacks are not accurate for endpoints running MSMQ. This tries to clarify that you can hardcode the instance id under certain circumstances