### PR TITLE
Document the XMLSerializers ability to infer message type from root node

### DIFF
--- a/nservicebus/serialization/xml.md
+++ b/nservicebus/serialization/xml.md
@@ -16,11 +16,11 @@ A custom written XML serializer.
 
 snippet: XmlSerialization
 
-## Infering message type from root node name
+## Inferring message type from root node name
 
-In integration scenarios where the sender is unable add headers to the message the serializer can infer the CLR message type based on the root node of the XML payload. This convention is that the `{xml root node name}` must match the [`Type.FullName`](https://msdn.microsoft.com/en-us/library/system.type.fullname) of a message type known to the receiving endpoint. 
+In integration scenarios where the sender is unable add headers to the message, the serializer can infer the CLR message type based on the root node of the XML payload. To take advantage of this, the name of the payload's root node must match the [`Type.FullName`](https://msdn.microsoft.com/en-us/library/system.type.fullname) of a message type known to the receiving endpoint.
 
-Using this technique messages without any headers, the `NServiceBus.EnclosedMessageTypes` header specifically, can be processed. This is demonstrated by the [native integration with RabbitMQ sample](/samples/rabbitmq/native-integration/).
+This technique enables messages without any headers, including the `NServiceBus.EnclosedMessageTypes` header, to be processed. This is demonstrated by the [native integration with RabbitMQ sample](/samples/rabbitmq/native-integration/).
 
 partial: raw
 

--- a/nservicebus/serialization/xml.md
+++ b/nservicebus/serialization/xml.md
@@ -16,6 +16,11 @@ A custom written XML serializer.
 
 snippet: XmlSerialization
 
+## Infering message type from root node name
+
+In integration scenarios where the sender is unable add headers to the message the serializer can infer the CLR message type based on the root node of the XML payload. This convention is that the `{xml root node name}` must match the [`Type.FullName`](https://msdn.microsoft.com/en-us/library/system.type.fullname) of a message type known to the receiving endpoint. 
+
+Using this technique messages without any headers, the `NServiceBus.EnclosedMessageTypes` header specifically, can be processed. This is demonstrated by the [native integration with RabbitMQ sample](/samples/rabbitmq/native-integration/).
 
 partial: raw
 


### PR DESCRIPTION
While reproducing https://github.com/Particular/NServiceBus/issues/5124 I realized that we never documented this. This feature has been present since the dawn of time and is demoed by https://docs.particular.net/samples/rabbitmq/native-integration/