### PR TITLE
Remove analyzers removal in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,4 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>IDE0018</WarningsAsErrors>
   </PropertyGroup>
-
-  <Target Name="DisableAnalyzers" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <Analyzer Remove="@(Analyzer)"/>
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
When smoke-tested changes for Core v6.5, have used one of the samples.
Because samples remove all analyzers, Particular Analyzer was removed as well, causing confusion and unnecessary "bug" hunting with @timbussmann and @bording.

![image](https://user-images.githubusercontent.com/1309622/44492972-95acdc00-a623-11e8-80e2-aa909a0ef048.png)

Unless there's a reason to do so, I recommend to remove this task from samples.