### PR TITLE
How to use a shared Ninject kernel between instances

### DIFF
--- a/dummy
+++ b/dummy
@@ -1,0 +1,1 @@
+Dummy to easily force rebuild

--- a/dummy
+++ b/dummy
@@ -1,1 +1,2 @@
 Dummy to easily force rebuild
+Another dummy, as the previous build is gone from TC

--- a/dummy
+++ b/dummy
@@ -1,2 +1,0 @@
-Dummy to easily force rebuild
-Another dummy, as the previous build is gone from TC

--- a/nservicebus/dependency-injection/ninject.md
+++ b/nservicebus/dependency-injection/ninject.md
@@ -27,6 +27,10 @@ snippet: Ninject_Existing
 
 partial: uow
 
+### Multi hosting
+
+Sometimes you want to host multiple endpoints in a single process. You cannot share a single Ninject kernel with multiple endpoint instances. You need to create a child container. Ninject supports this with the [Ninject.Extensions.ChildKernel](https://github.com/ninject/Ninject.Extensions.ChildKernel) extension. Before you pass the kernel to NServiceBus you need to do `new ChildKernel(parentKernel)` and pass this new kernel instance.
+
 
 ### DependencyLifecycle Mapping
 

--- a/nservicebus/dependency-injection/ninject.md
+++ b/nservicebus/dependency-injection/ninject.md
@@ -29,7 +29,7 @@ partial: uow
 
 ### Multi hosting
 
-Sometimes you want to host multiple endpoints in a single process. You cannot share a single Ninject kernel with multiple endpoint instances. You need to create a child container. Ninject supports this with the [Ninject.Extensions.ChildKernel](https://github.com/ninject/Ninject.Extensions.ChildKernel) extension. Before you pass the kernel to NServiceBus you need to do `new ChildKernel(parentKernel)` and pass this new kernel instance.
+Multiple endpoints in a single process cannot share a single Ninject kernel. Each requires its own container instance or each requires its own child container. Ninject supports this with the [Ninject.Extensions.ChildKernel](https://github.com/ninject/Ninject.Extensions.ChildKernel) extension. Execute `new ChildKernel(parentKernel)` and pass this new kernel instance to NServiceBus.
 
 
 ### DependencyLifecycle Mapping


### PR DESCRIPTION
Added remark on how to use a shared Ninject kernel between multiple NServiceBus endpoint instances