### PR TITLE
Removed `installInfrastructure` parameter

### DIFF
--- a/nservicebus/hosting/nservicebus-host/installation.md
+++ b/nservicebus/hosting/nservicebus-host/installation.md
@@ -28,7 +28,6 @@ NServiceBus.Host.exe /install
 [/description:<string>]
 [/endpointConfigurationType:<string>]
 [/endpointName:<string>]
-[/installInfrastructure]
 [/scannedAssemblies:<string>]
 [/dependsOn:<string>]
 [/sideBySide]


### PR DESCRIPTION
Removed `installInfrastructure` parameter since it's been removed from code entirely.

As can be seen here: https://github.com/Particular/NServiceBus.Host/search?q=installInfrastructure&type=Code
There is no PR/commit that shows this, it's gone _that long_