### PR TITLE
Replace TimeToKeepDeduplicationData with RunDeduplicationDataCleanupEvery

### DIFF
--- a/Snippets/SqlPersistence/SqlPersistence_4/OutboxSettings.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_4/OutboxSettings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NServiceBus;
-using NServiceBus.InMemory.Outbox;
 
 class OutboxSettings
 {
@@ -11,7 +10,7 @@ class OutboxSettings
         var outboxSettings = endpointConfiguration.EnableOutbox();
 
         outboxSettings.KeepDeduplicationDataFor(TimeSpan.FromDays(6));
-        outboxSettings.TimeToKeepDeduplicationData(TimeSpan.FromMinutes(15));
+        outboxSettings.RunDeduplicationDataCleanupEvery(TimeSpan.FromMinutes(15));
 
         #endregion
     }


### PR DESCRIPTION
`TimeToKeepDeduplicationData` is related to in memory outbox. The article where the snipped is shown is about Sql Outbox and talks about cleanup frequency.