### PR TITLE
Add support for .net 5

### DIFF
--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -15,6 +15,7 @@ Note: If possible, packages will target [.NET Standard](https://docs.microsoft.c
 | Target Framework | Version | Platform | Notes |
 |------------------|:-------:|:--------:|:-----|
 | .NET Framework | 4.5.2 or later | [Windows](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies) | Some packages may require a later version. |
+| .NET 5 | 5.0.0 or later | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) | macOS is supported only for development purposes. |
 | .NET Core | 2.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) | macOS is supported only for development purposes. |
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | macOS is supported only for development purposes. |
 


### PR DESCRIPTION
We already have customers using NSB and .NET 5. In addition, we already have a number of engineers already using .NET 5 too.

If there are any problems, our normal support procedure are more than sufficient to triage, diagnose, and fix anything that potentially comes up.

Changing our build server to target net 5 can be done as a separate step.