### PR TITLE
Add note about context funcs

### DIFF
--- a/Snippets/Ninject/Ninject.sln
+++ b/Snippets/Ninject/Ninject.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29728.190
@@ -6,6 +5,8 @@ MinimumVisualStudioVersion = 15.0.26730.12
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ninject_5", "Ninject_5\Ninject_5.csproj", "{0164A346-454F-444B-BEF5-A84DF95A3DE7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ninject_6", "Ninject_6\Ninject_6.csproj", "{246D18F5-9B0E-4B10-95AD-FB01B7D81C6C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ninject_7", "Ninject_7\Ninject_7.csproj", "{3285F2DF-FE27-452D-8160-6D4920A03BE1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,6 +17,8 @@ Global
 		{0164A346-454F-444B-BEF5-A84DF95A3DE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{246D18F5-9B0E-4B10-95AD-FB01B7D81C6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{246D18F5-9B0E-4B10-95AD-FB01B7D81C6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3285F2DF-FE27-452D-8160-6D4920A03BE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3285F2DF-FE27-452D-8160-6D4920A03BE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Snippets/Ninject/Ninject_5/Ninject_5.csproj
+++ b/Snippets/Ninject/Ninject_5/Ninject_5.csproj
@@ -4,6 +4,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.2.0" />
     <PackageReference Include="NServiceBus.Ninject" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/Ninject/Ninject_5/Usage.cs
+++ b/Snippets/Ninject/Ninject_5/Usage.cs
@@ -1,6 +1,7 @@
 ﻿using Ninject;
 using NServiceBus;
 using NServiceBus.ObjectBuilder.Ninject;
+using Ninject.Extensions.ContextPreservation;
 
 class Usage
 {
@@ -57,6 +58,19 @@ class Usage
         kernel.Bind<MyService>().ToSelf()
             .WhenInUnitOfWork()
             .InSingletonScope();
+
+        #endregion
+    }
+
+    void UseFuncBinding()
+    {
+        #region NinjectContextPreservationFuncBinding
+
+        var kernel = new StandardKernel();
+
+        kernel.Bind<MyService>()
+            .ToMethod(ctx => ctx.ContextPreservingGet<MyService>())
+            .InUnitOfWorkScope();
 
         #endregion
     }

--- a/Snippets/Ninject/Ninject_6/Ninject_6.csproj
+++ b/Snippets/Ninject/Ninject_6/Ninject_6.csproj
@@ -4,6 +4,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.2.0" />
     <PackageReference Include="NServiceBus.Ninject" Version="6.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/Ninject/Ninject_6/Usage.cs
+++ b/Snippets/Ninject/Ninject_6/Usage.cs
@@ -1,6 +1,7 @@
 ﻿using Ninject;
 using NServiceBus;
 using NServiceBus.ObjectBuilder.Ninject;
+using Ninject.Extensions.ContextPreservation;
 
 class Usage
 {
@@ -57,6 +58,19 @@ class Usage
         kernel.Bind<MyService>().ToSelf()
             .WhenInUnitOfWork()
             .InSingletonScope();
+
+        #endregion
+    }
+
+    void UseFuncBinding()
+    {
+        #region NinjectContextPreservationFuncBinding
+
+        var kernel = new StandardKernel();
+
+        kernel.Bind<MyService>()
+            .ToMethod(ctx => ctx.ContextPreservingGet<MyService>())
+            .InUnitOfWorkScope();
 
         #endregion
     }

--- a/Snippets/Ninject/Ninject_7/Ninject_7.csproj
+++ b/Snippets/Ninject/Ninject_7/Ninject_7.csproj
@@ -4,6 +4,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.3.1" />
     <PackageReference Include="NServiceBus.Ninject" Version="7.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/Ninject/Ninject_7/Usage.cs
+++ b/Snippets/Ninject/Ninject_7/Usage.cs
@@ -1,6 +1,7 @@
 ﻿using Ninject;
 using NServiceBus;
 using NServiceBus.ObjectBuilder.Ninject;
+using Ninject.Extensions.ContextPreservation;
 
 class Usage
 {
@@ -57,6 +58,19 @@ class Usage
         kernel.Bind<MyService>().ToSelf()
             .WhenInUnitOfWork()
             .InSingletonScope();
+
+        #endregion
+    }
+
+    void UseFuncBinding()
+    {
+        #region NinjectContextPreservationFuncBinding
+
+        var kernel = new StandardKernel();
+
+        kernel.Bind<MyService>()
+            .ToMethod(ctx => ctx.ContextPreservingGet<MyService>())
+            .InUnitOfWorkScope();
 
         #endregion
     }

--- a/nservicebus/dependency-injection/ninject.md
+++ b/nservicebus/dependency-injection/ninject.md
@@ -1,7 +1,7 @@
 ---
 title: Ninject
 summary: Configure NServiceBus to use Ninject for dependency injection.
-reviewed: 2018-12-05
+reviewed: 2020-07-28
 component: Ninject
 related:
  - samples/dependency-injection/ninject
@@ -39,6 +39,10 @@ snippet: NinjectUnitOfWork
 Services using `InUnitOfWorkScope()` can only be injected into code which is processing messages. To inject the service somewhere else (e.g. because of an user interaction) define conditional bindings:
 
 snippet: NinjectConditionalBindings
+
+Funcs can only be injected when using the [ContextPreservation Ninject extension](https://github.com/ninject/Ninject.Extensions.ContextPreservation/).
+
+snippet: NinjectContextPreservationFuncBinding
 
 ### Multi hosting
 


### PR DESCRIPTION
Has an example for conserving the context between scopes. This allows for the context of the NamedScope to be used when resolving Func's