### PR TITLE
add tutorial to the menu

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -19,6 +19,8 @@
         Title: Publishing events
       - Url: tutorials/nservicebus-step-by-step/5-retrying-errors
         Title: Retrying errors
+    - Url: tutorials/message-replay
+      Title: Message replay tutorial
     - Url: tutorials/nservicebus-sagas/1-getting-started
       Title: "NServiceBus sagas: Getting started"
     - Url: tutorials


### PR DESCRIPTION
Message replay tutorial is not visible in the menu. The only way to view the content is to click button 'Next: Replaying failed messages' in the tutorial 'Introduction to NServiceBus' lesson ''Retrying errors'.