### PR TITLE
Resolved build warning because System.Net.Http should not be included

### DIFF
--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
@@ -1,14 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
-    <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.*" />
-    <PackageReference Include="NServiceBus" Version="7.*" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+        <OutputType>Exe</OutputType>
+        <LangVersion>7.3</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+        <Reference Include="System.Net.Http"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" Version="12.*"/>
+        <PackageReference Include="NServiceBus" Version="7.*"/>
+        <PackageReference Include="NServiceBus.CustomChecks" Version="3.*"/>
+        <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolved build warning because System.Net.Http should not be included for .net core.

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2084,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Net.Http". Check to make sur
e the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\Users\Ramon\src\particular\docs.particular.net\samples\servicecontrol\monitoring3rdparty\CustomChecks_3\Sample\Sample.csproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2084,5): warning MSB3243: No way to resolve conflict between "System.Net.Http, Version=4.2.2.0, Culture=neutral, PublicKeyToke
n=b03f5f7f11d50a3a" and "System.Net.Http". Choosing "System.Net.Http, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" arbitrarily. [C:\Users\Ramon\src\particular\docs.particular.net\samples\servicecontrol\monitoring3rdparty\CustomCh
ecks_3\Sample\Sample.csproj]
```