### PR TITLE
Added note from which version this is added.

### DIFF
--- a/nservicebus/recoverability/index_unrecoverableexceptions_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_unrecoverableexceptions_core_[6.0,).partial.md
@@ -1,5 +1,7 @@
 ## Unrecoverable exceptions
 
+Note: This is added to NServiceBus 6.2
+
 If a message processing fails due to an unrecoverable exception being thrown, then the retry process is skipped. The failed message is then immediately moved to the error queue after the first failure. 
 
 According to the default policy, only exceptions of type `MessageDeserializationException` are considered unrecoverable. However, it's possible to customize the policy and declare additional types as unrecoverable exceptions. That allows to skip retries for certain exceptions, when it's known in advance that retries won't resolve the issue.


### PR DESCRIPTION
Instead of using document url `index_unrecoverableexceptions_core_[6.0,).partial.md` it maybe needs to be `index_unrecoverableexceptions_core_[6.2,).partial.md`. Not sure if that is supported.

@Particular/docs-maintainers 