### PR TITLE
Update supported-platforms.md

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -93,7 +93,7 @@
       - Url: nservicebus/upgrades/all-versions
         Title: All versions
       - Url: nservicebus/upgrades/supported-platforms
-        Title: Supported platforms
+        Title: Supported frameworks and platforms
     - Url: nservicebus/upgrades/release-policy
       Title: Release Policy
     - Url: nservicebus/upgrades/third-party-licenses

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -1,7 +1,7 @@
 ---
-title: Supported platforms
-summary: Platforms that are supported by NServiceBus
-reviewed: 2019-07-19
+title: Supported platforms and frameworks
+summary: Platforms and frameworks supported by NServiceBus
+reviewed: 2021-02-04
 related:
  - nservicebus/licensing
  - nservicebus/upgrades/release-policy

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -1,6 +1,6 @@
 ---
-title: Supported platforms and frameworks
-summary: Platforms and frameworks supported by NServiceBus
+title: Supported frameworks and platforms
+summary: Frameworks and platforms supported by NServiceBus
 reviewed: 2021-02-04
 related:
  - nservicebus/licensing

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -8,7 +8,7 @@ related:
  - nservicebus/upgrades/supported-versions
 ---
 
-| Target Framework | Version | Platform | Support | Notes |
+| Framework | Version | Platform | Support | Notes |
 |------------------|:-------:|:--------:|:-------:|:------|
 | .NET Framework | 4.5.2 or later | [Windows](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies) | Supported | Some packages may require a later version. |
 | .NET Core | 2.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) | Supported | macOS is supported only for development purposes. |


### PR DESCRIPTION
"Target Framework" and "Platform" are not the right terms to describe frameworks such as ".NET Framework", ".NET Core", or ".NET 5.0". Those are frameworks. "Platform" and "target framework" have different connotations.

For example, "cross-platform" is associated with OS platforms. Windows to Linux would be considered cross-platform. 
When talking about _frameworks_ for .NET, cross-framework would be the right term to describe interoperability between .NET Framework and .NET 5.0.