### PR TITLE
Remove backwards compatibility

### DIFF
--- a/nservicebus/gateway/index.md
+++ b/nservicebus/gateway/index.md
@@ -76,6 +76,6 @@ partial: recoverability
 
 ### Version compatibility
 
-The gateway component ensures only forward compatibility for one major version. That means a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the Gateway package targeting NServiceBus 5.x).
+The gateway component ensures only compatibility for one major version. That means a message sent by the NServiceBus 3.x Gateway can be understood by the NServiceBus 4.x Gateway, and a message sent by the NServiceBus 4.x Gateway can be understood by NServiceBus.Gateway 1.x (the Gateway package targeting NServiceBus 5.x).
 
-However, a message sent by the NServiceBus 3.x Gateway will not be understood by NServiceBus.Gateway 1.x (NServiceBus 5.x) as this skips a major version. Likewise, a message sent by NServiceBus.Gateway 2.x will not be understood by NServiceBus.Gateway 1.x, as backwards communication is not supported.
+However, a message sent by the NServiceBus 3.x Gateway will not be understood by NServiceBus.Gateway 1.x (NServiceBus 5.x) as this skips a major version.


### PR DESCRIPTION
We say that backwards compatibility is not supported but I see no reason why. I pinged in the support channel to get specifics and no answer given.

In the absence of any real reasons, we should not say it's not supported. If it is in-fact not supported, we should give reasons why and not just say "It might work, but we don't guarantee it". This causes confusion for customers so we should be clearer here.

This PR is an attempt to get consensus on this and make sure the decision is made explicitly.