### PR TITLE
SQLT Multi-schema doco updates

### DIFF
--- a/transports/sql/connection-settings.md
+++ b/transports/sql/connection-settings.md
@@ -33,7 +33,7 @@ The SQL Server transport uses `dbo` as a default schema. It is used for every qu
 
 partial: custom-schema
 
-NOTE: When subscribing to events between endpoints in different database schemas, a [shared subscription table needs to be configured](/transports/sql/native-publish-subscribe#configure-subscription-table).
+NOTE: When subscribing to events between endpoints in different database schemas, a [shared subscription table needs to be configured](/transports/sql/native-publish-subscribe.md#configure-subscription-table).
 
 ## Custom SQL Server transport connection factory
 

--- a/transports/sql/connection-settings.md
+++ b/transports/sql/connection-settings.md
@@ -33,6 +33,8 @@ The SQL Server transport uses `dbo` as a default schema. It is used for every qu
 
 partial: custom-schema
 
+NOTE: When subscribing to events between endpoints in different database schemas, a [shared subscription table needs to be configured](/transports/sql/native-publish-subscribe#configure-subscription-table).
+
 ## Custom SQL Server transport connection factory
 
 In some environments it might be necessary to adapt to the database server settings, or to perform additional operations. For example, if the `NOCOUNT` setting is enabled on the server, then it is necessary to send the `SET NOCOUNT OFF` command right after opening the connection.

--- a/transports/sql/native-publish-subscribe.md
+++ b/transports/sql/native-publish-subscribe.md
@@ -28,7 +28,7 @@ snippet: disable-subscription-cache
 
 ## Configure subscription table
 
-A single subscription table is used by all endpoints. By default this table will be named `[SubscriptionRouting]` and be created in the `[dbo]` schema of the catalog specified in the connection string. To change where this table is created and how it is named, use the following API:
+A single subscription table is used by all endpoints. By default this table will be named `[SubscriptionRouting]` and be created in the default schema of the catalog specified in the connection string. To change where this table is created and how it is named, use the following API:
 
 snippet: configure-subscription-table
 


### PR DESCRIPTION
Some clarification about using a shared subscription table when using multiple schemas across pub-sub endpoints.