### PR TITLE
Fix on-premise showcase sample

### DIFF
--- a/samples/show-case/on-premise/Core_6/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/on-premise/Core_6/Store.ECommerce/Store.ECommerce.csproj
@@ -39,14 +39,14 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.SystemWeb" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin.Security" Version="3.*" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.4" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.4" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.SystemWeb" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
+    <PackageReference Include="Microsoft.Owin" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Owin.Security" Version="4.0.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="6.*" />

--- a/samples/show-case/on-premise/Core_6/Store.ECommerce/Web.config
+++ b/samples/show-case/on-premise/Core_6/Store.ECommerce/Web.config
@@ -17,15 +17,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/samples/show-case/on-premise/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Store.Shared\Store.Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/show-case/on-premise/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Store.Shared\Store.Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/show-case/on-premise/Core_7/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.ECommerce/Store.ECommerce.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -20,6 +20,7 @@
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,14 +40,14 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.SystemWeb" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="3.*" />
-    <PackageReference Include="Microsoft.Owin.Security" Version="3.*" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.4" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.4" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.SystemWeb" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
+    <PackageReference Include="Microsoft.Owin" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Owin.Security" Version="4.0.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
@@ -69,13 +70,17 @@
     <Compile Include="App_Start\RouteConfig.cs" />
     <Content Include="Content\js\product.js" />
     <Content Include="Global.asax" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Views\Web.config" />
     <Content Include="Views\_ViewStart.cshtml" />
     <Content Include="Views\Shared\_Layout.cshtml" />
     <Content Include="Views\Home\Index.cshtml" />
-    <Folder Include="App_Data\" />
     <Content Include="app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v15.0\WebApplications\Microsoft.WebApplication.targets" />
@@ -93,7 +98,8 @@
           <IISUrl>http://localhost:50485/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl />
+          <CustomServerUrl>
+          </CustomServerUrl>
           <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>

--- a/samples/show-case/on-premise/Core_7/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.ECommerce/Store.ECommerce.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
     <PackageReference Include="Owin" Version="1.*" />
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />
     <ProjectReference Include="..\Store.Shared\Store.Shared.csproj" />

--- a/samples/show-case/on-premise/Core_7/Store.ECommerce/Web.config
+++ b/samples/show-case/on-premise/Core_7/Store.ECommerce/Web.config
@@ -8,32 +8,20 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NServiceBus.Core" publicKeyToken="9fc386479f8a226c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/show-case/on-premise/Core_7/Store.Messages/Store.Messages.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.Messages/Store.Messages.csproj
@@ -6,6 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/show-case/on-premise/Core_7/Store.Operations/Store.Operations.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.Operations/Store.Operations.csproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="..\Store.Shared\Store.Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/show-case/on-premise/Core_7/Store.Sales/Store.Sales.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.Sales/Store.Sales.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Store.Shared\Store.Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>

--- a/samples/show-case/on-premise/Core_7/Store.Shared/DebugFlagMutator.cs
+++ b/samples/show-case/on-premise/Core_7/Store.Shared/DebugFlagMutator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using NServiceBus;
 using NServiceBus.MessageMutator;
 
 public class DebugFlagMutator :

--- a/samples/show-case/on-premise/Core_7/Store.Shared/Store.Shared.csproj
+++ b/samples/show-case/on-premise/Core_7/Store.Shared/Store.Shared.csproj
@@ -6,6 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="1.*" />
+    <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Referenced the correct RC compatible 2.0-rc1 package of NServiceBus.Encryption.MessageProperty
* Updated the Assembly redirects to the newer dependency versions
* Fixed the dependency versions to avoid misaligned redirects on the next patch release. @Particular/docs-maintainers thoughts about that approach? Other samples use wildcard dependencies but in this case there seems to be a big risk in regards to the required assembly redirects?