### PR TITLE
Yet another small changes

### DIFF
--- a/tutorials/intro-to-nservicebus/3-multiple-endpoints/tutorial.md
+++ b/tutorials/intro-to-nservicebus/3-multiple-endpoints/tutorial.md
@@ -59,7 +59,7 @@ Therefore, it makes sense that logical routing is defined in code.
 
 ### Defining logical routes
 
-[**Message routing**](/nservicebus/messaging/routing.md) is a function of the message transport, so all routing functionality is accessed from the `transport` object returned when we defined the message transport, as shown in this example using the MSMQ transport:
+[**Message routing**](/nservicebus/messaging/routing.md) is a function of the message transport, so all routing functionality is accessed from the `transport` object returned when we defined the message transport, as shown in this example using the Learning transport:
 
 snippet: RoutingSettings
 

--- a/tutorials/intro-to-nservicebus/3-multiple-endpoints/tutorial.md
+++ b/tutorials/intro-to-nservicebus/3-multiple-endpoints/tutorial.md
@@ -59,7 +59,7 @@ Therefore, it makes sense that logical routing is defined in code.
 
 ### Defining logical routes
 
-[**Message routing**](/nservicebus/messaging/routing.md) is a function of the message transport, so all routing functionality is accessed from the `transport` object returned when we defined the message transport, as shown in this example using the Learning transport:
+[**Message routing**](/nservicebus/messaging/routing.md) is a function of the message transport, so all routing functionality is accessed from the `transport` object returned when we defined the message transport, as shown in this example using the MSMQ transport:
 
 snippet: RoutingSettings
 

--- a/tutorials/intro-to-nservicebus/4-publishing-events/Solution/ClientUI/Program.cs
+++ b/tutorials/intro-to-nservicebus/4-publishing-events/Solution/ClientUI/Program.cs
@@ -14,14 +14,10 @@ namespace ClientUI
 
             var endpointConfiguration = new EndpointConfiguration("ClientUI");
 
-            var transport = endpointConfiguration.UseTransport<MsmqTransport>();
+            var transport = endpointConfiguration.UseTransport<LearningTransport>();
 
             var routing = transport.Routing();
             routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
-
-            endpointConfiguration.UsePersistence<InMemoryPersistence>();
-            endpointConfiguration.SendFailedMessagesTo("error");
-            endpointConfiguration.EnableInstallers();
 
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);

--- a/tutorials/intro-to-nservicebus/5-retrying-errors/Solution/Sales/PlaceOrderHandler.cs
+++ b/tutorials/intro-to-nservicebus/5-retrying-errors/Solution/Sales/PlaceOrderHandler.cs
@@ -3,6 +3,8 @@ using Messages;
 using NServiceBus;
 using NServiceBus.Logging;
 
+#pragma warning disable 162
+
 namespace Sales
 {
     using System;

--- a/tutorials/message-replay/Solution/Sales/PlaceOrderHandler.cs
+++ b/tutorials/message-replay/Solution/Sales/PlaceOrderHandler.cs
@@ -7,6 +7,8 @@ using NServiceBus.Logging;
 
 namespace Sales
 {
+    using System;
+
     public class PlaceOrderHandler :
         IHandleMessages<PlaceOrder>
     {

--- a/tutorials/message-replay/Solution/Sales/PlaceOrderHandler.cs
+++ b/tutorials/message-replay/Solution/Sales/PlaceOrderHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using Messages;
 using NServiceBus;
 using NServiceBus.Logging;
@@ -7,8 +8,6 @@ using NServiceBus.Logging;
 
 namespace Sales
 {
-    using System;
-
     public class PlaceOrderHandler :
         IHandleMessages<PlaceOrder>
     {


### PR DESCRIPTION
Hi again :)

@weralabaj I read tutorials to checking out Platform new features and yes the reason for changes is to be consistent about transport usage across all tutorial lessons.

@weralabaj @DavidBoike Thanks for approval previous pull requests!

I don't read [step-by-step](https://docs.particular.net/samples/step-by-step/) tutorial yet but in quick review I see that **LearningTransport** is use and there are two maybe not necessary endpoint configuration features:
- endpointConfiguration.EnableInstallers();
- endpointConfiguration.SendFailedMessagesTo("error");

Let me know what you think and I can change the code and doc content to practice pull requests :)

I'm hope that I don't give you additional work.

Regards
Michał