### PR TITLE
Fix default value for ServiceControl/LogLevel

### DIFF
--- a/servicecontrol/creating-config-file.md
+++ b/servicecontrol/creating-config-file.md
@@ -101,11 +101,11 @@ Controls the LogLevel of the ServiceControl logs.
 
 Type: string
 
-Default: `Warn`
+Default: `Info`
 
 In ServiceControl version 1.9 and above, valid settings are: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`.
 
-This setting will default to `Warn` if an invalid value is assigned.
+This setting will default to `Info` if an invalid value is assigned.
 
 In version 1.8 and below, the log level is `Info` and can not be changed.
 


### PR DESCRIPTION
The default value for LogLevel I observe in reality is `Info` and not, as documented, `Warn`.
Not sure if the docs are wrong, or it's a bug. Log excerpt below.

2019-07-03 07:58:02.7225|4|Info|Particular.ServiceControl.Bootstrapper|
-------------------------------------------------------------
ServiceControl Version:             3.0.0.0
Audit Retention Period:             30.00:00:00
Error Retention Period:             15.00:00:00
Ingest Error Messages:              True
Ingest Audit Messages:              True
Forwarding Error Messages:          False
Forwarding Audit Messages:          False
Database Size:                      41943040 bytes
ServiceControl Logging Level:       Info
RavenDB Logging Level:              Warn
Selected Transport Customization:   ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer