### PR TITLE
NativeDeferral clarifications

### DIFF
--- a/transports/sqs/configuration-options.md
+++ b/transports/sqs/configuration-options.md
@@ -2,7 +2,7 @@
 title: Configuration Options
 summary: Configuration options for the SQS transport.
 component: SQS
-reviewed: 2017-06-28
+reviewed: 2018-01-11
 tags:
 - AWS
 redirects:

--- a/transports/sqs/configuration-options_nativeDeferral_sqs_[2,).partial.md
+++ b/transports/sqs/configuration-options_nativeDeferral_sqs_[2,).partial.md
@@ -4,9 +4,11 @@
 
 **Default**: `false`.
  
-SQS supports delaying message delivery by up to 15 minutes. When this option is set to `true`, The SQS transport will not use the timeout manager for message deferral and will use the delayed delivery feature of SQS instead. 
+SQS supports delaying message delivery by up to 15 minutes. When this option is set to `true`, the SQS transport will not use the timeout manager for message deferral and will use the delayed delivery feature of SQS instead. 
 
-Enabling this on an endpoint means that a separate timeout queue is not used, thus saving the cost of continuously polling it. However when the need arises to delay the delivery of messages by a time span of more than 15 minutes, the SQS delayed delivery cannot be used.
+Enabling this on an endpoint means that a separate timeout queue is not used, thus saving the cost of continuously polling it. 
+
+WARNING: SQS delayed delivery cannot be used for messages delayed by more than 15 minutes.
 
 **Example**
 


### PR DESCRIPTION
A warning about delays longer than 15 mins should stand out and not blend with the rest of the description.