### PR TITLE
Preview images for tweetable content

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ Causes two things:
 
  * Stops search engines from finding the page using a `<meta name="robots" content="noindex" />`.
  * Prevents the page from being found in the docs search.
+ 
+ 
+### Preview Image
+
+```
+previewImage: preview-image.png
+```
+
+Populates a feature image for the [Open Graph](http://ogp.me/) and [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started.html) meta tags for social sharing.
+
+The URL should be a relative URL, usually just the filename in the same directory as the article, but `../` to go up a directory is also supported. If it works in a Markdown image tag `![](relative-url.png)` then it should work for the metadata.
 
 
 ### Related

--- a/samples/logging/application-insights/sample.md
+++ b/samples/logging/application-insights/sample.md
@@ -11,6 +11,7 @@ related:
  - samples/azure
 redirects:
 - samples/application-insights
+previewImage: example-graph-events.png
 ---
 
 

--- a/samples/logging/new-relic/sample.md
+++ b/samples/logging/new-relic/sample.md
@@ -4,6 +4,7 @@ summary: Illustrates how to capture, store and visualize NServiceBus metrics in 
 component: Metrics
 isLearningPath: true
 reviewed: 2019-07-22
+previewImage: newrelic-processingtime.png
 ---
 
 ## Introduction

--- a/samples/logging/prometheus-grafana/sample.md
+++ b/samples/logging/prometheus-grafana/sample.md
@@ -4,6 +4,7 @@ summary: Illustrates using Prometheus and Grafana to capture and visualize NServ
 component: Metrics
 isLearningPath: true
 reviewed: 2019-07-22
+previewImage: grafana-graph.png
 ---
 
 

--- a/tutorials/message-replay/tutorial.md
+++ b/tutorials/message-replay/tutorial.md
@@ -2,6 +2,7 @@
 title: Message replay tutorial
 reviewed: 2019-03-07
 summary: In this tutorial, you'll learn how to replay a failed message using the Particular Service Platform tools.
+previewImage: failed-message-groups.png
 ---
 
 One of the most powerful features of NServiceBus is the ability to replay a message that has failed. By the time a message reaches the error queue, it will have already progressed through multiple retries via the [immediate retries](/nservicebus/recoverability/#immediate-retries) and [delayed retries](/nservicebus/recoverability/#delayed-retries) process, so you can be sure that the exception is systemic.

--- a/tutorials/quickstart/tutorial.md
+++ b/tutorials/quickstart/tutorial.md
@@ -7,6 +7,7 @@ extensions:
 - !!tutorial
   nextText: "Next: NServiceBus from the ground up"
   nextUrl: tutorials/nservicebus-step-by-step/1-getting-started
+previewImage: add-shipping-endpoint.png
 ---
 
 include: quickstart-tutorial-intro-paragraph


### PR DESCRIPTION
Since https://github.com/Particular/DocsEngine/pull/429 is deployed, pages that we share on Twitter can have a preview image to go with the other metadata.