### PR TITLE
Remove unneeded ifdef in SQL pass through sample

### DIFF
--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleEndpoint/Program.cs
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleEndpoint/Program.cs
@@ -28,11 +28,6 @@ namespace SampleEndpoint
             endpointConfiguration.EnableAttachments(SqlHelper.ConnectionString, TimeToKeep.Default);
             var transport = endpointConfiguration.UseTransport<SqlServerTransport>();
             transport.ConnectionString(SqlHelper.ConnectionString);
-            #if NETCOREAPP2_0
-            // Since Transaction scope mode is not supported in .NET Core 2.0
-            // https://docs.particular.net/transports/sql/transactions#transaction-scope-distributed-transaction
-            transport.Transactions(TransportTransactionMode.SendsAtomicWithReceive);
-            #endif
             endpointConfiguration.EnableInstallers();
 
             #endregion

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleWeb/Properties/launchSettings.json
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_2/SampleWeb/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "SampleClient",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Works fine in netcoreapp2.1 since the sample doesn't need to escalate to DTC. Tested with attachments as well

Closes #4199 