### PR TITLE
UniformSession plugin needs to be enabled now

### DIFF
--- a/Snippets/UniformSession/UniformSession_1/EnableUniformSession.cs
+++ b/Snippets/UniformSession/UniformSession_1/EnableUniformSession.cs
@@ -1,0 +1,16 @@
+﻿namespace UniformSession_2
+{
+    using NServiceBus;
+
+    public class EnableUniformSession
+    {
+        void Configure(EndpointConfiguration endpointConfiguration)
+        {
+            #region enable-uniformsession
+
+            endpointConfiguration.EnableUniformSession();
+
+            #endregion
+        }
+    }
+}

--- a/Snippets/UniformSession/UniformSession_2/EnableUniformSession.cs
+++ b/Snippets/UniformSession/UniformSession_2/EnableUniformSession.cs
@@ -1,0 +1,16 @@
+﻿namespace UniformSession_2
+{
+    using NServiceBus;
+
+    public class EnableUniformSession
+    {
+        void Configure(EndpointConfiguration endpointConfiguration)
+        {
+            #region enable-uniformsession
+
+            endpointConfiguration.EnableUniformSession();
+
+            #endregion
+        }
+    }
+}

--- a/nservicebus/messaging/uniformsession.md
+++ b/nservicebus/messaging/uniformsession.md
@@ -22,7 +22,11 @@ Install the `NServiceBus.UniformSession` NuGet package available for endpoints u
 
 ## Usage
 
-`IUniformSession` is automatically registered in the container and can safely be injected into component hierarchies that are reused in different contexts such as WebApi and the message handler for example. The following snippet illustrates such a scenario:
+To enable the uniform session functionality, enable the package via the endpoint configuration:
+
+snippet: enable-uniformsession
+
+When enabled, `IUniformSession` is automatically registered in the container and can safely be injected into component hierarchies that are reused in different contexts such as WebApi and the message handler for example. The following snippet illustrates such a scenario:
 
 snippet: uniformsession-usage
 


### PR DESCRIPTION
The plugin is no longer auto enabled and needs to be explicitly enabled instead. 

This PR does not compile as the required updated packages are not on myget yet.