### PR TITLE
RavenDB fix - proper overload used for UseSharedAsyncSession

### DIFF
--- a/Snippets/Raven/Raven_5/Configure.cs
+++ b/Snippets/Raven/Raven_5/Configure.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.IO;
-using NServiceBus;
+﻿using NServiceBus;
 using NServiceBus.Persistence.RavenDB;
 using Raven.Client.Document;
-using Raven.Client.Document.DTC;
 
 class Configure
 {
@@ -15,7 +12,7 @@ class Configure
         // configure documentStore here
         var persistence = endpointConfiguration.UsePersistence<RavenDBPersistence>();
         persistence.UseSharedAsyncSession(
-            getAsyncSessionFunc: () =>
+            getAsyncSessionFunc: headers =>
             {
                 var session = documentStore.OpenAsyncSession();
                 // customize session here


### PR DESCRIPTION
This PR amends an overload used for `.UseSharedAsyncSession` that was obsoleted with `TreatAsError = true` in this release: https://github.com/Particular/NServiceBus.RavenDB/releases/tag/5.0.0-Beta6