### PR TITLE
Refactor supported versions script

### DIFF
--- a/tools/supportedVersions.linq
+++ b/tools/supportedVersions.linq
@@ -134,7 +134,7 @@ public static class TextWriterExtensions
 					{
 						if (!packageHeadingWritten)
 						{
-							output.WriteLine($"#### [{package.Id}](/nuget/{package.Id})");							
+							output.WriteLine($"#### [{package.Id}](/nuget/{package.Id})");
 							output.WriteLine();
 
 							if (endOfLifePackages.TryGetValue(package.Id, out var reason))
@@ -314,19 +314,19 @@ public static class PackageExtensions
 		package.Id.Dump("Package");
 
 		package.Versions
-		   .OrderByDescending(version => version.First.Identity.Version.Major)
-		   .ThenByDescending(version => version.First.Identity.Version.Minor)
-		   .Select(version => new
-		   {
-			   Package = version.ToString(),
-			   Published = version.First.Published?.UtcDateTime.Date.ToString("yyyy-MM-dd"),
-			   BoundedBy = version.BoundedBy?.ToString(),
-			   ExtendedBy = version.ExtendedBy?.ToString(),
-			   PatchingEnd = version.PatchingEnd?.ToString("yyyy-MM-dd"),
-			   PatchingEndReason = version.PatchingEndReason,
-			   CurrentlyPatched = !version.PatchingEnd.HasValue || version.PatchingEnd.Value > utcTomorrow
-		   })
-		   .Dump("Versions");
+			.OrderByDescending(version => version.First.Identity.Version.Major)
+			.ThenByDescending(version => version.First.Identity.Version.Minor)
+			.Select(version => new
+			{
+				Package = version.ToString(),
+				Published = version.First.Published?.UtcDateTime.Date.ToString("yyyy-MM-dd"),
+				BoundedBy = version.BoundedBy?.ToString(),
+				ExtendedBy = version.ExtendedBy?.ToString(),
+				PatchingEnd = version.PatchingEnd?.ToString("yyyy-MM-dd"),
+				PatchingEndReason = version.PatchingEndReason,
+				CurrentlyPatched = !version.PatchingEnd.HasValue || version.PatchingEnd.Value > utcTomorrow
+			})
+			.Dump("Versions");
 	}
 }
 

--- a/tools/supportedVersions.linq
+++ b/tools/supportedVersions.linq
@@ -200,15 +200,12 @@ public static class TextWriterExtensions
 
 public static class PackageMetadataResourceExtensions
 {
-    static SourceCacheContext sourceCacheContext;
-    
-    static PackageMetadataResourceExtensions()
-    {
-        sourceCacheContext = new SourceCacheContext();
-        sourceCacheContext.MaxAge = DateTimeOffset.UtcNow;
-        sourceCacheContext.NoCache = true;
-    }
-    
+	private static SourceCacheContext sourceCacheContext = new SourceCacheContext
+	{
+		MaxAge = DateTimeOffset.UtcNow,
+		NoCache = true,
+	};
+
 	public static async Task<List<Version>> GetVersions(
 		this PackageMetadataResource resource, string packageId, ILogger logger, int majorOverlapYears, int minorOverlapMonths, List<Version> upstreamVersions, Dictionary<string, string> endOfLifePackages)
 	{


### PR DESCRIPTION
@DavidBoike there are two commits here. The second is just whitespace (I'm not sure when it became inconsistent). The first commit refactors the static state you added to `PackageMetadataResourceExtensions`. Are you OK with the change?