### PR TITLE
Resolve build warning by targeting x64 Platform

### DIFF
--- a/Snippets/Gateway/Gateway.sln
+++ b/Snippets/Gateway/Gateway.sln
@@ -10,23 +10,23 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gateway_3", "Gateway_3\Gate
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gateway_3.1", "Gateway_3.1\Gateway_3.1.csproj", "{0BED58FB-CD98-42F0-AF7E-57CE049AA972}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gateway_4", "Gateway_4\Gateway_4.csproj", "{4CD1DE4F-A335-4C91-8C88-6B599907392D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gateway_4", "Gateway_4\Gateway_4.csproj", "{4CD1DE4F-A335-4C91-8C88-6B599907392D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3645B2AA-B83A-4C76-A518-4E133B75B740}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3645B2AA-B83A-4C76-A518-4E133B75B740}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0BED58FB-CD98-42F0-AF7E-57CE049AA972}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0BED58FB-CD98-42F0-AF7E-57CE049AA972}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4CD1DE4F-A335-4C91-8C88-6B599907392D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4CD1DE4F-A335-4C91-8C88-6B599907392D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30F5B3E6-2B7F-46BE-8086-169FD856BA64}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|x64.ActiveCfg = Debug|x64
+		{EC4A0E0D-C95A-4936-BD4F-73959DE7B516}.Debug|x64.Build.0 = Debug|x64
+		{3645B2AA-B83A-4C76-A518-4E133B75B740}.Debug|x64.ActiveCfg = Debug|x64
+		{3645B2AA-B83A-4C76-A518-4E133B75B740}.Debug|x64.Build.0 = Debug|x64
+		{0BED58FB-CD98-42F0-AF7E-57CE049AA972}.Debug|x64.ActiveCfg = Debug|x64
+		{0BED58FB-CD98-42F0-AF7E-57CE049AA972}.Debug|x64.Build.0 = Debug|x64
+		{4CD1DE4F-A335-4C91-8C88-6B599907392D}.Debug|x64.ActiveCfg = Debug|x64
+		{4CD1DE4F-A335-4C91-8C88-6B599907392D}.Debug|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Snippets/Gateway/Gateway_1/Gateway_1.csproj
+++ b/Snippets/Gateway/Gateway_1/Gateway_1.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway" Version="1.*" />

--- a/Snippets/Gateway/Gateway_2/Gateway_2.csproj
+++ b/Snippets/Gateway/Gateway_2/Gateway_2.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.*" />

--- a/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
+++ b/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway" Version="3.1.0" />

--- a/Snippets/Gateway/Gateway_3/Gateway_3.csproj
+++ b/Snippets/Gateway/Gateway_3/Gateway_3.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.*" />

--- a/Snippets/Gateway/Gateway_4/Gateway_4.csproj
+++ b/Snippets/Gateway/Gateway_4/Gateway_4.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>Gateway_3.2</RootNamespace>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway" Version="4.0.0-alpha.173" />


### PR DESCRIPTION
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2084,5): warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "C:\Users\Ramon\.nuget\packages\microsoft.servicefabric.data\2.8.232\lib\net45\Microsoft.ServiceFabric.Data.dll", "AMD64". This mismatch may cause runtime failures. Please consider changing the targ
eted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project. [C:\Users\Ramon\src\particular\docs.particular.net\Snippets\Gateway\Gateway_2\Gateway_2.csproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2084,5): warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "C:\Users\Ramon\.nuget\packages\microsoft.servicefabric.data\2.8.232\lib\net45\Microsoft.ServiceFabric.Data.Interfaces.dll", "AMD64". This mismatch may cause runtime failures. Please consider changi
ng the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project. [C:\Users\Ramon\src\particular\docs.particular.net\Snippets\Gateway\Gateway_2\Gateway_2.csproj]
```