### PR TITLE
Data bus name fix

### DIFF
--- a/transports/azure-service-bus/index.md
+++ b/transports/azure-service-bus/index.md
@@ -21,7 +21,7 @@ The Azure Service Bus transport leverages the .NET Standard [Microsoft.Azure.Ser
 |Transactions |None, ReceiveOnly, SendsWithAtomicReceive
 |Pub/Sub                    |Native
 |Timeouts                   |Native
-|Large message bodies       | with Premium tier or DataBus
+|Large message bodies       | with Premium tier or data bus
 |Scale-out             |Competing consumer
 |Scripted Deployment        |Supported using `NServiceBus.Transport.AzureServiceBus.CommandLine`
 |Installers                 |Optional

--- a/transports/azure-service-bus/legacy/index.md
+++ b/transports/azure-service-bus/legacy/index.md
@@ -34,7 +34,7 @@ include: azure-transports
 |Transactions |None, ReceiveOnly, SendsWithAtomicReceive
 |Pub/Sub                    |Native
 |Timeouts                   |Native
-|Large message bodies       |via higher tier (e.g. Premium) or DataBus
+|Large message bodies       |via higher tier (e.g. Premium) or data bus
 |Scale-out             |Competing consumer
 |Scripted Deployment        | Not supported
 |Installers                 |Optional

--- a/transports/azure-storage-queues/index.md
+++ b/transports/azure-storage-queues/index.md
@@ -26,7 +26,7 @@ include: azure-transports
 |Transactions |None, ReceiveOnly (Message visibility timeout)
 |Pub/Sub                    |Message driven
 |Timeouts                   |Native (Requires Storage Table)
-|Large message bodies       |Databus
+|Large message bodies       |Data bus
 |Scale-out             |Competing consumer
 |Scripted Deployment        |Not supported
 |Installers                 |Mandatory

--- a/transports/msmq/index.md
+++ b/transports/msmq/index.md
@@ -24,7 +24,7 @@ WARNING: As Microsoft is not making MSMQ available for .NET Core, building new s
 |Transactions |None, ReceiveOnly, SendsWithAtomicReceive, TransactionScope
 |Pub/Sub                    |message driven
 |Timeouts                   |via timeouts storage
-|Large message bodies       |via DataBus
+|Large message bodies       |via data bus
 |Scale-out             |Distributor or Windows Network Load Balancing
 |Scripted Deployment        |C#, PowerShell
 |Installers                 |Optional

--- a/transports/sql/index.md
+++ b/transports/sql/index.md
@@ -24,7 +24,7 @@ WARNING: Although this transport will run on the free version of the engine, i.e
 |Transactions |None, ReceiveOnly, SendWithAtomicReceive, TransactionScope
 |Pub/Sub                    |Native
 |Timeouts                   |Native
-|Large message bodies       |SqlServer can handle arbitrary message size within available resources, very large messages via DataBus
+|Large message bodies       |SqlServer can handle arbitrary message size within available resources, very large messages via data bus
 |Scale-out             |Competing consumer
 |Scripted Deployment        |Sql Scripts
 |Installers                 |Optional


### PR DESCRIPTION
The work on `Transport at a glance` started before data bus name was standardized.
This PR fixes it.