### PR TITLE
Azure Service Bus Standard sample fixes

### DIFF
--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
@@ -15,7 +15,8 @@ class Program
             throw new Exception("Could not read the 'AzureServiceBus_ConnectionString' environment variable. Check the sample prerequisites.");
         }
 
-        var queueClient = new QueueClient(connectionString, "Samples.ASB.NativeIntegration");
+        // ReSharper disable once StringLiteralTypo
+        var queueClient = new QueueClient(connectionString, "samples.asb.nativeintegration");
 
         #region SerializedMessage
 

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
@@ -12,7 +12,7 @@ class Program
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
-            throw new Exception("Could not read the 'AzureServiceBus.ConnectionString' environment variable. Check the sample prerequisites.");
+            throw new Exception("Could not read the 'AzureServiceBus_ConnectionString' environment variable. Check the sample prerequisites.");
         }
 
         var queueClient = new QueueClient(connectionString, "Samples.ASB.NativeIntegration");

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Program.cs
@@ -25,7 +25,7 @@ class Program
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
-            throw new Exception("Could not read the 'AzureServiceBus.ConnectionString' environment variable. Check the sample prerequisites.");
+            throw new Exception("Could not read the 'AzureServiceBus_ConnectionString' environment variable. Check the sample prerequisites.");
         }
         transport.ConnectionString(connectionString);
 


### PR DESCRIPTION
This PR includes a few fixes for samples:
- aligning names of environmental variables in the exceptions to the ones used by system
- lower-casing the entity name for the native sender, as the queue name created by NSB endpoint is lowered as well