### PR TITLE
Be explicit about netcore license locations

### DIFF
--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -1,23 +1,33 @@
+{{NOTE:
+Depending on the operating system, the paths may be case sensitive.
+
+NServiceBus uses the [`Environment.GetFolderPath(SpecialFolder)`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.getfolderpath) method to determine the locations of some paths on each OS.
+}}
+
+
 ### Application-specific license location
 
 A license located at `{AppDomain.CurrentDomain.BaseDirectory}/license.xml` will be automatically detected.
 
 
-### Machine-wide license locations
+### User-specific license location
 
-Licenses can be shared across all endpoints and Particular Service Platform applications by placing them into one of the following locations:
-* `{SpecialFolder.LocalApplicationData}\ParticularSoftware\license.xml`
-* `{SpecialFolder.CommonApplicationData}\ParticularSoftware\license.xml`
+To install a license for all endpoints and Particular Service Platform applications run by a specific user, install the license file to `{SpecialFolder.LocalApplicationData}\ParticularSoftware\license.xml`.
 
-For Windows, these locations are:
-* `%LOCALAPPDATA%\ParticularSoftware\license.xml`
-* `%PROGRAMDATA%\ParticularSoftware\license.xml`
+This location can be expressed using environment variables on Windows, or a bash expression on Linux/macOS:
 
-For Linux/macOS, these locations are:
-* `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
-* `/usr/share/ParticularSoftware/license.xml`
+* Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
+* Linux:macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
 
-Note: Depending on the operating system, the paths may be case sensitive.
+
+### Machine-wide license location
+
+To install a license for all endpoints and Particular Service Platform applications on an entire machine, install the license file to `{SpecialFolder.CommonApplicationData}\ParticularSoftware\license.xml`.
+
+This location can be expressed using environment variables on Windows, or as a literal path on Linux/macOS.
+
+* Windows: `%PROGRAMDATA%\ParticularSoftware\license.xml`
+* Linux/macOS: `/usr/share/ParticularSoftware/license.xml`
 
 
 ### Code-first configuration

--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -14,7 +14,7 @@ For Windows, these locations are:
 * `%PROGRAMDATA%\ParticularSoftware\license.xml`
 
 For Linux/macOS, these locations are:
-* `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware`
+* `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
 * `/usr/share/ParticularSoftware/license.xml`
 
 Note: Depending on the operating system, the paths may be case sensitive.

--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -1,9 +1,9 @@
-### Application specific license location
+### Application-specific license location
 
 A license located at `{AppDomain.CurrentDomain.BaseDirectory}/license.xml` will be automatically detected.
 
 
-### Machine wide license locations
+### Machine-wide license locations
 
 Licenses can be shared across all endpoints and Particular Service Platform applications by placing them into one of the following locations:
 * `{SpecialFolder.LocalApplicationData}\ParticularSoftware\license.xml`
@@ -20,7 +20,7 @@ For Linux/macOS, these locations are:
 Note: Depending on the operating system, the paths may be case sensitive.
 
 
-### Code first configuration
+### Code-first configuration
 
 A license can be configured via code first configuration API:
 

--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -9,6 +9,14 @@ Licenses can be shared across all endpoints and Particular Service Platform appl
 * `{SpecialFolder.LocalApplicationData}\ParticularSoftware\license.xml`
 * `{SpecialFolder.CommonApplicationData}\ParticularSoftware\license.xml`
 
+For Windows, these locations are:
+* `%LOCALAPPDATA%\ParticularSoftware\license.xml`
+* `%PROGRAMDATA%\ParticularSoftware\license.xml`
+
+For Linux/macOS, these locations are:
+* `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware`
+* `/usr/share/ParticularSoftware/license.xml`
+
 Note: Depending on the operating system, the paths may be case sensitive.
 
 

--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -17,7 +17,7 @@ To install a license for all endpoints and Particular Service Platform applicati
 This location can be expressed using environment variables on Windows, or a bash expression on Linux/macOS:
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
-* Linux:macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
+* Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
 
 
 ### Machine-wide license location


### PR DESCRIPTION
References:

### Windows

Well, mostly LinqPad, but [this is source for both](https://github.com/dotnet/corefx/blob/v2.0.6/src/System.Runtime.Extensions/src/System/Environment.Win32.cs#L65-L70).

### Linux/macOS
* [LocalApplicationData](https://github.com/dotnet/corefx/blob/v2.0.6/src/System.Runtime.Extensions/src/System/Environment.Unix.cs#L139-L147)
* [CommonApplicationData](https://github.com/dotnet/corefx/blob/v2.0.6/src/System.Runtime.Extensions/src/System/Environment.Unix.cs#L101)