### PR TITLE
Clarify ServiceControl 3to4 upgrade guide

### DIFF
--- a/servicecontrol/upgrades/2to3.md
+++ b/servicecontrol/upgrades/2to3.md
@@ -55,3 +55,8 @@ The transports above have been tweaked with sensible defaults and manual configu
 ### Upgrading ServiceControl
 
 Once the prerequisites are met the upgrade to ServiceControl version 3 can be done as an in-place upgrade.
+
+
+### Time for upgrade
+
+This upgrade does not contain any data migrations, so the size of the database does not have any impact on the time to perform the upgrade.

--- a/servicecontrol/upgrades/3to4/index.md
+++ b/servicecontrol/upgrades/3to4/index.md
@@ -30,7 +30,7 @@ ServiceControl Management version 4 cannot be used to edit ServiceControl instan
 Upgrades that include the separate Audit embedded database will increase disk usage since databases are not automatically compacted. The new Audit embedded database will grow to the same peak storage usage as the original ServiceControl instance embedded audit message storage usage unless the original instance database is compacted after the data is removed via the audit retention process. This could result in as much as double the data usage.
 
 {{NOTE:
-After the upgrade is complete, the Audit information contained in the original ServiceControl instance will become read-only, but will continue to be deleted as it passes the time specified by the retention policy. However, since RavenDB does not release storage space back to the OS, the database will continue to be the same size.
+After the upgrade is complete, the Audit information contained in the original ServiceControl instance will become read-only, but will continue to be deleted as it passes the time specified by the [retention policy](/servicecontrol/creating-config-file.md#data-retention). However, since the internal database does not release storage space back to the OS, the database will continue to be the same size.
 
 After one retention period after upgrade has elapsed, the original ServiceControl instance's database will be mostly empty. At that point, the original database can be compacted to a very small size. See [Compacting RavenDB](/servicecontrol/db-compaction.md) for instructions on compacting the database of the original ServiceControl instance once old audit messages have been cleaned up by the retention policy.
 }}

--- a/servicecontrol/upgrades/3to4/index.md
+++ b/servicecontrol/upgrades/3to4/index.md
@@ -11,6 +11,10 @@ Upgrading ServiceControl from version 3 to version 4 is a major upgrade and requ
 
 ## Planning
 
+### Time for upgrade
+
+This upgrade does not contain any data migrations, so the size of the database does not have any impact on the time to perform the upgrade.
+
 ### Required minimum version
 
 Before upgrading to ServiceControl version 4 the instance being upgraded must be upgraded to at least [version 3.8.2](https://github.com/Particular/ServiceControl/releases/tag/3.8.2).
@@ -25,7 +29,11 @@ ServiceControl Management version 4 cannot be used to edit ServiceControl instan
 
 Upgrades that include the separate Audit embedded database will increase disk usage since databases are not automatically compacted. The new Audit embedded database will grow to the same peak storage usage as the original ServiceControl instance embedded audit message storage usage unless the original instance database is compacted after the data is removed via the audit retention process. This could result in as much as double the data usage.
 
-See [Compacting RavenDB](/servicecontrol/db-compaction.md) for instructions on compacting the database of the original ServiceControl instance once old audit messages have been cleaned up by the retention policy.
+{{NOTE:
+After the upgrade is complete, the Audit information contained in the original ServiceControl instance will become read-only, but will continue to be deleted as it passes the time specified by the retention policy. However, since RavenDB does not release storage space back to the OS, the database will continue to be the same size.
+
+After one retention period after upgrade has elapsed, the original ServiceControl instance's database will be mostly empty. At that point, the original database can be compacted to a very small size. See [Compacting RavenDB](/servicecontrol/db-compaction.md) for instructions on compacting the database of the original ServiceControl instance once old audit messages have been cleaned up by the retention policy.
+}}
 
 
 ## ServiceControl Audit


### PR DESCRIPTION
* Note explicitly that there are no lengthy data migrations
* Be more specific about how original SC database can be compacted after 1 retention period has elapsed.