### PR TITLE
Remove transport implementation guidance

### DIFF
--- a/nservicebus/messaging/message-identity.md
+++ b/nservicebus/messaging/message-identity.md
@@ -5,7 +5,7 @@ component: Core
 ---
 
 
-Each message that is dispatched from an [Endpoint](/nservicebus/endpoints/) has a unique identity. NServiceBus generates and stores this value as a [header](/nservicebus/messaging/headers.md) on the message named `NServiceBus.MessageId`. If the selected transport supports message identity, and there is value in using the NServiceBus MessageId, this value can be optionally used as the transport level message identity as well.
+Each message that is dispatched from an [Endpoint](/nservicebus/endpoints/) has a unique identity. NServiceBus generates and stores this value as a [header](/nservicebus/messaging/headers.md) on the message named `NServiceBus.MessageId`.
 
 Many features take advantage of message identity. For example, the [Outbox](/nservicebus/outbox) uses message identity to deduplicate messages and [recoverability](/nservicebus/recoverability/) uses message identity to keep track of how many times the endpoint has tried to process a message.
 


### PR DESCRIPTION
Since it only makes sense to transport implementors and also is a bit questionable since using the MessageId can be dangerous since its not guaranteed to be unique since users can set it