### PR TITLE
Allow package versions >9

### DIFF
--- a/tests/IntegrityTests/ValidatePrereleaseTxt.cs
+++ b/tests/IntegrityTests/ValidatePrereleaseTxt.cs
@@ -74,7 +74,7 @@ namespace IntegrityTests
             while (dirPath.Length >= TestSetup.DocsRootPath.Length)
             {
                 string dirName = Path.GetFileName(dirPath);
-                if (Regex.IsMatch(dirName, @"_(All|\d(\.\d)?)$"))
+                if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d)?)$"))
                 {
                     var componentName = dirName.Substring(0, dirName.IndexOf('_'));
                     return (dirPath, componentName);

--- a/tests/IntegrityTests/ValidatePrereleaseTxt.cs
+++ b/tests/IntegrityTests/ValidatePrereleaseTxt.cs
@@ -74,7 +74,7 @@ namespace IntegrityTests
             while (dirPath.Length >= TestSetup.DocsRootPath.Length)
             {
                 string dirName = Path.GetFileName(dirPath);
-                if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d)?)$"))
+                if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d+)?)$"))
                 {
                     var componentName = dirName.Substring(0, dirName.IndexOf('_'));
                     return (dirPath, componentName);


### PR DESCRIPTION
investigating why the build fails on this PR: https://github.com/Particular/docs.particular.net/pull/4302 it seems the regex can't match for packages with version number > 9. With my limited regex skills, my only idea was to allow multiple digits per version segment. 🤷‍♂️ 