### PR TITLE
Remove references to archived Labs projects

### DIFF
--- a/nservicebus/recoverability/configure-error-handling.md
+++ b/nservicebus/recoverability/configure-error-handling.md
@@ -44,8 +44,3 @@ If either ServicePulse or ServiceInsight are not available in the environment, t
  * [MSMQ Scripting](/transports/msmq/operations-scripting.md)
  * [RabbitMQ Scripting](/transports/rabbitmq/operations-scripting.md)
  * [SQL Server Scripting](/transports/sql/operations-scripting.md)
-
-
-### ReturnToSourceQueue.exe
-
-The MSMQ command line tool `ReturnToSourceQueue` has been deprecated and moved to [ParticularLabs/MsmqReturnToSourceQueue](https://github.com/ParticularLabs/MsmqReturnToSourceQueue/).

--- a/nservicebus/security/generating-encryption-keys.md
+++ b/nservicebus/security/generating-encryption-keys.md
@@ -64,37 +64,3 @@ openssl rand 32
 ```
 
 NOTE: Be aware that strings parsed by NServiceBus do not use extended ASCII which limits the key range to 7 bits per character.
-
-
-### CryptoKeyGenerator
-
-A key generator exists in ParticularLabs that uses the .NET framework crypto provider to generate a key.
-
-Download the [CryptoKeyGenerator](https://github.com/ParticularLabs/CryptoKeyGenerator) labs project, run it, and copy the random key in its correct format.
-
-
-The tool generates one key and outputs this key in multiple formats.
-
-Output
-
-```
-Strip 8th bit: True
-Strip control: True
-Key bit length: 256
-
-Base64:
-        KzpSTk1pezg5eTJRNmhWJmoxdFo6UDk2WlhaOyQ5N0U=
-        |---------||---------||---------||---------|
-
-Hex:
-        2b3a524e4d697b3839793251366856266a31745a3a5039365a585a3b24393745
-        |--------------||--------------||--------------||--------------|
-
-ASCII:
-        +:RNMi{89y2Q6hV&j1tZ:P96ZXZ;$97E     xml escape: +:RNMi{89y2Q6hV&amp;j1tZ:P96ZXZ;$97E
-        |------||------||------||------|
-
-ASCII-EX:
-        +:RNMi{89y2Q6hV&j1tZ:P96ZXZ;$97E     xml escape: +:RNMi{89y2Q6hV&amp;j1tZ:P96ZXZ;$97E
-        |------||------||------||------|
-```

--- a/transports/index.md
+++ b/transports/index.md
@@ -33,7 +33,3 @@ Initially, it's challenging to decide which queueing technology may be best for 
 ## Community-maintained transports
 
 There are several community-maintained transports which can be found in the full list of [extensions](/components#transports).
-
-## WebSphereMQ transport
-
-There is also a WebSphereMQ transport but it is not supported by Particular Software at this time. The code is available [on GitHub](https://github.com/ParticularLabs/NServiceBus.WebSphereMQ) as-is, for legacy, community use and reference. [Contact Particular Software](https://particular.net/contactus) for licensing.


### PR DESCRIPTION
This removes references to the Labs projects that we archived.

Note, there is still a reference to `MsmqReturnToSourceQueue` [here](https://docs.particular.net/nservicebus/upgrades/5to6/tools-and-helpers), but since it was in an upgrade guide, I thought it made sense to keep it.