### PR TITLE
Make ECommerce project loadable from VS19

### DIFF
--- a/samples/showcase/on-premises/Core_6/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_6/Store.ECommerce/Store.ECommerce.csproj
@@ -79,7 +79,7 @@
     <Folder Include="App_Data\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v15.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
   </Target>


### PR DESCRIPTION
The ECommerce.csproj wouldn't load in VS19 because of the hardcoded VS version.