### PR TITLE
Azure Functions bug fix

### DIFF
--- a/nservicebus/hosting/azure-functions/index.md
+++ b/nservicebus/hosting/azure-functions/index.md
@@ -5,7 +5,7 @@ tags:
  - Hosting
 related:
  - samples/azure/functions
-reviewed: 2019-08-28
+reviewed: 2019-09-23
 ---
 
 Azure Functions, and serverless computing in general, are designed to accelerate and simplify application development. NServiceBus endpoints can be hosted in Azure Functions and are subject to the constraints enforced by the Azure Functions hosting and development model.
@@ -26,6 +26,5 @@ When using Azure Functions with Azure Service Bus (ASB) or Azure Storage Queues 
   - Other triggers will not result in the invocation of the NServiceBus pipeline, but can be used with a send-only endpoint to translate a function invocation into a command.
 - The Configuration API exposes NServiceBus transport configuration options via the `configuration.Transport` method to allow customization; however, not all of the options will be applicable to execution within Azure Functions.
 - The NServiceBus `ILog` logging abstraction and the Azure Functions `ILogger` are not wired to work together.
-- While the Azure Functions runtime uses the default connection string in the app setting that is named "AzureWebJobsServiceBus" (ASB) or "AzureWebJobsStorage" (ASQ), there's a [bug](https://github.com/Azure/azure-functions-servicebus-extension/issues/7) with the Service Bus and the trigger connection has to be specified.
 - When using the default recoverability or specifying custom number of immediate retries, the number of delivery attempts specified on the underlying queue (ASB) or Azure Functions host (ASB) must be more than then number of the immediate retries. The Azure Functions defaults are 10 (`MaxDeliveryCount`) for the ASB trigger and 5 (`DequeueCount`) for the ASQ trigger.
 - Delayed Retries are supported only with Azure Service Bus, and not with Azure Storage Queues.

--- a/samples/azure/functions/index.md
+++ b/samples/azure/functions/index.md
@@ -1,6 +1,6 @@
 ---
 title: Using NServiceBus in Azure Functions
-reviewed: 2019-08-27
+reviewed: 2019-09-23
 ---
 
 include: azure-functions-experimental

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureFunctions.ASBTrigger.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
@@ -10,7 +10,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.AzureFunctions.ServiceBus" Version="0.1.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
   </ItemGroup>

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
@@ -8,7 +8,6 @@ using NServiceBus.AzureFunctions.ServiceBus;
 public class AzureServiceBusTriggerFunction
 {
     private const string EndpointName = "ASBTriggerQueue";
-    private const string ConnectionStringName = "ASBConnectionString";
 
     #region Function
 

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.ASBTrigger/AzureServiceBusTriggerFunction.cs
@@ -14,7 +14,7 @@ public class AzureServiceBusTriggerFunction
 
     [FunctionName(EndpointName)]
     public static async Task Run(
-        [ServiceBusTrigger(queueName: EndpointName, Connection = ConnectionStringName )]
+        [ServiceBusTrigger(queueName: EndpointName)]
         Message message,
         ILogger logger,
         ExecutionContext executionContext)
@@ -28,7 +28,7 @@ public class AzureServiceBusTriggerFunction
 
     private static readonly FunctionEndpoint endpoint = new FunctionEndpoint(executionContext =>
     {
-        var configuration = new ServiceBusTriggeredEndpointConfiguration(EndpointName, ConnectionStringName);
+        var configuration = new ServiceBusTriggeredEndpointConfiguration(EndpointName);
         configuration.UseSerialization<NewtonsoftSerializer>();
 
         // optional: log startup diagnostics using Functions provided logger

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.Console/Program.cs
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/AzureFunctions.Console/Program.cs
@@ -43,7 +43,7 @@ class Program
             endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
 
             var transport = endpointConfiguration.UseTransport<AzureServiceBusTransport>();
-            transport.ConnectionString(config.GetValue<string>("Values:ASBConnectionString"));
+            transport.ConnectionString(config.GetValue<string>("Values:AzureWebJobsServiceBus"));
 
             asbEndpoint = await Endpoint.Start(endpointConfiguration);
         }

--- a/samples/azure/functions/service-bus/ASBFunctions_0.1/local.settings.json
+++ b/samples/azure/functions/service-bus/ASBFunctions_0.1/local.settings.json
@@ -4,6 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
-    "ASBConnectionString": "<set your ASB connection string here>"
+    "AzureWebJobsServiceBus": "<set your ASB connection string here>"
   }
 }

--- a/samples/azure/functions/service-bus/sample.md
+++ b/samples/azure/functions/service-bus/sample.md
@@ -1,6 +1,6 @@
 ---
 title: Using NServiceBus in Azure Functions with Service Bus triggers
-reviewed: 2019-09-01
+reviewed: 2019-09-23
 component: ASBFunctions
 related:
  - samples/azure/functions/storage-queues

--- a/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
+++ b/samples/azure/functions/storage-queues/ASQFunctions_0.1/AzureFunctions.ASQTrigger/AzureFunctions.ASQTrigger.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.0" />
+    <PackageReference Include="NServiceBus.AzureFunctions.StorageQueues" Version="0.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />

--- a/samples/azure/functions/storage-queues/sample.md
+++ b/samples/azure/functions/storage-queues/sample.md
@@ -1,6 +1,6 @@
 ---
 title: Using NServiceBus in Azure Functions with Storage Queue triggers
-reviewed: 2019-09-01
+reviewed: 2019-09-23
 component: ASQFunctions
 related:
  - samples/azure/functions/service-bus


### PR DESCRIPTION
- Removed the need to specify Service Bus Connection string setting name, following the same model as Storage Queues sample.
- Removed constraint from the [constraints and limitation document](https://docs.particular.net/nservicebus/hosting/azure-functions/) 
> - While the Azure Functions runtime uses the default connection string in the app setting that is named "AzureWebJobsServiceBus" (ASB) or "AzureWebJobsStorage" (ASQ), there's a bug with the Service Bus and the trigger connection has to be specified.