### PR TITLE
Add section about usage of ConfigureAwait(false)

### DIFF
--- a/samples/index.md
+++ b/samples/index.md
@@ -51,6 +51,11 @@ Unless otherwise specified (by an individual sample) the following are the defau
 All samples target **C# 7.1** to take advantage of the new language features. If any help is required in converting to earlier versions of C#, [raise an issue](https://github.com/Particular/docs.particular.net/issues).
 
 
+### ConfigureAwait
+
+Samples by default use `ConfigureAwait(false)` when awaiting asynchronous methods. Using `ConfigureAwait(false)` whenever possible is [considered a best practice](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx) which helps avoiding deadlocks and improving performance.
+
+
 ### [Transport](/transports/)
 
 Samples default to the [learning transport](/transports/learning/) as it has the least friction for experimentation. **The [learning transport](/transports/learning/) is not for production use**.

--- a/samples/index.md
+++ b/samples/index.md
@@ -53,7 +53,7 @@ All samples target **C# 7.1** to take advantage of the new language features. If
 
 ### ConfigureAwait
 
-Samples by default use `ConfigureAwait(false)` when awaiting asynchronous methods. Using `ConfigureAwait(false)` whenever possible is [considered a best practice](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx) which helps avoiding deadlocks and improving performance.
+Samples by default use `ConfigureAwait(false)` when awaiting asynchronous methods. Using `ConfigureAwait(false)` whenever possible is [considered a best practice](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx) which helps avoiding deadlocks and improves performance.
 
 
 ### [Transport](/transports/)


### PR DESCRIPTION
Related to https://github.com/Particular/docs.particular.net/issues/4427

Adding a section to our samples documentation to indicate that we're using ConfigureAwait(false) consistently and why we're doing that.

cc @gbiellem 