### PR TITLE
Multi-instance mode in menu

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1066,6 +1066,8 @@
         Url: servicecontrol/installation-powershell
       - Title: Cluster Deployment
         Url: servicecontrol/deploying-servicecontrol-in-a-cluster
+      - Title: Multiple Instances
+        Url: servicecontrol/servicecontrol-instances/distributed-instances  
       - Title: Settings
         Url: servicecontrol/creating-config-file
       - Title: Overriding the host identifier


### PR DESCRIPTION
For a period of time we decided not to have it in the menu because it is an advanced scenario that not everybody should be using. Still for customers with larger loads, it would make sense that the doco is more discoverable. So add it to the menu?