### PR TITLE
Mention IServiceCollection methods on DI upgrade guide

### DIFF
--- a/nservicebus/upgrades/7to8/dependency-injection.md
+++ b/nservicebus/upgrades/7to8/dependency-injection.md
@@ -54,6 +54,14 @@ may be replaced with:
 endpointConfiguration.RegisterComponents(s => s.AddTransient<MyService>());
 ```
 
+See the following table for recommended replacements. See the [IServiceCollection documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection?view=dotnet-plat-ext-3.1) for a full list of available registration methods.
+
+| `ConfigureComponents` usage                                               | Replacement                  |
+| ------------------------------------------------------------------------- | ---------------------------- |
+| `ConfigureComponent<MyService>(DependencyLifecyle.InstancePerCall)`       | `AddTransient<MyService>()`  |
+| `ConfigureComponent<MyService>(DependencyLifecyle.SingleInstance)`        | `AddSingleton<MyService>()`  |
+| `ConfigureComponent<MyService>(DependencyLifecyle.InstancePerUnitOfWork)` | `AddScoped<MyService>()`     |
+
 The former `ConfigureComponents` automatically registered all interfaces of a given type. The `IServiceCollection.Add` methods do not do this. Any inherited interfaces must be registered explicitly. For example, their registrations may be forwarded to the inheriting type:
 
 ```


### PR DESCRIPTION
Feedback that has been provided by @aleksandr-samila was that it wasn't clear what methods one should use if not familiar with the IServiceCollection API yet. Added a list of the typical replacement methods and a docs link to other available extension methods.

@aleksandr-samila does that address the concerns you raised? (sorry it has been a while already)