### PR TITLE
No nuget warn for outbox

### DIFF
--- a/samples/outbox/multi-tenant/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/multi-tenant/Core_7/Receiver/Receiver.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1603</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1603</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="NHibernate" Version="4.*" />

--- a/samples/outbox/multi-tenant/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/multi-tenant/Core_7/Sender/Sender.csproj
@@ -4,6 +4,12 @@
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1603</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1705;NU1603</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="NHibernate" Version="4.*" />


### PR DESCRIPTION
`NHibernate` requires the `Iesi Collections` package. NuGet complains when restoring the dependent package and finding the closest version that matches the one specified by NH package. 

I thought that it could be useful to do not have a Warning in a sample project.