### PR TITLE
Fix ASP.NET Core samples

### DIFF
--- a/samples/dependency-injection/aspnetcore/Core_7.2/Sample/Sample.Core.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7.2/Sample/Sample.Core.csproj
@@ -7,6 +7,6 @@
     <ProjectReference Include="..\NServiceBus.Extensions.DependencyInjection\NServiceBus.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/samples/dependency-injection/aspnetcore/Core_7.2/SampleAutofac/SampleAutofac.Core.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7.2/SampleAutofac/SampleAutofac.Core.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.*" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/samples/gateway/Gateway_3/WebClient.Core/Properties/launchSettings.json
+++ b/samples/gateway/Gateway_3/WebClient.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:64485/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebClient.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:64486/"
+    }
+  }
+}

--- a/samples/gateway/Gateway_3/WebClient.Core/WebClient.Core.csproj
+++ b/samples/gateway/Gateway_3/WebClient.Core/WebClient.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
@@ -7,6 +7,6 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/samples/showcase/on-premises/Core_7/Store.ECommerce.Core/Properties/launchSettings.json
+++ b/samples/showcase/on-premises/Core_7/Store.ECommerce.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:64875/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Store.ECommerce.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:64876/"
+    }
+  }
+}

--- a/samples/showcase/on-premises/Core_7/Store.ECommerce.Core/Store.ECommerce.Core.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ECommerce.Core/Store.ECommerce.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Alexinea.Autofac.Extensions.DependencyInjection" Version="4.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/AsyncPagesMVC.Core.csproj
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/AsyncPagesMVC.Core.csproj
@@ -1,15 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/Properties/launchSettings.json
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:64996/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "AsyncPagesMVC.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:64997/"
+    }
+  }
+}

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/Startup.cs
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC.Core/Startup.cs
@@ -24,13 +24,13 @@ namespace AsyncPagesMVC.Core
             services.AddMvc();
             var builder = new ContainerBuilder();
 
-			builder.Populate(services);
+            builder.Populate(services);
 
-			builder.Register(c => endpoint)
-				.As<IEndpointInstance>()
-				.SingleInstance();
+            builder.Register(c => endpoint)
+                .As<IEndpointInstance>()
+                .SingleInstance();
 
-			var container = builder.Build();
+            var container = builder.Build();
 
             var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.WebApplication");
             endpointConfiguration.MakeInstanceUniquelyAddressable("1");
@@ -55,7 +55,6 @@ namespace AsyncPagesMVC.Core
 
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
 

--- a/samples/web/asp-web-application/Core_7/WebApplication.Core/Properties/launchSettings.json
+++ b/samples/web/asp-web-application/Core_7/WebApplication.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65145/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApplication.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:65146/"
+    }
+  }
+}

--- a/samples/web/asp-web-application/Core_7/WebApplication.Core/Startup.cs
+++ b/samples/web/asp-web-application/Core_7/WebApplication.Core/Startup.cs
@@ -56,7 +56,6 @@ namespace WebApplication.Core
 
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
 

--- a/samples/web/asp-web-application/Core_7/WebApplication.Core/WebApplication.Core.csproj
+++ b/samples/web/asp-web-application/Core_7/WebApplication.Core/WebApplication.Core.csproj
@@ -1,17 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_7.2/WebApplication/WebApplication.Core.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7.2/WebApplication/WebApplication.Core.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/Properties/launchSettings.json
+++ b/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65407/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApplication.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:65408/"
+    }
+  }
+}

--- a/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/Startup.cs
+++ b/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/Startup.cs
@@ -54,7 +54,6 @@ namespace WebApplication.Core
 
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
 

--- a/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/WebApplication.Core.csproj
+++ b/samples/web/send-from-mvc-controller/Core_7/WebApplication.Core/WebApplication.Core.csproj
@@ -1,15 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />

--- a/samples/web/send-from-nancy-module/Core_7/WebApplication.Core/Properties/launchSettings.json
+++ b/samples/web/send-from-nancy-module/Core_7/WebApplication.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49235/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApplication.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:49236/"
+    }
+  }
+}

--- a/samples/web/send-from-nancy-module/Core_7/WebApplication.Core/WebApplication.Core.csproj
+++ b/samples/web/send-from-nancy-module/Core_7/WebApplication.Core/WebApplication.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\Shared\Shared.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
   </ItemGroup>
 </Project>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleEndpoint/SampleEndpoint.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleEndpoint/SampleEndpoint.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleWeb/SampleWeb.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleWeb/SampleWeb.Core.csproj
@@ -1,16 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="SampleClient.html" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="NServiceBus.Attachments.Sql.Raw" Version="1.*" />
     <PackageReference Include="NServiceBus.SqlServer.HttpPassthrough" Version="4.*" />

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleWeb/SampleWeb.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/SampleWeb/SampleWeb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <LangVersion>7.1</LangVersion>
@@ -7,10 +7,10 @@
     <Content Include="SampleClient.html" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="NServiceBus.Attachments.Sql.Raw" Version="1.*" />
     <PackageReference Include="NServiceBus.SqlServer.HttpPassthrough" Version="4.*" />

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Shared/Shared.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Shared/Shared.Core.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Tests/Tests.Core.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Tests/Tests.Core.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.*" />
   </ItemGroup>

--- a/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Tests/Tests.csproj
+++ b/samples/web/sql-http-passthrough/SqlHttpPassthrough_4/Tests/Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.*" />
   </ItemGroup>


### PR DESCRIPTION
Now that the DocsEngine fix has been deployed, we can properly update the ASP.NET Core samples.

This updates the projects to use the `Microsoft.AspNetCore.App` package.