### PR TITLE
Fix throttling sample

### DIFF
--- a/samples/throttling/Core_6/Limited/ThrottlingBehavior.cs
+++ b/samples/throttling/Core_6/Limited/ThrottlingBehavior.cs
@@ -21,6 +21,7 @@ public class ThrottlingBehavior :
             log.Info($"Rate limit exceeded. Retry after {rateLimitReset} UTC ({localTime} local).");
             await DelayMessage(context, rateLimitReset.Value)
                 .ConfigureAwait(false);
+            return;
         }
 
         try

--- a/samples/throttling/Core_7/Limited/ThrottlingBehavior.cs
+++ b/samples/throttling/Core_7/Limited/ThrottlingBehavior.cs
@@ -21,6 +21,7 @@ public class ThrottlingBehavior :
             log.Info($"Rate limit exceeded. Retry after {rateLimitReset} UTC ({localTime} local).");
             await DelayMessage(context, rateLimitReset.Value)
                 .ConfigureAwait(false);
+            return;
         }
 
         try


### PR DESCRIPTION
Without returning at this point, the handler will be invoked, will cause the throttling exception and cause a second delayed message to go out, effectively eliminating the purpose of the first check + creating duplicates.