### PR TITLE
Fix docker sample

### DIFF
--- a/samples/hosting/docker/Core_7/docker-compose.yml
+++ b/samples/hosting/docker/Core_7/docker-compose.yml
@@ -5,8 +5,6 @@ services:
         build:
             context: .
             dockerfile: ./Sender/Dockerfile
-        networks:
-            - new
         depends_on:
             rabbitmq:
                 condition: service_healthy
@@ -15,8 +13,6 @@ services:
         build:
             context: .
             dockerfile: ./Receiver/Dockerfile
-        networks:
-            - new
         depends_on:
             rabbitmq:
                 condition: service_healthy
@@ -24,11 +20,8 @@ services:
         image: "rabbitmq:3-management"
         ports:
             - "15672:15672"
-        networks:
-            - new
+            - "5672:5672"
         healthcheck:
             test: ["CMD-SHELL", "if rabbitmqctl status; then \nexit 0 \nfi \nexit 1"]
             interval: 10s
             retries: 5
-networks:
-    new:


### PR DESCRIPTION
- Remove network new because it is unnecessary
- Specify hostname rabbitmq and connection port to allow other containers to connect to broker