### PR TITLE
LogManager.Use TestingLoggerFactory only works for one use

### DIFF
--- a/Snippets/Testing/Testing_7/Logging/LoggingTest.cs
+++ b/Snippets/Testing/Testing_7/Logging/LoggingTest.cs
@@ -24,5 +24,20 @@ public class LoggingTests
 
         StringAssert.Contains("Some log message", logStatements.ToString());
     }
+    [Test]
+    public async Task ShouldLogCorrectlyASecondTime()
+    {
+        var logStatements = new StringBuilder();
+
+        LogManager.Use<TestingLoggerFactory>()
+            .WriteTo(new StringWriter(logStatements));
+
+        var handler = new MyHandlerWithLogging();
+
+        await handler.Handle(new MyRequest(), new TestableMessageHandlerContext())
+            .ConfigureAwait(false);
+
+        StringAssert.Contains("Some log message", logStatements.ToString());
+    }
     #endregion
 }


### PR DESCRIPTION
since it is a static config, the second time you 

```
 LogManager.Use<TestingLoggerFactory>()
            .WriteTo(new StringWriter(logStatements));
```

it is ignored since the handler has already setup its logger in the static context.

`ShouldLogCorrectlyASecondTime` will fail after `ShouldLogCorrectly` runs first