### PR TITLE
Tutorials --> monitoring-setup --> sp url fix

### DIFF
--- a/tutorials/monitoring-setup/index.md
+++ b/tutorials/monitoring-setup/index.md
@@ -140,7 +140,7 @@ NOTE: Make sure that ServiceControl and ServiceControl monitoring instances are 
 
 [ServicePulse](/servicepulse/) is a web application for production monitoring and recoverability. It connects to a monitoring instance to display monitoring data and to a ServiceControl instance to display recoverability data.
 
-Download and run the latest [ServicePulse installer](https://github.com/Particular/ServicePulse/releases/download/1.10.1/Particular.ServicePulse-1.10.1.exe).
+Download and run the latest [ServicePulse installer](https://github.com/Particular/ServicePulse/releases/).
 
 NOTE: In order to configure ServicePulse to connect to a ServiceControl monitoring instance you must download the latest version, then uninstall your current version and install the downloaded version.
 


### PR DESCRIPTION
This is the simplest variant of the fix. Just to point user to the list of releases that is sorted by latest version.

Or we should implement something to automatically identify the latest release, to prepare the latest *.exe link. Something like we have for SC on this page. In this case it's better to ignore this PR and to create an issue.