### PR TITLE
Clarify SQLP saga concurrency

### DIFF
--- a/persistence/sql/saga-concurrency.md
+++ b/persistence/sql/saga-concurrency.md
@@ -20,5 +20,4 @@ The persister uses unique key constraints that will result in an exception being
 
 partial: implementation
 
-include: saga-concurrency
 

--- a/persistence/sql/saga-concurrency_implementation_sqlpersistence_[,4.1).partial.md
+++ b/persistence/sql/saga-concurrency_implementation_sqlpersistence_[,4.1).partial.md
@@ -1,2 +1,4 @@
 
 The persister provides [optimistic concurrency](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) using an incrementing counter.
+
+include: saga-concurrency


### PR DESCRIPTION
I've moved the blue box so it is only included for versions that don't support `select for update`