### PR TITLE
Azure Functions - ASQ - remove required connection string

### DIFF
--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureStorageQueueTriggerFunction.cs
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureStorageQueueTriggerFunction.cs
@@ -8,13 +8,12 @@ using System.Threading.Tasks;
 public class AzureStorageQueueTriggerFunction
 {
     private const string EndpointName = "ASQTriggerQueue";
-    private const string ConnectionStringName = "ASQConnectionString";
 
     #region Function
 
     [FunctionName(EndpointName)]
     public static async Task QueueTrigger(
-        [QueueTrigger(EndpointName, Connection = ConnectionStringName)]
+        [QueueTrigger(EndpointName)]
         CloudQueueMessage message,
         ILogger log,
         ExecutionContext context)
@@ -28,7 +27,7 @@ public class AzureStorageQueueTriggerFunction
 
     private static FunctionEndpoint endpoint = new FunctionEndpoint(executionContext =>
     {
-        var configuration = new StorageQueueTriggeredEndpointConfiguration(EndpointName, ConnectionStringName);
+        var configuration = new StorageQueueTriggeredEndpointConfiguration(EndpointName);
 
         configuration.UseSerialization<NewtonsoftSerializer>();
 

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.Console/Program.cs
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.Console/Program.cs
@@ -45,7 +45,7 @@ class Program
             endpointConfiguration.DisableFeature<MessageDrivenSubscriptions>();
 
             var transport = endpointConfiguration.UseTransport<AzureStorageQueueTransport>();
-            transport.ConnectionString(config.GetValue<string>("Values:ASQConnectionString"));
+            transport.ConnectionString(config.GetValue<string>("Values:AzureWebJobsStorage"));
 
             asqEndpoint = await Endpoint.Start(endpointConfiguration);
         }

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/local.settings.json
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/local.settings.json
@@ -2,8 +2,6 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-
-    "ASQConnectionString": "<set your ASQ connection string here>"
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet"
   }
 }


### PR DESCRIPTION
With ASQ (ASB is broken for now) it's possible to use the default connection string rather than specify one. This PR updates the ASQ sample to remove the requirement to specify the connection string.