### PR TITLE
Correct description of how many Delayed Retries are performed

### DIFF
--- a/Snippets/Core/Core_6/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
+++ b/Snippets/Core/Core_6/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
@@ -42,7 +42,7 @@
             // override delayed retry decision for custom exception
             // i.e. MyOtherBusinessException should do fixed backoff of 5 seconds
             if (context.Exception is MyOtherBusinessException &&
-                context.DelayedDeliveriesPerformed <= config.Delayed.MaxNumberOfRetries)
+                context.DelayedDeliveriesPerformed < config.Delayed.MaxNumberOfRetries)
             {
                 return RecoverabilityAction.DelayedRetry(TimeSpan.FromSeconds(5));
             }
@@ -101,7 +101,7 @@
             // override delayed retry decision for custom exception
             // i.e. MyOtherBusinessException should do fixed backoff of 5 seconds
             if (context.Exception is MyOtherBusinessException &&
-                context.DelayedDeliveriesPerformed <= config.Delayed.MaxNumberOfRetries)
+                context.DelayedDeliveriesPerformed < config.Delayed.MaxNumberOfRetries)
             {
                 return RecoverabilityAction.DelayedRetry(TimeSpan.FromSeconds(5));
             }

--- a/Snippets/Core/Core_7.2/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
+++ b/Snippets/Core/Core_7.2/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
@@ -53,7 +53,7 @@
             // override delayed retry decision for custom exception
             // i.e. MyOtherBusinessException should do fixed backoff of 5 seconds
             if (context.Exception is MyOtherBusinessException &&
-                context.DelayedDeliveriesPerformed <= config.Delayed.MaxNumberOfRetries)
+                context.DelayedDeliveriesPerformed < config.Delayed.MaxNumberOfRetries)
             {
                 return RecoverabilityAction.DelayedRetry(TimeSpan.FromSeconds(5));
             }

--- a/Snippets/Core/Core_7/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
+++ b/Snippets/Core/Core_7/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
@@ -46,7 +46,7 @@
             // override delayed retry decision for custom exception
             // i.e. MyOtherBusinessException should do fixed backoff of 5 seconds
             if (context.Exception is MyOtherBusinessException &&
-                context.DelayedDeliveriesPerformed <= config.Delayed.MaxNumberOfRetries)
+                context.DelayedDeliveriesPerformed < config.Delayed.MaxNumberOfRetries)
             {
                 return RecoverabilityAction.DelayedRetry(TimeSpan.FromSeconds(5));
             }

--- a/Snippets/Core/Core_8/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
+++ b/Snippets/Core/Core_8/Recoverability/Delayed/CustomPolicies/FullyCustomizedPolicy.cs
@@ -53,7 +53,7 @@
             // override delayed retry decision for custom exception
             // i.e. MyOtherBusinessException should do fixed backoff of 5 seconds
             if (context.Exception is MyOtherBusinessException &&
-                context.DelayedDeliveriesPerformed <= config.Delayed.MaxNumberOfRetries)
+                context.DelayedDeliveriesPerformed < config.Delayed.MaxNumberOfRetries)
             {
                 return RecoverabilityAction.DelayedRetry(TimeSpan.FromSeconds(5));
             }

--- a/nservicebus/recoverability/custom-recoverability-policy.md
+++ b/nservicebus/recoverability/custom-recoverability-policy.md
@@ -17,7 +17,7 @@ The default policy works in the following way:
 
  1. If an unrecoverable exception is raised, then the `MoveToError` action is returned immediately with the default error queue. 
  1. If the `ImmediateProcessingFailures` value is less or equal to the configured `MaxNumberOfRetries` for Immediate Retries, then the `ImmediateRetry` action is returned.
- 1. If Immediate Retries are exceeded, then the Delayed Retries configuration is considered. If the `DelayedDeliveriesPerformed` is less or equal than `MaxNumberOfRetries` and the message hasn't reached the maximum time allowed for retries (24 hours), then the `DelayedRetry` action is returned. The delay is calculated according to the following formula:
+ 1. If Immediate Retries are exceeded, then the Delayed Retries configuration is considered. If the `DelayedDeliveriesPerformed` is less than `MaxNumberOfRetries` and the message hasn't reached the maximum time allowed for retries (24 hours), then the `DelayedRetry` action is returned. The delay is calculated according to the following formula:
 
     `delay = DelayedRetry.TimeIncrease * (DelayedDeliveriesPerformed + 1)`.
 

--- a/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
+++ b/nservicebus/recoverability/index_retrycount_core_[6.0,).partial.md
@@ -20,7 +20,7 @@ Given a variety of immediate and delayed configuration values here are the resul
 | 1                | 2              | 6                       |
 | 2                | 2              | 9                       |
 | 1                | 3              | 8                       |
-| **3**            | **5**          | **24  (default)**       |
+| **5**            | **3**          | **24  (default)**       |
 
 ### Scale-out multiplier
 


### PR DESCRIPTION
The [documentation for the Default Recoverability Policy](https://docs.particular.net/nservicebus/recoverability/custom-recoverability-policy?) is correct when it describes Immediate Retries:

> If the ImmediateProcessingFailures value is less or equal to the configured MaxNumberOfRetries for Immediate Retries, then the ImmediateRetry action is returned.

[Relevant code](https://github.com/Particular/NServiceBus/blob/c936c938c76f6a2e2e98a2849a9f029bb530e09b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs#L30-L33):

```c#
if (errorContext.ImmediateProcessingFailures <= config.Immediate.MaxNumberOfRetries)
{
    return RecoverabilityAction.ImmediateRetry();
}
```

But it incorrectly uses "less or equal" when describing Delayed Retires:

> If the DelayedDeliveriesPerformed is less or equal than MaxNumberOfRetries and the message hasn't reached the maximum time allowed for retries (24 hours), then the DelayedRetry action is returned.

[The code](https://github.com/Particular/NServiceBus/blob/c936c938c76f6a2e2e98a2849a9f029bb530e09b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs#L52-L55) actually stops when DelayedDeliveriesPerformed equals MaxNumberOfRetries

```c#
if (delayedDeliveriesPerformed >= config.MaxNumberOfRetries)
{
    return false;
}
```

The snippet for the for the fully customised Recoverability Policy also uses this "less or equal" - this isn't necessarily incorrect, as the snippet is _not_ trying to show the Default Recoverability Policy, but it can lead to confusion.