### PR TITLE
Remove link to azure transactions

### DIFF
--- a/nservicebus/architecture/scaling.md
+++ b/nservicebus/architecture/scaling.md
@@ -32,7 +32,7 @@ However, a centralized resource, such as a database, may also be a bottleneck. S
 
 ### Competing consumers
 
-The easiest way to scale out is with [brokered transports](/transports/types.md#broker-transports), as those can make use of the *[competing consumer pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)*. This is done by deploying multiple instances of an endpoint that will all start processing messages from the same queue. When a message is delivered, any of the endpoint instances could potentially process it. The NServiceBus transport will try to ensure that only one instance will actually process the message. Be aware of [the need for idempotency](/nservicebus/azure/ways-to-live-without-transactions.md#the-need-for-idempotency).
+The easiest way to scale out is with [brokered transports](/transports/types.md#broker-transports), as those can make use of the *[competing consumer pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)*. This is done by deploying multiple instances of an endpoint that will all start processing messages from the same queue. When a message is delivered, any of the endpoint instances could potentially process it. The NServiceBus transport will try to ensure that only one instance will actually process the message.
 
 The image below shows the component `ClientUI` sending a command message to the logical endpoint `Sales`. But with messaging, the message is actually sent to the `Sales` queue. With two consumers competing for the `Sales` endpoint, both could potentially process the incoming message.
 


### PR DESCRIPTION
The `Be aware of idempotency` note seems to be confusing as there is no specific reason stated why idempotency would be specifically relevant for competing consumers. Also the link points to a page about transactions in Azure which seems even more confusing.