### PR TITLE
Use correct transport for TwoWayRouterConfig

### DIFF
--- a/Snippets/Router/Router_2/API.cs
+++ b/Snippets/Router/Router_2/API.cs
@@ -32,7 +32,7 @@ public class API
         routerConfig.AddInterface<MsmqTransport>("Msmq", 
             customization: transportExtensions => { });
 
-        routerConfig.AddInterface<MsmqTransport>("Rabbit",
+        routerConfig.AddInterface<RabbitMQTransport>("Rabbit",
             customization: transportExtensions =>
             {
                 transportExtensions.ConnectionString("host=localhost");


### PR DESCRIPTION
Should second transport not be of type RabbitMQTransport?