### PR TITLE
Remove incorrect information

### DIFF
--- a/nservicebus/recoverability/subscribing-to-error-notifications.md
+++ b/nservicebus/recoverability/subscribing-to-error-notifications.md
@@ -24,8 +24,6 @@ snippet: SubscribeToErrorsNotifications
 
 include: notificationThread
 
-The notification instance is also injected into [dependency injection](/nservicebus/dependency-injection/).
-
 
 partial: reactive
 


### PR DESCRIPTION
This doesn't appear to be true. An attempt to retrieve `Notifications` from container will always throw. Instead, it's only possible to get it via `Settings` (separate PR?).