### PR TITLE
Show component name when failing the test

### DIFF
--- a/tests/IntegrityTests/ValidatePrereleaseTxt.cs
+++ b/tests/IntegrityTests/ValidatePrereleaseTxt.cs
@@ -23,7 +23,7 @@ namespace IntegrityTests
                     var versionSplit = versionedName.Split('_');
                     var componentName = versionSplit[0];
 
-                    if (!TestSetup.ComponentMetadata.TryGetValue(componentName + "x", out var component))
+                    if (!TestSetup.ComponentMetadata.TryGetValue(componentName, out var component))
                     {
                         Assert.Warn($"Component metadata for component name '{componentName}' was not found.");
                     }

--- a/tests/IntegrityTests/ValidatePrereleaseTxt.cs
+++ b/tests/IntegrityTests/ValidatePrereleaseTxt.cs
@@ -23,7 +23,10 @@ namespace IntegrityTests
                     var versionSplit = versionedName.Split('_');
                     var componentName = versionSplit[0];
 
-                    var component = TestSetup.ComponentMetadata[componentName];
+                    if (!TestSetup.ComponentMetadata.TryGetValue(componentName + "x", out var component))
+                    {
+                        Assert.Warn($"Component metadata for component name '{componentName}' was not found.");
+                    }
 
                     var packageNames = component.NugetOrder;
 


### PR DESCRIPTION
Prior to this change:

```
A total of 1 test files matched the specified pattern.
  Failed VerifyPrereleaseTxtHasPrereleaseComponent [295 ms]
  Error Message:
   System.Collections.Generic.KeyNotFoundException : The given key was not present in the dictionary.
  Stack Trace:
     at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at IntegrityTests.ValidatePrereleaseTxt.<VerifyPrereleaseTxtHasPrereleaseComponent>b__0_0(String path) in C:\github\nsb\docs.particular.net\tests\IntegrityTests\ValidatePrereleaseTxt.cs:line 26
   at IntegrityTests.TestRunner.Run(Func`2 testDelegate) in C:\github\nsb\docs.particular.net\tests\IntegrityTests\Infrastructure\TestRunner.cs:line 40
   at IntegrityTests.ValidatePrereleaseTxt.VerifyPrereleaseTxtHasPrereleaseComponent() in C:\github\nsb\docs.particular.net\tests\IntegrityTests\ValidatePrereleaseTxt.cs:line 18
```

After this change:

```
A total of 1 test files matched the specified pattern.
  Failed VerifyPrereleaseTxtHasPrereleaseComponent [293 ms]
  Error Message:
   System.NullReferenceException : Object reference not set to an instance of an object.  1) Component metadata for component name 'ABSDataBus' was not found.

  Stack Trace:
     at IntegrityTests.ValidatePrereleaseTxt.<VerifyPrereleaseTxtHasPrereleaseComponent>b__0_0(String path) in C:\github\nsb\docs.particular.net\tests\IntegrityTests\ValidatePrereleaseTxt.cs:line 31
   at IntegrityTests.TestRunner.Run(Func`2 testDelegate) in C:\github\nsb\docs.particular.net\tests\IntegrityTests\Infrastructure\TestRunner.cs:line 40
   at IntegrityTests.ValidatePrereleaseTxt.VerifyPrereleaseTxtHasPrereleaseComponent() in C:\github\nsb\docs.particular.net\tests\IntegrityTests\ValidatePrereleaseTxt.cs:line 18
```