### PR TITLE
Improve awareness of generating timeout manager duplicates 

### DIFF
--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -10,7 +10,7 @@ related:
  - nservicebus/messaging/delayed-delivery
 ---
 
-NOTE: Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/index.md) or otherwise idempotent processing.
+NOTE: Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/) or otherwise idempotent processing.
 
 NServiceBus provides a delayed-delivery implementation for transports that don't support it natively. All Transports except MSMQ support delayed delivery natively.
 

--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -13,7 +13,7 @@ related:
 {{NOTE:
 Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/) or otherwise idempotent processing.
 
-Exact-once timeouts only possible with MSMQ and SQL Transports in combination with NHibernate or SQL Persistence with (their default) transaction mode TransactionScope.
+Exact-once timeouts are only possible with MSMQ and SQL Transports with NHibernate or SQL Persistence when they are configured to share the transactional context.
 }}
 
 

--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -13,7 +13,7 @@ related:
 {{NOTE:
 Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/) or otherwise idempotent processing.
 
-Exact-once timeouts are only possible with MSMQ and SQL Transports with NHibernate or SQL Persistence when they are configured to share the transactional context.
+Exact-once timeouts are only possible with [MSMQ](/transports/msmq/) or [SQL](/transports/sql/) transports with [NHibernate](/persistence/nhibernate/) or [SQL](/persistence/sql/) Persistence **and** configured to share the transactional context (distributed transactions or connection sharing).
 }}
 
 

--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -10,10 +10,11 @@ related:
  - nservicebus/messaging/delayed-delivery
 ---
 
+NOTE: Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/index.md) or otherwise idempotent processing.
+
 NServiceBus provides a delayed-delivery implementation for transports that don't support it natively. All Transports except MSMQ support delayed delivery natively.
 
 The delayed-delivery feature uses a built-in persistent store and requires using NServiceBus persistence. The timeout data is stored in three different locations at various stages of processing: `[endpoint_queue_name].Timeouts` queue, timeouts storage location specific for the chosen persistence (e.g. dedicated table or document type) and `[endpoint_queue_name].TimeoutsDipatcher` queue. The queues are automatically created by [NServiceBus installers](/nservicebus/operations/installers.md) when setting up the endpoint.
-
 
 ### Storing timeout messages
 
@@ -21,19 +22,13 @@ When NServiceBus detects that an outgoing message should be delayed, it routes i
 
 The `[endpoint_queue_name].Timeouts` queue is monitored by NServiceBus [internal receiver](/nservicebus/satellites). The receiver picks up timeout messages and stores them using the selected NServiceBus persistence. 
 
-If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions then *exactly-once* semantics of the store operation are guaranteed, meaning that timeouts in the store will not get duplicated.
-
 The delayed messages will be stored for the specified delay time, using persistance implementation specified in the configuration:
 
 snippet: configure-persistence-timeout
 
-
 ### Retrieving expired timeouts
 
 NServiceBus periodically retrieves expiring timeouts from persistence. When a timeout expires, then a message with that timeout ID is sent to the `[endpoint_queue_name].TimeoutsDipatcher` queue. That queue is monitored by NServiceBus internal receiver. When the receiver picks up a message, it looks up the corresponding timeout in the storage. If it finds it, it dispatches the timeout message to the destination queue.
-
-If the transport is configured to use [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction) and the selected persistence supports `TransactionScope` transactions, then NServiceBus guarantees *exactly-once* semantics of the dispatch operations, meaning that outgoing expired delayed messages will not get duplicated. If any of these conditions is not met, the timeout messages might get duplicated and the receiving endpoint has to account for that.
-
 
 ### Handling of persistence errors
 

--- a/nservicebus/messaging/timeout-manager.md
+++ b/nservicebus/messaging/timeout-manager.md
@@ -10,7 +10,12 @@ related:
  - nservicebus/messaging/delayed-delivery
 ---
 
-NOTE: Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/) or otherwise idempotent processing.
+{{NOTE:
+Duplicate timeouts can be dispatched if the transport and persistence is configured not to use or does not support [TransactionScope mode](/transports/transactions.md#transactions-transaction-scope-distributed-transaction). Scaled-out environments are extra vulnerable. The receiving endpoint must account for that via for example [Outbox](/nservicebus/outbox/) or otherwise idempotent processing.
+
+Exact-once timeouts only possible with MSMQ and SQL Transports in combination with NHibernate or SQL Persistence with (their default) transaction mode TransactionScope.
+}}
+
 
 NServiceBus provides a delayed-delivery implementation for transports that don't support it natively. All Transports except MSMQ support delayed delivery natively.
 


### PR DESCRIPTION
Based on https://discuss.particular.net/t/duplicate-messages-for-delayed-retries-when-scaled-out-using-sql-transport-with-native-delayed-delivery/1763