### PR TITLE
Add externally managed mode sample

### DIFF
--- a/nservicebus/dependency-injection/index.md
+++ b/nservicebus/dependency-injection/index.md
@@ -10,6 +10,7 @@ redirects:
 related:
  - samples/dependency-injection
  - samples/dependency-injection/extensions-dependency-injection
+ - samples/dependency-injection/externally-managed-mode
 ---
 NServiceBus automatically registers and invokes message handlers, sagas, and other user-provided extension points using a dependency injection container.
 

--- a/samples/dependency-injection/externally-managed-mode/Core_8/ExternallyManagedContainer.DotSettings
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/ExternallyManagedContainer.DotSettings
@@ -1,0 +1,6 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/RelativePath/@EntryValue">..\..\..\..\..\tools\Shared.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File2EF370E98D1FDC4E9FD6E29F173EB613/RelativePriority/@EntryValue">1</s:Double>
+	</wpf:ResourceDictionary>

--- a/samples/dependency-injection/externally-managed-mode/Core_8/ExternallyManagedContainer.sln
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/ExternallyManagedContainer.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "Sample\Sample.csproj", "{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3673C976-8AFC-4169-A103-E016521D0868}
+	EndGlobalSection
+EndGlobal

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MessageSenderService.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MessageSenderService.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+
+#region InjectingMessageSession
+public class MessageSenderService
+{
+    private readonly IMessageSession messageSession;
+
+    public MessageSenderService(IMessageSession messageSession)
+    {
+        this.messageSession = messageSession;
+    }
+
+    public Task SendMessage()
+    {
+        var myMessage = new MyMessage();
+        return messageSession.SendLocal(myMessage);
+    }
+}
+#endregion

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyHandler.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+#region InjectingDependency
+public class MyHandler :
+    IHandleMessages<MyMessage>
+{
+    MyService myService;
+
+    public MyHandler(MyService myService)
+    {
+        this.myService = myService;
+    }
+
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        myService.WriteHello();
+        return Task.CompletedTask;
+    }
+}
+#endregion

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyMessage.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyMessage.cs
@@ -1,0 +1,5 @@
+﻿using NServiceBus;
+
+public class MyMessage : IMessage
+{
+}

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyService.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/MyService.cs
@@ -1,0 +1,11 @@
+﻿using NServiceBus.Logging;
+
+public class MyService
+{
+    static ILog log = LogManager.GetLogger<MyService>();
+
+    public void WriteHello()
+    {
+        log.Info("Hello from MyService.");
+    }
+}

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Program.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Program.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+
+static class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Samples.NServiceBus.Extensions.DependencyInjection";
+
+        var endpointConfiguration = new EndpointConfiguration("Sample");
+        endpointConfiguration.UseTransport<LearningTransport>();
+
+        #region ContainerConfiguration
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<MyService>();
+        serviceCollection.AddSingleton<MessageSenderService>();
+
+        var endpointWithExternallyManagedContainer = EndpointWithExternallyManagedContainer
+            .Create(endpointConfiguration, serviceCollection);
+        // if needed register the session
+        serviceCollection.AddSingleton(p => endpointWithExternallyManagedContainer.MessageSession.Value);
+
+        #endregion
+
+        using (var serviceProvider = serviceCollection.BuildServiceProvider())
+        {
+            var endpoint = await endpointWithExternallyManagedContainer.Start(serviceProvider)
+                .ConfigureAwait(false);
+
+            var senderService = serviceProvider.GetRequiredService<MessageSenderService>();
+            await senderService.SendMessage()
+                .ConfigureAwait(false);
+
+            Console.WriteLine("Press any key to exit");
+            Console.ReadKey();
+            await endpoint.Stop()
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha*" />
+  </ItemGroup>
+</Project>

--- a/samples/dependency-injection/externally-managed-mode/sample.md
+++ b/samples/dependency-injection/externally-managed-mode/sample.md
@@ -1,0 +1,33 @@
+---
+title: Externally managed container mode usage
+summary: A sample that uses the NServiceBus externally managed container mode to configure a DI container.
+component: Core
+reviewed: 2020-09-04
+related:
+ - nservicebus/dependency-injection
+---
+
+### Configuring an endpoint to use ServiceProvider
+
+The following code configures an endpoint with the [externally managed mode](/nservicebus/dependency-injection/#externally-managed-mode) using Microsoft's dependency injection container.
+
+snippet: ContainerConfiguration
+
+### Injecting the dependency in the handler
+
+Services that have been registered with the `IServiceCollection` can be injected into message handlers via constructor injection:
+
+snippet: InjectingDependency
+
+### Injecting the message session into dependencies
+
+The `IMessageSession` can be registered with the `IServiceCollection` so it can be injected as a dependency into other classes:
+
+```csharp
+serviceCollection.AddSingleton(p => endpointWithExternallyManagedContainer.MessageSession.Value);
+```
+
+snippet: InjectingMessageSession
+
+NOTE: The `IMessageSession` can only be resolved from the `IServiceProvider` once the endpoint has been started.
+

--- a/samples/dependency-injection/externally-managed-mode/sample.md
+++ b/samples/dependency-injection/externally-managed-mode/sample.md
@@ -1,5 +1,5 @@
 ---
-title: Externally managed container mode usage
+title: Externally Managed Container Mode Usage
 summary: A sample that uses the NServiceBus externally managed container mode to configure a DI container.
 component: Core
 reviewed: 2020-09-04


### PR DESCRIPTION
Adds a sample for the externally managed mode in NServiceBus version 8. I did not add a v7 sample as v7 would require custom adapters to integrate with the v7 NSB DI abstractions and that's what the NServiceBus.Extensions.DependencyInjection package (and sample) is for.