### PR TITLE
Avoid discard syntax when value is used

### DIFF
--- a/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/OrderSaga.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/OrderSaga.cs
@@ -20,7 +20,7 @@ namespace SqlPersistence_1.UsingSaga
 
         protected override void ConfigureMapping(MessagePropertyMapper<SagaData> mapper)
         {
-            mapper.MapMessage<StartOrder>(_ => _.OrderId);
+            mapper.MapMessage<StartOrder>(message => message.OrderId);
         }
 
         public Task Handle(StartOrder message, IMessageHandlerContext context)

--- a/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/SagaWithCorrelation.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/SagaWithCorrelation.cs
@@ -17,7 +17,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(MessagePropertyMapper<SagaData> mapper)
         {
-            mapper.MapMessage<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.MapMessage<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         public Task Handle(StartSagaMessage message, IMessageHandlerContext context)

--- a/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/SagaWithCorrelationAndTransitional.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_1/UsingSaga/SagaWithCorrelationAndTransitional.cs
@@ -18,8 +18,8 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(MessagePropertyMapper<SagaData> mapper)
         {
-            mapper.MapMessage<StartSagaMessage>(_ => _.CorrelationProperty);
-            mapper.MapMessage<StartSagaMessage>(_ => _.TransitionalCorrelationProperty);
+            mapper.MapMessage<StartSagaMessage>(message => message.CorrelationProperty);
+            mapper.MapMessage<StartSagaMessage>(message => message.TransitionalCorrelationProperty);
         }
 
         public Task Handle(StartSagaMessage message, IMessageHandlerContext context)

--- a/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/OrderSaga.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/OrderSaga.cs
@@ -17,7 +17,7 @@ namespace SqlPersistence_1.UsingSaga
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartOrder>(_ => _.OrderId);
+            mapper.ConfigureMapping<StartOrder>(message => message.OrderId);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.OrderId);

--- a/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/SagaWithCorrelation.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/SagaWithCorrelation.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/SagaWithCorrelationAndTransitional.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_2/UsingSaga/SagaWithCorrelationAndTransitional.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/OrderSaga.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/OrderSaga.cs
@@ -17,7 +17,7 @@ namespace SqlPersistence_1.UsingSaga
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartOrder>(_ => _.OrderId);
+            mapper.ConfigureMapping<StartOrder>(message => message.OrderId);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.OrderId);

--- a/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/SagaWithCorrelation.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/SagaWithCorrelation.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/SagaWithCorrelationAndTransitional.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_3/UsingSaga/SagaWithCorrelationAndTransitional.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/OrderSaga.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/OrderSaga.cs
@@ -17,7 +17,7 @@ namespace SqlPersistence_1.UsingSaga
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartOrder>(_ => _.OrderId);
+            mapper.ConfigureMapping<StartOrder>(message => message.OrderId);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.OrderId);

--- a/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/SagaWithCorrelation.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/SagaWithCorrelation.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/SagaWithCorrelationAndTransitional.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_4/UsingSaga/SagaWithCorrelationAndTransitional.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/OrderSaga.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/OrderSaga.cs
@@ -17,7 +17,7 @@ namespace SqlPersistence_1.UsingSaga
 
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartOrder>(_ => _.OrderId);
+            mapper.ConfigureMapping<StartOrder>(message => message.OrderId);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.OrderId);

--- a/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/SagaWithCorrelation.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/SagaWithCorrelation.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/SagaWithCorrelationAndTransitional.cs
+++ b/Snippets/SqlPersistence/SqlPersistence_5/UsingSaga/SagaWithCorrelationAndTransitional.cs
@@ -14,7 +14,7 @@ namespace SqlPersistence_1.UsingSaga
     {
         protected override void ConfigureMapping(IMessagePropertyMapper mapper)
         {
-            mapper.ConfigureMapping<StartSagaMessage>(_ => _.CorrelationProperty);
+            mapper.ConfigureMapping<StartSagaMessage>(message => message.CorrelationProperty);
         }
 
         protected override string CorrelationPropertyName => nameof(SagaData.CorrelationProperty);

--- a/persistence/sql/sqlsaga.md
+++ b/persistence/sql/sqlsaga.md
@@ -4,7 +4,7 @@ summary: An alternate base class for use with SQL persistence
 component: SqlPersistence
 related:
  - persistence/sql/saga
-reviewed: 2018-07-19
+reviewed: 2020-04-17
 ---
 
 `SqlSaga<T>` is an alternate saga base class for use with SQL persistence that offers a less verbose mapping API than `NServiceBus.Saga<T>`. It's generally advisable to use `NServiceBus.Saga<T>` by default for most new projects, and to switch to `SqlSaga<T>` when advantageous to cut down on the need for repetitive `.ToSaga(...)` expressions in sagas that handle several message types.


### PR DESCRIPTION
Avoid `_` since that is associated with the [discard syntax in C# 7](https://docs.microsoft.com/en-us/dotnet/csharp/discards). Technically, discard syntax is not supported in lamdas so this doesn't cause any issues but it might be confusing and in general `_` stands for values which aren't used, so the naming doesn't align with that convention.