### PR TITLE
Add recommendations for upgrade procedure due to major version upgrade

### DIFF
--- a/persistence/mongodb/migrating-from-sbmako.md
+++ b/persistence/mongodb/migrating-from-sbmako.md
@@ -13,6 +13,12 @@ This package was designed to be fully compatible with the community [`NServiceBu
 
 include: migration-warning
 
+
+## NServiceBus upgrade
+
+`NServiceBus.Storage.MongoDB` is available for NServiceBus Version 7 and later. It is recommended to upgrade endpoints to NServiceBus Version 7 before migrating to the `NServiceBus.Storage.MongoDB` package.
+
+
 ## Configuration
 
 Use the following compatibility API to configure the package to work with existing saga data:

--- a/persistence/mongodb/migrating-from-tekmaven.md
+++ b/persistence/mongodb/migrating-from-tekmaven.md
@@ -13,6 +13,12 @@ The `NServiceBus.Storage.MongoDB` package was designed to be fully compatible wi
 
 include: migration-warning
 
+
+## NServiceBus upgrade
+
+`NServiceBus.Storage.MongoDB` is available for NServiceBus Version 7 and later. When migrating from `NServiceBus.Persistence.MongoDB` it is recommended to remove the persistence package and upgrade the endpoint to NServiceBus Version 7 before installing the `NServiceBus.Storage.MongoDB` package.
+
+
 ## Customizing the connection
 
 `NServiceBus.Storage.MongoDB` does not provide a configuration setting to pass a connection string directly. Instead, a `MongoClient` can be passed to the new configuration API.


### PR DESCRIPTION
some more feedback based on the migration walkthroughs.

Mention in the upgrade guides that a migration to NServiceBus 7 is currently mandatory as this is non-obvious otherwise.

This isn't true for the `NServiceBus.MongoDB` package as it supports v7 of NSB by now.