### PR TITLE
Use wildcard dependencies in perf counters sample

### DIFF
--- a/samples/performance-counters/PerfCounters_3/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_3/Sample/Sample.csproj
@@ -6,8 +6,8 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="3.0.0-beta0005" />
-    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters.MsBuild" Version="3.0.0-beta0005" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
+    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Metrics.PerformanceCounters.MsBuild" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Most samples are using wildcard dependencies for the nsb packages. Is there any reason this sample doesn't align with the other samples regarding specifying dependencies? @Particular/metrics-maintainers 