### PR TITLE
Removed SendLocal from sender

### DIFF
--- a/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_4/Receiver/Program.cs
@@ -20,9 +20,6 @@ class Program
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
-        var myMessage = new MyMessage();
-        await endpointInstance.SendLocal(myMessage)
-            .ConfigureAwait(false);
         Console.WriteLine("Press any key to exit");
         Console.ReadKey();
         await endpointInstance.Stop()

--- a/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Program.cs
@@ -20,9 +20,6 @@ class Program
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
-        var myMessage = new MyMessage();
-        await endpointInstance.SendLocal(myMessage)
-            .ConfigureAwait(false);
         Console.WriteLine("Press any key to exit");
         Console.ReadKey();
         await endpointInstance.Stop()


### PR DESCRIPTION
The RabbitMQ Native sample contained a `SendLocal` in `Program.cs` with an empty message, causing every start of the receiver an empty message to be received.
This was confusing and has now been removed.

Discussion in Slack: https://particularsoftware.slack.com/archives/C06CXSNF4/p1527156607000068