### PR TITLE
Dynamic strikethrough for unsupported versions

### DIFF
--- a/nservicebus/upgrades/all-versions.md
+++ b/nservicebus/upgrades/all-versions.md
@@ -12,3 +12,5 @@ related:
 This page lists all versions of all currently and previously supported NServiceBus packages.
 
 include: all-versions
+
+<script type="text/javascript" src="supported-versions.js"></script>

--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -39,7 +39,6 @@ include: supported-versions-nservicebus
 
 For other NServiceBus packages, refer to [the list of supported versions of all packages](supported-versions.md).
 
-
 ## Extended support
 
 Extended support is offered on major versions of NServiceBus for a period of 2 years after the expiration of mainstream support, for an additional fee. Because major versions of NServiceBus are generally supported for at least 3 years (or longer, depending upon the cadence of NServiceBus major releases), extended support affords the peace of mind that a major version of NServiceBus will be supported for at least 5 years. To qualify for extended support, a valid support agreement with Particular Software is required.
@@ -60,11 +59,9 @@ The following table describes the extended support status for all major versions
 |NServiceBus 4|2013-07-11|Unsupported|2016-09-29|2018-09-29|
 |NServiceBus 3|2012-03-08|Unsupported|2015-07-11|2017-07-11|
 
-
 ## Compatibility guarantees
 
 All new features are backward compatible by default. In rare cases when this is not possible, the new feature will be disabled by default and require an explicit opt-in in order to be enabled. These features are covered in the [upgrade guide](/nservicebus/upgrades/) for the new target version.
-
 
 ## Upgrading
 
@@ -73,7 +70,6 @@ NServiceBus versions are wire-compatible; endpoints using different versions of 
 However, some features might require data migration (e.g. converting from an old to a new format). The migration might be performed as a one-off automated action done through [installers](/nservicebus/operations/installers.md) or in the background by a running endpoint. If the conversion cannot be automated, the applicable upgrade guide will contain a description of the manual process (e.g. what script to run).
 
 Therefore the recommended approach is to upgrade *one* major version at a time, including a full regression test of the system and deployment to production after each major version upgrade.
-
 
 ## FAQ
 
@@ -94,3 +90,5 @@ In accordance with the [release policy](release-policy.md), important fixes are 
 Component packages, such as [transports](/transports/), [persisters](/persistence/), [dependency injection](/nservicebus/dependency-injection/), or [serializers](/nservicebus/serialization/), have much less upgrade risk than the NServiceBus package. Therefore, the commitment to backporting fixes affecting the NServiceBus package is higher than for the many component packages.
 
 The support dates for NServiceBus and each component package can be found on the [supported versions](supported-versions.md) page.
+
+<script type="text/javascript" src="supported-versions.js"></script>

--- a/nservicebus/upgrades/supported-versions.js
+++ b/nservicebus/upgrades/supported-versions.js
@@ -1,23 +1,26 @@
-var now = new Date();
-var x = document.getElementsByTagName("tr");
-var i;
-for (i = 0; i < x.length; i++) {
-    var tr = x[i];
-
-    if(tr.childNodes.length>3)
-    {
-        var dateString = tr.childNodes[2].innerText
-        var extended = tr.childNodes[3].innerText
-        var isExtended = extended.startsWith("Extended");
-        if(isExtended)
+'use strict';
+(function () {
+    var now = new Date();
+    var x = document.getElementsByTagName("tr");
+    var i;
+    for (i = 0; i < x.length; i++) {
+        var tr = x[i];
+    
+        if(tr.childNodes.length>3)
         {
-            dateString = extended.slice(-10);
-        }
-        var d = new Date(dateString);
-        var isPast = now > d;
-        if(isPast)
-        {
-            tr.style='color:maroon;text-decoration:line-through';
+            var dateString = tr.childNodes[2].innerText
+            var extended = tr.childNodes[3].innerText
+            var isExtended = extended.startsWith("Extended");
+            if(isExtended)
+            {
+                dateString = extended.slice(-10);
+            }
+            var d = new Date(dateString);
+            var isPast = now > d;
+            if(isPast)
+            {
+                tr.style='text-decoration:line-through';
+            }
         }
     }
-}
+} ());

--- a/nservicebus/upgrades/supported-versions.js
+++ b/nservicebus/upgrades/supported-versions.js
@@ -1,0 +1,23 @@
+var now = new Date();
+var x = document.getElementsByTagName("tr");
+var i;
+for (i = 0; i < x.length; i++) {
+    var tr = x[i];
+
+    if(tr.childNodes.length>3)
+    {
+        var dateString = tr.childNodes[2].innerText
+        var extended = tr.childNodes[3].innerText
+        var isExtended = extended.startsWith("Extended");
+        if(isExtended)
+        {
+            dateString = extended.slice(-10);
+        }
+        var d = new Date(dateString);
+        var isPast = now > d;
+        if(isPast)
+        {
+            tr.style='color:maroon;text-decoration:line-through';
+        }
+    }
+}

--- a/nservicebus/upgrades/supported-versions.md
+++ b/nservicebus/upgrades/supported-versions.md
@@ -13,3 +13,5 @@ This page lists both currently and recently supported versions of all NServiceBu
 
 include: supported-versions-nservicebus
 include: supported-versions-downstreams
+
+<script type="text/javascript" src="supported-versions.js"></script>


### PR DESCRIPTION
Does not require the version script to run only for applying strikethrough styling.

![image](https://user-images.githubusercontent.com/152998/110805232-2ea6af80-8281-11eb-940c-ad855991772f.png)
