### PR TITLE
UseNServiceBus must be specified before ConfigureWebHostDefaults

### DIFF
--- a/nservicebus/hosting/extensions-hosting.md
+++ b/nservicebus/hosting/extensions-hosting.md
@@ -17,6 +17,7 @@ snippet: extensions-host-configuration
 
 This code will register the endpoint with the hosting infrastructure and automatically start and stop it based on the host's application lifetime.
 
+WARNING: `UseNServiceBus` must be specified before any other service (e.g. `ConfigureWebHostDefaults`) which requires access to the `IMessageSession`.
 
 ## Dependency injection integration
 


### PR DESCRIPTION
See https://github.com/Particular/NServiceBus.Extensions.Hosting/issues/23

Looking at the implementation, the asp.net web hosting is also using an `IHostedService`. Given those are Started in order and the web host seems to start accepting requests right after that, there is a race condition which might lead to the message session not being available yet (and therefore breaking the lazy). Ensuring that the NServiceBus hosted service starts first should resolve this problem.

Documenting this behavior for now, going to raise a dedicated issue about this in a bit.