### PR TITLE
Samples for NHibernate 8.1

### DIFF
--- a/samples/entity-framework/Core_7/Endpoint.NHibernate/Endpoint.NHibernate.csproj
+++ b/samples/entity-framework/Core_7/Endpoint.NHibernate/Endpoint.NHibernate.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />

--- a/samples/entity-framework/Core_7/Shared/Shared.csproj
+++ b/samples/entity-framework/Core_7/Shared/Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <LangVersion>7.1</LangVersion>

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/MsmqPublisher.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/MsmqPublisher.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.*" />
   </ItemGroup>

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/SqlRelay.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/SqlRelay.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/CustomMappings.Core.sln
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/CustomMappings.Core.sln
@@ -1,0 +1,44 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4890E6F8-97BD-4892-A01B-BA792F9D973B}"
+	ProjectSection(SolutionItems) = preProject
+		..\sample.md = ..\sample.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.XmlMapping", "Sample.XmlMapping\Sample.XmlMapping.Core.csproj", "{48F718EE-6C45-41BA-80EC-81BF34D4A623}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Attributes", "Sample.Attributes\Sample.Attributes.Core.csproj", "{EEFB1685-825D-4E6D-8D8D-1093796EBCE6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Fluent", "Sample.Fluent\Sample.Fluent.Core.csproj", "{99EA52C4-9EDB-4000-8796-3836AF288BEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Loquacious", "Sample.Loquacious\Sample.Loquacious.Core.csproj", "{FAB1B4F0-CF49-4F53-B0CA-D85330182170}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.Core.csproj", "{5544A0E8-00CD-4D09-AEBA-FE37C8FF3B2D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Default", "Sample.Default\Sample.Default.Core.csproj", "{1A43EBF6-636B-4647-899F-FE5BB982326C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFB1685-825D-4E6D-8D8D-1093796EBCE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFB1685-825D-4E6D-8D8D-1093796EBCE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99EA52C4-9EDB-4000-8796-3836AF288BEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99EA52C4-9EDB-4000-8796-3836AF288BEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAB1B4F0-CF49-4F53-B0CA-D85330182170}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAB1B4F0-CF49-4F53-B0CA-D85330182170}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5544A0E8-00CD-4D09-AEBA-FE37C8FF3B2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5544A0E8-00CD-4D09-AEBA-FE37C8FF3B2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A43EBF6-636B-4647-899F-FE5BB982326C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A43EBF6-636B-4647-899F-FE5BB982326C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/nhibernate/custom-mappings/NHibernate_8/CustomMappings.Core.sln.DotSettings
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/CustomMappings.Core.sln.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.Core.csproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="IEsi.Collections" Version="4.0.*" />
+    <PackageReference Include="NHibernate.Mapping.Attributes" Version="5.*" />
+    <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="IEsi.Collections" Version="4.0.*" />
-    <PackageReference Include="NHibernate.Mapping.Attributes" Version="4.*" />
+    <PackageReference Include="NHibernate.Mapping.Attributes" Version="5.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.Core.csproj
@@ -6,8 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="IEsi.Collections" Version="4.0.*" />
+    <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="IEsi.Collections" Version="4.0.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.Core.csproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Iesi.Collections" Version="4.*" />
+    <PackageReference Include="FluentNHibernate" Version="2.1.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="IEsi.Collections" Version="4.0.*" />
+    <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="FluentNHibernate" Version="2.0.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="FluentNHibernate" Version="2.1.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="IEsi.Collections" Version="4.0.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.Core.csproj
@@ -6,8 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="IEsi.Collections" Version="4.0.*" />
+    <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="IEsi.Collections" Version="4.0.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.Core.csproj
@@ -5,9 +5,15 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <None Update="OrderSagaDataXml.hbm.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="IEsi.Collections" Version="4.0.*" />
+    <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="IEsi.Collections" Version="4.0.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Shared/Shared.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Shared/Shared.Core.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.*" />
+  </ItemGroup>
+</Project>

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.Core.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.Core.csproj" />
+    <PackageReference Include="Iesi.Collections" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/samples/nhibernate/simple/NHibernate_8/Sample.Core.sln
+++ b/samples/nhibernate/simple/NHibernate_8/Sample.Core.sln
@@ -1,0 +1,29 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.Core.csproj", "{963CD471-E882-45C4-A884-96592FA6E730}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.Core.csproj", "{A7BBC993-9A52-4CA8-9CD8-22FBEAFF7D1B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.Core.csproj", "{65572BB2-1E39-463A-87BF-53B84DBA7D94}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{963CD471-E882-45C4-A884-96592FA6E730}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{963CD471-E882-45C4-A884-96592FA6E730}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7BBC993-9A52-4CA8-9CD8-22FBEAFF7D1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7BBC993-9A52-4CA8-9CD8-22FBEAFF7D1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65572BB2-1E39-463A-87BF-53B84DBA7D94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65572BB2-1E39-463A-87BF-53B84DBA7D94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C1C82675-E1DD-470C-965E-315B5E508EE9}
+	EndGlobalSection
+EndGlobal

--- a/samples/nhibernate/simple/NHibernate_8/Sample.Core.sln.DotSettings
+++ b/samples/nhibernate/simple/NHibernate_8/Sample.Core.sln.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>

--- a/samples/nhibernate/simple/NHibernate_8/Sample.sln
+++ b/samples/nhibernate/simple/NHibernate_8/Sample.sln
@@ -1,13 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26730.12
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Server\Server.csproj", "{963CD471-E882-45C4-A884-96592FA6E730}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{963CD471-E882-45C4-A884-96592FA6E730}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{A7BBC993-9A52-4CA8-9CD8-22FBEAFF7D1B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{A7BBC993-9A52-4CA8-9CD8-22FBEAFF7D1B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{65572BB2-1E39-463A-87BF-53B84DBA7D94}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{65572BB2-1E39-463A-87BF-53B84DBA7D94}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,5 +22,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C1C82675-E1DD-470C-965E-315B5E508EE9}
 	EndGlobalSection
 EndGlobal

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.Core.csproj" />
+    <PackageReference Include="Iesi.Collections" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
+    <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/samples/nhibernate/simple/NHibernate_8/Shared/Shared.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Shared/Shared.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.*" />
+  </ItemGroup>
+</Project>

--- a/samples/outbox/multi-tenant/Core_7/Receiver/MultiTenantConnectionProvider.cs
+++ b/samples/outbox/multi-tenant/Core_7/Receiver/MultiTenantConnectionProvider.cs
@@ -1,10 +1,10 @@
-﻿using System.Data;
+﻿using System.Data.Common;
 using NHibernate.Connection;
 
 class MultiTenantConnectionProvider :
     DriverConnectionProvider
 {
-    public override IDbConnection GetConnection()
+    public override DbConnection GetConnection()
     {
         #region GetConnectionFromContext
 

--- a/samples/outbox/multi-tenant/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/multi-tenant/Core_7/Receiver/Receiver.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.*" />
   </ItemGroup>

--- a/samples/outbox/multi-tenant/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/multi-tenant/Core_7/Sender/Sender.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.*" />
   </ItemGroup>

--- a/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
   </ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />

--- a/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransport_4/Endpoint.NHibernate/Endpoint.NHibernate.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransport_4/Endpoint.NHibernate/Endpoint.NHibernate.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Iesi.Collections" Version="4.*" />
-    <PackageReference Include="NHibernate" Version="4.*" />
+    <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />


### PR DESCRIPTION
- [x] \samples\nhibernate
- [x] \samples\entity-framework\Core_7\
- [x] \samples\msmq\msmqtosqlrelay\MsmqTransport_1\
- [x] \samples\outbox\multi-tenant\Core_7\
- [x] \samples\saga\nh-custom-sagafinder\NHibernate_8\
- [x] \samples\sqltransport\native-timeout-migration\SqlTransport_4\
- [x] \samples\sqltransport-nhpersistence\

Additionally, after publishing, run the tools\supportedVersions.linq in doco to update the supported version dates due to the new minor
