### PR TITLE
Using transactionscope instead of Create/Begin/Commit/Dispose TX methods to resolve strange TX issue

### DIFF
--- a/persistence/ravendb/connection.md
+++ b/persistence/ravendb/connection.md
@@ -7,14 +7,14 @@ redirects:
  - nservicebus/using-ravendb-in-nservicebus-connecting
  - nservicebus/ravendb/connecting
  - nservicebus/ravendb/connection
-reviewed: 2019-06-10
+reviewed: 2021-06-14
 ---
 
 include: dtc-warning
 
 include: cluster-configuration-warning
 
-The following sections outline various ways to connect to the RavenDB server. Specifying an external shared store (providing a fully configured RavenDB `DocumentStore` instance) is preferred so that the configuration of the DocumentStore is not obscured.
+The following sections outlines various ways to connect to the RavenDB server. Specifying an external shared store (providing a fully configured RavenDB `DocumentStore` instance) is preferred so that the configuration of the DocumentStore is not obscured.
 
 include: raven-dispose-warning
 
@@ -30,9 +30,12 @@ By default, a `DocumentStore` is created that connects to `http://localhost:8080
 
 ## Database used
 
-After connecting to a RavenDB server, decide which database to use. Unless NServiceBus finds a default database specified in the connection string, NServiceBus uses the endpoint name as the database name. This means that if the endpoint is named `MyServer`, the database name will be `MyServer`. Each endpoint has a separate database unless explicitly overridden via the connection string. Prior to RavenDB 4.0, RavenDB automatically creates the database if it doesn't already exist, but this is no longer the case in RavenDB 4.0 and above.
+After connecting to a RavenDB server, decide which database to use. Unless NServiceBus finds a default database specified in the connection string, NServiceBus uses the endpoint name as the database name. This means that if the endpoint is named `MyServer`, the database name will be `MyServer`. Each endpoint has a separate database unless explicitly overridden via the connection string.
 
 See also [How to specify endpoint name](/nservicebus/endpoints/specify-endpoint-name.md).
 
+## Database creation
+
+Prior to RavenDB 4.0, RavenDB automatically creates the database if it doesn't already exist, but this is no longer the case in RavenDB 4.0 and above.
 
 partial: caveats

--- a/persistence/ravendb/connection.md
+++ b/persistence/ravendb/connection.md
@@ -14,7 +14,7 @@ include: dtc-warning
 
 include: cluster-configuration-warning
 
-The following sections outlines various ways to connect to the RavenDB server. Specifying an external shared store (providing a fully configured RavenDB `DocumentStore` instance) is preferred so that the configuration of the DocumentStore is not obscured.
+The following sections outline various ways to connect to the RavenDB server. Specifying an external shared store (providing a fully configured RavenDB `DocumentStore` instance) is preferred so that the configuration of the DocumentStore is not obscured.
 
 include: raven-dispose-warning
 

--- a/persistence/ravendb/dtc.md
+++ b/persistence/ravendb/dtc.md
@@ -1,13 +1,12 @@
 ---
 title: DTC not supported for RavenDB Persistence
 component: raven
-reviewed: 2019-06-10
+reviewed: 2021-06-14
 ---
 
 RavenDB's implementation of distributed transactions contains a bug that can cause an endpoint, in certain (rare) conditions, to lose data. The RavenDB team [has no further plans to address this issue](https://issues.hibernatingrhinos.com/issue/RavenDB-4431). Starting with RavenDB 4.0, RavenDB will not support the Distributed Transaction Coordinator (DTC), making this bug have no practical relevance beyond RavenDB 3.5.
 
 Although the chances of the data loss bug occurring are slim, the use of DTC transactions with RavenDB is not recommended and not supported.
-
 
 ## Affected versions
 
@@ -17,7 +16,6 @@ Customers using RavenDB with local transactions only, and who have disabled the 
 
 All affected versions of the NServiceBus.RavenDB package have been patched to log a warning if an unsafe configuration is detected. In Versions 5.0 and above, the configuration will not be supported and will throw an exception if detected.
 
-
 ## Cause of data loss
 
 RavenDB uses a client-side DTC implementation, where the RavenDB client library stores the results of in-flight transactions in local storage. During the Prepare phase of the transaction, RavenDB creates a file in the local storage and writes transaction recovery information into it. During the Commit phase, the session commits the transaction to the server and then deletes the recovery file.
@@ -25,7 +23,6 @@ RavenDB uses a client-side DTC implementation, where the RavenDB client library 
 The Commit phase does not occur on the thread running the transaction scope. Instead, Commit occurs on a separate ThreadPool thread, after the TransactionScope has been completed and disposed. This means that if a failure occurs during the Commit phase, perhaps due to a temporary network issue or database restart, the calling code has no way to know the failure occurred and it has already moved on to subsequent instructions after the end of the transaction.
 
 The data for the pending transaction has not yet been sent to the server at the end of the Prepare phase. As such it is possible for the transaction to be effectively lost if the RavenDB database becomes unavailable between the execution of the Prepare and Commit phases. In this circumstance, no exception is thrown on the main thread, so NServiceBus has no way to know that the transaction is effectively lost.
-
 
 ## Recommendations
 
@@ -35,7 +32,6 @@ All customers using RavenDB persistence are recommended to either:
 
  1. Disable the Distributed Transaction Coordinator altogether and use the [Outbox feature](/nservicebus/outbox/) to manage consistency between message transport and persistence
  1. Migrate to a different persistence technology altogether
-
 
 ### Disabling DTC + Outbox
 
@@ -51,11 +47,9 @@ The Outbox relies upon the local RavenDB database transaction, this means that a
 
 To migrate away from DTC, refer to the [Outbox documentation](/nservicebus/outbox/), especially the section on [converting from DTC to Outbox](/nservicebus/outbox/#converting-from-dtc-to-outbox), as well as the [Outbox with RavenDB persistence](/persistence/ravendb/outbox.md) article, especially the section on the [effect of the Outbox on a RavenDB DocumentStore](/persistence/ravendb/outbox.md?version=raven_4#effect-on-ravendb-documentstore), being sure to use the *Switch Version* button just below the article titles to customize the content for the versions of NServiceBus and NServiceBus.RavenDB currently in use.
 
-
 ### Transitioning to a different persistence
 
 The path to transition from RavenDB to a different persistence vary by version of NServiceBus.
-
 
 #### NServiceBus 6.x
 
@@ -63,10 +57,9 @@ To maintain use of the DTC, the best solution is to transition away from RavenDB
 
 In this situation, consider switching to the [SQL Persistence](/persistence/sql/) library, with data stored in Microsoft SQL Server or Oracle, both of which support distributed transactions.
 
-Because it stores saga data as JSON blobs in much the same way as RavenDB, SQL persistence also provides a smooth data migration path from existing RavenDB data. Contact [support@particular.net](mailto:support@particular.net) to pursue this option.
+Because it stores saga data as JSON blobs in much the same way as RavenDB, SQL persistence also provides a smooth data migration path from existing RavenDB data. Contact <support@particular.net> to pursue this option.
 
 Before beginning a migration, remember that different persistence can be used by different endpoints within the same solution. Therefore, any new endpoint added to a current solution should use the new persistence from the start.
-
 
 #### NServiceBus 5.x and lower
 
@@ -74,7 +67,6 @@ SQL persistence is only available for NServiceBus 6 and above. Therefore, custom
 
 It is also possible to migrate to [NHibernate Persistence](/persistence/nhibernate/), however due to mismatches in how RavenDB and NHibernate Persistence store saga data, this type of migration can be much more cumbersome.
 
-
 ## Summary
 
-Going forward, DTC transactions with RavenDB will not be supported, although support will be given to existing customers to migrate to a different solution using one of the alternatives above. Contact [support@particular.net](mailto:support@particular.net) for a more thorough discussion of a migration path.
+Going forward, DTC transactions with RavenDB will not be supported, although support will be given to existing customers to migrate to a different solution using one of the alternatives above. Contact <support@particular.net> for a more thorough discussion of a migration path.

--- a/persistence/ravendb/installation.md
+++ b/persistence/ravendb/installation.md
@@ -18,6 +18,7 @@ include: cluster-configuration-warning
 To install RavenDB, [download the server](https://ravendb.net/download) and install as described in the [RavenDB documentation](https://ravendb.net/docs/) or use a hosted RavenDB provider such as [RavenHQ](https://www.ravenhq.com/).
 
 RavenDB should only be used for NServiceBus persistence when the endpoint's business data is already stored in RavenDB. NServiceBus shares the same `DocumentStore` object used for business data, configured using the [RavenDB connection options](connection.md).
+
 ## Upgrading RavenDB
 
 To upgrade an existing RavenDB installation, refer to the [RavenDB upgrade process](https://ravendb.net/docs/search/latest/csharp?searchTerm=server-administration%20upgrade).

--- a/persistence/ravendb/installation.md
+++ b/persistence/ravendb/installation.md
@@ -3,7 +3,7 @@ title: Installing RavenDB
 summary: How to install RavenDB when using RavenDB persistence for various versions of NServiceBus.
 component: core
 versions: "[3,)"
-reviewed: 2019-06-10
+reviewed: 2021-06-14
 related:
  - nservicebus/operations
 redirects:
@@ -15,11 +15,7 @@ include: dtc-warning
 
 include: cluster-configuration-warning
 
-
 To install RavenDB, [download the server](https://ravendb.net/download) and install as described in the [RavenDB documentation](https://ravendb.net/docs/) or use a hosted RavenDB provider such as [RavenHQ](https://www.ravenhq.com/).
-
-RavenDB should only be used for NServiceBus persistence when the endpoint's business data is already stored in RavenDB. NServiceBus shares the same `DocumentStore` object used for business data, configured using the [RavenDB connection options](connection.md).
-
 
 ## Upgrading RavenDB
 

--- a/persistence/ravendb/installation.md
+++ b/persistence/ravendb/installation.md
@@ -17,6 +17,7 @@ include: cluster-configuration-warning
 
 To install RavenDB, [download the server](https://ravendb.net/download) and install as described in the [RavenDB documentation](https://ravendb.net/docs/) or use a hosted RavenDB provider such as [RavenHQ](https://www.ravenhq.com/).
 
+RavenDB should only be used for NServiceBus persistence when the endpoint's business data is already stored in RavenDB. NServiceBus shares the same `DocumentStore` object used for business data, configured using the [RavenDB connection options](connection.md).
 ## Upgrading RavenDB
 
 To upgrade an existing RavenDB installation, refer to the [RavenDB upgrade process](https://ravendb.net/docs/search/latest/csharp?searchTerm=server-administration%20upgrade).


### PR DESCRIPTION
When testing with large batches/load testing with different transaction modes the implementation failed. One of the failures is the following and seems to indicate an issue with leaking connections or transactions. This PR relies fully on transactionscope and uses `Required` when the transport is configured to use `TransactionScope` and otherwise uses `RequiresNew` (isolated inner transaction to either store the timeout in SQL or dispatch the timeout to MSMQ).

```txt
[22988] OnError 1b5fb9f7-ba9c-4483-9870-ad56008c3704 System.Exception: Error while storing delayed message ---> System.InvalidOperationException: The connection does not support MultipleActiveResultSets. 
[22988]    at System.Data.SqlClient.SqlInternalConnectionTds.ValidateConnectionForExecute(SqlCommand command) 
[22988]    at System.Data.SqlClient.SqlInternalTransaction.Commit() 
[22988]    at System.Data.SqlClient.SqlTransaction.Commit() 
[22988]    at SqlTimeoutStorage.CommitTransaction(TransportTransaction transaction) in S:\NServiceBus.Transport.Msmq\src\NServiceBus.Transport.Msmq\Timeouts\Sql\SqlTimeoutStorage.cs:line 221 
```