### PR TITLE
Retry counting when scaled-out

### DIFF
--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -21,7 +21,7 @@ Given a variety of Immediate and Delayed configuration values here are the resul
 | 2                | 1              | 6                       |
 | 2                | 2              | 9                       |
 | 3                | 1              | 8                       |
-| 3                | 5              | 24                      |
+| 3                | 5              | 24  (default)           |
 
 ### Scale-out multiplier
 

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -21,7 +21,7 @@ Given a variety of Immediate and Delayed configuration values here are the resul
 | 2                | 1              | 6                       |
 | 2                | 2              | 9                       |
 | 3                | 1              | 8                       |
-| 3                | 5              | 24  (default)           |
+| **3**            | **5**          | **24  (default)**       |
 
 ### Scale-out multiplier
 

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -21,6 +21,7 @@ So for example given a variety of Immediate and Delayed here are the resultant p
 | 2                | 1              | 6                       |
 | 2                | 2              | 9                       |
 | 3                | 1              | 8                       |
+| 3                | 5              | 24                      |
 
 ### Scale-out multiplier
 
@@ -32,13 +33,15 @@ Affected transports:
 - SQL Server
 - RabbitMQ
 - Amazon SQS
-- Learning (Only if running multiple instance on the same machine which is not advised)
 - MSMQ (only if running multiple instance on the same machine)
 
-Azure Service Bus transports use native delivery counter for immediate retries which guarantees that the retry number is the same regardless if the endpoint is scaled out.
+Unaffected transports:
 
 - Azure Service Bus
 - Azure Service Bus Legacy
+
+Azure Service Bus transports use a native delivery counter for immediate retries which guarantees that the retry number is the same regardless if the endpoint is scaled out.
+
 
 The number of instances act as a multiplier for the maximum number of attempts.
 
@@ -46,3 +49,8 @@ The number of instances act as a multiplier for the maximum number of attempts.
 Mininum Attempts = (ImmediateRetries:NumberOfRetries + 1) * (DelayedRetries:NumberOfRetries + 1)
 Maximum Attempts = MininumAttempts * NumberOfInstances
 ```
+
+Example:
+
+When taking the default values for immediate (5) and delayed retries (3) and 5 instances the total number of attempts will be a minumum of (5+1)*(3+1)=24 attempts and a maximum of 120.
+

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -1,17 +1,48 @@
 
 The total number of possible retries can be calculated with the following formula
 
-```
-Total Attempts = (ImmediateRetries:NumberOfRetries + 1) * (DelayedRetries:NumberOfRetries + 1)
+```txt
+Attempts = (ImmediateRetries:NumberOfRetries + 1) * (DelayedRetries:NumberOfRetries + 1)
 ```
 
 So for example given a variety of Immediate and Delayed here are the resultant possible attempts.
 
 | ImmediateRetries | DelayedRetries | Total possible attempts |
 |------------------|----------------|-------------------------|
+| 0                | 0              | 1                       |
+| 0                | 1              | 2                       |
+| 0                | 2              | 3                       |
+| 0                | 3              | 4                       |
+| 1                | 0              | 2                       |
+| 1                | 1              | 4                       |
 | 1                | 1              | 4                       |
 | 1                | 2              | 6                       |
 | 1                | 3              | 8                       |
 | 2                | 1              | 6                       |
-| 3                | 1              | 8                       |
 | 2                | 2              | 9                       |
+| 3                | 1              | 8                       |
+
+### Scale-out multiplier
+
+If an endpoint is scaled-out the number of attempts increases if instance are retrieving messages from the same queue and the transport does not have a native delivery counter.
+
+Affected transports:
+
+- Azure Storage Queues
+- SQL Server
+- RabbitMQ
+- Amazon SQS
+- Learning (Only if running multiple instance on the same machine which is not advised)
+- MSMQ (Only if running multiple instance on the same machine which is not advised)
+
+Unaffected transports:
+
+- Azure Service Bus (native delivery counter)
+- Azure Service Bus Legacy (native delivery counter)
+
+The number of instances act as a multiplier for the maximum number of attempts.
+
+```txt
+Mininum Attempts = (ImmediateRetries:NumberOfRetries + 1) * (DelayedRetries:NumberOfRetries + 1)
+Maximum Attempts = MininumAttempts * NumberOfInstances
+```

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -25,6 +25,8 @@ So for example given a variety of Immediate and Delayed here are the resultant p
 
 ### Scale-out multiplier
 
+NOTE: When scaled-out this behavior can be interpreted as if retries result in duplicates. Although this behavior can result in excessive retries no duplicate messages are created. Ensure that logging uses unique identifiers for each instance.
+
 If an endpoint is scaled-out the number of attempts increases if instance are retrieving messages from the same queue and the transport does not have a native delivery counter.
 
 Affected transports:

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -5,7 +5,7 @@ The total number of possible retries can be calculated with the following formul
 Attempts = (ImmediateRetries:NumberOfRetries + 1) * (DelayedRetries:NumberOfRetries + 1)
 ```
 
-So for example given a variety of Immediate and Delayed here are the resultant possible attempts.
+Given a variety of Immediate and Delayed configuration values here are the resultant possible attempts.
 
 | ImmediateRetries | DelayedRetries | Total possible attempts |
 |------------------|----------------|-------------------------|
@@ -25,9 +25,9 @@ So for example given a variety of Immediate and Delayed here are the resultant p
 
 ### Scale-out multiplier
 
-NOTE: When scaled-out this behavior can be interpreted as if retries result in duplicates. Although this behavior can result in excessive retries no duplicate messages are created. Ensure that logging uses unique identifiers for each instance.
+NOTE: Retry behavior can be interpreted as if retries result in duplicates when scaled-out. Retry behavior can result in excessive processing attempts but no duplicate messages are created. Ensure that logging uses unique identifiers for each endpoint instance.
 
-If an endpoint is scaled-out the number of attempts increases if instance are retrieving messages from the same queue and the transport does not have a native delivery counter.
+If an endpoint is scaled-out the number of processing attempts increase if instances are retrieving messages from the same queue and the transport does not have a native delivery counter.
 
 Affected transports:
 
@@ -42,7 +42,7 @@ Unaffected transports:
 - Azure Service Bus
 - Azure Service Bus Legacy
 
-Azure Service Bus transports use a native delivery counter for immediate retries which guarantees that the retry number is the same regardless if the endpoint is scaled out.
+Azure Service Bus transports use a native delivery counter which is incremented after any endpoint instance fetches a message from a (shared) queue. The native delivery counter guarantees that the retry number is the same regardless if the endpoint is scaled out.
 
 
 The number of instances act as a multiplier for the maximum number of attempts.

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -33,12 +33,12 @@ Affected transports:
 - RabbitMQ
 - Amazon SQS
 - Learning (Only if running multiple instance on the same machine which is not advised)
-- MSMQ (Only if running multiple instance on the same machine which is not advised)
+- MSMQ (only if running multiple instance on the same machine)
 
-Unaffected transports:
+Azure Service Bus transports use native delivery counter for immediate retries which guarantees that the retry number is the same regardless if the endpoint is scaled out.
 
-- Azure Service Bus (native delivery counter)
-- Azure Service Bus Legacy (native delivery counter)
+- Azure Service Bus
+- Azure Service Bus Legacy
 
 The number of instances act as a multiplier for the maximum number of attempts.
 


### PR DESCRIPTION
After merging, update https://discuss.particular.net/t/duplicate-messages-for-delayed-retries-when-scaled-out-using-sql-transport-with-native-delayed-delivery/1763