### PR TITLE
ASB native customization not supported with Outbox

### DIFF
--- a/transports/azure-service-bus/native-message-access.md
+++ b/transports/azure-service-bus/native-message-access.md
@@ -22,3 +22,5 @@ The behavior above uses the native message's `LockedUntilUtc` system property to
 It can also be useful to access the native Service Bus outgoing message from behaviors and handlers for customizations. 
 
 partial: snippets
+
+Note: Native outgoing messages cannot be customized when using the Outbox as customizations are not persistent.

--- a/transports/azure-service-bus/native-message-access.md
+++ b/transports/azure-service-bus/native-message-access.md
@@ -23,4 +23,4 @@ It can also be useful to access the native Service Bus outgoing message from beh
 
 partial: snippets
 
-Note: Native outgoing messages cannot be customized when using the Outbox as customizations are not persistent.
+Note: Native outgoing messages cannot be customized when using the [Outbox](/nservicebus/outbox/) as customizations are not persistent.


### PR DESCRIPTION
Documents that native message customization is not supported when the Outbox is enabled.