### PR TITLE
Correct gateway receive channel docs when wildcards are used

### DIFF
--- a/Snippets/Gateway/Gateway_2/Channels/Wildcard.config.xml
+++ b/Snippets/Gateway/Gateway_2/Channels/Wildcard.config.xml
@@ -9,7 +9,7 @@
     <Channels>
       <Channel Address="http://+:25899/RemoteSite/"
                ChannelType="Http"/>               
-      <Channel Address="http://gateway.mycorp.com:25899/RemoteSite/"
+      <Channel Address="http://gateway.mycorp.com:25900/RemoteSite/"
                ChannelType="Http"
                Default="true"/>       
     </Channels>

--- a/Snippets/Gateway/Gateway_3/Channels/Wildcard.config.xml
+++ b/Snippets/Gateway/Gateway_3/Channels/Wildcard.config.xml
@@ -9,7 +9,7 @@
     <Channels>
       <Channel Address="http://+:25899/RemoteSite/"
                ChannelType="Http"/>               
-      <Channel Address="http://gateway.mycorp.com:25899/RemoteSite/"
+      <Channel Address="http://gateway.mycorp.com:25900/RemoteSite/"
                ChannelType="Http"
                Default="true"/> 
     </Channels>

--- a/Snippets/Gateway/Gateway_3/Channels/Wildcard.config.xml
+++ b/Snippets/Gateway/Gateway_3/Channels/Wildcard.config.xml
@@ -8,8 +8,10 @@
   <GatewayConfig>
     <Channels>
       <Channel Address="http://+:25899/RemoteSite/"
+               ChannelType="Http"/>               
+      <Channel Address="http://gateway.mycorp.com:25899/RemoteSite/"
                ChannelType="Http"
-               Default="true"/>
+               Default="true"/> 
     </Channels>
   </GatewayConfig>
 </configuration>


### PR DESCRIPTION
Need to have a non wildcard default for replies to be routed properly