### PR TITLE
Update Azure DataBus cleanup section to include policy reference

### DIFF
--- a/nservicebus/messaging/databus/azure-blob-storage.md
+++ b/nservicebus/messaging/databus/azure-blob-storage.md
@@ -18,11 +18,28 @@ Azure Blob Storage DataBus will **remove** the [Azure storage blobs](https://doc
 snippet: AzureDataBus
 
 
-## Cleanup strategy
+## Cleanup strategies
+
+Discarding old Azure DataBus attachments can be performed in one of the following ways:
+
+1. Using built-in method (enabled by default)
+2. Using Azure Durable Function
+3. Using Blob Lifecycle Management policy
+
+### Using built-in clean-up method
 
 Specify a value for the `TimeToBeReceived` property. For more details on how to specify this, see the article on [discarding old messages](/nservicebus/messaging/discard-old-messages.md).
 
-Alternatively, consider disabling Blob cleanup using Azure DataBus. Instead, use Durable Azure Function to perform this functionality.
+WARN: the built-in method executed continuous blob scanning. This can add up to the cost of the storage operations. It is **not** recommended for multiple endpoints that are scaled out. In case this method is not used and alternative is implemented, see how to disable built-in cleanup below. 
+
+### Using Azure Durable Function
+
+Alternatively, consider disabling Blob cleanup using Azure DataBus. Instead, use [Durable Azure Function](/samples/azure/blob-storage-databus-cleanup-function/) to perform this functionality.
+
+### Using Blob Lifecycle Management policy
+
+Attachment blobs can be cleaned up using [Blob Storage Lifecycle feature](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-lifecycle-management-concepts). This method allows configuring a single policy for all DataBus related. Those blobs can be either deleted or archived. The policy does not require custom code and is deployed directly to the storage account. Storage account has to be GPv2 or Blob storage account and cannot be GPv1 account. 
+
 
 ## Configuration
 

--- a/nservicebus/messaging/databus/azure-blob-storage.md
+++ b/nservicebus/messaging/databus/azure-blob-storage.md
@@ -38,7 +38,7 @@ Alternatively, consider disabling Blob cleanup using Azure DataBus. Instead, use
 
 ### Using Blob Lifecycle Management policy
 
-Attachment blobs can be cleaned up using [Blob Storage Lifecycle feature](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-lifecycle-management-concepts). This method allows configuring a single policy for all DataBus related. Those blobs can be either deleted or archived. The policy does not require custom code and is deployed directly to the storage account. Storage account has to be GPv2 or Blob storage account and cannot be GPv1 account. 
+Attachment blobs can be cleaned up using [Blob Storage Lifecycle feature](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-lifecycle-management-concepts). This method allows configuring a single policy for all DataBus related blobs. Those blobs can be either deleted or archived. The policy does not require custom code and is deployed directly to the storage account. This feature can only be used on GPv2 and Blob storage accounts, not on GPv1 accounts. 
 
 
 ## Configuration


### PR DESCRIPTION
Adding a third option to clean up Azure DataBus attachments based on [customer feedback](https://particularsoftware.slack.com/files/U03241PMC/FJ0QX2X4Z/TAM_call_with_Pharmerica).

1. Add lifecycle management policy section
1. Warn about potential costs associated with the built-in method