### PR TITLE
Document assembly scanning AdditionalAssemblyScanningPath feature

### DIFF
--- a/Snippets/Core/Core.sln
+++ b/Snippets/Core/Core.sln
@@ -23,33 +23,20 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Release|Any CPU.Build.0 = Release|Any CPU
 		{54784406-19E1-4211-B394-AC5CFC8C313B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54784406-19E1-4211-B394-AC5CFC8C313B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54784406-19E1-4211-B394-AC5CFC8C313B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54784406-19E1-4211-B394-AC5CFC8C313B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6560BD09-1817-4223-891F-C2BEAC39917E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6560BD09-1817-4223-891F-C2BEAC39917E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A925B42-05C6-46B8-AA36-8872879CDF5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Snippets/Core/Core.sln
+++ b/Snippets/Core/Core.sln
@@ -23,20 +23,33 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D52A6FEB-CC19-49C3-AF92-475669D2FF25}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F02C8A5-55E9-4B79-9C0F-8FB525EBE326}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C3223BA-E6AB-4A5B-BACB-28D3E1724A75}.Release|Any CPU.Build.0 = Release|Any CPU
 		{54784406-19E1-4211-B394-AC5CFC8C313B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54784406-19E1-4211-B394-AC5CFC8C313B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54784406-19E1-4211-B394-AC5CFC8C313B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54784406-19E1-4211-B394-AC5CFC8C313B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6560BD09-1817-4223-891F-C2BEAC39917E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6560BD09-1817-4223-891F-C2BEAC39917E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A925B42-05C6-46B8-AA36-8872879CDF5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Snippets/Core/Core_7.4/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Core/Core_7.4/Scanning/ScanningPublicApi.cs
@@ -1,0 +1,20 @@
+﻿#pragma warning disable 618
+namespace Core7.Scanning
+{
+    using NServiceBus;
+
+    class ScanningPublicApi
+    {
+        void ScanningNestedAssembliesEnabled(EndpointConfiguration endpointConfiguration)
+        {
+            var additionalPathToScanAssemblies = "";
+
+            #region AdditionalAssemblyScanningPath
+
+            var scanner = endpointConfiguration.AssemblyScanner();
+            scanner.AdditionalAssemblyScanningPath = additionalPathToScanAssemblies;
+
+            #endregion
+        }
+    }
+}

--- a/Snippets/Core/Core_8/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Core/Core_8/Scanning/ScanningPublicApi.cs
@@ -89,7 +89,7 @@ namespace Core8.Scanning
             #endregion
         }
 
-        void ScanningNestedAssembliesEnabled(EndpointConfiguration endpointConfiguration)
+        void AdditionalAssemblyScanningPath(EndpointConfiguration endpointConfiguration)
         {
             var additionalPathToScanAssemblies = "";
 

--- a/Snippets/Core/Core_8/Scanning/ScanningPublicApi.cs
+++ b/Snippets/Core/Core_8/Scanning/ScanningPublicApi.cs
@@ -88,5 +88,17 @@ namespace Core8.Scanning
 
             #endregion
         }
+
+        void ScanningNestedAssembliesEnabled(EndpointConfiguration endpointConfiguration)
+        {
+            var additionalPathToScanAssemblies = "";
+
+            #region AdditionalAssemblyScanningPath
+
+            var scanner = endpointConfiguration.AssemblyScanner();
+            scanner.AdditionalAssemblyScanningPath = additionalPathToScanAssemblies;
+
+            #endregion
+        }
     }
 }

--- a/nservicebus/hosting/assembly-scanning.md
+++ b/nservicebus/hosting/assembly-scanning.md
@@ -55,3 +55,5 @@ partial: mixing
 partial: appdomain
 
 partial: suppress
+
+partial: additional-path

--- a/nservicebus/hosting/assembly-scanning_additional-path_core_[7.4,].partial.md
+++ b/nservicebus/hosting/assembly-scanning_additional-path_core_[7.4,].partial.md
@@ -1,0 +1,9 @@
+
+
+## Additional assembly scanning path
+
+NOTE: This configuration option is only available in NServiceBus 7.4 and above.
+
+Assembly scanning can be configured to scan an additional path for assemblies located outside of the default scanning path.
+
+snippet: AdditionalAssemblyScanningPath


### PR DESCRIPTION
Document a new feature added to the Core ([support for setting an additional assembly scanning path](https://github.com/Particular/NServiceBus/pull/5653)) that hasn't been released yet.