### PR TITLE
Enable installers on FileBasedRouting sample

### DIFF
--- a/samples/routing/file-based-routing/FileBasedRouting_2/Billing/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_2/Billing/Program.cs
@@ -11,6 +11,8 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Billing");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
+        endpointConfiguration.EnableInstallers();
+
         var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();
         routing.UseFileBasedRouting(@"..\..\..\..\endpoints.xml");

--- a/samples/routing/file-based-routing/FileBasedRouting_2/Client/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_2/Client/Program.cs
@@ -15,6 +15,7 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Client");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
+        endpointConfiguration.EnableInstallers();
 
         #region FileBasedRouting
 

--- a/samples/routing/file-based-routing/FileBasedRouting_2/Sales/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_2/Sales/Program.cs
@@ -11,6 +11,7 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Sales");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
+        endpointConfiguration.EnableInstallers();
 
         var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();

--- a/samples/routing/file-based-routing/FileBasedRouting_2/Shipping/Program.cs
+++ b/samples/routing/file-based-routing/FileBasedRouting_2/Shipping/Program.cs
@@ -11,6 +11,7 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.FileBasedRouting.Shipping");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("Samples.FileBasedRouting.Error");
+        endpointConfiguration.EnableInstallers();
 
         var transport = endpointConfiguration.UseTransport<MsmqTransport>();
         var routing = transport.Routing();

--- a/samples/routing/file-based-routing/sample.md
+++ b/samples/routing/file-based-routing/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Using centralized routing configuration
 summary: Using file to control message routing in entire NServiceBus system
-reviewed: 2016-12-16
+reviewed: 2018-11-15
 component: FileBasedRouting
 tags:
  - Routing


### PR DESCRIPTION
an alternative would be to use the learning transport instead but the LT supports native pub/sub and therefore isn't the best option to demonstrate the capabilities of FileBasedRouting