### PR TITLE
Remove reference to MSBuild package in samples

### DIFF
--- a/samples/entity-framework/Core_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/Core_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -9,7 +9,6 @@
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>

--- a/samples/outbox/sql/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/outbox/sql/Core_7/Receiver/Receiver.Core.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>

--- a/samples/outbox/sql/Core_7/Sender/Sender.Core.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.Core.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/outbox/sql/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>

--- a/samples/saga/migration/Core_7/Server.New/Server.New.csproj
+++ b/samples/saga/migration/Core_7/Server.New/Server.New.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.Core.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.Core.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.Core.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.Core.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.Core.csproj
@@ -11,6 +11,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
@@ -11,6 +11,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.Core.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.Core.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.Core.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.Core.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
@@ -7,6 +7,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.Core.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.Core.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.*" />

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.*" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransport_4/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransport_4/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="4.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql.MsBuild" Version="4.*" />
     <PackageReference Include="NServiceBus.SqlServer" Version="4.*" />
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>


### PR DESCRIPTION
This updates all the of the Sql persistence 4 samples to remove the now-unneeded NServiceBus.Persistence.Sql.MsBuild package.