### PR TITLE
Resolves build warnings "Could not locate the assembly "Microsoft.CSharp""

### DIFF
--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <Compile Include="..\Consumer1\Contracts\Consumer1Contract.cs" />
     <Compile Include="..\Consumer2\Contracts\Consumer2Contract.cs" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
 </Project>

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
@@ -4,7 +4,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
 </Project>

--- a/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
@@ -4,7 +4,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
 </Project>

--- a/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.MessageRouting" Version="3.*" />

--- a/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.MessageRouting" Version="3.*" />

--- a/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.MessageRouting" Version="3.*" />

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
@@ -5,7 +5,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />


### PR DESCRIPTION
```
warning MSB3245: Could not resolve this reference. Could not locate the assembly "Microsoft.CSharp". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
```