### PR TITLE
Namespace instead of fully qualified name

### DIFF
--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The `NServiceBus.EnclosedMessageTypes` property must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
+NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers#serialization-headers-nservicebus-enclosedmessagetypes) must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must contain the type FullName (namespace and name) expected by the NServiceBus endpoint. Not to be confused with [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly and version of the type.
+NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must atleast contain the type FullName (namespace and name) expected by the NServiceBus endpoint but can contain the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly and version of the type. The Assembly Qualified Name is the default NServiceBus uses.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers#serialization-headers-nservicebus-enclosedmessagetypes) must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
+NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The `NServiceBus.EnclosedMessageTypes` property must contain the the fully-qualified name of the type expected by the NServiceBus endpoint.
+NOTE: The `NServiceBus.EnclosedMessageTypes` property must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might require also require the fully-qualified name including the assembly of the type.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The `NServiceBus.EnclosedMessageTypes` property must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might require also require the fully-qualified name including the assembly of the type.
+NOTE: The `NServiceBus.EnclosedMessageTypes` property must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must contain the namespace and name of the type expected by the NServiceBus endpoint. Some serializers might also require the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly of the type.
+NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must contain the type FullName (namespace and name) expected by the NServiceBus endpoint. Not to be confused with [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly and version of the type.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 

--- a/samples/azure-service-bus-netstandard/native-integration/sample.md
+++ b/samples/azure-service-bus-netstandard/native-integration/sample.md
@@ -46,7 +46,7 @@ For a native message to be processed, NServiceBus endpoints using the Azure Serv
 
 snippet: NecessaryHeaders
 
-NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must atleast contain the type FullName (namespace and name) expected by the NServiceBus endpoint but can contain the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly and version of the type. The Assembly Qualified Name is the default NServiceBus uses.
+NOTE: The [`NServiceBus.EnclosedMessageTypes` header property](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) must atleast contain the type [FullName](https://docs.microsoft.com/en-us/dotnet/api/system.type.fullname) of the message expected by the NServiceBus endpoint but can contain the [Assembly Qualified Name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) which also includes the assembly and version of the type. The Assembly Qualified Name is the default NServiceBus uses.
 
 The message itself is defined using [conventions](/nservicebus/messaging/conventions.md) in the `Receiver` project.
 


### PR DESCRIPTION
The namespace must always be present AFAIK but the assembly does not. This depends I think on the configured serializer.