### PR TITLE
Multi-instance doco tweaks

### DIFF
--- a/servicecontrol/servicecontrol-instances/distributed-instances.md
+++ b/servicecontrol/servicecontrol-instances/distributed-instances.md
@@ -6,25 +6,29 @@ component: ServiceControl
 
 NOTE: A multi-instance ServiceControl installation can be complex to maintain. Before splitting ServiceControl, it is recommended to follow the capacity planning guides described in the [ServiceControl Capacity Planning](/servicecontrol/capacity-and-planning.md) documentation.
 
-Operating ServiceControl at scale with many endpoints producing many thousands of audit messages per second can lead to bottlenecks and congestion when a single ServiceControl instance is used. ServiceControl can operate in "multi-instance mode" which overcomes the bottlenecks of a single ServiceControl instance. 
+Audit message processing can become a performance challange when running NServiceBus systems at a scale. Multi-instance deployment enables sharding audit data between ServiceControl instances. 
 
-Running multiple instances of ServiceControl is supported to reduce the load of a ServiceControl instance by either running multiple instances of ServiceControl on the same audit queue (competing consumer) or by splitting the audit queue into multiple audit queues. In a message-based system, the audit queue, in contrast to the error queue for recoverability purposes, is the queue with the most load since all consumed messages are forwarded to the audit queue. ServiceControl ingests the messages available in the audit queue and aggregates them for querying and analysis within [ServiceInsight](/serviceinsight/). 
+ServiceControl multi-intance deployments should be considered in scenarios when the audit message load in continously high and too big for a single instance to handle.
 
-Aggregating the data for querying and analysis takes considerable computation resources, memory, disk IO, as well as queuing system resources. Under high load a single instance might not be able to keep up with indexing the data and the incoming audited queue length might start to increase. If the load only spikes occasionally, this may not be a problem since ServiceControl will eventually catch up processing the incoming audit messages. If the load is continuously high however, multiple instances of ServiceControl can be deployed in a manner that enables competing consumers on the same incoming audit queue, or splits the single audit queue into multiple audit queues, or a combination of both.
+## Overview
 
-### Overview of setup
+Multi-instance deployments consist of at least two ServiceControl instances. In such a setup there is a single designated instance - a master responsible for processing error messages and optionally audit messages. All other existing ServiceControl instances are slaves responsible **only** for processing audit messages. 
 
-The following is a high-level look at the steps needed to set up multiple instances of ServiceControl:
+It is only the master instance that handles the external API requests (from ServicePulse or ServiceInstance). Master is the only party communicating with slave instances directly for the purpose of query execution.
+
+The following is a high-level look at the steps needed to deploy ServiceControl in multi-instance mode:
 
 - Install a ServiceControl master instance and configure it to route API queries to its slave instances
 - Install one or more ServiceControl slave instances
-- If the audit queue was split, the production endpoints must route audited messages to different [audit queues](/nservicebus/operations/auditing.md) which will be consumed by different instances of ServiceControl (either master instances or slave instances)
+- Audit message sharding can be performend at the queue level (separate audit queue per shard). In such case the production endpoints must forward audit messages to different [audit queues](/nservicebus/operations/auditing.md) consumed by different ServiceControl instances
 
-WARNING: At this time, recoverability or error queue handling cannot be scaled out to multiple ServiceControl instances. Thus all endpoints still need to route error messages to a centralized [error queue](/nservicebus/recoverability/configure-error-handling.md).
+NOTE: Apart from mulit-region deployments ServicePulse and ServiceInsight should always connect to the ServiceControl master.
 
-### Multi-instance installation with competing consumers
+WARNING: All instances of ServiceControl MUST have a unique name
 
-This section walks through a fresh installation of multiple ServiceControl instances.
+### Sharding audit messages with competing consumers
+
+This section walks through a fresh installation of multiple ServiceControl instances where audit messages are sharded with competing consumers approach - two instances of ServiceControl (master and slave) compete for audit messages on a single audit queue. All of the endpoints will forward their audit messages to `audit`. All error messages are forwarded to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
 
 ```mermaid
 graph TD
@@ -40,10 +44,8 @@ Errors-- ingested by --> Master
 Master -. connected to .-> Slave
 ```
 
-In this example, two ServiceControl instances are used where one is the master and the other the slave for auditing. All of the endpoints will forward their audit messages to `audit`. All error messages are forwarded to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
-
-1. Install the ServiceControl master instance which points to `audit` according to the [installation guidelines](/servicecontrol/installation.md).
-2. Install the ServiceControl slave instance (on separate infrastructure) which points to `audit` according to the [installation guidelines](/servicecontrol/installation.md). Each slave instance must have a unique name. The ServiceControl instance name and the port are required to configure the master instance (for example `Particular.ServiceControl.Slave` and the port `33334`). Make sure error queue processing is disabled by specifying `!disable` as the error queue field in the ServiceControl Management Utility, or as the error queue parameter of the [Powershell](/servicecontrol/installation-powershell.md) installation script, or by editing `ServiceControl.exe.config` as shown below:
+Setup steps:
+1. Install the ServiceControl slave instance (on separate infrastructure) which points to `audit` according to the [installation guidelines](/servicecontrol/installation.md). Each slave instance must have a unique name. The ServiceControl instance name and the port are required to configure the master instance (for example `Particular.ServiceControl.Slave` and the port `33334`). Make sure error queue processing is disabled by specifying `!disable` as the error queue field in the ServiceControl Management Utility, or as the error queue parameter of the [Powershell](/servicecontrol/installation-powershell.md) installation script, or by editing `ServiceControl.exe.config` as shown below:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -56,6 +58,7 @@ In this example, two ServiceControl instances are used where one is the master a
 
 If the error queue is set to `!disable` then error forwarding will be ignored even if enabled.
 
+2. Install the ServiceControl master instance which points to `audit` according to the [installation guidelines](/servicecontrol/installation.md).
 3. Stop the ServiceControl master instance and edit the [`ServiceControl.exe.config` ](/servicecontrol/creating-config-file.md) with the `RemoteInstances` key. The value for the key is a json array.
 
 ```xml
@@ -69,9 +72,9 @@ If the error queue is set to `!disable` then error forwarding will be ignored ev
 4. Start the ServiceControl master instance.
 5. Validate ServiceInsight and ServicePulse are connecting to the master instance only.
 
-### Multi-instance installation with split audit queue
+### Sharding audit messages with split audit queue
 
-This section walks through a fresh installation of multiple instances of ServiceControl with split audit queues. 
+This section walks through a fresh installation of multiple instances of ServiceControl in which audit messages are sharded with separate audit queues. Some of the endpoints will forward their audit messages to `audit-master` processed by the master while others will forward their audit messages to `audit-slave` processed by the slave. All error messages are forwared to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
 
 ```mermaid
 graph TD
@@ -89,10 +92,9 @@ AuditsSlave -- ingested by --> Slave
 Master -. connected to .-> Slave
 ```
 
-In this example, two ServiceControl instances are used where one is the master and the other the slave for auditing. Some of the endpoints will forward their audit messages to `audit-master` while others will forward their audit messages to `audit-slave`. All error messages are forwared to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
+Setup steps:
 
-1. Install the ServiceControl master instance which ingests messages from the `audit-master` queue according to the [installation guidelines](/servicecontrol/installation.md).
-2. Install the ServiceControl slave instance (on separate infrastructure) which ingests messages from the `audit-slave` queue according to the [installation guidelines](/servicecontrol/installation.md). Each slave instance must have a unique name. The ServiceControl instance name and the port are required to configure the master instance. In this example, the name `Particular.ServiceControl.Slave` and the port `33334` is used. Make sure error queue processing is disabled by specifying `!disable` as the error queue field in the ServiceControl Management Utility, or as the error queue parameter of the [Powershell](/servicecontrol/installation-powershell.md) installation script, or by editing `ServiceControl.exe.config` as shown below:
+1. Install the ServiceControl slave instance (on separate infrastructure) which ingests messages from the `audit-slave` queue according to the [installation guidelines](/servicecontrol/installation.md). Each slave instance must have a unique name. The ServiceControl instance name and the port are required to configure the master instance. In this example, the name `Particular.ServiceControl.Slave` and the port `33334` is used. Make sure error queue processing is disabled by specifying `!disable` as the error queue field in the ServiceControl Management Utility, or as the error queue parameter of the [Powershell](/servicecontrol/installation-powershell.md) installation script, or by editing `ServiceControl.exe.config` as shown below:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -105,6 +107,7 @@ In this example, two ServiceControl instances are used where one is the master a
 
 If the error queue is set to `!disable` then error forwarding will be ignored even if enabled.
 
+2. Install the ServiceControl master instance which ingests messages from the `audit-master` queue according to the [installation guidelines](/servicecontrol/installation.md).
 3. Stop the ServiceControl master instance and edit the [`ServiceControl.exe.config` ](/servicecontrol/creating-config-file.md) with the `RemoteInstances` key. The value for the key is a json array.
 
 ```xml
@@ -126,9 +129,9 @@ This section walks through converting a single existing ServiceControl installat
 2. Configure production endpoints to send audit messages to the newly added ServiceControl instance.
 3. Make the original endpoint a designated master by adding `ServiceControl/RemoteInstances` setting, pointing to the slave instance of ServiceControl.
 
-### Advanced scenarios
+## Advanced scenarios
 
-#### Audit retention
+### Audit retention
 
 ```mermaid
 graph TD
@@ -145,7 +148,9 @@ Master -. connected to .-> Slave
 
 Each ServiceControl instance can have different settings. For example it is possible to have different [audit retention periods](/servicecontrol/creating-config-file.md#data-retention-servicecontrolauditretentionperiod). With that in mind, high volume endpoints can report audits to a ServiceControl instance with shorter retention periods (thus evicting old messages faster). This allows catering settings as well as resources being used by ServiceControl to the needs of the endpoints configured to audit to a specific ServiceControl instance.
 
-#### Migration
+NOTE: If there are conversations that span `HighVolumenEndpoints` and `LowVolumeEndpoints` data available in audit store might be incomplete.
+
+### Migration
 
 Sometimes it is necessary to migrate a ServiceControl master to a different machine with better hardware. By taking the audit retention period into account it is possible to migrate ServiceControl instances without needing to backup and restore data.
 
@@ -161,7 +166,11 @@ Configure slave 1 to be the new master, enable error
 Shutdown master
 Point tools to Slave 1 which is the new master
 
-#### Multi-region handling
+### Multi-region deployments
+
+Mutli-region deployments are partially supported (error data sharding is not supported). Such setup consists of ServiceControl slave deployed in each region and a master instance responsible for aggregating audit data. 
+
+In this scenario all cross-region audit data can be queried via ServiceInsight connected to the master. However to use the recoverability features a dedicated ServicePulse installation in each region is required. 
 
 ```mermaid
 graph TD
@@ -177,12 +186,7 @@ SPA[ServicePulse Instance] -->SCA
 end
 Master -.->SCA
 ```
-
-Using ServiceInsight with a system split into multiple regions is possible using multiple ServiceControl instances. In this scenario each region will contain a dedicated instance of ServiceControl and ServicePulse.
-
-An instance of ServiceControl configured as a master will be required that does not service any region. ServiceInsight can then be connected to the master instance of ServiceControl in order to view messages across all regions.
-
-#### Configuration of multiple slaves
+## Configuration of multiple slaves
 
 Multiple slave instances can be configured as follows:
 
@@ -194,7 +198,7 @@ Multiple slave instances can be configured as follows:
 </configuration>
 ```
 
-#### Disabling auditing
+## Disabling auditing
 
 With multiple instances in place, it is possible to disable the auditing in the master instance and only perform auditing in the slaves. Auditing can be disabled by specifying `!disabled` in the audit queue name field in the ServiceControl Management utility, or by editing the `ServiceControl.exe.config` as follows:
 
@@ -208,9 +212,7 @@ With multiple instances in place, it is possible to disable the auditing in the 
 ```
 Audit forwarding, if enabled, will be ignored.
 
-### Known limitations
-
-WARNING: All instances of ServiceControl MUST have a unique name
+# Known limitations
 
 - Splitting into multiple ServiceControl instances is supported only for auditing.
 - Only one ServiceControl instance should have error handling / recoverability enabled (usually the master) unless the multi-region scenario is used.

--- a/servicecontrol/servicecontrol-instances/distributed-instances.md
+++ b/servicecontrol/servicecontrol-instances/distributed-instances.md
@@ -150,7 +150,7 @@ Master -. connected to .-> Slave
 
 Each ServiceControl instance can have different settings. For example it is possible to have different [audit retention periods](/servicecontrol/creating-config-file.md#data-retention-servicecontrolauditretentionperiod). With that in mind, high volume endpoints can report audits to a ServiceControl instance with shorter retention periods (thus evicting old messages faster). This allows catering settings as well as resources being used by ServiceControl to the needs of the endpoints configured to audit to a specific ServiceControl instance.
 
-NOTE: If there are conversations that span `HighVolumenEndpoints` and `LowVolumeEndpoints` data available in audit store might be incomplete.
+NOTE: If there are message conversations that span `HighVolumenEndpoints` and `LowVolumeEndpoints` data available in audit store might be incomplete.
 
 ### Migration
 
@@ -170,7 +170,7 @@ Point tools to Slave 1 which is the new master
 
 ### Multi-region deployments
 
-Mutli-region deployments are partially supported (error data sharding is not supported). Such setup consists of ServiceControl slave deployed in each region and a master instance responsible for aggregating audit data. 
+Multi-region deployments are partially supported (error data sharding is not supported). Such setup consists of ServiceControl slave deployed in each region and a master instance responsible for aggregating audit data. 
 
 In this scenario all cross-region audit data can be queried via ServiceInsight connected to the master. However to use the recoverability features a dedicated ServicePulse installation in each region is required. 
 

--- a/servicecontrol/servicecontrol-instances/distributed-instances.md
+++ b/servicecontrol/servicecontrol-instances/distributed-instances.md
@@ -6,23 +6,23 @@ component: ServiceControl
 
 NOTE: A multi-instance ServiceControl installation can be complex to maintain. Before splitting ServiceControl, it is recommended to follow the capacity planning guides described in the [ServiceControl Capacity Planning](/servicecontrol/capacity-and-planning.md) documentation.
 
-Audit message processing can become a performance challange due to high message throughput when running NServiceBus systems at a scale. Multi-instance deployment helps mitigate that problem by enabling audit data sharding between group of ServiceControl instances. 
+Audit message processing can become a performance challenge due to high message throughput when running NServiceBus systems at a scale. Multi-instance deployment helps mitigate that problem by enabling audit data sharding between a group of ServiceControl instances. 
 
-ServiceControl multi-instance deployments should be considered in scenarios when the audit message load in continously high and too big for a single instance to handle. In a message-based system, the audit queue, in contrast to the error queue, is the one with the most load as every single message is forwarded there for the auditing purposes. ServiceControl ingests the messages available in the audit queue and aggregates them for querying and analysis within [ServiceInsight](/serviceinsight/). 
+ServiceControl multi-instance deployments should be considered in scenarios when the audit message load in continuously high and too big for a single instance to handle. In a message-based system, the audit queue, in contrast to the error queue, is the one with the most load as every single message is forwarded there for the auditing purposes. ServiceControl ingests the messages available in the audit queue and aggregates them for querying and analysis within [ServiceInsight](/serviceinsight/). 
 
-Aggregating the data for querying and analysis takes considerable resources in terms of CPU, memory, disk IO, as well as queuing system. Under high load a single instance might not be able to keep up with indexing the data and the audit queue length might start to increase. If the load spikes only occasionally, this may not be a problem since ServiceControl will eventually catch up processing the incoming audit messages. If the load is continuously high however, multiple instances of ServiceControl may be needed to cope with it.
+Aggregating the data for querying and analysis takes considerable resources regarding CPU, memory, disk IO, as well as the queuing system. Under high load, a single instance might not be able to keep up with indexing the data, and the audit queue length might start to increase. If the load spikes only occasionally, this may not be a problem since ServiceControl will eventually catch up processing the incoming audit messages. If the load is continuously high, however, multiple instances of ServiceControl may be needed to cope with it.
 
 ## Overview
 
 Multi-instance deployments consist of at least two ServiceControl instances. In such a setup there is a single designated instance - a master responsible for processing error messages and optionally audit messages. All other existing ServiceControl instances are slaves responsible **only** for processing audit messages. 
 
-It is only the master instance that handles the external API requests (from [ServicePulse](/servicepulse/) or [ServiceInsight](/serviceinsight/)). Master is the only party communicating with slave instances directly for the purpose of query execution.
+It is only the master instance that handles the external API requests (from [ServicePulse](/servicepulse/) or [ServiceInsight](/serviceinsight/)). Master is the only party communicating with slave instances directly for query execution.
 
 The following is a high-level look at the steps needed to deploy ServiceControl in multi-instance mode:
 
 - Install one or more ServiceControl slave instances
 - Install a ServiceControl master instance and configure it to route API queries to its slave instances
-- When using audit queue per shard the production endpoints must be reconfigured to forward audit messages to different [audit queues](/nservicebus/operations/auditing.md) consumed by different ServiceControl instances
+- When using audit queue per shard, the production endpoints must be reconfigured to forward audit messages to different [audit queues](/nservicebus/operations/auditing.md) consumed by different ServiceControl instances
 
 WARNING: Error queue sharding is not supported and all endpoints need to route error messages to a centralized [error queue](/nservicebus/recoverability/configure-error-handling.md) handled by the master.
 
@@ -76,7 +76,7 @@ If the error queue is set to `!disable` then error forwarding will be ignored ev
 
 ### Sharding audit messages with split audit queue
 
-This section walks through a fresh installation of multiple instances of ServiceControl in which audit messages are sharded with separate audit queues. Some of the endpoints will forward their audit messages to `audit-master` processed by the master while others will forward their audit messages to `audit-slave` processed by the slave. All error messages are forwared to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
+This section walks through a fresh installation of multiple instances of ServiceControl in which audit messages are sharded with separate audit queues. Some of the endpoints will forward their audit messages to `audit-master` processed by the master while others will forward their audit messages to `audit-slave` processed by the slave. All error messages are forwarded to the `error` queue. ServiceInsight and ServicePulse are connected to the master instance.
 
 ```mermaid
 graph TD
@@ -127,7 +127,7 @@ If the error queue is set to `!disable` then error forwarding will be ignored ev
 
 This section walks through converting a single existing ServiceControl installation into a master-slave configuration.
 
-1. Add an additional ServiceControl instance (on separate infrastructure and with a unique name) intended to ingest audit messages only. Disable error queue processing as described above. This will be a slave instance.
+1. Add a ServiceControl instance (on separate infrastructure and with a unique name) intended to ingest audit messages only. Disable error queue processing as described above. This will be a slave instance.
 2. Configure production endpoints to send audit messages to the newly added ServiceControl instance.
 3. Make the original endpoint a designated master by adding `ServiceControl/RemoteInstances` setting, pointing to the slave instance of ServiceControl.
 
@@ -148,13 +148,13 @@ AuditsLow-- ingested by --> Slave
 Master -. connected to .-> Slave
 ```
 
-Each ServiceControl instance can have different settings. For example it is possible to have different [audit retention periods](/servicecontrol/creating-config-file.md#data-retention-servicecontrolauditretentionperiod). With that in mind, high volume endpoints can report audits to a ServiceControl instance with shorter retention periods (thus evicting old messages faster). This allows catering settings as well as resources being used by ServiceControl to the needs of the endpoints configured to audit to a specific ServiceControl instance.
+Each ServiceControl instance can have different settings. For example, it is possible to have different [audit retention periods](/servicecontrol/creating-config-file.md#data-retention-servicecontrolauditretentionperiod). With that in mind, high volume endpoints can report audits to a ServiceControl instance with shorter retention periods (thus evicting old messages faster). This allows catering settings as well as resources being used by ServiceControl to the needs of the endpoints configured to audit to a specific ServiceControl instance.
 
 NOTE: If there are message conversations that span `HighVolumenEndpoints` and `LowVolumeEndpoints` data available in audit store might be incomplete.
 
 ### Migration
 
-Sometimes it is necessary to migrate a ServiceControl master to a different machine with better hardware. By taking the audit retention period into account it is possible to migrate ServiceControl instances without needing to backup and restore data.
+Sometimes it is necessary to migrate a ServiceControl master to a different machine with better hardware. By taking the audit retention period into account, it is possible to migrate ServiceControl instances without needing to backup and restore data.
 
 Describe
 
@@ -163,7 +163,7 @@ Server Fast 1: Slave 1 (error disabled, audit enabled)
 Server Fast 2: Slave 2 (error disabled, audit enabled)
 
 endpoints point to Slave 1 Audit and Slave 2 audit
-after 7 days
+after seven days
 Configure slave 1 to be the new master, enable error
 Shutdown master
 Point tools to Slave 1 which is the new master
@@ -172,7 +172,7 @@ Point tools to Slave 1 which is the new master
 
 Multi-region deployments are partially supported (error data sharding is not supported). Such setup consists of ServiceControl slave deployed in each region and a master instance responsible for aggregating audit data. 
 
-In this scenario all cross-region audit data can be queried via ServiceInsight connected to the master. However to use the recoverability features a dedicated ServicePulse installation in each region is required. 
+In this scenario, all cross-region audit data can be queried via ServiceInsight connected to the master. However, to use the recoverability features a dedicated ServicePulse installation in each region is required. 
 
 ```mermaid
 graph TD
@@ -221,5 +221,5 @@ Audit forwarding, if enabled, will be ignored.
 - Pagination with ServiceInsight may not work as traditional pagination would. For example, some pages might be filled unevenly depending on how the load is scattered between the different ServiceControl instances.
 - Data from remote instances that cannot be reached by the master instance will not be included in the results.
 - Multi-instance configuration is a manual setup process and cannot be done via the ServiceControl Management application.
-- Incorrect configuration could introduce cyclic loops.
+- An incorrect configuration could introduce cyclic loops.
 - Having multiple masters is discouraged.

--- a/servicecontrol/servicecontrol-instances/distributed-instances.md
+++ b/servicecontrol/servicecontrol-instances/distributed-instances.md
@@ -202,7 +202,7 @@ Multiple slave instances can be configured as follows:
 
 ## Disabling auditing
 
-With multiple instances in place, it is possible to disable the auditing in the master instance and only perform auditing in the slaves. Auditing can be disabled by specifying `!disabled` in the audit queue name field in the ServiceControl Management utility, or by editing the `ServiceControl.exe.config` as follows:
+With multiple instances in place, it is possible to disable the auditing in the master instance and only perform auditing in the slaves. Auditing can be disabled by specifying `!disable` in the audit queue name field in the ServiceControl Management utility, or by editing the `ServiceControl.exe.config` as follows:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/servicecontrol/servicecontrol-instances/distributed-instances.md
+++ b/servicecontrol/servicecontrol-instances/distributed-instances.md
@@ -214,7 +214,7 @@ With multiple instances in place, it is possible to disable the auditing in the 
 ```
 Audit forwarding, if enabled, will be ignored.
 
-# Known limitations
+## Known limitations
 
 - Splitting into multiple ServiceControl instances is supported only for auditing.
 - Only one ServiceControl instance should have error handling / recoverability enabled (usually the master) unless the multi-region scenario is used.


### PR DESCRIPTION
## Overview

The reason for this PR is to disucc possible changes in the way we introduce multi-instance support for SC.

The main assumptions that I made are:
  * Multi-instance is about sharding/partitioning audit data,
  * Error data sharding/partitioning is not supported,
  * The topology is always  single master (error+ optional audit) and number of slaves (audits only)
  * Multi-region is partially supported.

All the changes made in the doco are result of those assumptions.