### PR TITLE
align topology casing and definite articles

### DIFF
--- a/servicecontrol/installation.md
+++ b/servicecontrol/installation.md
@@ -42,7 +42,7 @@ In ServiceControl version 1.7 and above, the transport DLLs are managed by the i
 
  Certain features of the transports are not supported natively by ServiceControl and will require a [transport adapter](/servicecontrol/transport-adapter).
  
-For preliminary Azure Service Bus .NET Standard support select Azure Service Bus Forwarding Topology.
+For preliminary Azure Service Bus .NET Standard support select the Azure Service Bus forwarding topology.
 
 Adding third party transports via the Management Utility is not supported. If MSMQ is the selected transport then ensure the service has been installed and configured as outlined in [Installing The Platform Components Manually](/platform/installer/offline.md#platform-installer-components-nservicebus-prerequisites).
 

--- a/transports/azure-service-bus/publisher-names-configuration.md
+++ b/transports/azure-service-bus/publisher-names-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Publishers name configuration
-summary: Configuration mapping between publisher names and event types for Endpoint Oriented Topology
+summary: Configuration mapping between publisher names and event types for the endpoint oriented topology
 component: ASB
 versions: "[7,)"
 tags:

--- a/transports/azure-service-bus/topologies/index.md
+++ b/transports/azure-service-bus/topologies/index.md
@@ -33,7 +33,7 @@ Both topologies create a single input queue per endpoint and implement [Publish-
 No default topology is set by the Azure Service Bus transport. Topology has to be explicitly configured using [configuration API](/transports/azure-service-bus/configuration/full.md).
 
 
-### Endpoint Oriented Topology
+### Endpoint oriented topology
 
 In the `EndpointOrientedTopology` each publishing endpoint creates a topic called `<publishing_endpoint_name>.events`. The subscribing endpoints subscribe to the topic, by creating a subscription for a particular event type called `<subscriber_endpoint_name>.<event_type_name>`. Note that each subscription has a single rule, used to filter a specific event type.
 
@@ -50,7 +50,7 @@ The `EndpointOrientedTopology` topology has several drawbacks:
 ![EndpointOrientedTopology](endpoint-oriented-topology.png "width=500")
 
 
-### Forwarding Topology
+### Forwarding topology
 
 The `ForwardingTopology` is designed to take advantage of several native broker features offered by the Azure Service Bus. Unlike `EndpointOrientedTopology`, it doesn't work with a single topic per publisher. All publishers use a single topic bundle.
 

--- a/transports/upgrades/asb-7to8.md
+++ b/transports/upgrades/asb-7to8.md
@@ -15,7 +15,7 @@ upgradeGuideCoreVersions:
 ---
 
 
-## [Forwarding Topology](/transports/azure-service-bus/topologies/) number of entities in bundle removed
+## [Forwarding topology](/transports/azure-service-bus/topologies/) number of entities in bundle removed
 
 In Versions 8 and above the API to configure bundle prefix and number of entities in a bundle has been removed:
 

--- a/transports/upgrades/rabbitmq-4.0to4.1.md
+++ b/transports/upgrades/rabbitmq-4.0to4.1.md
@@ -13,7 +13,7 @@ upgradeGuideCoreVersions:
 ---
 
 
-## [Custom Routing Topology](/transports/rabbitmq/routing-topology.md#custom-routing-topology)
+## [Custom routing topology](/transports/rabbitmq/routing-topology.md#custom-routing-topology)
 
 The `UseRoutingTopology` method has a new overload with a parameter representing a factory delegate which creates the custom routing topology. This allows the use of non-default constructors for custom routing topology instances. The `UseRoutingTopology` method overload with no parameters is deprecated.
 


### PR DESCRIPTION
These are not proper nouns, so they should be lower case. They should also be preceded with the definite article ("the") (can be excluded for section titles).

In most instances, the casing and definite article usage is correct. This fixes the outliers.