### PR TITLE
Add a prerequisite step for ServiceControl

### DIFF
--- a/servicecontrol/upgrades/1to2.md
+++ b/servicecontrol/upgrades/1to2.md
@@ -11,7 +11,7 @@ Upgrading ServiceControl from version 1 to version 2 is a major upgrade and requ
 
 ## Pre-requisites
 
-Before upgrading to ServiceControl version 2 the instance being upgraded must at least be upgraded to version 1.41.3. If the instance being upgraded is lower than that it is possible that the upgrade process could fail.
+Before upgrading to ServiceControl version 2 the instance being upgraded must at least be upgraded to [version 1.41.3](https://github.com/Particular/ServiceControl/releases/tag/1.43.1). If the instance being upgraded is lower than that it is possible that the upgrade process could fail.
 
 ### New settings added to ServiceControl
 

--- a/servicecontrol/upgrades/1to2.md
+++ b/servicecontrol/upgrades/1to2.md
@@ -9,6 +9,10 @@ reviewed: 2018-06-01
 
 Upgrading ServiceControl from version 1 to version 2 is a major upgrade and requires careful planning. During the upgrade process, the instance of ServiceControl that is being upgraded will no longer be available and will not be ingesting any messages. The upgrade process is not reversible and cannot be reversed once started.
 
+## Pre-requisites
+
+Before upgrading to ServiceControl version 2 the instance being upgraded must at least be upgraded to version 1.41.3. If the instance being upgraded is lower than that it is possible that the upgrade process could fail.
+
 ### New settings added to ServiceControl
 
 A new setting has been added to ServiceControl version 2. This setting is the [Maintenance Port](/servicecontrol/creating-config-file.md#host-settings-servicecontroldatabasemaintenanceport) and is used as the port that the internal ServiceControl database is exposed over when ServiceControl has been switched to [maintenance mode](/servicecontrol/use-ravendb-studio.md). The value for this setting must be an unused port. For new instances of ServiceControl, this value defaults to `33334`.


### PR DESCRIPTION
This pre-requisite ensures that the internal data migrations will already be run and completed before the major upgrade is run