### PR TITLE
Added note on RavenDB shared session

### DIFF
--- a/persistence/ravendb/index.md
+++ b/persistence/ravendb/index.md
@@ -41,6 +41,8 @@ There are a variety of options for configuring the connection to a RavenDB Serve
 
 ## Shared session
 
+NOTE: Shared RavenDB session is automatically activated when enabling Outbox or when Sagas are present.
+
 NServiceBus supports sharing the same RavenDB document session between Saga persistence, Outbox persistence, and business data, so that a single transaction can be used to persist the data for all three concerns atomically.
 
 Shared session is only applicable to Saga and Outbox storage. It can be configured via


### PR DESCRIPTION
Based on:

- https://discuss.particular.net/t/nsb-5-raven-msmq-when-moving-to-outbox-shouldnt-we-be-using-a-shared-document-session/293
- https://github.com/Particular/NServiceBus.RavenDB/issues/71