### PR TITLE
Business Continuity / Disaster Recovery configuration for SC

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1128,6 +1128,8 @@
         Url: servicecontrol/securing-servicecontrol
       - Title: Non-Privileged Accounts
         Url: servicecontrol/configure-non-privileged-service-account
+      - Title: Business Continuity / Disaster Recovery
+        Url: servicecontrol/bcdr
     - Title: Installation
       Url: servicecontrol/installation
       Articles:

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -43,7 +43,7 @@ To install this configuration perform the following actions:
 1. Create the standard error and audit queues.
 1. Create the backup error and audit queues.
 1. Set up the primary ServiceControl instances and configure them to forward errors and audit messages to the backup queues.
-1. Setup the backup ServiceControl instances and configure them to use the backup queues.
+1. Set up the backup ServiceControl instances and configure them to use the backup queues.
 
 WARN: Make sure the names of the backup ServiceControl instances are named differently from the primary ServiceControl instances otherwise unexpected behavior may result.
 

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -36,7 +36,7 @@ SCAA --forwards to-->AB
 AB --ingested by-->SCAB
 ```
 
-This configuration works by combining multiple instances with [aduit log forwarding](creating-config-file.md#servicecontrolforwardauditmessages) and [error log forwarding](creating-config-file.md#servicebuserrorlogqueue). Failed and audited messages will be forwarded by the primary instances to the backup instances through log forwarding queues.
+This configuration works by combining multiple instances with [audit log forwarding](creating-config-file.md#servicecontrolforwardauditmessages) and [error log forwarding](creating-config-file.md#servicebuserrorlogqueue). Failed and audited messages will be forwarded by the primary instances to the backup instances through log forwarding queues.
 
 To install this configuration perform the following actions:
 

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -36,7 +36,7 @@ SCAA --forwards to-->AB
 AB --ingested by-->SCAB
 ```
 
-This configuration works by combining multiple instances with [audit log forwarding](creating-config-file.md#servicecontrolforwardauditmessages) and [error log forwarding](creating-config-file.md#servicebuserrorlogqueue). Failed and audited messages will be forwarded by the primary instances to the backup instances through log forwarding queues.
+This configuration works by combining multiple instances with [audit log forwarding](creating-config-file.md#transport-servicebusauditlogqueue) and [error log forwarding](creating-config-file.md#transport-servicebuserrorlogqueue). Failed and audited messages will be forwarded by the primary instances to the backup instances through log forwarding queues.
 
 To install this configuration perform the following actions:
 

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -49,7 +49,7 @@ WARN: Make sure the names of the backup ServiceControl instances are named diffe
 
 ## How retrying works
 
-Retrying a message from the primary instance will work as usual, however the backup instances will not update the status of the failed messages to retry pending. Once the successful audit message is received the backup instance will be notified as well and the failed message record in both instances will reflect the messages as having been successfully retried.
+Retrying a message from the primary instance will work as usual, however the backup instances will not update the status of the failed messages to "retry pending". Once the successful audit message is received, the backup instance will be notified as well and the failed message record in both instances will reflect the messages as having been successfully retried.
 
 WARN: It is possible to duplicate messages when retrying from the backup instance if a retry has already been sent from the primary instance.
 

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -47,7 +47,7 @@ To install this configuration perform the following actions:
 
 WARN: Make sure the names of the backup ServiceControl instances are named differently from the primary ServiceControl instances otherwise unexpected behavior may result.
 
-## What happens when you retry a message
+## How retrying works
 
 Retrying a message from the primary instance will work as usual, however the backup instances will not update the status of the failed messages to retry pending. Once the successful audit message is received the backup instance will be notified as well and the failed message record in both instances will reflect the messages as having been successfully retried.
 

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -1,0 +1,56 @@
+---
+title: Business Continuity / Disaster Recovery
+summary: Solutions for business continuity / disaster recovery with ServiceControl
+reviewed: 2019-10-08
+tags:
+- Backup
+related:
+- servicecontrol/backup-sc-database
+- servicecontrol/deploying-servicecontrol-in-a-cluster
+---
+
+Multiple instances can be used to create a business continuity / disaster recovery configuration. By forwarding failed and audited messages to backup instances of ServiceControl it is possible to resume operations in the case that the primary instances are no longer available.
+
+```mermaid
+graph TD
+EPB[Endpoints] 
+E((error queue))
+EPB --failed messages -->E
+E --ingested by-->SCEA
+EPB --audit messages-->A
+A((audit queue))
+A --ingested by-->SCAA
+subgraph Primary
+SCEA["ServiceControl Instance"]
+SCAA["ServiceControl Audit Instance"]
+end
+subgraph Backup
+SCEB["ServiceControl Instance"]
+SCAB["ServiceControl Audit Instance"]
+end
+EB((error_backup<br/>queue))
+SCEA --forwards to-->EB
+EB --ingested by-->SCEB
+AB((audit_backup<br/>queue))
+SCAA --forwards to-->AB
+AB --ingested by-->SCAB
+```
+
+This configuration works by combining multiple instances with [aduit log forwarding](creating-config-file.md#servicecontrolforwardauditmessages) and [error log forwarding](creating-config-file.md#servicebuserrorlogqueue). Failed and audited messages will be forwarded by the primary instances to the backup instances through log forwarding queues.
+
+To install this configuration perform the following actions:
+
+1. Create an error and audit queue for your endpoints.
+1. Create the backup error and audit queues.
+1. Setup the primary ServiceControl instances and configure them to forward errors and audit messages to the backup queues.
+1. Setup the backup ServiceControl instances and configure them to use the backup queues.
+
+WARN: Make sure the names of the backup ServiceControl instances are named differently from the primary ServiceControl instances otherwise unexpected behavior may result.
+
+## What happens when you retry a message
+
+Retrying a message from the primary instance will work as usual, however the backup instances will not update the status of the failed messages to retry pending. Once the successful audit message is received the backup instance will be notified as well and the failed message record in both instances will reflect the messages as having been successfully retried.
+
+WARN: It is possible to duplicate messages when retrying from the backup instance if a retry has already been sent from the primary instance.
+
+

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -42,7 +42,7 @@ To install this configuration perform the following actions:
 
 1. Create the standard error and audit queues.
 1. Create the backup error and audit queues.
-1. Setup the primary ServiceControl instances and configure them to forward errors and audit messages to the backup queues.
+1. Set up the primary ServiceControl instances and configure them to forward errors and audit messages to the backup queues.
 1. Setup the backup ServiceControl instances and configure them to use the backup queues.
 
 WARN: Make sure the names of the backup ServiceControl instances are named differently from the primary ServiceControl instances otherwise unexpected behavior may result.

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -40,7 +40,7 @@ This configuration works by combining multiple instances with [aduit log forward
 
 To install this configuration perform the following actions:
 
-1. Create an error and audit queue for your endpoints.
+1. Create the standard error and audit queues.
 1. Create the backup error and audit queues.
 1. Setup the primary ServiceControl instances and configure them to forward errors and audit messages to the backup queues.
 1. Setup the backup ServiceControl instances and configure them to use the backup queues.

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -9,7 +9,7 @@ related:
 - servicecontrol/deploying-servicecontrol-in-a-cluster
 ---
 
-Multiple instances can be used to create a business continuity / disaster recovery configuration. By forwarding failed and audited messages to backup instances of ServiceControl it is possible to resume operations in the case that the primary instances are no longer available.
+Multiple ServiceControl instances can be used to create a business continuity / disaster recovery configuration. By forwarding failed and audited messages to backup instances of ServiceControl it is possible to resume operations in the case that the primary instances are no longer available.
 
 ```mermaid
 graph TD

--- a/servicecontrol/bcdr.md
+++ b/servicecontrol/bcdr.md
@@ -2,8 +2,6 @@
 title: Business Continuity / Disaster Recovery
 summary: Solutions for business continuity / disaster recovery with ServiceControl
 reviewed: 2019-10-08
-tags:
-- Backup
 related:
 - servicecontrol/backup-sc-database
 - servicecontrol/deploying-servicecontrol-in-a-cluster


### PR DESCRIPTION
This is a potential configuration for ServiceControl which allows for business continuity / disaster recovery without the use of Windows Clusters, for instance in the case of using multiple availability zones in a cloud provider.