### PR TITLE
Difference in $type handling for json.net btw embedded core v6 and the external serializer

### DIFF
--- a/Snippets/Newtonsoft/Newtonsoft_1/Usage.cs
+++ b/Snippets/Newtonsoft/Newtonsoft_1/Usage.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using NServiceBus;
 
 class Usage
@@ -115,4 +117,48 @@ class Usage
     }
 
     #endregion
+
+    void KnownTypesBinderConfig(EndpointConfiguration endpointConfiguration)
+    {
+        #region KnownTypesBinderConfig
+        endpointConfiguration.UseSerialization<NewtonsoftSerializer>()
+            .Settings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto,
+                SerializationBinder = new SkipAssemblyNameForMessageTypesBinder(new[]
+                {
+                    typeof(MyNativeIntegrationMessage)
+                })
+            });
+
+        #endregion
+    }
+
+    #region KnownTypesBinder
+    class SkipAssemblyNameForMessageTypesBinder : ISerializationBinder
+    {
+        Type[] messageTypes;
+
+        public SkipAssemblyNameForMessageTypesBinder(Type[] messageTypes)
+        {
+            this.messageTypes = messageTypes;
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            return messageTypes.FirstOrDefault(messageType => messageType.FullName == typeName);
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            assemblyName = serializedType.Assembly.FullName;
+            typeName = serializedType.FullName;
+        }
+    }
+    #endregion
+
+    class MyNativeIntegrationMessage
+    {
+
+    }
 }

--- a/Snippets/Newtonsoft/Newtonsoft_2/Usage.cs
+++ b/Snippets/Newtonsoft/Newtonsoft_2/Usage.cs
@@ -134,7 +134,7 @@ class Usage
         #endregion
     }
 
-    #region KnownTypesBinderConfig
+    #region KnownTypesBinder
     class SkipAssemblyNameForMessageTypesBinder : ISerializationBinder
     {
         Type[] messageTypes;

--- a/nservicebus/serialization/json.md
+++ b/nservicebus/serialization/json.md
@@ -62,6 +62,11 @@ The result will be
 
 partial: encoding
 
+## Inferring message type from $type
+
+For integration scenarios where the sender is unable to add message headers the serializer is able to infer the message type from the [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). By default json.net requires the property to contain the assembly qualified name of the message type but to make integration easier the serializer also registers a custom binder that allows only the full type name to be passed.  
+
+See our [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
 
 ## Bson
 

--- a/nservicebus/serialization/json.md
+++ b/nservicebus/serialization/json.md
@@ -66,7 +66,7 @@ partial: encoding
 
 For integration scenarios where the sender is unable to add message headers the serializer is able to infer the message type from the [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). By default json.net requires the property to contain the assembly qualified name of the message type but to make integration easier the serializer also registers a custom binder that allows only the full type name to be passed.  
 
-See our [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
+See [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
 
 ## Bson
 

--- a/nservicebus/serialization/newtonsoft.md
+++ b/nservicebus/serialization/newtonsoft.md
@@ -94,7 +94,7 @@ At configuration time the JsonConverter can then be used with the following.
 
 snippet: UseConverter
 
-## Use of $type requires an assembly qualified name
+### Use of $type requires an assembly qualified name
 
 The [core serializer](json.md) is registering a custom serialization binder to not require the assembly name to be present when inferring message type from the special [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). Not having to specify the assembly name can be useful to reduce coupling when using the serializer for native integration scenarios like [demonstrated in this sample](/samples/sqltransport/native-integration).
 

--- a/nservicebus/serialization/newtonsoft.md
+++ b/nservicebus/serialization/newtonsoft.md
@@ -62,7 +62,9 @@ snippet: NewtonsoftBson
 
 ## Compatibility with the core JSON serializer
 
-The only incompatibility with the [core serializer](json.md) is that this serializer does not support the serialization of `XContainer` and `XDocument` properties. If XML properties are required on messages strings should be used instead. If `XContainer` and `XDocument` properties are required [use a JsonConverter](newtonsoft.md#compatibility-with-the-core-json-serializer-use-a-jsonconverter-for-xcontainer-and-xdocument).
+### No support for `XContainer` and `XDocument` properties
+
+In contrast to the [core serializer](json.md) is that this serializer does not support the serialization of `XContainer` and `XDocument` properties. If XML properties are required on messages strings should be used instead. If `XContainer` and `XDocument` properties are required [use a JsonConverter](newtonsoft.md#compatibility-with-the-core-json-serializer-use-a-jsonconverter-for-xcontainer-and-xdocument).
 
 {{WARNING:
 This serializer is not compatible with multiple bundled messages (when using the `Send(object[] messages)` APIs) sent from Versions 3 and below of NServiceBus. If this scenario is detected then an exception with the following message will be thrown:
@@ -76,18 +78,30 @@ The `AddDeserializer` API can help transition between serializers. See the [Mult
 }}
 
 
-### Use a JsonConverter for XContainer and XDocument
+#### Use a JsonConverter for XContainer and XDocument
 
 
-#### The JsonConverter
+##### The JsonConverter
 
 This is a custom [JsonConverter](http://www.newtonsoft.com/json/help/html/CustomJsonConverter.htm) that replicates the approach used by the [core serializer](json.md).
 
 snippet: XContainerJsonConverter
 
 
-#### Use the JsonConverter
+##### Use the JsonConverter
 
 At configuration time the JsonConverter can then be used with the following.
 
 snippet: UseConverter
+
+## Use of $type requires an assembly qualified name
+
+The [core serializer](json.md) is registering a custom serialization binder to not require the assembly name to be present when inferring message type from the special [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). Not having to specify the assembly name can be useful to reduce coupling when using the serializer for native integration scenarios like [demonstrated in this sample](/samples/sqltransport/native-integration).
+
+To make the serializer compatible with this behavior the following serialization binder can be used:
+
+snippet: KnownTypesBinder
+
+and configured using the following configuration:
+
+snippet: KnownTypesBinderConfig

--- a/nservicebus/serialization/newtonsoft.md
+++ b/nservicebus/serialization/newtonsoft.md
@@ -56,7 +56,7 @@ snippet: NewtonsoftContentTypeKey
 
 For integration scenarios where the sender is unable to add message headers the serializer is able to infer the message type from the [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). 
 
-See our [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
+See [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
 
 ## BSON
 

--- a/nservicebus/serialization/newtonsoft.md
+++ b/nservicebus/serialization/newtonsoft.md
@@ -52,6 +52,11 @@ include: custom-contenttype-key
 
 snippet: NewtonsoftContentTypeKey
 
+## Inferring message type from $type
+
+For integration scenarios where the sender is unable to add message headers the serializer is able to infer the message type from the [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). 
+
+See our [native integration with SqlTransport sample](/samples/sqltransport/native-integration) for more details.
 
 ## BSON
 
@@ -62,11 +67,20 @@ snippet: NewtonsoftBson
 
 ## Compatibility with the core JSON serializer
 
+Up to Version 6 of NServiceBus a [JSON serializer based on Json.net](json.md) was bundled inside the core package. This section outlines the compatibility considerations when switching to this serializer.
+
 ### No support for `XContainer` and `XDocument` properties
 
-In contrast to the [core serializer](json.md) is that this serializer does not support the serialization of `XContainer` and `XDocument` properties. If XML properties are required on messages strings should be used instead. If `XContainer` and `XDocument` properties are required [use a JsonConverter](newtonsoft.md#compatibility-with-the-core-json-serializer-use-a-jsonconverter-for-xcontainer-and-xdocument).
+In contrast to the bundled serializer `XContainer` and `XDocument` properties are no longer supported. If `XContainer` and `XDocument` properties are required [use a JsonConverter](newtonsoft.md#compatibility-with-the-core-json-serializer-use-a-jsonconverter-for-xcontainer-and-xdocument) as shown below:
 
-{{WARNING:
+snippet: XContainerJsonConverter
+
+Configure the converter like shown below:
+
+snippet: UseConverter
+
+###  No support for bundled logical messages
+
 This serializer is not compatible with multiple bundled messages (when using the `Send(object[] messages)` APIs) sent from Versions 3 and below of NServiceBus. If this scenario is detected then an exception with the following message will be thrown:
 
 ```
@@ -75,33 +89,15 @@ Multiple messages in the same stream are not supported.
 
 The `AddDeserializer` API can help transition between serializers. See the [Multiple Deserializers Sample](/samples/serializers/multiple-deserializers/) for more information.
 
-}}
-
-
-#### Use a JsonConverter for XContainer and XDocument
-
-
-##### The JsonConverter
-
-This is a custom [JsonConverter](http://www.newtonsoft.com/json/help/html/CustomJsonConverter.htm) that replicates the approach used by the [core serializer](json.md).
-
-snippet: XContainerJsonConverter
-
-
-##### Use the JsonConverter
-
-At configuration time the JsonConverter can then be used with the following.
-
-snippet: UseConverter
 
 ### Use of $type requires an assembly qualified name
 
-The [core serializer](json.md) is registering a custom serialization binder to not require the assembly name to be present when inferring message type from the special [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). Not having to specify the assembly name can be useful to reduce coupling when using the serializer for native integration scenarios like [demonstrated in this sample](/samples/sqltransport/native-integration).
+The bundled serializer registers a custom serialization binder in order to not require the assembly name to be present when inferring message type from the [`$type` property supported by json.net](https://www.newtonsoft.com/json/help/html/SerializeTypeNameHandling.htm). Not having to specify the assembly name can be useful to reduce coupling when using the serializer for native integration scenarios like [demonstrated in this sample](/samples/sqltransport/native-integration).
 
-To make the serializer compatible with this behavior the following serialization binder can be used:
+To make the serializer compatible with this behavior use the following serialization binder:
 
 snippet: KnownTypesBinder
 
-and configured using the following configuration:
+and configured as follows:
 
 snippet: KnownTypesBinderConfig

--- a/nservicebus/serialization/newtonsoft.md
+++ b/nservicebus/serialization/newtonsoft.md
@@ -71,7 +71,7 @@ Up to Version 6 of NServiceBus a [JSON serializer based on Json.net](json.md) wa
 
 ### No support for `XContainer` and `XDocument` properties
 
-In contrast to the bundled serializer `XContainer` and `XDocument` properties are no longer supported. If `XContainer` and `XDocument` properties are required [use a JsonConverter](newtonsoft.md#compatibility-with-the-core-json-serializer-use-a-jsonconverter-for-xcontainer-and-xdocument) as shown below:
+In contrast to the bundled serializer `XContainer` and `XDocument` properties are no longer supported. If `XContainer` and `XDocument` properties are required [use a JsonConverter](https://www.newtonsoft.com/json/help/html/CustomJsonConverter.htm) as shown below:
 
 snippet: XContainerJsonConverter
 

--- a/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Program.cs
+++ b/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Program.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Data;
 using System.Data.SqlClient;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using NServiceBus;
 
 class Program
@@ -18,6 +21,12 @@ class Program
         transport.Transactions(TransportTransactionMode.SendsAtomicWithReceive);
         transport.ConnectionString(connectionString);
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
+        endpointConfiguration.UseSerialization<NewtonsoftSerializer>()
+            .Settings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto,
+                SerializationBinder = new SkipAssemblyNameForMessageTypesBinder(new[] { typeof(PlaceOrder) })
+            });
         #endregion
 
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
@@ -43,7 +52,7 @@ class Program
                 .ConfigureAwait(false);
         }
         await endpointInstance.Stop()
-            .ConfigureAwait(false);
+                    .ConfigureAwait(false);
     }
 
     static async Task PlaceOrder()
@@ -82,5 +91,26 @@ class Program
         }
 
         #endregion
+    }
+}
+
+class SkipAssemblyNameForMessageTypesBinder : ISerializationBinder
+{
+    Type[] messageTypes;
+
+    public SkipAssemblyNameForMessageTypesBinder(Type[] messageTypes)
+    {
+        this.messageTypes = messageTypes;
+    }
+
+    public Type BindToType(string assemblyName, string typeName)
+    {
+        return messageTypes.FirstOrDefault(messageType => messageType.FullName == typeName);
+    }
+
+    public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+    {
+        assemblyName = serializedType.Assembly.FullName;
+        typeName = serializedType.FullName;
     }
 }

--- a/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Program.cs
+++ b/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Program.cs
@@ -52,7 +52,7 @@ class Program
                 .ConfigureAwait(false);
         }
         await endpointInstance.Stop()
-                    .ConfigureAwait(false);
+            .ConfigureAwait(false);
     }
 
     static async Task PlaceOrder()


### PR DESCRIPTION
This was discovered when @HEskandari was testing the https://docs.particular.net/samples/sqltransport/native-integration/?version=sqltransport_4 sample