### PR TITLE
Ensure LangVersion = 7.1 for VS2017-style projects

### DIFF
--- a/tests/IntegrityTests/Infrastructure/TestRunner.cs
+++ b/tests/IntegrityTests/Infrastructure/TestRunner.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using NUnit.Framework;
 
 namespace IntegrityTests
@@ -18,8 +17,10 @@ namespace IntegrityTests
         {
             this.glob = glob;
             this.errorMessage = errorMessage;
-            this.ignoreRegexes = new List<Regex>();
-            this.ignoreRegexes.Add(new Regex(@"\\IntegrityTests\\"));
+            ignoreRegexes = new List<Regex>
+            {
+                new Regex(@"\\IntegrityTests\\")
+            };
         }
 
         public void Run(Func<string, bool> testDelegate)
@@ -37,7 +38,7 @@ namespace IntegrityTests
                         continue;
                     }
 
-                    bool success = testDelegate(projectFilePath);
+                    var success = testDelegate(projectFilePath);
 
                     if (!success)
                     {
@@ -60,7 +61,7 @@ namespace IntegrityTests
 
         public TestRunner IgnoreWildcard(string wildcardExpression)
         {
-            string pattern = Regex.Escape(wildcardExpression).Replace(@"\*", ".*").Replace(@"\?", ".");
+            var pattern = Regex.Escape(wildcardExpression).Replace(@"\*", ".*").Replace(@"\?", ".");
             return IgnoreRegex(pattern);
         }
 

--- a/tests/IntegrityTests/Infrastructure/TestSetup.cs
+++ b/tests/IntegrityTests/Infrastructure/TestSetup.cs
@@ -26,7 +26,7 @@ namespace IntegrityTests
 
             RootDirectories = new[] { DocsRootPath };
 
-            string componentsYamlPath = Path.Combine(TestSetup.DocsRootPath, "components\\components.yaml");
+            var componentsYamlPath = Path.Combine(TestSetup.DocsRootPath, "components\\components.yaml");
             var componentsText = File.ReadAllText(componentsYamlPath);
 
             var builder = new DeserializerBuilder();

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using NUnit.Framework;
+
+namespace IntegrityTests
+{
+    using System;
+
+    public class ProjectLangVersion
+    {
+       [Test]
+        public void ShouldUseLangVersionLatest()
+        {
+            new TestRunner("*.csproj", "VS2017 format project files must specify LangVersion=7.1 - This is the default in VS2019 but the property is needed to run correctly in VS2017.")
+                .IgnoreSnippets()
+                .Run(projectFilePath =>
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+
+                    // Ignore VS2015 style projects
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        return true;
+                    }
+
+                    var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/LangVersion");
+                    var value = firstTargetFrameworksElement?.Value;
+
+                    return value == "7.1";
+                });
+        }
+    }
+}

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -1,25 +1,26 @@
-﻿using System.Linq;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using System.Xml.XPath;
 using NUnit.Framework;
 
 namespace IntegrityTests
 {
-    using System;
-
     public class ProjectLangVersion
     {
        [Test]
         public void ShouldUseLangVersionLatest()
         {
+            // Also reflected in https://docs.particular.net/samples/#technology-choices-c-language-level
+            // And in /tools/projectStandards.linq
+
             new TestRunner("*.csproj", "VS2017 format project files must specify LangVersion=7.1 - This is the default in VS2019 but the property is needed to run correctly in VS2017.")
                 .IgnoreSnippets()
                 .Run(projectFilePath =>
                 {
                     var xdoc = XDocument.Load(projectFilePath);
 
-                    // Ignore VS2015 style projects
-                    if (xdoc.Root.Attribute("xmlns") != null)
+                    // Ignore non-Sdk (VS2015 and previous) style projects
+                    var sdk = xdoc.Root.Attribute("Sdk");
+                    if (sdk == null)
                     {
                         return true;
                     }

--- a/tests/IntegrityTests/ValidatePrereleaseTxt.cs
+++ b/tests/IntegrityTests/ValidatePrereleaseTxt.cs
@@ -7,8 +7,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using NUnit.Framework;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace IntegrityTests
 {
@@ -73,7 +71,7 @@ namespace IntegrityTests
 
             while (dirPath.Length >= TestSetup.DocsRootPath.Length)
             {
-                string dirName = Path.GetFileName(dirPath);
+                var dirName = Path.GetFileName(dirPath);
                 if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d+)?)$"))
                 {
                     var componentName = dirName.Substring(0, dirName.IndexOf('_'));


### PR DESCRIPTION
VS2019 changes the default for LangVersion to latest, so you could presumably create a sample in VS2019 with `async Main` that works great but bombs in VS2017.