### PR TITLE
Fix conventions inheritance example

### DIFF
--- a/Snippets/Core/Core_7/Conventions/Usage.cs
+++ b/Snippets/Core/Core_7/Conventions/Usage.cs
@@ -28,15 +28,15 @@ namespace Core7.Conventions
             var conventions = endpointConfiguration.Conventions();
             conventions.DefiningCommandsAs(type =>
                 type.Namespace == "MyNamespace.Messages.Commands"
-                || type.IsAssignableFrom(typeof(ICommand))
+                || typeof(ICommand).IsAssignableFrom(type)
             );
             conventions.DefiningEventsAs(type =>
                 type.Namespace == "MyNamespace.Messages.Events"
-                || type.IsAssignableFrom(typeof(IEvent))
+                || typeof(IEvent).IsAssignableFrom(type)
             );
             conventions.DefiningMessagesAs(type =>
                 type.Namespace == "MyNamespace.Messages"
-                || type.IsAssignableFrom(typeof(IMessage))
+                || typeof(IMessage).IsAssignableFrom(type)
             );
             conventions.DefiningDataBusPropertiesAs(property =>
                 property.Name.EndsWith("DataBus")


### PR DESCRIPTION
@seanfarmar 

Can you confirm if this docs fix is correct?

Example reproduction:

```csharp
using NServiceBus;
using System;

namespace NSBConventions
{
    class Program
    {
        static void Main(string[] args)
        {
            var ourType = typeof(TestNSBClass);

            Console.WriteLine($"NSB Docs way, is assignable: {ourType.IsAssignableFrom(typeof(ICommand))}");
            Console.WriteLine($"My way, is assignable: {typeof(ICommand).IsAssignableFrom(ourType)}");
        }
    }

    public class TestNSBClass : ICommand
    {
    }
}
```