### PR TITLE
Fix callbacks sample

### DIFF
--- a/samples/callbacks/Callbacks_2/WebSender/Web.config
+++ b/samples/callbacks/Callbacks_2/WebSender/Web.config
@@ -50,7 +50,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/callbacks/Callbacks_2/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_2/WebSender/WebSender.csproj
@@ -36,10 +36,10 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.4" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.4" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
     <PackageReference Include="NServiceBus" Version="6.*" />
     <PackageReference Include="NServiceBus.Callbacks" Version="2.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_3/WebSender/Web.config
+++ b/samples/callbacks/Callbacks_3/WebSender/Web.config
@@ -50,7 +50,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/callbacks/Callbacks_3/WebSender/WebSender.Core.csproj
+++ b/samples/callbacks/Callbacks_3/WebSender/WebSender.Core.csproj
@@ -36,10 +36,10 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.4" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.4" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-*" />
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />

--- a/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
@@ -36,10 +36,10 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.*" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.*" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.*" />
-    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.*" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.4" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.4" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />


### PR DESCRIPTION
we need to lock the ASP package dependencies as it breaks the assembly redirects otherwise. The v2 version of the sample was also affected.