### PR TITLE
Add additional notes about externally managed mode

### DIFF
--- a/nservicebus/dependency-injection/extensions-dependencyinjection.md
+++ b/nservicebus/dependency-injection/extensions-dependencyinjection.md
@@ -16,6 +16,8 @@ The `NServiceBus.Extensions.DependencyInjection` package provides integration wi
 
 NOTE: It's recommended to use [Microsoft's generic host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) to manage application and dependency injection container lifecycle. Use the [NServiceBus.Extensions.Hosting](/nservicebus/hosting/extensions-hosting.md) package to host an NServiceBus endpoint with the generic host.
 
+WARN: `IServiceCollection` and `IServiceProvider` instances must not be shared across mutliple NServiceBus endpoints to avoid conflicting registration that might cause incorrect behavior or runtime errors.
+
 ## Usage with ServiceCollection
 
 The following snippet shows how to configure NServiceBus to use Microsoft's built-in dependency injection container:

--- a/nservicebus/dependency-injection/index_ownership_core_[7.2,).partial.md
+++ b/nservicebus/dependency-injection/index_ownership_core_[7.2,).partial.md
@@ -10,6 +10,8 @@ include: internallymanagedcontainer
 
 In *externally managed* mode, NServiceBus registers its components in the container but does not own the container's lifecycle. The container is provided by the user in two phases, one for registration (`IConfigureComponents`) and one for resolution (`IBuilder`).
 
+WARN: Every NServiceBus endpoint requires its own dependency injection container. Sharing containers across multiple endpoints results in conflicting registrations and might cause incorrect behavior or runtime errors.
+
 During the registration phase, an instance of `IConfigureComponents` is passed to the `EndpointWithExternallyManagedContainer.Create` method. For example, for Autofac's `ContainerBuilder`, this is the phase during which its type registration methods would be called.
 
 snippet: ExternalPrepare
@@ -18,7 +20,7 @@ Later, during the resolution phase, the `Start` method requires an instance of `
 
 snippet: ExternalStart
 
-NOTE: The `Adapt` methods are implemented by the user and are container-specific. See the [ASP.NET Core sample](/samples/dependency-injection/aspnetcore/) to see how these methods are implemented based on the ASP.NET Core dependency injection abstractions.
+NOTE: The `Adapt` methods are implemented by the user and are container-specific. [NServiceBus.Extensions.DependencyInjection]() supports externally managed mode using `Microsoft.Extensions.DependencyInejction` abstractions (`IServiceCollection` and `IServiceProvider`) that are supported by most dependency injection containers.
 
 ### Injecting the message session
 

--- a/nservicebus/dependency-injection/index_ownership_core_[7.2,).partial.md
+++ b/nservicebus/dependency-injection/index_ownership_core_[7.2,).partial.md
@@ -20,7 +20,7 @@ Later, during the resolution phase, the `Start` method requires an instance of `
 
 snippet: ExternalStart
 
-NOTE: The `Adapt` methods are implemented by the user and are container-specific. [NServiceBus.Extensions.DependencyInjection]() supports externally managed mode using `Microsoft.Extensions.DependencyInejction` abstractions (`IServiceCollection` and `IServiceProvider`) that are supported by most dependency injection containers.
+NOTE: The `Adapt` methods are implemented by the user and are container-specific. [NServiceBus.Extensions.DependencyInjection](/nservicebus/dependency-injection/extensions-dependencyinjection.md) supports externally managed mode using `Microsoft.Extensions.DependencyInejction` abstractions (`IServiceCollection` and `IServiceProvider`) that are supported by most dependency injection containers.
 
 ### Injecting the message session
 


### PR DESCRIPTION
based on the feedback on https://github.com/Particular/NServiceBus/issues/5700 we need to be more clear that sharing containers across endpoints is not supported.

I've also updated the note about the ASP.NET Core sample because that sample uses the generic host extension and therefore doesn't show how to do externally managed mode.