### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root                      = true
+
+[*]
+trim_trailing_whitespace  = true


### PR DESCRIPTION
Any objections?

This is a fairly uncontroversial setting. It only ensures that lines do not have redundant, trailing whitespace.

With this in place, when using an editor which respects `.editorconfig`, saving the file removes that trailing whitespace.