### PR TITLE
fix string comparison in Installers sample code

### DIFF
--- a/Snippets/Core/Core_5/Installers.cs
+++ b/Snippets/Core/Core_5/Installers.cs
@@ -28,7 +28,7 @@ namespace Core5
         {
             #region InstallersRunWhenNecessaryCommandLine
                 
-            var runInstallers = Environment.GetCommandLineArgs().Any(x => x.ToLower() == "/runInstallers");
+            var runInstallers = Environment.GetCommandLineArgs().Any(x => string.Equals(x, "/runInstallers", StringComparison.OrdinalIgnoreCase));
 
             if (runInstallers)
             {

--- a/Snippets/Core/Core_6/Installers.cs
+++ b/Snippets/Core/Core_6/Installers.cs
@@ -30,7 +30,7 @@ namespace Core6
         {
             #region InstallersRunWhenNecessaryCommandLine
                 
-            var runInstallers = Environment.GetCommandLineArgs().Any(x => x.ToLower() == "/runInstallers");
+            var runInstallers = Environment.GetCommandLineArgs().Any(x => string.Equals(x, "/runInstallers", StringComparison.OrdinalIgnoreCase));
 
             if (runInstallers)
             {

--- a/Snippets/Core/Core_7/Installers.cs
+++ b/Snippets/Core/Core_7/Installers.cs
@@ -30,7 +30,7 @@ namespace Core7
         {
             #region InstallersRunWhenNecessaryCommandLine
 
-            var runInstallers = Environment.GetCommandLineArgs().Any(x => x.ToLower() == "/runInstallers");
+            var runInstallers = Environment.GetCommandLineArgs().Any(x => string.Equals(x, "/runInstallers", StringComparison.OrdinalIgnoreCase));
 
             if (runInstallers)
             {


### PR DESCRIPTION
Fix the comparison, as it always evaluated to false.
Also use OrdinalIgnoreCase comparison instead of culture-specific ToLower().