### PR TITLE
Align Data Bus menu title with page title

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -332,7 +332,7 @@
     - Url: nservicebus/outbox
       Title: Outbox
     - Url: nservicebus/messaging/databus
-      Title: Databus
+      Title: Data Bus
       Articles:
       - Url: nservicebus/messaging/databus/file-share
         Title: File Share


### PR DESCRIPTION
The page seems to use "Data Bus" consistently, only the menu showed "Databus".