### PR TITLE
Recommend generic host instead of using an internal DI container

### DIFF
--- a/nservicebus/dependency-injection/extensions-dependencyinjection.md
+++ b/nservicebus/dependency-injection/extensions-dependencyinjection.md
@@ -14,6 +14,7 @@ redirects:
 
 The `NServiceBus.Extensions.DependencyInjection` package provides integration with the `Microsoft.Extensions.DependencyInjection` dependency injection abstraction.
 
+NOTE: It's recommended to use [Microsoft's generic host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) to manage application and dependency injection container lifecycle. Use the [NServiceBus.Extensions.Hosting](/nservicebus/hosting/extensions-hosting.md) package to host an NServiceBus endpoint with the generic host.
 
 ## Usage with ServiceCollection
 


### PR DESCRIPTION
Adds a note to the NServiceBus.Extensions.DependencyInjection doco page to recommend the generic host instead. The generic host should be the better choice generally as it gives users the benefit of an externally managed container (access to the `IServiceProvider` in their code) while not having to configure the externally managed container mode manually