### PR TITLE
Update to the latest Functions (fixed logging and re-added FunctionExecutionContext)

### DIFF
--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.0-function-executi0001" />
+    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.0-alpha0038" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.0-alpha0034" />
+    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.0-function-executi0001" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
@@ -28,7 +28,7 @@ public class AzureServiceBusTriggerFunction
 
     private static readonly FunctionEndpoint endpoint = new FunctionEndpoint(executionContext =>
     {
-        var configuration = new ServiceBusTriggeredEndpointConfiguration(EndpointName, executionContext.Logger, ConnectionStringName);
+        var configuration = new ServiceBusTriggeredEndpointConfiguration(EndpointName, ConnectionStringName);
         configuration.UseSerialization<NewtonsoftSerializer>();
 
         // optional: log startup diagnostics using Functions provided logger
@@ -48,7 +48,7 @@ public class AzureServiceBusTriggerFunction
     private static readonly FunctionEndpoint autoConfiguredEndpoint = new FunctionEndpoint(executionContext =>
     {
         // endpoint name, logger, and connection strings are automatically derived from FunctionName and ServiceBusTrigger attributes
-        var configuration = ServiceBusTriggeredEndpointConfiguration.FromAttributes(executionContext);
+        var configuration = ServiceBusTriggeredEndpointConfiguration.FromAttributes();
 
         configuration.UseSerialization<NewtonsoftSerializer>();
 

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.0-function-executi0001" />
+    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.0-alpha0038" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.0-alpha0034" />
+    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.0-function-executi0001" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureStorageQueueTriggerFunction.cs
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureStorageQueueTriggerFunction.cs
@@ -27,7 +27,7 @@ public class AzureStorageQueueTriggerFunction
 
     private static FunctionEndpoint endpoint = new FunctionEndpoint(executionContext =>
     {
-        var configuration = new StorageQueueTriggeredEndpointConfiguration(EndpointName, executionContext.Logger);
+        var configuration = new StorageQueueTriggeredEndpointConfiguration(EndpointName);
 
         configuration.UseSerialization<NewtonsoftSerializer>();
 
@@ -48,7 +48,7 @@ public class AzureStorageQueueTriggerFunction
     private static readonly FunctionEndpoint autoConfiguredEndpoint = new FunctionEndpoint(executionContext =>
     {
         // endpoint name, logger, and connection strings are automatically derived from FunctionName and QueueTrigger attributes
-        var configuration = StorageQueueTriggeredEndpointConfiguration.FromAttributes(executionContext);
+        var configuration = StorageQueueTriggeredEndpointConfiguration.FromAttributes();
 
         configuration.UseSerialization<NewtonsoftSerializer>();
 


### PR DESCRIPTION
To contrast with PR #4482 

Specifically, this PR is using `FunctionExecutionContext` exposing `ILogger`:

https://github.com/Particular/docs.particular.net/blob/3358576500883f66158eb9e798dd578d48e29ba3/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs#L35-L39