### PR TITLE
Update samples to netcoreapp2.1

### DIFF
--- a/samples/attachments-fileshare/AttachmentsFileShare_1/Endpoint/Endpoint.Core.csproj
+++ b/samples/attachments-fileshare/AttachmentsFileShare_1/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/attachments-sql/AttachmentsSql_1/Endpoint/Endpoint.Core.csproj
+++ b/samples/attachments-sql/AttachmentsSql_1/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/audit-filter/AuditFilter_1/Endpoint/Endpoint.Core.csproj
+++ b/samples/audit-filter/AuditFilter_1/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
     <ApplicationIcon />

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.Core.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_2/Receiver/Receiver.Core.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_2/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_2/Sender/Sender.Core.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_2/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-persistence/ASP_2/Client/Client.Core.csproj
+++ b/samples/azure/storage-persistence/ASP_2/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-persistence/ASP_2/Server/Server.Core.csproj
+++ b/samples/azure/storage-persistence/ASP_2/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-persistence/ASP_2/Shared/Shared.Core.csproj
+++ b/samples/azure/storage-persistence/ASP_2/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   

--- a/samples/azure/storage-persistence/ASP_2/StorageReader/StorageReader.Core.csproj
+++ b/samples/azure/storage-persistence/ASP_2/StorageReader/StorageReader.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQ_8/Shared/Shared.Core.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.Core.csproj
+++ b/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_3/Receiver/Receiver.Core.csproj
+++ b/samples/callbacks/Callbacks_3/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_3/Sender/Sender.Core.csproj
+++ b/samples/callbacks/Callbacks_3/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.Core.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.Core.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Producer/Producer.Core.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Producer.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/custom-transport/Core_7/CustomTransport.TransportTests/CustomTransport.TransportTests.Core.csproj
+++ b/samples/custom-transport/Core_7/CustomTransport.TransportTests/CustomTransport.TransportTests.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/custom-transport/Core_7/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/custom-transport/Core_7/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/custom-transport/Core_7/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/custom-transport/Core_7/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/custom-transport/Core_7/Shared/Shared.Core.csproj
+++ b/samples/custom-transport/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/databus/custom-serializer/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_7/Sender/Sender.Core.csproj
+++ b/samples/databus/custom-serializer/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Client/Client.Core.csproj
+++ b/samples/delayed-delivery/Core_7/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Server/Server.Core.csproj
+++ b/samples/delayed-delivery/Core_7/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Shared/Shared.Core.csproj
+++ b/samples/delayed-delivery/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/core_7/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/aspnetcore/core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/autofac/Autofac_7/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/autofac/Autofac_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/castle/Castle_7/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/castle/Castle_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/structuremap/StructureMap_7/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/structuremap/StructureMap_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/unity/Unity_9/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/unity/Unity_9/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.Core.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.Core.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Shared/Shared.Core.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/endpoint-configuration/Core_7/Sample/Sample.Core.csproj
+++ b/samples/endpoint-configuration/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_7/Shared/Shared.Core.csproj
+++ b/samples/errorhandling/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.Core.csproj
+++ b/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.Core.csproj
+++ b/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Client/Client.Core.csproj
+++ b/samples/faulttolerance/Core_7/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Server/Server.Core.csproj
+++ b/samples/faulttolerance/Core_7/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Shared/Shared.Core.csproj
+++ b/samples/faulttolerance/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/feature/Core_7/Sample/Sample.Core.csproj
+++ b/samples/feature/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/file-share-databus/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Sender/Sender.Core.csproj
+++ b/samples/file-share-databus/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Shared/Shared.Core.csproj
+++ b/samples/file-share-databus/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/fullduplex/Core_7/Client/Client.Core.csproj
+++ b/samples/fullduplex/Core_7/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Server/Server.Core.csproj
+++ b/samples/fullduplex/Core_7/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Shared/Shared.Core.csproj
+++ b/samples/fullduplex/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/gateway/Gateway_3/Headquarters/Headquarters.Core.csproj
+++ b/samples/gateway/Gateway_3/Headquarters/Headquarters.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_3/RemoteSite/RemoteSite.Core.csproj
+++ b/samples/gateway/Gateway_3/RemoteSite/RemoteSite.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_3/WebClient.Core/WebClient.Core.csproj
+++ b/samples/gateway/Gateway_3/WebClient.Core/WebClient.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/handler-ordering-by-interface/HandlerOrdering_2/Sample/Sample.Core.csproj
+++ b/samples/handler-ordering-by-interface/HandlerOrdering_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/header-manipulation/Core_7/Sample/MyHandler.cs
+++ b/samples/header-manipulation/Core_7/Sample/MyHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Logging;
+using NServiceBus.Settings;
 
 #region handler
 
@@ -9,9 +10,17 @@ public class MyHandler :
     IHandleMessages<MyMessage>
 {
     static ILog log = LogManager.GetLogger<MyHandler>();
+    ReadOnlySettings _settings;
+
+    public MyHandler(ReadOnlySettings settings)
+    {
+        _settings = settings;
+    }
 
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
+        
+
         log.Info("Hello from MyHandler");
         var headers = context.MessageHeaders;
         foreach (var line in headers.OrderBy(x => x.Key)

--- a/samples/header-manipulation/Core_7/Sample/Sample.Core.csproj
+++ b/samples/header-manipulation/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/docker/Core_7/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/multi-hosting/Core_7/Instance1/Instance1.Core.csproj
+++ b/samples/hosting/multi-hosting/Core_7/Instance1/Instance1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/multi-hosting/Core_7/Instance2/Instance2.Core.csproj
+++ b/samples/hosting/multi-hosting/Core_7/Instance2/Instance2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/multi-hosting/Core_7/Sample/Sample.Core.csproj
+++ b/samples/hosting/multi-hosting/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/multi-hosting/Core_7/Shared/Shared.Core.csproj
+++ b/samples/hosting/multi-hosting/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/self-hosting/Core_7/Sample/Sample.Core.csproj
+++ b/samples/hosting/self-hosting/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/windows-service/Core_7/Sample/Sample.Core.csproj
+++ b/samples/hosting/windows-service/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/windows-service/sample_netcore_core_[7.0,).partial.md
+++ b/samples/hosting/windows-service/sample_netcore_core_[7.0,).partial.md
@@ -15,10 +15,10 @@ The `ServiceBase` functionality is provided by the [System.ServiceProcess.Servic
 To use the installation approach described above, a self contained exe is required. [dotnet-publish](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish) can be used to produce an exe from a .NET Core console project. This can be done by using the following command from the [Package Manager Console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console):
 
 ```
-dotnet publish WindowsServiceHosting.Core.sln --framework netcoreapp2.0 --runtime win10-x64
+dotnet publish WindowsServiceHosting.Core.sln --framework netcoreapp2.1 --runtime win10-x64
 ```
 
-`Sample.Core.exe` will then exist in `Sample\bin\Debug\netcoreapp2.0\win10-x64\publish`.
+`Sample.Core.exe` will then exist in `Sample\bin\Debug\netcoreapp2.1\win10-x64\publish`.
 
 
 ### Via dotnet.exe

--- a/samples/learning-transport/Core_7/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/learning-transport/Core_7/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/learning-transport/Core_7/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/learning-transport/Core_7/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/learning-transport/Core_7/Shared/Shared.Core.csproj
+++ b/samples/learning-transport/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/logging/anotar/Anotar_4/Sample/Sample.Core.csproj
+++ b/samples/logging/anotar/Anotar_4/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.Core.csproj
+++ b/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.Core.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.Core.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_7/Sample/Sample.Core.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.Core.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.Core.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_7/Sample/Sample.Core.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/serilog-custom/Serilog_4/Sample/Sample.Core.csproj
+++ b/samples/logging/serilog-custom/Serilog_4/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/serilog-seq/SerilogTracing_4/Sample/Sample.Core.csproj
+++ b/samples/logging/serilog-seq/SerilogTracing_4/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.Core.csproj
+++ b/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_7/Sample/Sample.Core.csproj
+++ b/samples/messagemutators/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.Core.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/sql/Core_7/Sender/Sender.Core.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.Core.csproj
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.Core.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/handler-timer/Core_7/Sample/Sample.Core.csproj
+++ b/samples/pipeline/handler-timer/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Sender/Sender.Core.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Shared/Shared.Core.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/Sender/Sender.Core.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.Core.csproj
+++ b/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_7/Sender/Sender.Core.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_7/Shared/Shared.Core.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.Core.csproj
+++ b/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.Core.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.Core.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>..\CustomExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.Core.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.Core.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>..\MefExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/Shared/Shared.Core.csproj
+++ b/samples/plugin-based-config/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/Core_7/Publisher/Publisher.Core.csproj
+++ b/samples/pubsub/Core_7/Publisher/Publisher.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/Core_7/Shared/Shared.Core.csproj
+++ b/samples/pubsub/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/Core_7/Subscriber/Subscriber.Core.csproj
+++ b/samples/pubsub/Core_7/Subscriber/Subscriber.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_5/NativeSender/NativeSender.Core.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_5/NativeSender/NativeSender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Receiver.Core.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_5/Sample/Sample.Core.csproj
+++ b/samples/rabbitmq/simple/Rabbit_5/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_5/Client/Client.Core.csproj
+++ b/samples/ravendb/simple/Raven_5/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_5/Server/Server.Core.csproj
+++ b/samples/ravendb/simple/Raven_5/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_5/Shared/Shared.Core.csproj
+++ b/samples/ravendb/simple/Raven_5/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_3/Messages/Messages.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/Messages/Messages.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/Sender/Sender.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepA/StepA.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepA/StepA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepB/StepB.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepB/StepB.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepC/StepC.Core.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepC/StepC.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/routing/command-routing/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Sender/Sender.Core.csproj
+++ b/samples/routing/command-routing/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Shared/Shared.Core.csproj
+++ b/samples/routing/command-routing/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.Core.csproj
+++ b/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.Core.csproj
+++ b/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/fowarding-address/Core_7/Sender/Sender.Core.csproj
+++ b/samples/routing/fowarding-address/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/saga/simple/Core_7/Sample/Sample.Core.csproj
+++ b/samples/saga/simple/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.Core.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.Core.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.Core.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Shared/Shared.Core.csproj
+++ b/samples/scheduling/hangfire/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/scheduling/quartz/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.Core.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Shared/Shared.Core.csproj
+++ b/samples/scheduling/quartz/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/scheduler/Core_7/Sample/Sample.Core.csproj
+++ b/samples/scheduling/scheduler/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/bond/Bond_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/bond/Bond_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.Core.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
     <AssemblyName>SamplePhase1</AssemblyName>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.Core.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/hyperion/Hyperion_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/hyperion/Hyperion_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/jil/Jil_3/Sample/Sample.Core.csproj
+++ b/samples/serializers/jil/Jil_3/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/JilEndpoint/JilEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/JilEndpoint/JilEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/WireEndpoint/WireEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/WireEndpoint/WireEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.Core.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/protobufgoogle/ProtoBufGoogle_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/protobufgoogle/ProtoBufGoogle_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/protobufnet/ProtoBufNet_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/protobufnet/ProtoBufNet_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.Core.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.Core.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.Core.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.Core.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/Shared/Shared.Core.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/wire/Wire_3/Sample/Sample.Core.csproj
+++ b/samples/serializers/wire/Wire_3/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/xml/Core_7/Sample/Sample.Core.csproj
+++ b/samples/serializers/xml/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/zeroformatter/ZeroFormatter_2/Sample/Sample.Core.csproj
+++ b/samples/serializers/zeroformatter/ZeroFormatter_2/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.Core.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.Core.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.Core.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Adapter/Adapter.Core.csproj
+++ b/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Adapter/Adapter.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Sales/Sales.Core.csproj
+++ b/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Sales/Sales.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Shipping/Shipping.Core.csproj
+++ b/samples/servicecontrol/adapter-rabbitmq-different-topologies/SCTransportAdapter_2/Shipping/Shipping.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.Core.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.Core.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>        

--- a/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>        

--- a/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>    

--- a/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>    

--- a/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.Core.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.Core.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Receiver.Core.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_4/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
     <AssemblyName>Receiver</AssemblyName>

--- a/samples/sqltransport/simple/SqlTransport_4/Receiver/Receiver.Core.csproj
+++ b/samples/sqltransport/simple/SqlTransport_4/Receiver/Receiver.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_4/Sender/Sender.Core.csproj
+++ b/samples/sqltransport/simple/SqlTransport_4/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_4/Shared/Shared.Core.csproj
+++ b/samples/sqltransport/simple/SqlTransport_4/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/sql-native/SqlTransportNative_2/AuditConsumer/AuditConsumer.Core.csproj
+++ b/samples/sqltransport/sql-native/SqlTransportNative_2/AuditConsumer/AuditConsumer.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/sql-native/SqlTransportNative_2/ErrorProcessor/ErrorProcessor.Core.csproj
+++ b/samples/sqltransport/sql-native/SqlTransportNative_2/ErrorProcessor/ErrorProcessor.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/sql-native/SqlTransportNative_2/NativeEndpoint/NativeEndpoint.Core.csproj
+++ b/samples/sqltransport/sql-native/SqlTransportNative_2/NativeEndpoint/NativeEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/sql-native/SqlTransportNative_2/NsbEndpoint/NsbEndpoint.Core.csproj
+++ b/samples/sqltransport/sql-native/SqlTransportNative_2/NsbEndpoint/NsbEndpoint.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/sql-native/SqlTransportNative_2/Shared/Shared.Core.csproj
+++ b/samples/sqltransport/sql-native/SqlTransportNative_2/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqs/simple/Sqs_4/Sample/Sample.Core.csproj
+++ b/samples/sqs/simple/Sqs_4/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/startup-shutdown-sequence/Core_7/Sample/Sample.Core.csproj
+++ b/samples/startup-shutdown-sequence/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Limited/Limited.Core.csproj
+++ b/samples/throttling/Core_7/Limited/Limited.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Sender/Sender.Core.csproj
+++ b/samples/throttling/Core_7/Sender/Sender.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Shared/Shared.Core.csproj
+++ b/samples/throttling/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unit-of-work/Core_7/Sample/Sample.Core.csproj
+++ b/samples/unit-of-work/Core_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/unit-testing/Testing_7/Sample/Sample.Core.csproj
+++ b/samples/unit-testing/Testing_7/Sample/Sample.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unobtrusive/Core_7/Client/Client.Core.csproj
+++ b/samples/unobtrusive/Core_7/Client/Client.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_7/Server/Server.Core.csproj
+++ b/samples/unobtrusive/Core_7/Server/Server.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_7/Shared/Shared.Core.csproj
+++ b/samples/unobtrusive/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/username-header/Core_7/Endpoint1/Endpoint1.Core.csproj
+++ b/samples/username-header/Core_7/Endpoint1/Endpoint1.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Endpoint2/Endpoint2.Core.csproj
+++ b/samples/username-header/Core_7/Endpoint2/Endpoint2.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Shared/Shared.Core.csproj
+++ b/samples/username-header/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/AsyncPagesMVC.Core.csproj
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/AsyncPagesMVC.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_7/Server/Server.Core.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Server/Server.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/asp-web-application/Core_7/Server/Server.Core.csproj
+++ b/samples/web/asp-web-application/Core_7/Server/Server.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/asp-web-application/Core_7/WebApplication.Core/WebApplication.Core.csproj
+++ b/samples/web/asp-web-application/Core_7/WebApplication.Core/WebApplication.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.Core.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.Core.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/WebApplication/WebApplication.Core.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/WebApplication/WebApplication.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/samples/web/send-from-mvc-controller/Core_7/Endpoint/Endpoint.Core.csproj
+++ b/samples/web/send-from-mvc-controller/Core_7/Endpoint/Endpoint.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/WebApplication.Core.csproj
+++ b/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/WebApplication.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleEndpoint/SampleEndpoint.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleEndpoint/SampleEndpoint.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleWeb/SampleWeb.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleWeb/SampleWeb.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/Shared/Shared.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/Tests/Tests.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/Tests/Tests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Part of the work on https://github.com/Particular/PlatformDevelopment/issues/2149 which is updating our packages, samples, and infrastructure to use .NET Core 2.1 since 2.0 is has a support end date of Oct 1 2018.