### PR TITLE
Remove mentioning of default since it is not true

### DIFF
--- a/transports/azure-storage-queues/configuration_parallelismdegree_asq_[7,].partial.md
+++ b/transports/azure-storage-queues/configuration_parallelismdegree_asq_[7,].partial.md
@@ -18,7 +18,7 @@ Degree of parallelism = square root of MaxConcurrency
 | 200 | 14 |
 | 1000 | 32 [max] |
 
-This means that `DegreeOfReceiveParallelism` message processing loops will receive up to the configured `BatchSize` number of messages in parallel. For example with the default `BatchSize` of 32 and a degree of parallelism of 10 the transport will be able to receive 320 messages from the storage queue at the same time.
+This means that `DegreeOfReceiveParallelism` message processing loops will receive up to the configured `BatchSize` number of messages in parallel. For example using a `BatchSize` of 32 (Default) and parallelism set to 10 will allow the transport to receive 320 messages from the storage queue at the same time.
 
 WARNING: Changing the value of `DegreeOfReceiveParallelism` will influence the total number of storage operations against Azure Storage Services and can result in higher costs.
 

--- a/transports/azure-storage-queues/configuration_parallelismdegree_asq_[7,].partial.md
+++ b/transports/azure-storage-queues/configuration_parallelismdegree_asq_[7,].partial.md
@@ -14,11 +14,11 @@ Degree of parallelism = square root of MaxConcurrency
 | 10 | 3 |
 | 20 | 4 |
 | 50 | 7 |
-| 100 | 10 [default] |
+| 100 | 10 |
 | 200 | 14 |
 | 1000 | 32 [max] |
 
-This means that `DegreeOfReceiveParallelism` message processing loops will receive up to the configured `BatchSize` number of messages in parallel. For example with the default `BatchSize` of 32 and the default degree of parallelism of 10 the transport will be able to receive 320 messages from the storage queue at the same time.
+This means that `DegreeOfReceiveParallelism` message processing loops will receive up to the configured `BatchSize` number of messages in parallel. For example with the default `BatchSize` of 32 and a degree of parallelism of 10 the transport will be able to receive 320 messages from the storage queue at the same time.
 
 WARNING: Changing the value of `DegreeOfReceiveParallelism` will influence the total number of storage operations against Azure Storage Services and can result in higher costs.
 


### PR DESCRIPTION
@Particular/azure-maintainers 

I think this is a left over from the area when the core set the concurrency to 100 by default which then set the maximum degree of parallelism to 10.

https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs#L15