### PR TITLE
Azure Service Bus Standard - fixup

### DIFF
--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/Program.cs
@@ -15,8 +15,7 @@ class Program
             throw new Exception("Could not read the 'AzureServiceBus_ConnectionString' environment variable. Check the sample prerequisites.");
         }
 
-        // ReSharper disable once StringLiteralTypo
-        var queueClient = new QueueClient(connectionString, "samples.asb.nativeintegration");
+        var queueClient = new QueueClient(connectionString, "Samples.ASB.NativeIntegration");
 
         #region SerializedMessage
 


### PR DESCRIPTION
Undoing wrongly understood endpoint casing introduced in #4165