### PR TITLE
Exclude .dependabot/config.yml from repo sync

### DIFF
--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,0 +1,2 @@
+exclusions:
+- .dependabot/config.yml


### PR DESCRIPTION
Related to https://github.com/Particular/RepoStandards/pull/22