### PR TITLE
Add warning about outbox cleanup when running RavenDB in multi-tenant mode

### DIFF
--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -31,6 +31,8 @@ snippet: OutboxRavendBTimeToKeep
 
 partial: disable-cleanup
 
+WARN: When running in [multi-tenant mode](/persistence/ravendb.md#multi-tenant-support) cleanup needs to be handled manually since NServiceBus can't know what databases are in use.
+
 NOTE: It is advised to run the cleanup task on only one NServiceBus endpoint instance per RavenDB database and disable the cleanup task on all other NServiceBus endpoint instances for the most efficient cleanup execution.
 
 partial: effect-on-docstore

--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -31,7 +31,7 @@ snippet: OutboxRavendBTimeToKeep
 
 partial: disable-cleanup
 
-WARN: When running in [multi-tenant mode](/persistence/ravendb.md#multi-tenant-support), cleanup needs to be manually handled since NServiceBus does not know what databases are in use.
+WARN: When running in [multi-tenant mode](/persistence/ravendb/#multi-tenant-support), cleanup needs to be manually handled since NServiceBus does not know what databases are in use.
 
 NOTE: It is advised to run the cleanup task on only one NServiceBus endpoint instance per RavenDB database and disable the cleanup task on all other NServiceBus endpoint instances for the most efficient cleanup execution.
 

--- a/persistence/ravendb/outbox.md
+++ b/persistence/ravendb/outbox.md
@@ -31,9 +31,8 @@ snippet: OutboxRavendBTimeToKeep
 
 partial: disable-cleanup
 
-WARN: When running in [multi-tenant mode](/persistence/ravendb.md#multi-tenant-support) cleanup needs to be handled manually since NServiceBus can't know what databases are in use.
+WARN: When running in [multi-tenant mode](/persistence/ravendb.md#multi-tenant-support), cleanup needs to be manually handled since NServiceBus does not know what databases are in use.
 
 NOTE: It is advised to run the cleanup task on only one NServiceBus endpoint instance per RavenDB database and disable the cleanup task on all other NServiceBus endpoint instances for the most efficient cleanup execution.
 
 partial: effect-on-docstore
-


### PR DESCRIPTION
This makes the users aware that they need to handle outbox cleanup manually when using the multi-tenant support of the RavenDB persister.