### PR TITLE
Added reference to the Azure client library used in the legacy warning

### DIFF
--- a/transports/azure-service-bus/legacy/legacy-asb-warning.include.md
+++ b/transports/azure-service-bus/legacy/legacy-asb-warning.include.md
@@ -1,1 +1,1 @@
-WARNING: This page refers to the **deprecated** legacy Azure Service Bus transport. All users should migrate to the [Azure Service Bus transport](/transports/azure-service-bus) transport.
+WARNING: This page refers to the **deprecated** legacy Azure Service Bus transport that uses the [WindowsAzure.ServiceBus NuGet package](https://www.nuget.org/packages/WindowsAzure.ServiceBus/). All users should migrate to the [Azure Service Bus transport](/transports/azure-service-bus) transport.


### PR DESCRIPTION
Given that Microsoft is working on another Azure SDK, it will become more confusing to users to correlate our transports to the target Azure SDK.
The current azure service bus transport refers to the nuget package used: Microsoft.Azure.ServiceBus, but the legacy one didn't  (WindowsAzure.ServiceBus).

Related to https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/149 and https://github.com/Particular/NServiceBus.AzureServiceBus/pull/902