### PR TITLE
editorial review of SC remotes

### DIFF
--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -6,7 +6,6 @@ component: ServiceControl
 
 [ServiceInsight](/serviceinsight/) connects to a [ServiceControl instance](/servicecontrol/servicecontrol-instances/) via an http api in order to create visualizations. In some installations, data to complete a visualization may reside in multiple ServiceControl instances. The ServiceControl Remotes features allows a ServiceControl instance to include results from other ServiceControl instances when responding to queries about audit messages, providing a unified experience in ServiceInsight.
 
-
 ## Overview
 
 Designate one ServiceControl instance to be the _primary_ instance. All other ServiceControl instances will be _remote_ instances. Queries to the primary ServiceControl instance will include results from the primary instance and from all of the remote ServiceControl instances. ServiceInsight should be configured to connect to the primary ServiceControl instance.
@@ -14,7 +13,6 @@ Designate one ServiceControl instance to be the _primary_ instance. All other Se
 NOTE: The term remote refers to the fact that instances run in a separate process. A primary instance can run on the same machine as one or more of it's remote instances.
 
 In ServiceControl version 4 and above, a primary ServiceControl instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
-
 
 ### Default deployment
 
@@ -32,7 +30,6 @@ AuditsMain -- ingested by --> Secondary
 Errors-- ingested by --> Primary
 Primary -. connected to .-> Secondary
 ```
-
 
 ### Sharding audit messages with competing consumers
 
@@ -54,17 +51,16 @@ Primary -. connected to .-> Secondary1
 Primary -. connected to .-> Secondary2
 ```
 
-
 ### Sharding audit messages with split audit queue
 
-Endpoints are partitioned to send processed messages to different audit queues. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for different sets of endpoints. 
+Endpoints are partitioned to send processed messages to different audit queues. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for different sets of endpoints.
 
 ```mermaid
 graph TD
 SI[ServiceInsight] -. connected to .->Primary
 SP[ServicePulse] -. connected to .-> Primary
 Endpoints -- audits to--> AuditsMain(audit-1)
-OtherEndpoints -- auditsto--> AuditsSecondary(audit-2)
+OtherEndpoints -- audits to--> AuditsSecondary(audit-2)
 Endpoints -- errors to --> Errors(error)
 Primary[ServiceControl<br/>Primary]
 Secondary1[ServiceControl<br/>Audit remote 1]
@@ -76,13 +72,11 @@ Primary -. connected to .-> Secondary1
 Primary -. connected to .-> Secondary2
 ```
 
-
 ## Configuration
 
-The ServiceControl primary instance maintains a list of remotes in it's configuration file under the key `ServiceControl/RemoteInstances`. The value of this setting is a json array of remote instances. Each entry must have an `api_url` property that contains the api url of the remote instance. In version 3 and below, each entry must also have a `queue_address` property that contains the queue address for the remote instance. 
+The ServiceControl primary instance maintains a list of remotes in it's configuration file under the key `ServiceControl/RemoteInstances`. The value of this setting is a json array of remote instances. Each entry must have an `api_url` property that contains the api url of the remote instance. In version 3 and below, each entry must also have a `queue_address` property that contains the queue address for the remote instance.
 
 NOTE: Changes to the configuration file will not take effect until the primary instance is restarted.
-
 
 ### Version 3 and below
 
@@ -94,7 +88,6 @@ NOTE: Changes to the configuration file will not take effect until the primary i
 </configuration>
 ```
 
-
 ### Version 4 and above
 
 ```xml
@@ -104,7 +97,6 @@ NOTE: Changes to the configuration file will not take effect until the primary i
   </appSettings>/
 </configuration>
 ```
-
 
 ## PowerShell
 
@@ -118,7 +110,6 @@ The following cmdlets are available in ServiceControl version 4 and above, for t
 
 See [Manage ServiceControl instances via PowerShell](/servicecontrol/installation-powershell.md) and [Managing ServiceControl Audit instances via PowerShell](/servicecontrol/audit-instances/installation-powershell.md) for details on how to find ServiceControl instance names and urls.
 
-
 ### Add a remote instance
 
 Use the `Add-ServiceControlRemote` cmdlet to add a remote instance to a primary ServiceControl instance.
@@ -126,7 +117,6 @@ Use the `Add-ServiceControlRemote` cmdlet to add a remote instance to a primary 
 ```ps
 Add-ServiceControlRemote -Name Particular.ServiceControl -RemoteInstanceAddress "http://localhost:44444/api"
 ```
-
 
 ### Remove a remote instance
 
@@ -136,7 +126,6 @@ Use the `Remove-ServiceControlRemote` cmdlet to remove a remote instance from a 
 Remove-ServiceControlRemote -Name Particular.ServiceControl -RemoteInstanceAddress "http://localhost:44444/api"
 ```
 
-
 ### List remote instance
 
 Use the `Get-ServiceControlRemotes` cmdlet to get a list of remote instances for a primary ServiceControl instance.
@@ -145,21 +134,19 @@ Use the `Get-ServiceControlRemotes` cmdlet to get a list of remote instances for
 Get-ServiceControlRemotes -Name Particular.ServiceControl
 ```
 
-
 ### Moving a remote instance
 
 If a remote instance must be moved to a different host or port number, follow these steps:
 
 1. Remove the old address from the list of remote instances
-  - `Remove-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $oldAddress`
+   - `Remove-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $oldAddress`
 2. Restart the primary ServiceControl instance to refresh the list of remote instances
 3. Stop the remote instance to be moved
 4. Modify the host and port number of the remote instance using the ServiceControl Management utility
 5. Start the remote instance at it's new address
 6. Add the new address to the list of remote instances
-  - `Add-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $newAddress`
+   - `Add-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $newAddress`
 7. Restart the primary ServiceControl instance to refresh the list of remote instances
-
 
 ## Considerations
 

--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -4,91 +4,122 @@ reviewed: 2021-04-06
 component: ServiceControl
 ---
 
-[ServiceInsight](/serviceinsight/) connects to a [ServiceControl instance](/servicecontrol/servicecontrol-instances/) via an http api in order to create visualizations. In some installations, data to complete a visualization may reside in multiple ServiceControl instances. The ServiceControl Remotes features allows a ServiceControl instance to include results from other ServiceControl instances when responding to queries about audit messages, providing a unified experience in ServiceInsight.
+[ServiceInsight](/serviceinsight/) and [ServicePulse](/servicepulse) retrieve data from a [ServiceControl instance](/servicecontrol/servicecontrol-instances/) using an HTTP API. In some installations, that data may reside in multiple ServiceControl instances. The ServiceControl Remotes features allows a ServiceControl instance to aggregate data from other ServiceControl instances, providing a unified experience in ServiceInsight and ServicePulse.
 
 ## Overview
 
-Designate one ServiceControl instance to be the _primary_ instance. All other ServiceControl instances will be _remote_ instances. Queries to the primary ServiceControl instance will include results from the primary instance and from all of the remote ServiceControl instances. ServiceInsight should be configured to connect to the primary ServiceControl instance.
+One ServiceControl instance is designated as the _primary_ instance. All other ServiceControl instances are _remote_ instances. The HTTP API of the primary instance aggregates data from the primary instance and from all the remote instances. ServiceInsight and ServicePulse are configured to connect to the primary instance.
 
-NOTE: The term remote refers to the fact that instances run in a separate process. A primary instance can run on the same machine as one or more of it's remote instances.
+NOTE: The term _remote_ refers to the fact that remote instances are run in separate processes. The primary instance and one or more remote instances can run on the same machine.
 
-In ServiceControl version 4 and above, a primary ServiceControl instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
+In ServiceControl version 4 and later, a primary ServiceControl instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
 
 ### Default deployment
 
-In ServiceControl version 4 and above, the ServiceControl Management utility will create a primary ServiceControl instance and a remote ServiceControl Audit instance.
+In ServiceControl version 4 and above, the ServiceControl Management utility creates a primary ServiceControl instance and a remote ServiceControl Audit instance.
 
 ```mermaid
 graph TD
-SI[ServiceInsight] -. connected to .->Primary
-SP[ServicePulse] -. connected to .-> Primary
-Endpoints -- audits to--> AuditsMain(audit)
-Endpoints -- errors to --> Errors(error)
-Primary[ServiceControl<br/>Primary]
-Secondary[ServiceControl<br/>Audit remote]
-AuditsMain -- ingested by --> Secondary
-Errors-- ingested by --> Primary
-Primary -. connected to .-> Secondary
+Endpoints[endpoints] -- send audits to --> AuditQueue(audit queue)
+
+Endpoints -- send errors to --> ErrorQueue(error queue)
+
+ErrorQueue -- ingested by --> ServiceControl[ServiceControl<br/>primary]
+ServiceInsight -. connected to .-> ServiceControl
+ServicePulse -. connected to .-> ServiceControl
+
+AuditQueue -- ingested by --> ServiceControlAudit[ServiceControl Audit<br/>remote]
+ServiceControl -. connected to .-> ServiceControlAudit
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class Endpoints Endpoints
+class ServiceInsight ServiceInsight
+class ServicePulse ServicePulse
+class ServiceControl ServiceControlPrimary
+class ServiceControlAudit ServiceControlRemote
 ```
 
 ### Sharding audit messages with competing consumers
 
-Two ServiceControl Audit instances manage the same audit queue. This approach can be applied to handle large audit queues.
+Two ServiceControl Audit instances ingest messages from the same audit queue. This approach can be used to scale out the ingestion of messages from high-volume audit queues.
 
 ```mermaid
 graph TD
-SI[ServiceInsight] -. connected to .->Primary
-SP[ServicePulse] -. connected to .-> Primary
-Endpoints -- audits to--> AuditsMain(audit)
-Endpoints -- errors to --> Errors(error)
-Primary[ServiceControl<br/>Primary]
-Secondary1[ServiceControl<br/>Audit remote 1]
-Secondary2[ServiceControl<br/>Audit remote 2]
-AuditsMain -- ingested by --> Secondary1
-AuditsMain -- ingested by --> Secondary2
-Errors-- ingested by --> Primary
-Primary -. connected to .-> Secondary1
-Primary -. connected to .-> Secondary2
+Endpoints[endpoints] -- send audits to --> AuditQueue(audit queue)
+
+Endpoints -- send errors to --> ErrorQueue(error queue)
+
+ErrorQueue -- ingested by --> ServiceControl[ServiceControl<br/>primary]
+ServiceInsight -. connected to .-> ServiceControl
+ServicePulse -. connected to .-> ServiceControl
+
+AuditQueue -- ingested by --> ServiceControlAudit1[ServiceControl Audit 1<br/>remote]
+ServiceControl -. connected to .-> ServiceControlAudit1
+
+AuditQueue -- ingested by --> ServiceControlAudit2[ServiceControl Audit 2<br/>remote]
+ServiceControl -. connected to .-> ServiceControlAudit2
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class Endpoints Endpoints
+class ServiceInsight ServiceInsight
+class ServicePulse ServicePulse
+class ServiceControl ServiceControlPrimary
+class ServiceControlAudit1,ServiceControlAudit2 ServiceControlRemote
 ```
 
-### Sharding audit messages with split audit queue
+### Sharding audit messages with split audit queues
 
-Endpoints are partitioned to send processed messages to different audit queues. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for different sets of endpoints.
+Endpoints are partitioned into groups. Each group sends messages to its own a different audit queue. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for specific groups of endpoints.
 
 ```mermaid
 graph TD
-SI[ServiceInsight] -. connected to .->Primary
-SP[ServicePulse] -. connected to .-> Primary
-Endpoints -- audits to--> AuditsMain(audit-1)
-OtherEndpoints -- audits to--> AuditsSecondary(audit-2)
-Endpoints -- errors to --> Errors(error)
-Primary[ServiceControl<br/>Primary]
-Secondary1[ServiceControl<br/>Audit remote 1]
-Secondary2[ServiceControl<br/>Audit remote 2]
-AuditsMain -- ingested by --> Secondary1
-AuditsSecondary -- ingested by --> Secondary2
-Errors-- ingested by --> Primary
-Primary -. connected to .-> Secondary1
-Primary -. connected to .-> Secondary2
+Endpoints1[endpoints<br/>group 1] -- send audits to --> AuditQueue1(audit queue 1)
+
+Endpoints1 -- send errors to --> ErrorQueue(error queue)
+Endpoints2[endpoints<br/>group 2] -- send errors to --> ErrorQueue
+
+ErrorQueue -- ingested by --> ServiceControl[ServiceControl<br/>primary]
+ServiceInsight -. connected to .->ServiceControl
+ServicePulse -. connected to .-> ServiceControl
+
+Endpoints2 -- send audits to--> AuditQueue2(audit queue 2)
+
+AuditQueue1 -- ingested by --> ServiceControlAudit1[ServiceControl Audit 1<br/>remote]
+ServiceControl -. connected to .-> ServiceControlAudit1
+
+ServiceControl -. connected to .-> ServiceControlAudit2[ServiceControl Audit 2<br/>remote]
+AuditQueue2 -- ingested by --> ServiceControlAudit2
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class Endpoints1,Endpoints2 Endpoints
+class ServiceInsight ServiceInsight
+class ServicePulse ServicePulse
+class ServiceControl ServiceControlPrimary
+class ServiceControlAudit1,ServiceControlAudit2 ServiceControlRemote
 ```
 
 ## Configuration
 
-The ServiceControl primary instance maintains a list of remotes in it's configuration file under the key `ServiceControl/RemoteInstances`. The value of this setting is a json array of remote instances. Each entry must have an `api_url` property that contains the api url of the remote instance. In version 3 and below, each entry must also have a `queue_address` property that contains the queue address for the remote instance.
+Remote instances are listed in the `ServiceControl/RemoteInstances` app setting in the primary instance [configuration file](/servicecontrol/creating-config-file.md). The value of this setting is a JSON array of remote instances. Each entry requires an `api_url` property specifying the API URL of the remote instance. For ServiceControl version 3 and earlier, each entry requires a `queue_address` property specifying the queue address of the remote instance.
 
-NOTE: Changes to the configuration file will not take effect until the primary instance is restarted.
+NOTE: Changes to the configuration file do not take effect until the primary instance is restarted.
 
-### Version 3 and below
-
-```xml
-<configuration>
-  <appSettings>
-    <add key="ServiceControl/RemoteInstances" value="[{'api_uri':'http://localhost:33334/api', 'queue_address':'Particular.ServiceControl.Remote'}]"/>
-  </appSettings>/
-</configuration>
-```
-
-### Version 4 and above
+### Version 4 and later
 
 ```xml
 <configuration>
@@ -98,9 +129,19 @@ NOTE: Changes to the configuration file will not take effect until the primary i
 </configuration>
 ```
 
-## PowerShell
+### Version 3 and earlier
 
-The following cmdlets are available in ServiceControl version 4 and above, for the management of ServiceControl remotes.
+```xml
+<configuration>
+  <appSettings>
+    <add key="ServiceControl/RemoteInstances" value="[{'api_uri':'http://localhost:33334/api', 'queue_address':'Particular.ServiceControl.Remote'}]"/>
+  </appSettings>/
+</configuration>
+```
+
+## Managing remote instances using PowerShell
+
+The following cmdlets are available in ServiceControl version 4 and above, for the management of remote instances:
 
 | Alias                  | Cmdlet                                        |
 | ---------------------- | --------------------------------------------- |
@@ -108,11 +149,11 @@ The following cmdlets are available in ServiceControl version 4 and above, for t
 | sc-deleteremote        | Remove-ServiceControlRemote                   |
 | sc-remotes             | Get-ServiceControlRemotes                     |
 
-See [Manage ServiceControl instances via PowerShell](/servicecontrol/installation-powershell.md) and [Managing ServiceControl Audit instances via PowerShell](/servicecontrol/audit-instances/installation-powershell.md) for details on how to find ServiceControl instance names and urls.
+NOTE: The names and addresses of instances are controlled by the cmdlets for managing [ServiceControl](/servicecontrol/installation-powershell.md) and [ServiceControl Audit](/servicecontrol/audit-instances/installation-powershell.md) instances.
 
 ### Add a remote instance
 
-Use the `Add-ServiceControlRemote` cmdlet to add a remote instance to a primary ServiceControl instance.
+`Add-ServiceControlRemote` adds a remote instance to a primary instance.
 
 ```ps
 Add-ServiceControlRemote -Name Particular.ServiceControl -RemoteInstanceAddress "http://localhost:44444/api"
@@ -120,38 +161,38 @@ Add-ServiceControlRemote -Name Particular.ServiceControl -RemoteInstanceAddress 
 
 ### Remove a remote instance
 
-Use the `Remove-ServiceControlRemote` cmdlet to remove a remote instance from a primary ServiceControlInstance.
+`Remove-ServiceControlRemote` removes a remote instance from a primary instance.
 
 ```ps
 Remove-ServiceControlRemote -Name Particular.ServiceControl -RemoteInstanceAddress "http://localhost:44444/api"
 ```
 
-### List remote instance
+### List remote instances
 
-Use the `Get-ServiceControlRemotes` cmdlet to get a list of remote instances for a primary ServiceControl instance.
+`Get-ServiceControlRemotes` gets a list of remote instances from a primary instance.
 
 ```ps
 Get-ServiceControlRemotes -Name Particular.ServiceControl
 ```
 
-### Moving a remote instance
+### Changing the address of a remote instance
 
-If a remote instance must be moved to a different host or port number, follow these steps:
+To change the address of a remote instance to a new host and/or port number:
 
-1. Remove the old address from the list of remote instances
-   - `Remove-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $oldAddress`
-2. Restart the primary ServiceControl instance to refresh the list of remote instances
-3. Stop the remote instance to be moved
-4. Modify the host and port number of the remote instance using the ServiceControl Management utility
-5. Start the remote instance at it's new address
-6. Add the new address to the list of remote instances
+1. Remove the current address from the list of remote instances:
+   - `Remove-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $currentAddress`
+2. Restart the primary instance to refresh the list of remote instances
+3. Stop the remote instance
+4. Change the host and/or port number of the remote instance using the ServiceControl Management utility
+5. Start the remote instance at its new address
+6. Add the new address to the list of remote instances:
    - `Add-ServiceControlRemote -Name $primaryServiceControl.Name -RemoteInstanceAddress $newAddress`
-7. Restart the primary ServiceControl instance to refresh the list of remote instances
+7. Restart the primary instance to refresh the list of remote instances
 
 ## Considerations
 
-- Pagination with ServiceInsight may not work as traditional pagination would. For example, some pages might be filled unevenly depending on how the load is scattered between the different ServiceControl instances.
-- Data from remote instances that cannot be reached by the primary instance will not be included in the results.
-- Multi-instance configuration cannot be done via the ServiceControl Management application.
-- An incorrect configuration could introduce cyclic loops.
-- Having multiple primary instances is discouraged.
+- Pagination in ServiceInsight may not work as expected. For example, each page may contain a different number of items, depending on how those items are distributed across the various ServiceControl instances.
+- If the primary instance cannot contact a given remote instance, data from that remote instance will not be included in any views in either ServiceInsight or ServicePulse.
+- Multi-instance configuration is not possible the ServiceControl Management utility.
+- Incorrect configuration may cause cyclical dependencies. For example, instance A may attempt to get data from instance B, and instance B may attempt to get data from instance A.
+- It is recommended to run _only one_ primary instance. Multiple primary instances are _not recommended_.


### PR DESCRIPTION
## Charts

The _after_ images use the colour schemes of each component:

<img src="https://user-images.githubusercontent.com/677704/117297162-2e3c2680-ae76-11eb-9bb6-39234d5bbb7b.png" width="301px" />

### Before

![image](https://user-images.githubusercontent.com/677704/117296896-dd2c3280-ae75-11eb-831d-bc51aef80bc6.png)

### After

![image](https://user-images.githubusercontent.com/677704/117297029-01880f00-ae76-11eb-8c04-d399aac231dd.png)

### Before

![image](https://user-images.githubusercontent.com/677704/117296936-eb7a4e80-ae75-11eb-9127-5f5a93c8a5d6.png)

### After

![image](https://user-images.githubusercontent.com/677704/117297059-0b117700-ae76-11eb-964d-e38fac849f2b.png)

### Before

![image](https://user-images.githubusercontent.com/677704/117296977-f59c4d00-ae75-11eb-999b-d323a88611c3.png)

### After

![image](https://user-images.githubusercontent.com/677704/117297077-12d11b80-ae76-11eb-8f5c-9a41b1ba6c95.png)
