### PR TITLE
Fix MsLogging sample/snippets from 2.2.0 obsoletes

### DIFF
--- a/Snippets/MsLogging/MsLogging_1/MsLogging_1.csproj
+++ b/Snippets/MsLogging/MsLogging_1/MsLogging_1.csproj
@@ -5,9 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.MicrosoftLogging" Version="1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/MsLogging/MsLogging_1/ProgramService.cs
+++ b/Snippets/MsLogging/MsLogging_1/ProgramService.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.ServiceProcess;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Logging;
@@ -12,7 +13,7 @@ class ProgramService :
     ServiceBase
 {
     IEndpointInstance endpointInstance;
-    LoggerFactory loggerFactory;
+    Microsoft.Extensions.Logging.ILoggerFactory loggerFactory;
 
     static void Main()
     {
@@ -37,8 +38,16 @@ class ProgramService :
 
     async Task AsyncOnStart()
     {
-        loggerFactory = new LoggerFactory();
-        loggerFactory.AddConsole();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(loggingBuilder =>
+        {
+            loggingBuilder.AddFilter(level => level >= Microsoft.Extensions.Logging.LogLevel.Information);
+            loggingBuilder.AddConsole();
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        loggerFactory = serviceProvider.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
         var logFactory = LogManager.Use<MicrosoftLogFactory>();
         logFactory.UseMsFactory(loggerFactory);
         var endpointConfiguration = new EndpointConfiguration("EndpointName");

--- a/Snippets/MsLogging/MsLogging_1/Usage.cs
+++ b/Snippets/MsLogging/MsLogging_1/Usage.cs
@@ -1,6 +1,7 @@
 ﻿using NServiceBus;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 class Usage
 {
@@ -8,9 +9,17 @@ class Usage
     {
         #region MsLoggingInCode
 
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(loggingBuilder =>
+        {
+            loggingBuilder.AddFilter(level => level >= Microsoft.Extensions.Logging.LogLevel.Information);
+            loggingBuilder.AddConsole();
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
         using (var loggerFactory = new LoggerFactory())
         {
-            loggerFactory.AddConsole();
             var logFactory = LogManager.Use<MicrosoftLogFactory>();
             logFactory.UseMsFactory(loggerFactory);
             // endpoint startup and shutdown

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Program.cs
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Program.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.ComponentModel.Design;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
 using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 class Program
 {
@@ -11,9 +15,18 @@ class Program
         Console.Title = "Samples.Logging.MsLoggingCustom";
 
         #region MsLoggingInCode
-        using (var loggerFactory = new LoggerFactory())
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(loggingBuilder =>
         {
-            loggerFactory.AddConsole(Microsoft.Extensions.Logging.LogLevel.Information);
+            loggingBuilder.AddFilter(level => level >= LogLevel.Information);
+            loggingBuilder.AddConsole();
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        using (var loggerFactory = serviceProvider.GetService<ILoggerFactory>())
+        {
             var logFactory = LogManager.Use<MicrosoftLogFactory>();
             logFactory.UseMsFactory(loggerFactory);
 

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.Core.csproj
@@ -5,6 +5,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.*" />

--- a/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.csproj
+++ b/samples/logging/mslogging-custom/MsLogging_1/Sample/Sample.csproj
@@ -5,9 +5,10 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.MicrosoftLogging" Version="1.*" />
   </ItemGroup>


### PR DESCRIPTION
Hey @SimonCropp,

Microsoft.Extensions.Logging 2.2.0 made some APIs obsolete and wants them declared on an ILoggingBuilder instead of ILoggerFactory, the problem is how to generate that. In a previous commit I temporarily fixed the build by locking the versions to 2.1.*, but this is my attempt to fix it for real.

Does this look OK?