### PR TITLE
Disable the RavenDB outbox cleanup task

### DIFF
--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -30,5 +30,7 @@ These default settings can be changed by specifying new defaults in the settings
 
 snippet: OutboxRavendBTimeToKeep
 
+By specifying a value of -1 milliseconds for `SetFrequencyToRunDeduplicationDataCleanup` the cleanup task is disabled. This can be usefull when an endpoint is scaled out and instances are competing to run the cleanup task.
+
 
 partial: effect-on-docstore

--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -30,7 +30,7 @@ These default settings can be changed by specifying new defaults in the settings
 
 snippet: OutboxRavendBTimeToKeep
 
-By specifying a value of -1 milliseconds for `SetFrequencyToRunDeduplicationDataCleanup` the cleanup task is disabled. This can be usefull when an endpoint is scaled out and instances are competing to run the cleanup task.
+By specifying a value of -1 milliseconds (`Timeout.InfiniteTimeSpan`) for `SetFrequencyToRunDeduplicationDataCleanup` the cleanup task is disabled. This can be usefull when an endpoint is scaled out and instances are competing to run the cleanup task.
 
 
 partial: effect-on-docstore

--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -30,7 +30,7 @@ These default settings can be changed by specifying new defaults in the settings
 
 snippet: OutboxRavendBTimeToKeep
 
-By specifying a value of -1 milliseconds (`Timeout.InfiniteTimeSpan`) for `SetFrequencyToRunDeduplicationDataCleanup` the cleanup task is disabled. This can be usefull when an endpoint is scaled out and instances are competing to run the cleanup task.
+By specifying a value of -1 (`Timeout.InfiniteTimeSpan`) for `SetFrequencyToRunDeduplicationDataCleanup` the cleanup task is disabled. This can be usefull when an endpoint is scaled out and instances are competing to run the cleanup task.
 
 
 partial: effect-on-docstore


### PR DESCRIPTION
According to XML the cleanup task can be disabled:

https://github.com/Particular/NServiceBus.RavenDB/blob/master/src/NServiceBus.RavenDB/Outbox/RavenDBOutboxExtensions.cs#L34

> The frequency to run the deduplication data cleanup task. By specifying a negative time span (-1) the cleanup task will never run.