### PR TITLE
Clean up command line parameters

### DIFF
--- a/tools/build-samples-and-snippets.ps1
+++ b/tools/build-samples-and-snippets.ps1
@@ -99,11 +99,11 @@ foreach($sample in $samples) {
         if(Test-Path $msBuildMarkerFile)
         {
             Write-Output ("::warning::Using msbuild for sample using legacy csproj format: {0}" -f $sample.FullName)
-            msbuild $sample.Name -nodeReuse:true -verbosity:minimal -restore -property:RestorePackagesConfig=true
+            msbuild $sample.Name -verbosity:minimal -restore -property:RestorePackagesConfig=true
         }
         else 
         {
-            dotnet build $sample.Name -nodeReuse:true -verbosity:minimal -restore -property:RestorePackagesConfig=true
+            dotnet build $sample.Name --verbosity minimal
         }
         
         if( -not $? ) {


### PR DESCRIPTION
Makes the following changes:
- Removes `nodeReuse` from both commands since the default value is `true`
- Changes `dotnet` verbosity to the correct syntax for the command
- Removes `dotnet` property:RestorePackagesConfig because that doesn't do anything.

Default `dotnet` verbosity is already `minimal`, but I left it there for now.