### PR TITLE
Change support stance of SagaAudit plugin

### DIFF
--- a/nservicebus/sagas/saga-audit.md
+++ b/nservicebus/sagas/saga-audit.md
@@ -6,7 +6,7 @@ versions: 'SagaAudit:*'
 reviewed: 2019-09-03
 ---
 
-WARN: This plugin will result in a increase in the load placed on ServiceControl and the endpoint it is installed in. Use only if the environment is able to keep up with the increased load.
+WARN: This plugin will result in a increase in the load placed on ServiceControl and the endpoint it is installed in. It should only be used if the environment is able to keep up with the increased load.
 
 The SagaAudit plugin enables the [Saga View feature in ServiceInsight](/serviceinsight/#the-saga-view). 
 

--- a/nservicebus/sagas/saga-audit.md
+++ b/nservicebus/sagas/saga-audit.md
@@ -6,7 +6,7 @@ versions: 'SagaAudit:*'
 reviewed: 2019-09-03
 ---
 
-DANGER: **For Development only**. This plugin will result in a significant increase in the load placed on ServiceControl. As such it should not be used in production.
+WARN: This plugin will result in a increase in the load placed on ServiceControl and your endpoint. Use only if your environment is able to keep up with the increased load.
 
 The SagaAudit plugin enables the [Saga View feature in ServiceInsight](/serviceinsight/#the-saga-view). 
 

--- a/nservicebus/sagas/saga-audit.md
+++ b/nservicebus/sagas/saga-audit.md
@@ -6,7 +6,7 @@ versions: 'SagaAudit:*'
 reviewed: 2019-09-03
 ---
 
-WARN: This plugin will result in a increase in the load placed on ServiceControl and your endpoint. Use only if your environment is able to keep up with the increased load.
+WARN: This plugin will result in a increase in the load placed on ServiceControl and the endpoint it is installed in. Use only if the environment is able to keep up with the increased load.
 
 The SagaAudit plugin enables the [Saga View feature in ServiceInsight](/serviceinsight/#the-saga-view). 
 


### PR DESCRIPTION
The reasons behind why the SagaAudit plugin was not supported in production are no longer completely valid. The SagaAudit plugin put pressure on both the endpoint as well as ServiceControl. ServiceControl has undergone a number of changes that make it less of a concern (specifically: there have been lots of performance improvements, and ServiceControl itself can be scaled out horizontally). Based on this, I propose changing out stance from "Not supported in production" to a warning stating "Use with caution as this will add pressure to your endpoint and will reduce the processing throughput."