### PR TITLE
Use ReceiveOnly transaction mode to prevent usage of TransactionScope in ASB

### DIFF
--- a/samples/azure/azure-service-bus-msmq-bridge/sample.md
+++ b/samples/azure/azure-service-bus-msmq-bridge/sample.md
@@ -78,11 +78,5 @@ NOTE: This sample use a simple `InMemorySubscriptionStorage`. In production `Sql
 
 snippet: bridge-execution
 
-#### Forwarding interception
-
-In scenarios where forwarding operation requires customization, Bridge provides an option to intercept forwarding operation. For example, Azure Service Bus transport requires any non Azure Service Bus [transactional scope to be suppressed](/transports/azure-service-bus/understanding-transactions-and-delivery-guarantees.md). 
-
-snippet: suppress-transaction-scope-for-asb
-
 [asb-topology]: asb-topology.png "Azure Service Bus topology"
 [msmq-topology]: msmq-topology.png "MSMQ topology"


### PR DESCRIPTION
This does not change the behavior but is easier to configure.