### PR TITLE
Multi-hosting with generic host - workaround for a failing endpoint

### DIFF
--- a/samples/hosting/generic-multi-hosting/Core_7/Sample.MultiHosting/Program.cs
+++ b/samples/hosting/generic-multi-hosting/Core_7/Sample.MultiHosting/Program.cs
@@ -16,7 +16,10 @@ class Program
         var endpointOneBuilder = ConfigureEndpointOne(Host.CreateDefaultBuilder(args)).Build();
         var endpointTwoBuilder = ConfigureEndpointTwo(Host.CreateDefaultBuilder(args)).Build();
 
-        await Task.WhenAll(endpointOneBuilder.RunAsync(), endpointTwoBuilder.RunAsync());
+        await Task.WhenAll(endpointOneBuilder.StartAsync(), endpointTwoBuilder.StartAsync());
+        await Task.WhenAll(endpointOneBuilder.WaitForShutdownAsync(), endpointTwoBuilder.WaitForShutdownAsync());
+        endpointOneBuilder.Dispose();
+        endpointTwoBuilder.Dispose();
 
         #endregion
     }

--- a/samples/hosting/generic-multi-hosting/sample.md
+++ b/samples/hosting/generic-multi-hosting/sample.md
@@ -17,7 +17,9 @@ snippet: multi-hosting-startup
 
 An important thing to keep in mind is that [dependency injection](/nservicebus/dependency-injection/) is used internally to register components, handlers, and sagas. Each host has a separate ServiceProvider which means the containers are not shared between the endpoints. 
 
-To ensure that each endpoint instance registers only its own components like message handlers, it is important to specify an assembly scan policy using [one of the supported approaches](/nservicebus/hosting/assembly-scanning.md). 
+To ensure that each endpoint instance registers only its own components like message handlers, it is important to specify an assembly scan policy using [one of the supported approaches](/nservicebus/hosting/assembly-scanning.md).
+
+WARN: A single endpoint failure to start will cause the host to shutdown, terminating the other endpoint.
 
 In this example, complete isolation is required between the two endpoints so that the types from Instance2 are excluded from Instance1 and vice versa.
 


### PR DESCRIPTION
Workaround for a single endpoint failing scenario to take down the host to ensure no endpoint is reported as active.
Related to a support case that was a result of a public issue https://github.com/Particular/NServiceBus.Heartbeat/issues/121.