### PR TITLE
Reduce concurrency by applying sequential scatter/gather

### DIFF
--- a/nservicebus/sagas/concurrency.md
+++ b/nservicebus/sagas/concurrency.md
@@ -155,6 +155,8 @@ A simpler approach is to split the request just once and have a single level of 
 
 When using a [scatter-gather](https://www.enterpriseintegrationpatterns.com/patterns/messaging/BroadcastAggregate.html) pattern or similar, simultaneously sending a large number of requests may result in simultaneous processing of a large number of responses, which may lead to data contention. Instead, consider sending requests sequentially. In each iteration, send the next request only after the response from the previous request was processed. This approach removes data contention when processing responses but may increase both the overall duration and the size of saga state required to store data while waiting for responses.
 
+Usually, the tradeoff is that the message that initiated the scatter/gather contains data that must now be stored in the saga state so that it can be added to each outgoing request in each iteration.
+
 #### Create an append-only saga data model
 
 Currently, this is only possible with the NHibernate persister and a custom mapping. It requires advanced knowledge of NHibernate. Data added to a collection must be mapped to another entity so that the the master/parent row does not need to be updated. This way there is no data contention on the table row representing the saga instance data root.

--- a/nservicebus/sagas/concurrency.md
+++ b/nservicebus/sagas/concurrency.md
@@ -153,7 +153,7 @@ A simpler approach is to split the request just once and have a single level of 
 
 #### Sequential scatter/gather
 
-Instead of sending out a large number of requests where simultanious processing of all responses is causing data contention consider sending the requests sequentially. Meaning, send the next request only after the response of the previous request has been processed. This will remove data contention in the procesing of responses but will increase the total duration the gathering of data will take and increase the saga state to store the data for all requests.
+When using a [scatter-gather](https://www.enterpriseintegrationpatterns.com/patterns/messaging/BroadcastAggregate.html) pattern or similar, simultaneously sending a large number of requests may result in simultaneous processing of a large number of responses, which may lead to data contention. Instead, consider sending requests sequentially. In each iteration, send the next request only after the response from the previous request was processed. This approach removes data contention when processing responses but may increase both the overall duration and the size of saga state required to store data while waiting for responses.
 
 #### Create an append-only saga data model
 

--- a/nservicebus/sagas/concurrency.md
+++ b/nservicebus/sagas/concurrency.md
@@ -151,6 +151,10 @@ In the above example, the requests are split into two groups each time. Dependin
 
 A simpler approach is to split the request just once and have a single level of sub-sagas sending the requests and aggregating the responses. This will not reduce data contention to the same degree, since the originating saga will be aggregating more multiple responses.
 
+#### Sequential scatter/gather
+
+Instead of sending out a large number of requests where simultanious processing of all responses is causing data contention consider sending the requests sequentially. Meaning, send the next request only after the response of the previous request has been processed. This will remove data contention in the procesing of responses but will increase the total duration the gathering of data will take and increase the saga state to store the data for all requests.
+
 #### Create an append-only saga data model
 
 Currently, this is only possible with the NHibernate persister and a custom mapping. It requires advanced knowledge of NHibernate. Data added to a collection must be mapped to another entity so that the the master/parent row does not need to be updated. This way there is no data contention on the table row representing the saga instance data root.

--- a/nservicebus/sagas/concurrency.md
+++ b/nservicebus/sagas/concurrency.md
@@ -153,9 +153,7 @@ A simpler approach is to split the request just once and have a single level of 
 
 #### Sequential scatter/gather
 
-When using a [scatter-gather](https://www.enterpriseintegrationpatterns.com/patterns/messaging/BroadcastAggregate.html) pattern or similar, simultaneously sending a large number of requests may result in simultaneous processing of a large number of responses, which may lead to data contention. Instead, consider sending requests sequentially. In each iteration, send the next request only after the response from the previous request was processed. This approach removes data contention when processing responses but may increase both the overall duration and the size of saga state required to store data while waiting for responses.
-
-Usually, the tradeoff is that the message that initiated the scatter/gather contains data that must now be stored in the saga state so that it can be added to each outgoing request in each iteration.
+When using a [scatter-gather](https://www.enterpriseintegrationpatterns.com/patterns/messaging/BroadcastAggregate.html) pattern or similar, simultaneously sending a large number of requests may result in simultaneous processing of a large number of responses, which may lead to data contention. Instead, consider sending requests sequentially. In each iteration, send the next request only after the response from the previous request was processed. This approach removes data contention when processing responses but may increase the overall duration. Also, the size of the saga state may increase, because it may need to contain some of the data from the message which initiated the scatter-gather so that that data can be included in each request.
 
 #### Create an append-only saga data model
 


### PR DESCRIPTION
I saw this optimization is missing in the concurrency guidance.