### PR TITLE
Upgrade rules to prometheus 2.0

### DIFF
--- a/samples/logging/prometheus-grafana/nservicebus.rules.txt
+++ b/samples/logging/prometheus-grafana/nservicebus.rules.txt
@@ -1,7 +1,15 @@
-nservicebus_success_total:avg_rate5m = avg(rate(nservicebus_success_total[5m]))
-nservicebus_failure_total:avg_rate5m = avg(rate(nservicebus_failure_total[5m]))
-nservicebus_fetched_total:avg_rate5m = avg(rate(nservicebus_fetched_total[5m]))
-
-nservicebus_success_total:avg_rate1m = avg(rate(nservicebus_success_total[1m]))
-nservicebus_failure_total:avg_rate1m = avg(rate(nservicebus_failure_total[1m]))
-nservicebus_fetched_total:avg_rate1m = avg(rate(nservicebus_fetched_total[1m]))
+groups:
+- name: NServiceBus
+  rules:
+  - record: nservicebus_success_total:avg_rate5m
+    expr: avg(rate(nservicebus_success_total[5m]))
+  - record: nservicebus_failure_total:avg_rate5m
+    expr: avg(rate(nservicebus_failure_total[5m]))
+  - record: nservicebus_fetched_total:avg_rate5m
+    expr: avg(rate(nservicebus_fetched_total[5m]))
+  - record: nservicebus_success_total:avg_rate1m
+    expr: avg(rate(nservicebus_success_total[1m]))
+  - record: nservicebus_failure_total:avg_rate1m
+    expr: avg(rate(nservicebus_failure_total[1m]))
+  - record: nservicebus_fetched_total:avg_rate1m
+    expr: avg(rate(nservicebus_fetched_total[1m]))

--- a/samples/logging/prometheus-grafana/sample.md
+++ b/samples/logging/prometheus-grafana/sample.md
@@ -116,9 +116,15 @@ Edit `prometheus.yml` and  add a new target for scraping similar to
 Queries can be expensive operations. Prometheus allows defining pre-calculated queries by configuring rules that calculate rates based on the counters. 
 
 ```
-nservicebus_success_total:avg_rate5m = avg(rate(nservicebus_success_total[5m]))
-nservicebus_failure_total:avg_rate5m = avg(rate(nservicebus_failure_total[5m]))
-nservicebus_fetched_total:avg_rate5m = avg(rate(nservicebus_fetched_total[5m]))
+groups:
+- name: NServiceBus
+  rules:
+  - record: nservicebus_success_total:avg_rate5m
+    expr: avg(rate(nservicebus_success_total[5m]))
+  - record: nservicebus_failure_total:avg_rate5m
+    expr: avg(rate(nservicebus_failure_total[5m]))
+  - record: nservicebus_fetched_total:avg_rate5m
+    expr: avg(rate(nservicebus_fetched_total[5m]))
 ```
 
 The pre-calculated query can then be used.


### PR DESCRIPTION
Prometheus 2.0 was released and contained a breaking change to the rules files. I converted the rules by using the provided promtool and smoke tested it