### PR TITLE
Added note to storage types that storage type is only needed if transport is missing the feature natively

### DIFF
--- a/persistence/index.md
+++ b/persistence/index.md
@@ -14,10 +14,10 @@ NServiceBus needs to store data for various purposes, such as persisting the sta
 
  * [Sagas](/nservicebus/sagas/)
  * [Outbox](/nservicebus/outbox/)
- * [Subscriptions](/nservicebus/messaging/publish-subscribe/)
- * [Timeouts](/nservicebus/sagas/timeouts.md)
- * [Delayed Retries](/nservicebus/recoverability/#delayed-retries)
- * [Deferral](/nservicebus/messaging/delayed-delivery.md)
+ * [Subscriptions](/nservicebus/messaging/publish-subscribe/) (Storage required if transport does not support native publish-subscribe)
+ * [Timeouts](/nservicebus/sagas/timeouts.md) (Storage required if the transport does not support native delayed delivery)
+ * [Delayed Retries](/nservicebus/recoverability/#delayed-retries) (Storage required if the transport does not support native delayed delivery)
+ * [Deferral](/nservicebus/messaging/delayed-delivery.md) (Storage required if the transport does not support native delayed delivery)
  * [Gateway Deduplication](/nservicebus/gateway/)
 
 ## Selecting a persister


### PR DESCRIPTION
Customer feedback, unclear if storage was required when using Azure Service Bus.