### PR TITLE
Remove asm part in header to make it work for both netcore and fullfx

### DIFF
--- a/samples/gateway/Gateway_3/WebClient.Core/wwwroot/Index.html
+++ b/samples/gateway/Gateway_3/WebClient.Core/wwwroot/Index.html
@@ -23,7 +23,7 @@
                     "NServiceBus.AutoAck": "true",
                     "Content-MD5": md5,
                     "NServiceBus.Id": clientId,
-                    "NServiceBus.EnclosedMessageTypes": "Shared.UpdatePrice, Shared"
+                    "NServiceBus.EnclosedMessageTypes": "Shared.UpdatePrice"
                 },
                 dataType: 'jsonp',
                 success: function (data) {


### PR DESCRIPTION
Since the shared assembly is differently named