### PR TITLE
Use AWS_REGION instead of AWS_DEFAULT_REGION

### DIFF
--- a/samples/sqs/simple/sample.md
+++ b/samples/sqs/simple/sample.md
@@ -21,7 +21,7 @@ Add the [AWS Access Key ID and AWS Secret Access Key](http://docs.aws.amazon.com
 
  * Access Key ID in `AWS_ACCESS_KEY_ID`
  * Secret Access Key in `AWS_SECRET_ACCESS_KEY`
- * Default Region in `AWS_DEFAULT_REGION`
+ * Default Region in `AWS_REGION`
 
 See also [AWS Account Identifiers](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html), [Managing Access Keys for a AWS Account](http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html), and [IAM Security Credentials](https://console.aws.amazon.com/iam/home#/security_credential).
 

--- a/transports/sqs/configuration-options_source_sqs_[4,).partial.md
+++ b/transports/sqs/configuration-options_source_sqs_[4,).partial.md
@@ -20,7 +20,7 @@ snippet: S3CredentialSource
 
 **Default**: `AWS SDK`.
 
-By default the endpoint uses the SDK to retrieve the default AWS region from the `AWS_DEFAULT_REGION` environment variable.
+By default the endpoint uses the SDK to retrieve the default AWS region from the `AWS_REGION` environment variable.
 
 This is the Amazon Web Services [Region](http://docs.aws.amazon.com/general/latest/gr/rande.html) in which to access the SQS service. Must be a valid [AWS region code](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions).
 

--- a/transports/upgrades/amazonsqs-3to4.md
+++ b/transports/upgrades/amazonsqs-3to4.md
@@ -16,7 +16,7 @@ snippet: 3to4_MaxTTL
 
 ## Region
 
-To specify a region set the `AWS_DEFAULT_REGION` environment variable or overload the client factory.
+To specify a region set the `AWS_REGION` environment variable or overload the client factory.
 
 snippet: 3to4_Region
 
@@ -44,7 +44,7 @@ snippet: 3to4_S3BucketForLargeMessages
 
 ### Region
 
-To specify a region set the `AWS_DEFAULT_REGION` environment variable or overload the client factory.
+To specify a region set the `AWS_REGION` environment variable or overload the client factory.
 
 snippet: 3to4_S3Region
 


### PR DESCRIPTION
It seems that using AWS_REGION is the more commonly used approach over AWS_DEFAULT_REGION which is mostly used by CLI. 