### PR TITLE
Import-ServiceControlLicense docs writes to filesystem, not registry

### DIFF
--- a/servicecontrol/powershell.md
+++ b/servicecontrol/powershell.md
@@ -51,14 +51,11 @@ Get-Help Get-ServiceControlLicense
 
 ### Licensing
 
-Add the license file to the registry:
+Copies the license file to the correct location on the file system (`%PROGRAMDATA%/ParticularSoftware/license.xml`) so it is available to all instances of ServiceControl installed on the machine.
 
 ```ps
 Import-ServiceControlLicense <License-File>
 ```
-
-The license file is added to the `HKEY_LOCAL_MACHINE` registry hive so it is available to all instances of ServiceControl installed on the machine.
-
 
 ## Troubleshooting via PowerShell
 


### PR DESCRIPTION
Behavior of `Import-ServiceControlLicense` isn't aligned with the docs. Cmdlet writes to file-system and not the registry. Might have been introduced by 214c2e63acea74ce1dd99a0edefb062750a623e9

- [ ] Do we need to multi-verion this docs?