### PR TITLE
mention package name in note on RabbitMQ conventional routing topology

### DIFF
--- a/transports/rabbitmq/routing-topology_mandatory_rabbit_[5,).partial.md
+++ b/transports/rabbitmq/routing-topology_mandatory_rabbit_[5,).partial.md
@@ -1,1 +1,1 @@
-Note: The recommended routing topology is the conventional routing topology. It was the default topology prior to version 5.
+Note: The recommended routing topology is the conventional routing topology. It was the default topology prior to NServiceBus.RabbitMQ version 5.


### PR DESCRIPTION
I had an LC visitor today who was confused between versions of NServiceBus and NServiceBus.RabbitMQ.