### PR TITLE
IAmStartedByMessage initializes mapped correlation property

### DIFF
--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -45,7 +45,7 @@ Since a saga manages the state of a long-running process, under which conditions
 
 NOTE: `IHandleMessages<StartOrder>` is redundant since `IAmStartedByMessages<StartOrder>` already implies that.
 
-This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. The message will set it's mapped correlation property on the created saga data. In essence the semantics of `IAmStartedByMessages` is:
+This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. As a convenience, in NServiceBus version 6 and above, the message will set it's mapped correlation property on the created saga data. In essence the semantics of `IAmStartedByMessages` is:
 
 > Create a new instance if an existing one can't be found
 

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -45,7 +45,7 @@ Since a saga manages the state of a long-running process, under which conditions
 
 NOTE: `IHandleMessages<StartOrder>` is redundant since `IAmStartedByMessages<StartOrder>` already implies that.
 
-This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. In essence the semantics of `IAmStartedByMessages` is:
+This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. The message will set it's mapped correlation property on the saga data. In essence the semantics of `IAmStartedByMessages` is:
 
 > Create a new instance if an existing one can't be found
 

--- a/nservicebus/sagas/index.md
+++ b/nservicebus/sagas/index.md
@@ -45,7 +45,7 @@ Since a saga manages the state of a long-running process, under which conditions
 
 NOTE: `IHandleMessages<StartOrder>` is redundant since `IAmStartedByMessages<StartOrder>` already implies that.
 
-This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. The message will set it's mapped correlation property on the saga data. In essence the semantics of `IAmStartedByMessages` is:
+This interface tells NServiceBus that the saga not only handles `StartOrder`, but that when that type of message arrives, a new instance of this saga should be created to handle it, if there isn't already an existing saga that correlates to the message. The message will set it's mapped correlation property on the created saga data. In essence the semantics of `IAmStartedByMessages` is:
 
 > Create a new instance if an existing one can't be found
 


### PR DESCRIPTION
It may be obvious to you but I was very confused that it's not explicitly stated, that `IAmStartedByMessage` messages automatically initializes the correlation property on the `SagaData` which is mapped in the `ConfigureHowToFindSaga()` method.