### PR TITLE
Fix broken samples

### DIFF
--- a/Snippets/NHibernate/NHibernate_8/Usage.cs
+++ b/Snippets/NHibernate/NHibernate_8/Usage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using global::NHibernate.Cfg;
 using NServiceBus;
+using NServiceBus.Persistence;
 using NServiceBus.Persistence.NHibernate;
 
 class Usage

--- a/Snippets/Sqs/Sqs_All/SqsTransportConfigurationExtensions.cs
+++ b/Snippets/Sqs/Sqs_All/SqsTransportConfigurationExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace SqsAll
 {
+    using Amazon;
+    using Amazon.SQS;
     using NServiceBus;
 
     public static class SqsTransportConfigurationExtensions
@@ -12,17 +14,15 @@
 
         public static void ConfigureSqsTransport(this TransportExtensions<SqsTransport> transportConfiguration, string queueNamePrefix = null)
         {
-            var region = EnvironmentHelper.GetEnvironmentVariable(RegionEnvironmentVariableName) ?? "ap-southeast-2";
-
             transportConfiguration
-                .Region(region)
+                .ClientFactory(() => new AmazonSQSClient(new AmazonSQSConfig { RegionEndpoint = RegionEndpoint.APSoutheast2 }))
                 .QueueNamePrefix(queueNamePrefix);
 
             var s3BucketName = EnvironmentHelper.GetEnvironmentVariable(S3BucketEnvironmentVariableName);
 
             if (!string.IsNullOrEmpty(S3BucketName))
             {
-                transportConfiguration.S3BucketForLargeMessages(S3BucketName, "test");
+                transportConfiguration.S3(S3BucketName, "test");
             }
 
             var nativeDeferralRaw = EnvironmentHelper.GetEnvironmentVariable(NativeDeferralEnvironmentVariableName);

--- a/Snippets/Unity/Unity_3/Unity_3.csproj
+++ b/Snippets/Unity/Unity_3/Unity_3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_4/Unity_4.csproj
+++ b/Snippets/Unity/Unity_4/Unity_4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_5/Unity_5.csproj
+++ b/Snippets/Unity/Unity_5/Unity_5.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_6/Unity_6.csproj
+++ b/Snippets/Unity/Unity_6/Unity_6.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_7/Unity_7.csproj
+++ b/Snippets/Unity/Unity_7/Unity_7.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_8/Unity_8.csproj
+++ b/Snippets/Unity/Unity_8/Unity_8.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Unity/Unity_8/Usage.cs
+++ b/Snippets/Unity/Unity_8/Usage.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Practices.Unity;
-using NServiceBus;
+﻿using NServiceBus;
+using Unity;
 
 class Usage
 {

--- a/samples/azure/azure-service-bus-long-running/ASB_8/Client/Client.csproj
+++ b/samples/azure/azure-service-bus-long-running/ASB_8/Client/Client.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/azure-service-bus-long-running/ASB_8/Processor/Processor.csproj
+++ b/samples/azure/azure-service-bus-long-running/ASB_8/Processor/Processor.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure/azure-service-bus-long-running/ASB_8/Server/Server.csproj
+++ b/samples/azure/azure-service-bus-long-running/ASB_8/Server/Server.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure/azure-service-bus/ASB_8/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/azure-service-bus/ASB_8/Endpoint1/Endpoint1.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/azure-service-bus/ASB_8/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/azure-service-bus/ASB_8/Endpoint2/Endpoint2.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/azure-service-fabric-routing/Core_6/CandidateVoteCount/CandidateVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/CandidateVoteCount/CandidateVoteCount.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/azure-service-fabric-routing/Core_6/Contracts/Contracts.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-service-fabric-routing/Core_6/Shared/Shared.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-service-fabric-routing/Core_6/Voter/Voter.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/Voter/Voter.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/azure-service-fabric-routing/Core_6/ZipCodeVoteCount/ZipCodeVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_6/ZipCodeVoteCount/ZipCodeVoteCount.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/azure-service-fabric-routing/Core_7/CandidateVoteCount/CandidateVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/CandidateVoteCount/CandidateVoteCount.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/azure-service-fabric-routing/Core_7/Contracts/Contracts.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-service-fabric-routing/Core_7/Shared/Shared.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-service-fabric-routing/Core_7/Voter/Voter.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Voter/Voter.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/azure-service-fabric-routing/Core_7/ZipCodeVoteCount/ZipCodeVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/ZipCodeVoteCount/ZipCodeVoteCount.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>

--- a/samples/azure/custom-partitioning-asb/ASB_8/Publisher/Publisher.csproj
+++ b/samples/azure/custom-partitioning-asb/ASB_8/Publisher/Publisher.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/custom-partitioning-asb/ASB_8/Subscriber1/Subscriber1.csproj
+++ b/samples/azure/custom-partitioning-asb/ASB_8/Subscriber1/Subscriber1.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/custom-partitioning-asb/ASB_8/Subscriber2/Subscriber2.csproj
+++ b/samples/azure/custom-partitioning-asb/ASB_8/Subscriber2/Subscriber2.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/custom-sanitization-asb/ASB_8/Publisher/Publisher.csproj
+++ b/samples/azure/custom-sanitization-asb/ASB_8/Publisher/Publisher.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/custom-sanitization-asb/ASB_8/Subscriber/Subscriber.csproj
+++ b/samples/azure/custom-sanitization-asb/ASB_8/Subscriber/Subscriber.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/native-integration-asb/ASB_8/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asb/ASB_8/Receiver/Receiver.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/FastAtomicReceiver/FastAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/FastAtomicReceiver/FastAtomicReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/FastSender/FastSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/FastSender/FastSender.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/Shared/Shared.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/SlowAtomicReceiver/SlowAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/SlowAtomicReceiver/SlowAtomicReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_7/SlowSender/SlowSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_7/SlowSender/SlowSender.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/performance-tuning-asb/ASB_8/FastAtomicReceiver/FastAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastAtomicReceiver/FastAtomicReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastAtomicReceiver/FastAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastAtomicReceiver/FastAtomicReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastAtomicSenderReceiver/FastAtomicSenderReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicReceiver/FastNonAtomicReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastNonAtomicSenderReceiver/FastNonAtomicSenderReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastSender/FastSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastSender/FastSender.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/FastSender/FastSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/FastSender/FastSender.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/Shared/Shared.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowAtomicReceiver/SlowAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowAtomicReceiver/SlowAtomicReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowAtomicReceiver/SlowAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowAtomicReceiver/SlowAtomicReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowNonAtomicReceiver/SlowNonAtomicReceiver.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowSender/SlowSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowSender/SlowSender.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/performance-tuning-asb/ASB_8/SlowSender/SlowSender.csproj
+++ b/samples/azure/performance-tuning-asb/ASB_8/SlowSender/SlowSender.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmailGateway.Messages" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />

--- a/samples/azure/polymorphic-events-asb/ASB_8/Publisher/Publisher.csproj
+++ b/samples/azure/polymorphic-events-asb/ASB_8/Publisher/Publisher.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/polymorphic-events-asb/ASB_8/Publisher/Publisher.csproj
+++ b/samples/azure/polymorphic-events-asb/ASB_8/Publisher/Publisher.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/polymorphic-events-asb/ASB_8/Subscriber/Subscriber.csproj
+++ b/samples/azure/polymorphic-events-asb/ASB_8/Subscriber/Subscriber.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/polymorphic-events-asb/ASB_8/Subscriber/Subscriber.csproj
+++ b/samples/azure/polymorphic-events-asb/ASB_8/Subscriber/Subscriber.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-beta0002" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/messagemutators/Core_6/Sample/Program.cs
+++ b/samples/messagemutators/Core_6/Sample/Program.cs
@@ -15,7 +15,7 @@ class Program
         #region ComponentRegistration
 
         endpointConfiguration.RegisterMessageMutator(new ValidationMessageMutator());
-        endpointConfiguration.RegistermessageMutator(new TransportMessageCompressionMutator());
+        endpointConfiguration.RegisterMessageMutator(new TransportMessageCompressionMutator());
 
         #endregion
 

--- a/samples/messagemutators/Core_7/Sample/Program.cs
+++ b/samples/messagemutators/Core_7/Sample/Program.cs
@@ -21,7 +21,7 @@ class Program
         #region ComponentRegistration
 
         endpointConfiguration.RegisterMessageMutator(new ValidationMessageMutator());
-        endpointConfiguration.RegistermessageMutator(new TransportMessageCompressionMutator());
+        endpointConfiguration.RegisterMessageMutator(new TransportMessageCompressionMutator());
 
         #endregion
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.Core.csproj
@@ -9,6 +9,6 @@
     <Reference Include="System.Transactions" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.0.0-**" />
+    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/sqltransport/multi-instance-migration/SqlTransport_4/Bridge/Program.cs
+++ b/samples/sqltransport/multi-instance-migration/SqlTransport_4/Bridge/Program.cs
@@ -27,7 +27,7 @@ namespace Bridge
                         t => t.ConnectionString(ReceiverConnectionString));
 
             bridgeConfig.AutoCreateQueues();
-            bridgeConfig.UseSubscriptionPersistece<SqlPersistence>((e, p) =>
+            bridgeConfig.UseSubscriptionPersistence<SqlPersistence>((e, p) =>
             {
                 p.ConnectionBuilder(() => new SqlConnection(BridgeConnectionString));
                 p.SqlDialect<SqlDialect.MsSqlServer>();


### PR DESCRIPTION
The TC build script for the samples and snippets on TeamCity has been broken for a while allowing broken solutions to get deployed. This PR fixes most of those broken samples/snippets, with the exception of the ones in the SQL Persistence PR #3450 

The build script fix will be put in place once this PR is ready and merged to `master` (after #3450 has been committed and ff'd into this PR. That will break all of the other open PRs at that time. They will need to pull in the changes from this (rebase from `master`). An announcement will need to be made to let those PR owners know what they have to do.