### PR TITLE
Remove uneeded note about mutators and DI

### DIFF
--- a/nservicebus/pipeline/message-mutators.md
+++ b/nservicebus/pipeline/message-mutators.md
@@ -62,8 +62,6 @@ Mutators are registered using:
 
 snippet: MutatorRegistration
 
-NOTE: Mutators are **NOT** automatically registered using [dependency injection](/nservicebus/dependency-injection/) container. If DI is needed then use a [pipeline behavior](/nservicebus/pipeline/manipulate-with-behaviors.md).
-
 NOTE: Mutators are non-deterministic in terms of order of execution. If more fine-grained control is required over the pipeline see [Pipeline Introduction](/nservicebus/pipeline/manipulate-with-behaviors.md).
 
 


### PR DESCRIPTION
As part of fixing the recent issue with mutators and DI we concluded that since the API requires you to pass an instance of the mutator that you would like to register there is no point in mentioning DI since at that point users would have already "new"'ed up the instance or pulled it from their container of choice.

See https://github.com/Particular/NServiceBus/issues/5257