### PR TITLE
Relax TargetFrameworks rule to exclude Snippets. 

### DIFF
--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -11,6 +11,7 @@ namespace IntegrityTests
         public void DoNotUseTargetFrameworksPlural()
         {
             new TestRunner("*.csproj", "Project files should not be multi-targeted with <TargetFrameworks> element")
+                .IgnoreSnippets()
                 .Run(projectFilePath =>
                 {
                     var xdoc = XDocument.Load(projectFilePath);


### PR DESCRIPTION
Also API for easily excluding snippets/samples/tutorials or by wildcard/regex.