### PR TITLE
Remove "current status" column from extended support table

### DIFF
--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -51,13 +51,12 @@ During the extended support period:
 
 The following table describes the extended support status for all major versions:
 
-|Version|Released|Mainstream Support Expires|Extended Support Expires|
-|:-:|:-:|:-:|:-:|
-|NServiceBus 7|2018-03-30|Current Version|Current Version|
-|NServiceBus 6|2016-10-11|2020-05-29|2022-05-29|
-|NServiceBus 5|2014-09-29|2018-10-11|2020-10-12|
-|NServiceBus 4|2013-07-11|2016-09-29|2018-09-29|
-|NServiceBus 3|2012-03-08|2015-07-11|2017-07-11|
+|Version|Mainstream Support Expires|Extended Support Expires|
+|:-:|:-:|:-:|
+|NServiceBus 6|2020-05-29|2022-05-29|
+|NServiceBus 5|2018-10-11|2020-10-12|
+|NServiceBus 4|2016-09-29|2018-09-29|
+|NServiceBus 3|2015-07-11|2017-07-11|
 
 ## Compatibility guarantees
 

--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -51,7 +51,7 @@ During the extended support period:
 
 The following table describes the extended support status for all major versions:
 
-|Version|Released|Current Support|Extended Support Expires|
+|Version|Released|Mainstream Support Expires|Extended Support Expires|
 |:-:|:-:|:-:|:-:|
 |NServiceBus 7|2018-03-30|Current Version|Current Version|
 |NServiceBus 6|2016-10-11|2020-05-29|2022-05-29|

--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -51,13 +51,13 @@ During the extended support period:
 
 The following table describes the extended support status for all major versions:
 
-|Version|Released|Current Support|Mainstream Support Expires|Extended Support Expires|
-|:-:|:-:|:-:|:-:|:-:|
-|NServiceBus 7|2018-03-30|Mainstream|Current Version|Current Version|
-|NServiceBus 6|2016-10-11|Extended|2020-05-29|2022-05-29|
-|NServiceBus 5|2014-09-29|Unsupported|2018-10-11|2020-10-12|
-|NServiceBus 4|2013-07-11|Unsupported|2016-09-29|2018-09-29|
-|NServiceBus 3|2012-03-08|Unsupported|2015-07-11|2017-07-11|
+|Version|Released|Current Support|Extended Support Expires|
+|:-:|:-:|:-:|:-:|
+|NServiceBus 7|2018-03-30|Current Version|Current Version|
+|NServiceBus 6|2016-10-11|2020-05-29|2022-05-29|
+|NServiceBus 5|2014-09-29|2018-10-11|2020-10-12|
+|NServiceBus 4|2013-07-11|2016-09-29|2018-09-29|
+|NServiceBus 3|2012-03-08|2015-07-11|2017-07-11|
 
 ## Compatibility guarantees
 


### PR DESCRIPTION
Since it adds no value and can be forgotten when updating the page. The dates in there already show if it's supported or not. We could in theory make the column dynamic based on those dates but that is YAGNI for now

remains:

- [ ] Make Current Support dynamic