### PR TITLE
Update supported versions

### DIFF
--- a/nservicebus/upgrades/all-versions.include.md
+++ b/nservicebus/upgrades/all-versions.include.md
@@ -38,10 +38,10 @@
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
 | [5.3.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.3.1) | 2021-01-20     | -                 | -                                 |
-| [5.2.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.2.1) | 2020-10-20     | 2021-04-20        | Superseded by 5.3.x               |
+| [~~5.2.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.2.1) | ~~2020-10-20~~ | ~~2021-04-20~~    | ~~Superseded by 5.3.x~~           |
 | [~~5.1.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.1.2) | ~~2020-08-24~~ | ~~2021-01-20~~    | ~~Superseded by 5.2.x~~           |
 | [~~5.0.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.0.1) | ~~2020-04-27~~ | ~~2020-11-24~~    | ~~Superseded by 5.1.x~~           |
-| [4.4.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.4.1) | 2019-11-27     | 2021-04-27        | Superseded by 5.0.x               |
+| [~~4.4.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.4.2) | ~~2019-11-27~~ | ~~2021-04-27~~    | ~~Superseded by 5.0.x~~           |
 | [~~4.3.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.3.5) | ~~2019-02-22~~ | ~~2020-02-27~~    | ~~Superseded by 4.4.x~~           |
 | [~~4.2.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.2.3) | ~~2018-12-12~~ | ~~2019-05-22~~    | ~~Superseded by 4.3.x~~           |
 | [~~4.1.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.1.3) | ~~2018-06-01~~ | ~~2019-03-12~~    | ~~Superseded by 4.2.x~~           |
@@ -102,7 +102,8 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [6.0.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.0.0) | 2020-07-13     | -                 | -                                 |
+| [6.1.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.1.0) | 2021-05-07     | -                 | -                                 |
+| [6.0.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.0.0) | 2020-07-13     | 2021-08-07        | Superseded by 6.1.x               |
 | [5.2.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/5.2.0) | 2020-04-17     | 2021-07-13        | Superseded by 6.0.x               |
 | [~~5.1.x~~](https://www.nuget.org/packages/NServiceBus.RabbitMQ/5.1.2) | ~~2019-03-27~~ | ~~2020-07-17~~    | ~~Superseded by 5.2.x~~           |
 | [~~5.0.x~~](https://www.nuget.org/packages/NServiceBus.RabbitMQ/5.0.5) | ~~2018-05-29~~ | ~~2019-06-27~~    | ~~Superseded by 5.1.x~~           |
@@ -274,7 +275,7 @@ No versions released.
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [6.5.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.5.0) | 2021-03-04     | -                 | -                                 |
+| [6.5.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.5.1) | 2021-03-04     | -                 | -                                 |
 | [6.4.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.4.1) | 2020-07-29     | 2021-06-04        | Superseded by 6.5.x               |
 | [~~6.3.x~~](https://www.nuget.org/packages/NServiceBus.RavenDB/6.3.2) | ~~2020-05-28~~ | ~~2020-10-29~~    | ~~Superseded by 6.4.x~~           |
 | [~~6.2.x~~](https://www.nuget.org/packages/NServiceBus.RavenDB/6.2.0) | ~~2020-02-12~~ | ~~2020-08-28~~    | ~~Superseded by 6.3.x~~           |
@@ -312,7 +313,7 @@ No versions released.
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
 | [1.2.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.2.0) | 2021-02-11     | -                 | -                                 |
 | [1.1.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.1.0) | 2021-01-27     | 2021-05-11        | Superseded by 1.2.x               |
-| [1.0.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.0.3) | 2020-06-24     | 2021-04-27        | Superseded by 1.1.x               |
+| [~~1.0.x~~](https://www.nuget.org/packages/Particular.TimeoutMigration/1.0.3) | ~~2020-06-24~~ | ~~2021-04-27~~    | ~~Superseded by 1.1.x~~           |
 
 ### Serializer packages
 
@@ -533,6 +534,12 @@ No versions released.
 | [~~1.0.x~~](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/1.0.1) | ~~2016-10-11~~ | ~~2017-06-24~~    | ~~Superseded by 1.1.x~~           |
 
 ### Host packages
+
+#### [NServiceBus.AzureFunctions.InProcess.ServiceBus](/nuget/NServiceBus.AzureFunctions.InProcess.ServiceBus)
+
+| Version   | Released       | Supported until   | Notes                             |
+|:---------:|:--------------:|:-----------------:|:---------------------------------:|
+| [1.0.x](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/1.0.0) | 2021-04-23     | -                 | -                                 |
 
 #### [NServiceBus.Bootstrap.WindowsService](/nuget/NServiceBus.Bootstrap.WindowsService)
 
@@ -827,7 +834,8 @@ No versions released.
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [2.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/2.0.0) | 2021-03-23     | -                 | -                                 |
+| [3.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/3.0.0) | 2021-04-16     | -                 | -                                 |
+| [2.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/2.0.0) | 2021-03-23     | 2022-04-16        | Superseded by 3.0.x               |
 | [1.2.x](https://www.nuget.org/packages/ServiceControl.Contracts/1.2.0) | 2018-11-01     | 2022-03-23        | Superseded by 2.0.x               |
 | [~~1.1.x~~](https://www.nuget.org/packages/ServiceControl.Contracts/1.1.1) | ~~2015-02-05~~ | ~~2019-02-01~~    | ~~Superseded by 1.2.x~~           |
 | [~~1.0.x~~](https://www.nuget.org/packages/ServiceControl.Contracts/1.0.0) | ~~2014-10-13~~ | ~~2015-05-05~~    | ~~Superseded by 1.1.x~~           |

--- a/nservicebus/upgrades/supported-versions-downstreams.include.md
+++ b/nservicebus/upgrades/supported-versions-downstreams.include.md
@@ -5,10 +5,10 @@
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
 | [5.3.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.3.1) | 2021-01-20     | -                 | -                                 |
-| [5.2.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.2.1) | 2020-10-20     | 2021-04-20        | Superseded by 5.3.x               |
+| [~~5.2.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.2.1) | ~~2020-10-20~~ | ~~2021-04-20~~    | ~~Superseded by 5.3.x~~           |
 | [~~5.1.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.1.2) | ~~2020-08-24~~ | ~~2021-01-20~~    | ~~Superseded by 5.2.x~~           |
 | [~~5.0.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/5.0.1) | ~~2020-04-27~~ | ~~2020-11-24~~    | ~~Superseded by 5.1.x~~           |
-| [4.4.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.4.1) | 2019-11-27     | 2021-04-27        | Superseded by 5.0.x               |
+| [~~4.4.x~~](https://www.nuget.org/packages/NServiceBus.AmazonSQS/4.4.2) | ~~2019-11-27~~ | ~~2021-04-27~~    | ~~Superseded by 5.0.x~~           |
 | [3.3.x](https://www.nuget.org/packages/NServiceBus.AmazonSQS/3.3.5) | 2018-05-14     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
 #### [NServiceBus.Azure.Transports.WindowsAzureServiceBus](/nuget/NServiceBus.Azure.Transports.WindowsAzureServiceBus)
@@ -30,7 +30,8 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [6.0.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.0.0) | 2020-07-13     | -                 | -                                 |
+| [6.1.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.1.0) | 2021-05-07     | -                 | -                                 |
+| [6.0.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/6.0.0) | 2020-07-13     | 2021-08-07        | Superseded by 6.1.x               |
 | [5.2.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/5.2.0) | 2020-04-17     | 2021-07-13        | Superseded by 6.0.x               |
 | [4.4.x](https://www.nuget.org/packages/NServiceBus.RabbitMQ/4.4.5) | 2017-09-18     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
@@ -121,9 +122,8 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [6.5.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.5.0) | 2021-03-04     | -                 | -                                 |
+| [6.5.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.5.1) | 2021-03-04     | -                 | -                                 |
 | [6.4.x](https://www.nuget.org/packages/NServiceBus.RavenDB/6.4.1) | 2020-07-29     | 2021-06-04        | Superseded by 6.5.x               |
-| [~~6.3.x~~](https://www.nuget.org/packages/NServiceBus.RavenDB/6.3.2) | ~~2020-05-28~~ | ~~2020-10-29~~    | ~~Superseded by 6.4.x~~           |
 | [4.2.x](https://www.nuget.org/packages/NServiceBus.RavenDB/4.2.6) | 2017-06-28     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
 #### [NServiceBus.Storage.MongoDB](/nuget/NServiceBus.Storage.MongoDB)
@@ -144,7 +144,7 @@
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
 | [1.2.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.2.0) | 2021-02-11     | -                 | -                                 |
 | [1.1.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.1.0) | 2021-01-27     | 2021-05-11        | Superseded by 1.2.x               |
-| [1.0.x](https://www.nuget.org/packages/Particular.TimeoutMigration/1.0.3) | 2020-06-24     | 2021-04-27        | Superseded by 1.1.x               |
+| [~~1.0.x~~](https://www.nuget.org/packages/Particular.TimeoutMigration/1.0.3) | ~~2020-06-24~~ | ~~2021-04-27~~    | ~~Superseded by 1.1.x~~           |
 
 ### Serializer packages
 
@@ -246,6 +246,12 @@
 | [1.1.x](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/1.1.2) | 2017-03-24     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
 ### Host packages
+
+#### [NServiceBus.AzureFunctions.InProcess.ServiceBus](/nuget/NServiceBus.AzureFunctions.InProcess.ServiceBus)
+
+| Version   | Released       | Supported until   | Notes                             |
+|:---------:|:--------------:|:-----------------:|:---------------------------------:|
+| [1.0.x](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/1.0.0) | 2021-04-23     | -                 | -                                 |
 
 #### [NServiceBus.Bootstrap.WindowsService](/nuget/NServiceBus.Bootstrap.WindowsService)
 
@@ -423,7 +429,8 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [2.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/2.0.0) | 2021-03-23     | -                 | -                                 |
+| [3.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/3.0.0) | 2021-04-16     | -                 | -                                 |
+| [2.0.x](https://www.nuget.org/packages/ServiceControl.Contracts/2.0.0) | 2021-03-23     | 2022-04-16        | Superseded by 3.0.x               |
 | [1.2.x](https://www.nuget.org/packages/ServiceControl.Contracts/1.2.0) | 2018-11-01     | 2022-03-23        | Superseded by 2.0.x               |
 
 #### [ServiceControl.Plugin.Nsb6.CustomChecks](/nuget/ServiceControl.Plugin.Nsb6.CustomChecks)

--- a/nservicebus/upgrades/supported-versions-nservicebus.include.md
+++ b/nservicebus/upgrades/supported-versions-nservicebus.include.md
@@ -5,6 +5,5 @@
 | [7.4.x](https://www.nuget.org/packages/NServiceBus/7.4.6) | 2020-08-14     | -                 | -                                 |
 | [~~7.3.x~~](https://www.nuget.org/packages/NServiceBus/7.3.2) | ~~2020-05-08~~ | ~~2021-02-14~~    | ~~Superseded by 7.4.x~~           |
 | [~~7.2.x~~](https://www.nuget.org/packages/NServiceBus/7.2.5) | ~~2019-10-23~~ | ~~2020-11-08~~    | ~~Superseded by 7.3.x~~           |
-| [~~7.1.x~~](https://www.nuget.org/packages/NServiceBus/7.1.13) | ~~2018-08-30~~ | ~~2020-04-23~~    | ~~Superseded by 7.2.x~~           |
 | [6.5.x](https://www.nuget.org/packages/NServiceBus/6.5.10) | 2018-08-30     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 

--- a/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
+++ b/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
@@ -2,15 +2,14 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [4.16.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.16.0) | 2021-03-18     | -                 | -                                 |
+| [4.17.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.17.0) | 2021-05-06     | -                 | -                                 |
+| [~~4.16.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.16.0) | ~~2021-03-18~~ | ~~2021-05-06~~    | ~~Superseded by 4.17.x~~          |
 | [~~4.15.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.15.1) | ~~2020-12-23~~ | ~~2021-03-18~~    | ~~Superseded by 4.16.x~~          |
-| [~~4.14.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.14.2) | ~~2020-11-19~~ | ~~2020-12-23~~    | ~~Superseded by 4.15.x~~          |
-| [~~4.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.13.4) | ~~2020-09-28~~ | ~~2020-11-19~~    | ~~Superseded by 4.14.x~~          |
+| [~~4.14.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.14.2) | ~~2020-11-20~~ | ~~2020-12-23~~    | ~~Superseded by 4.15.x~~          |
+| [~~4.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.13.4) | ~~2020-09-28~~ | ~~2020-11-20~~    | ~~Superseded by 4.14.x~~          |
 | [~~4.12.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.12.1) | ~~2020-08-17~~ | ~~2020-09-28~~    | ~~Superseded by 4.13.x~~          |
-| [~~4.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.11.0) | ~~2020-07-29~~ | ~~2020-08-17~~    | ~~Superseded by 4.12.x~~          |
-| [~~4.10.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.10.2) | ~~2020-05-11~~ | ~~2020-07-29~~    | ~~Superseded by 4.11.x~~          |
-| [~~4.9.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.9.0) | ~~2020-05-03~~ | ~~2020-05-11~~    | ~~Superseded by 4.10.x~~          |
-| [~~4.8.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.8.0) | ~~2020-04-26~~ | ~~2020-05-03~~    | ~~Superseded by 4.9.x~~           |
-| [~~4.7.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.7.1) | ~~2020-03-05~~ | ~~2020-04-26~~    | ~~Superseded by 4.8.x~~           |
+| [~~4.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.11.0) | ~~2020-07-30~~ | ~~2020-08-17~~    | ~~Superseded by 4.12.x~~          |
+| [~~4.10.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.10.2) | ~~2020-05-11~~ | ~~2020-07-30~~    | ~~Superseded by 4.11.x~~          |
+| [~~4.9.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.9.0) | ~~2020-05-04~~ | ~~2020-05-11~~    | ~~Superseded by 4.10.x~~          |
 | [~~3.8.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/3.8.4) | ~~2019-06-04~~ | ~~2020-07-30~~    | ~~Superseded by 4.0.x~~           |
 

--- a/tools/supportedVersions.linq
+++ b/tools/supportedVersions.linq
@@ -291,8 +291,8 @@ public static class TextWriterExtensions
 
 public static class PackageMetadataResourceExtensions
 {
-	public static async Task<List<Version>> GetVersions(
-		this NuGetSearcher searcher, string packageId, ILogger logger, int majorOverlapYears, int minorOverlapMonths, List<Version> upstreamVersions, Dictionary<string, string> endOfLifePackages, int[] extendedSupportVersions)
+	public static async Task<List<UserQuery.Version>> GetVersions(
+		this NuGetSearcher searcher, string packageId, ILogger logger, int majorOverlapYears, int minorOverlapMonths, List<UserQuery.Version> upstreamVersions, Dictionary<string, string> endOfLifePackages, int[] extendedSupportVersions)
 	{
 		var minors = (await searcher.GetPackageAsync(packageId))
 			.OrderBy(package => package.Identity.Version)


### PR DESCRIPTION
Result from running https://github.com/Particular/docs.particular.net/blob/master/tools/supportedVersions.linq

had to specify the `Version` type more specifically in the linqpad script to make it compile.