### PR TITLE
Fix persistence dependencies on core sample

### DIFF
--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\SharedMessages\SharedMessages.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.1.0-pullrequest0183*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
     <PackageReference Include="npgsql" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\SharedMessages\SharedMessages.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.1.0-pullrequest0183*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SharedMessages\SharedMessages.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.1.0-pullrequest0183*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="3.1.0-pullrequest0183*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.0.0-*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
the .net framework projects were correctly referencing 4.0.0-* but the .net core projects weren't updated.
I wonder whether this could have happened on other samples as well