### PR TITLE
Link to Audit and Monitoring log configration

### DIFF
--- a/servicecontrol/logging.md
+++ b/servicecontrol/logging.md
@@ -69,7 +69,9 @@ NOTE: The change in log naming will result in logs produced prior to Version 1.1
 
 ### Logging Levels
 
-Instances of the ServiceControl service write logging information and failed message import stack traces to the file system.
+Instances of the ServiceControl service write logging information and failed message import stack traces to the file system. 
+
+To configure logging for ServiceControl Audit and Monitoring instances, refer to the [ServiceControl Audit configuration settings](/servicecontrol/audit-instances/creating-config-file.md#host-settings-servicecontrol-auditloglevel) or [ServiceControl Monitoring configuration settings](/servicecontrol/monitoring-instances/installation/creating-config-file.md#logging-monitoringloglevel) documentation pages.
 
 #### Versions 1.8.3 and below
 


### PR DESCRIPTION
The documentation can be a bit misleading when trying to change the log levels for audit or monitoring instances as it's not clear on this documentation page about logging in ServiceControl that the Audit and Monitoring instances use different config keys.