### PR TITLE
Added a comment in the snippets for SendOnly endpoints to clear up ambiguity

### DIFF
--- a/Snippets/Core/Core_5/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_5/Hosting/Hosting.cs
@@ -10,6 +10,7 @@
             #region Hosting-SendOnly
 
             var busConfiguration = new BusConfiguration();
+            // Apply other necessary endpoint configuration
             var sendOnlyBus = Bus.CreateSendOnly(busConfiguration);
 
             #endregion

--- a/Snippets/Core/Core_6/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_6/Hosting/Hosting.cs
@@ -12,6 +12,7 @@
             #region Hosting-SendOnly
 
             var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            // Apply other necessary endpoint configuration
             endpointConfiguration.SendOnly();
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
@@ -63,6 +64,7 @@
 
             var containerBuilder = new ContainerBuilder();
             var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            // Apply other necessary endpoint configuration
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
             containerBuilder.Register(_ => endpointInstance).InstancePerDependency();

--- a/Snippets/Core/Core_7/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_7/Hosting/Hosting.cs
@@ -13,6 +13,7 @@
 
             var endpointConfiguration = new EndpointConfiguration("EndpointName");
             endpointConfiguration.SendOnly();
+            // Apply other necessary endpoint configuration
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
 

--- a/Snippets/Core/Core_7/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_7/Hosting/Hosting.cs
@@ -64,6 +64,7 @@
 
             var containerBuilder = new ContainerBuilder();
             var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            // Apply other necessary endpoint configuration
             var endpointInstance = await Endpoint.Start(endpointConfiguration)
                 .ConfigureAwait(false);
             containerBuilder.Register(_ => endpointInstance).InstancePerDependency();


### PR DESCRIPTION
Docs Link: https://docs.particular.net/nservicebus/hosting/?

The code snippet that shows how to configure the send only endpoint implies that no other configuration is required for configuring the endpoint as send-only. However the user still needs to supply the needed configuration such as transport, etc.

This was reported by a customer. 