### PR TITLE
Explicit mention of NSB.Metrics.ServiceControl

### DIFF
--- a/nservicebus/operations/metrics/service-control.md
+++ b/nservicebus/operations/metrics/service-control.md
@@ -11,7 +11,7 @@ redirects:
 ---
 
 
-This component enables sending monitoring data gathered with `NServiceBus.Metrics` to an instance of `ServiceControl.Monitoring` service.
+The component `NServiceBus.Metrics.ServiceControl` enables sending monitoring data gathered with `NServiceBus.Metrics` to an instance of `ServiceControl.Monitoring` service.
 
 ## Configuration
 


### PR DESCRIPTION
This PR captures the name of the described component as the first mentioned package. Not mentioning it could have been confusing for users reading doco and noticing `NServiceBus.Metrics` as the first name.