### PR TITLE
Refer to unobstrusive mode as a possible way to solve dependency on Message contracts

### DIFF
--- a/nservicebus/messaging/evolving-contracts.md
+++ b/nservicebus/messaging/evolving-contracts.md
@@ -27,7 +27,7 @@ Messages define the data contract between two endpoints.
 
 It's recommended to use a dedicated assembly for message definitions. By keeping messages in a separate assembly, the amount of information and dependencies shared between services is minimized. Message definitions can be divided between multiple assemblies, which can be useful in more complex systems, for example, to narrow down the number of contracts exposed to different services.
 
-It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](/nservicebus/messaging/unobtrusive-mode.md) as well.
+It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can be accomplished by using [unobstrusive mode messages](/nservicebus/messaging/unobtrusive-mode.md) as well.
 
 
 ## Common challenges

--- a/nservicebus/messaging/evolving-contracts.md
+++ b/nservicebus/messaging/evolving-contracts.md
@@ -27,7 +27,7 @@ Messages define the data contract between two endpoints.
 
 It's recommended to use a dedicated assembly for message definitions. By keeping messages in a separate assembly, the amount of information and dependencies shared between services is minimized. Message definitions can be divided between multiple assemblies, which can be useful in more complex systems, for example, to narrow down the number of contracts exposed to different services.
 
-It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](https://docs.particular.net/nservicebus/messaging/unobtrusive-mode) as well.
+It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](/nservicebus/messaging/unobtrusive-mode) as well.
 
 
 ## Common challenges

--- a/nservicebus/messaging/evolving-contracts.md
+++ b/nservicebus/messaging/evolving-contracts.md
@@ -27,7 +27,7 @@ Messages define the data contract between two endpoints.
 
 It's recommended to use a dedicated assembly for message definitions. By keeping messages in a separate assembly, the amount of information and dependencies shared between services is minimized. Message definitions can be divided between multiple assemblies, which can be useful in more complex systems, for example, to narrow down the number of contracts exposed to different services.
 
-It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](/nservicebus/messaging/unobtrusive-mode) as well.
+It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](/nservicebus/messaging/unobtrusive-mode.md) as well.
 
 
 ## Common challenges

--- a/nservicebus/messaging/evolving-contracts.md
+++ b/nservicebus/messaging/evolving-contracts.md
@@ -23,11 +23,11 @@ Ensure that messages can be evolved by following general [messages design guidel
 
 ### Solution structure
 
-Messages define the data contract between two endpoints. 
+Messages define the data contract between two endpoints.
 
 It's recommended to use a dedicated assembly for message definitions. By keeping messages in a separate assembly, the amount of information and dependencies shared between services is minimized. Message definitions can be divided between multiple assemblies, which can be useful in more complex systems, for example, to narrow down the number of contracts exposed to different services.
 
-It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. 
+It's also possible to share messages as C# source files without packaging them into an assembly. One advantage of this approach is that messages don't need to be compiled against specific NServiceBus versions, so assembly redirects are not necessary. This can, however, be accomplished by using [unobstrusive mode messages](https://docs.particular.net/nservicebus/messaging/unobtrusive-mode) as well.
 
 
 ## Common challenges


### PR DESCRIPTION
Refer to unobstrusive mode as the second option proposed from the solution structure might seem plausible but can also be solved by conventions.

This change is a reaction to [this question](https://discuss.particular.net/t/sharing-message-contracts/1943/2) asked on discourse.