### PR TITLE
Ensure project references have lower bound to satisfy NU1604 error

### DIFF
--- a/Snippets/Core/Core_7/Core_7.csproj
+++ b/Snippets/Core/Core_7/Core_7.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NServiceBus.Callbacks" Version="3.0.0-*" />
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="2.0.0-*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.0-*" />
-    <PackageReference Include="Newtonsoft.Json" Version="*" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="System.Reactive" Version="3.*" />
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/MsLogging/MsLogging_1/MsLogging_1.csproj
+++ b/Snippets/MsLogging/MsLogging_1/MsLogging_1.csproj
@@ -6,9 +6,9 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.MicrosoftLogging" Version="1.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0-*" />
   </ItemGroup>
 </Project>

--- a/Snippets/SqlPersistence/SqlPersistence_3/SqlPersistence_3.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_3/SqlPersistence_3.csproj
@@ -7,6 +7,6 @@
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql.ScriptBuilder" Version="3.*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
@@ -7,6 +7,6 @@
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />
     <PackageReference Include="NServiceBus.Persistence.Sql.ScriptBuilder" Version="4.0.0-*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
@@ -5,9 +5,9 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.MicrosoftLogging" Version="1.0.0-*" />
   </ItemGroup>

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.csproj
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.csproj
@@ -5,9 +5,9 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.MicrosoftLogging" Version="1.0.0-*" />
   </ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_3/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_3/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -10,7 +10,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Transactions" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="6.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="3.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Transactions" />
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Transactions" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.0.0-*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Phase1\EndpointPostgreSql\Program.cs" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_3/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />
-    <PackageReference Include="Npgsql" Version="*" />
+    <PackageReference Include="Npgsql" Version="3.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Phase1\EndpointPostgreSql\Program.cs" />

--- a/tests/IntegrityTests/ReferenceVersions.cs
+++ b/tests/IntegrityTests/ReferenceVersions.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using NUnit.Framework;
+
+namespace IntegrityTests
+{
+    public class ReferenceVersions
+    {
+       [Test]
+        public void MustScopeReferencesToAMajorVersion()
+        {
+            new TestRunner("*.csproj", "Package References cannot have Version=\"*\" or restore will sometimes fail and yield old, incorrect, or mismatched versions.")
+                .Run(projectFilePath =>
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        // Ignore pre-VS2017 projects
+                        return true;
+                    }
+
+                    var badPackageRefs = xdoc.XPathSelectElements("/Project/ItemGroup/PackageReference[@Version='*']");
+                    return !badPackageRefs.Any();
+                });
+        }
+    }
+}


### PR DESCRIPTION
NU1604: Project dependency (whatever) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.

Build server must have timed out on a package source and started using cached packages. Result is wrong versions being used that don't have the correct types (Ngpsql in this case) or mismatched versions (ms-logging) and of course when you run it locally it's fine.

The included integrity test will keep it from happening again.