### PR TITLE
Add .NET Core samples for NServiceBus.NLog

### DIFF
--- a/Snippets/NLog/NLog_2/NLog_2.csproj
+++ b/Snippets/NLog/NLog_2/NLog_2.csproj
@@ -4,6 +4,6 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.NLog" Version="2.0.*" />
+    <PackageReference Include="NServiceBus.NLog" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -39,8 +39,6 @@ Some packages do not currently support .NET Core or running on non-Windows platf
   * NServiceBus.Persistence.Sql - Microsoft SQL Server and PostgreSQL are supported. Oracle is not supported due to the lack of a .NET Core version of Oracle.ManagedDataAccess. The MySQL library does support .NET Core, but it has not yet been validated to work with SQL Persistence.
 * Containers
   * NServiceBus.Spring - Spring.Core does not support .NET Core.
-* Loggers
-  * NServiceBus.NLog - Waiting for stable release of NLog 4.5.0, which introduces .NET Core support
 * Hosts
   * These hosts are being deprecated and will not receive .NET Core support. They are replaced by the [ParticularTemplates package](https://www.nuget.org/packages/ParticularTemplates) containing [templates for use with `dotnet new`](/nservicebus/dotnet-templates.md).
     * NServiceBus.Host

--- a/samples/logging/nlog-custom/NLog_2/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_2/Sample/Sample.csproj
@@ -7,6 +7,6 @@
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="6.*" />
-    <PackageReference Include="NServiceBus.NLog" Version="2.0.*" />
+    <PackageReference Include="NServiceBus.NLog" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/samples/logging/nlog-custom/NLog_3/NLogCustom.Core.sln
+++ b/samples/logging/nlog-custom/NLog_3/NLogCustom.Core.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.Core.csproj", "{48F718EE-6C45-41BA-80EC-81BF34D4A623}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/logging/nlog-custom/NLog_3/NLogCustom.Core.sln.DotSettings
+++ b/samples/logging/nlog-custom/NLog_3/NLogCustom.Core.sln.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.Core.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.Core.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_6/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_6/SampleWithClean/SampleWithClean.csproj
@@ -8,6 +8,6 @@
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />
     <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="6.*" />
-    <PackageReference Include="NServiceBus.NLog" Version="2.0.*" />
+    <PackageReference Include="NServiceBus.NLog" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/samples/logging/stack-trace-cleaning/Core_6/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_6/SampleWithoutClean/SampleWithoutClean.csproj
@@ -5,9 +5,8 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />
     <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="6.*" />
-    <PackageReference Include="NServiceBus.NLog" Version="2.0.*" />
+    <PackageReference Include="NServiceBus.NLog" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />
+    <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />
+    <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
@@ -5,6 +5,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
@@ -5,6 +5,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0-*" />
   </ItemGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/StackTraceCleaning.Core.sln
+++ b/samples/logging/stack-trace-cleaning/Core_7/StackTraceCleaning.Core.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWithClean", "SampleWithClean\SampleWithClean.Core.csproj", "{6987F415-B4D5-4380-ADED-EED5AF170608}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWithoutClean", "SampleWithoutClean\SampleWithoutClean.Core.csproj", "{110DC45A-E273-421B-B77F-CEA91F53B8E4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6987F415-B4D5-4380-ADED-EED5AF170608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6987F415-B4D5-4380-ADED-EED5AF170608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{110DC45A-E273-421B-B77F-CEA91F53B8E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{110DC45A-E273-421B-B77F-CEA91F53B8E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/logging/stack-trace-cleaning/Core_7/StackTraceCleaning.Core.sln.DotSettings
+++ b/samples/logging/stack-trace-cleaning/Core_7/StackTraceCleaning.Core.sln.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>


### PR DESCRIPTION
As of NServiceBus.NLog 3.0.0-rc2, .NET Core is now supported.