### PR TITLE
Document code-first license API behavior

### DIFF
--- a/nservicebus/licensing/index_license-management_core_[7,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,].partial.md
@@ -4,6 +4,14 @@ Depending on the operating system, the paths may be case sensitive.
 NServiceBus uses the [`Environment.GetFolderPath(SpecialFolder)`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.getfolderpath) method to determine the locations of some paths on each OS.
 }}
 
+### Code-first configuration
+
+A license can be configured via code first configuration API:
+
+snippet: License
+
+NOTE: Licenses configured via code-first API take precendence over every other license source.
+
 
 ### Application-specific license location
 
@@ -28,13 +36,6 @@ This location can be expressed using environment variables on Windows, or as a l
 
 * Windows: `%PROGRAMDATA%\ParticularSoftware\license.xml`
 * Linux/macOS: `/usr/share/ParticularSoftware/license.xml`
-
-
-### Code-first configuration
-
-A license can be configured via code first configuration API:
-
-snippet: License
 
 
 ### Application configuration file


### PR DESCRIPTION
Documenting the changes made in https://github.com/Particular/NServiceBus/pull/5453

I did not mention anything about this being shipped only as part of 7.2 as the discussion in https://github.com/Particular/NServiceBus/pull/5453 evolved around the assumption of this being a bug fixed in 7.2 so it's fair to state this as the expected behavior in v7. Thoughts?