### PR TITLE
Integrity tests for samples and snippets.

### DIFF
--- a/tests/IntegrityTests.sln
+++ b/tests/IntegrityTests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2005
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrityTests", "IntegrityTests\IntegrityTests.csproj", "{40D06B9E-4A74-48E4-89BA-74A765120802}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{40D06B9E-4A74-48E4-89BA-74A765120802}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40D06B9E-4A74-48E4-89BA-74A765120802}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40D06B9E-4A74-48E4-89BA-74A765120802}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40D06B9E-4A74-48E4-89BA-74A765120802}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E49A126D-A249-4C73-9C47-D303F192961B}
+	EndGlobalSection
+EndGlobal

--- a/tests/IntegrityTests/IntegrityTests.csproj
+++ b/tests/IntegrityTests/IntegrityTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/tests/IntegrityTests/IntegrityTests.csproj
+++ b/tests/IntegrityTests/IntegrityTests.csproj
@@ -11,8 +11,4 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -10,7 +10,7 @@ namespace IntegrityTests
        [Test]
         public void DoNotUseTargetFrameworksPlural()
         {
-            new TestRunner("*.csproj", "Project files should not be multi-targeted with <TargetFraemworks> element")
+            new TestRunner("*.csproj", "Project files should not be multi-targeted with <TargetFrameworks> element")
                 .Run(projectFilePath =>
                 {
                     var xdoc = XDocument.Load(projectFilePath);
@@ -25,17 +25,23 @@ namespace IntegrityTests
         }
 
         [Test]
-        public void WillPass()
+        public void EnsureSingleTargetFramework()
         {
-            new TestRunner("*.csproj", "Should pass")
-                .Run(path => true);
-        }
+            new TestRunner("*.csproj", "Project files should only contain a single <TargetFramework> element")
+                .Run(projectFilePath =>
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        return true;
+                    }
 
-        [Test]
-        public void WillFail()
-        {
-            new TestRunner("*.csproj", "Should pass")
-                .Run(path => false);
+                    var targetFrameworkElements = xdoc.XPathSelectElements("/Project/PropertyGroup/TargetFramework");
+
+                    // Project may have zero of these if it has TargetFrameworks, but then it fails DoNotUseTargetFrameworksPlural
+                    // Projects with no target framework will not build at all
+                    return targetFrameworkElements.Count() <= 1;
+                });
         }
     }
 }

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+﻿using System.Linq;
 using System.Xml.XPath;
 using NUnit.Framework;
 
@@ -10,41 +6,20 @@ namespace IntegrityTests
 {
     public class ProjectFrameworks
     {
-        [Test]
+       [Test]
         public void DoNotUseTargetFrameworksPlural()
         {
-            var currentDirectory = TestContext.CurrentContext.TestDirectory;
-            var docsDirectory = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\.."));
-
-            var projectFiles = Directory.GetFiles(docsDirectory, "*.csproj", SearchOption.AllDirectories);
-
-            var badProjects = new List<string>();
-
-            foreach (var projectFilePath in projectFiles)
-            {
-                var filename = Path.GetFileName(projectFilePath);
-                bool isCore = filename.EndsWith(".Core.csproj");
-
-                var xdoc = XDocument.Load(projectFilePath);
-
-                var xmlns = xdoc.Root.Attribute("xmlns");
-                if (xmlns != null)
+            new TestRunner("*.csproj")
+                .Run("Project files should not be multi-targeted with <TargetFraemworks> element", xdoc =>
                 {
-                    continue;
-                }
-                
-                var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        return true;
+                    }
 
-                if (firstTargetFrameworksElement != null)
-                {
-                    badProjects.Add(projectFilePath);
-                }
-            }
-
-            Assert.IsEmpty(badProjects, "Project files should not be multi-targeted with <TargetFraemworks> element.");
+                    var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+                    return firstTargetFrameworksElement == null;
+                });
         }
-
-
     }
-
 }

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using NUnit.Framework;
+
+namespace IntegrityTests
+{
+    public class ProjectFrameworks
+    {
+        [Test]
+        public void DoNotUseTargetFrameworksPlural()
+        {
+            var currentDirectory = TestContext.CurrentContext.TestDirectory;
+            var docsDirectory = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\.."));
+
+            var projectFiles = Directory.GetFiles(docsDirectory, "*.csproj", SearchOption.AllDirectories);
+
+            var badProjects = new List<string>();
+
+            foreach (var projectFilePath in projectFiles)
+            {
+                var filename = Path.GetFileName(projectFilePath);
+                bool isCore = filename.EndsWith(".Core.csproj");
+
+                var xdoc = XDocument.Load(projectFilePath);
+
+                var xmlns = xdoc.Root.Attribute("xmlns");
+                if (xmlns != null)
+                {
+                    continue;
+                }
+                
+                var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+
+                if (firstTargetFrameworksElement != null)
+                {
+                    badProjects.Add(projectFilePath);
+                }
+            }
+
+            Assert.IsEmpty(badProjects, "Project files should not be multi-targeted with <TargetFraemworks> element.");
+        }
+
+
+    }
+
+}

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Xml.Linq;
 using System.Xml.XPath;
 using NUnit.Framework;
 
@@ -9,9 +10,10 @@ namespace IntegrityTests
        [Test]
         public void DoNotUseTargetFrameworksPlural()
         {
-            new TestRunner("*.csproj")
-                .Run("Project files should not be multi-targeted with <TargetFraemworks> element", xdoc =>
+            new TestRunner("*.csproj", "Project files should not be multi-targeted with <TargetFraemworks> element")
+                .Run(projectFilePath =>
                 {
+                    var xdoc = XDocument.Load(projectFilePath);
                     if (xdoc.Root.Attribute("xmlns") != null)
                     {
                         return true;
@@ -20,6 +22,20 @@ namespace IntegrityTests
                     var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
                     return firstTargetFrameworksElement == null;
                 });
+        }
+
+        [Test]
+        public void WillPass()
+        {
+            new TestRunner("*.csproj", "Should pass")
+                .Run(path => true);
+        }
+
+        [Test]
+        public void WillFail()
+        {
+            new TestRunner("*.csproj", "Should pass")
+                .Run(path => false);
         }
     }
 }

--- a/tests/IntegrityTests/TestRunner.cs
+++ b/tests/IntegrityTests/TestRunner.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+using NUnit.Framework;
+
+namespace IntegrityTests
+{
+    public class TestRunner
+    {
+        private string glob;
+
+        public TestRunner(string glob)
+        {
+            this.glob = glob;
+        }
+        
+        public void Run(string message, Func<XDocument, bool> testDelegate)
+        {
+            var badProjects = new List<string>();
+
+            foreach (var rootPath in TestSetup.RootDirectories)
+            {
+                var projectFiles = Directory.GetFiles(rootPath, glob, SearchOption.AllDirectories);
+
+                foreach (var projectFilePath in projectFiles)
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+
+                    bool success = testDelegate(xdoc);
+
+                    if (!success)
+                    {
+                        badProjects.Add(projectFilePath);
+                    }
+                }
+            }
+
+            if (badProjects.Count > 0)
+            {
+                Assert.Fail($"{message}:\r\n  > {string.Join("\r\n  > ", badProjects)}");
+            }
+        }
+
+
+
+
+    }
+}

--- a/tests/IntegrityTests/TestRunner.cs
+++ b/tests/IntegrityTests/TestRunner.cs
@@ -9,13 +9,15 @@ namespace IntegrityTests
     public class TestRunner
     {
         private string glob;
+        private string errorMessage;
 
-        public TestRunner(string glob)
+        public TestRunner(string glob, string errorMessage)
         {
             this.glob = glob;
+            this.errorMessage = errorMessage;
         }
-        
-        public void Run(string message, Func<XDocument, bool> testDelegate)
+
+        public void Run(Func<string, bool> testDelegate)
         {
             var badProjects = new List<string>();
 
@@ -25,9 +27,7 @@ namespace IntegrityTests
 
                 foreach (var projectFilePath in projectFiles)
                 {
-                    var xdoc = XDocument.Load(projectFilePath);
-
-                    bool success = testDelegate(xdoc);
+                    bool success = testDelegate(projectFilePath);
 
                     if (!success)
                     {
@@ -38,12 +38,8 @@ namespace IntegrityTests
 
             if (badProjects.Count > 0)
             {
-                Assert.Fail($"{message}:\r\n  > {string.Join("\r\n  > ", badProjects)}");
+                Assert.Fail($"{errorMessage}:\r\n  > {string.Join("\r\n  > ", badProjects)}");
             }
         }
-
-
-
-
     }
 }

--- a/tests/IntegrityTests/TestSetup.cs
+++ b/tests/IntegrityTests/TestSetup.cs
@@ -11,6 +11,9 @@ namespace IntegrityTests
         [OneTimeSetUp]
         public void SetupRootDirectories()
         {
+            // ENHANCEMENT: Execute git commands when TeamCity environment variables are present
+            // to filter the set of files we run against based on changes in a given PR
+
             var currentDirectory = TestContext.CurrentContext.TestDirectory;
             var docsDirectory = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\.."));
 

--- a/tests/IntegrityTests/TestSetup.cs
+++ b/tests/IntegrityTests/TestSetup.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using NUnit.Framework;
+
+namespace IntegrityTests
+{
+    [SetUpFixture]
+    public class TestSetup
+    {
+        internal static string[] RootDirectories;
+
+        [OneTimeSetUp]
+        public void SetupRootDirectories()
+        {
+            var currentDirectory = TestContext.CurrentContext.TestDirectory;
+            var docsDirectory = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\.."));
+
+            RootDirectories = new[] { docsDirectory };
+        }
+    }
+}


### PR DESCRIPTION
As part of fixing up all the samples and stuff for the V7 launch, @bording discovered a swathe of inconsistencies and other bad things that it would be good to verify before PRs are even merged.

This PR is the start of some integrity tests to verify that. It includes 2 prototype tests:

1. Ensure that the `<TargetFrameworks>` element (plural) is not used
2. Ensure that multiple `<TargetFramework>` (singular) elements (for instance, used within conditional PropertyGroups) are not used

This PR should succeed against our current validation, as it's just a bit of extra code. The next step would be to set up the TeamCity pipeline so that these tests are executed as part of master and PR builds, but do not yet fail the build.

In the future we can use this infrastructure to prevent all sorts of issues from regressing, rather than having to do a bunch of manual search and cleanup. We also tried to design with an eye for future improvements, such as only examining directories that had been affected by a PR (like we currently do for building samples) or easily ignoring the Snippets directory for a rule that only applies to samples, etc.

At the point where this is a required part of the build process, we would then add information to the README mentioning the tests and what they validate.

@Particular/docs-maintainers please take a look.