### PR TITLE
Add OPTIONS verbs to web.config

### DIFF
--- a/Snippets/ServicePulse/ServicePulse_All/web.config
+++ b/Snippets/ServicePulse/ServicePulse_All/web.config
@@ -49,7 +49,7 @@
     <system.webServer>
       <security>
         <authorization>
-          <add accessType="Allow" roles="SPMonitoring" verbs="PATCH"/>
+          <add accessType="Allow" roles="SPMonitoring" verbs="PATCH,OPTIONS"/>
         </authorization>
       </security>
     </system.webServer>
@@ -72,6 +72,15 @@
       </security>
     </system.webServer>
   </location>
+  <location path="monitoring">
+    <system.webServer>
+      <security>
+        <authorization>
+          <add accessType="Allow" roles="SPMonitoring" verbs="OPTIONS"/>
+        </authorization>
+      </security>
+  </system.webServer>
+</location>
   <!-- endcode -->
 </configuration>
 


### PR DESCRIPTION
OPTIONS is used against the /monitoring and /api/endpoints and needs to be allowed.

I kept getting 401 errors and tracked it down to these verbs not being allowed.