### PR TITLE
Clarification why outbox does not support snapshot isolation

### DIFF
--- a/persistence/nhibernate/outbox_transactionisolation_nhibernate_[8.5,).partial.md
+++ b/persistence/nhibernate/outbox_transactionisolation_nhibernate_[8.5,).partial.md
@@ -4,4 +4,4 @@ The transaction isolation level for the outbox operation can be specified:
 
 snippet: OutboxTransactionIsolation
 
-Note: The default isolation level is `Serializable`. The isolation level values of `Chaos`, `ReadUncommitted`, `Snapshot` (outbox relies on pessimistic locking to prevent more-than-once invocation) and `Unspecified` are not allowed.
+Note: The default isolation level is `Serializable`. The isolation level values of `Chaos`, `ReadUncommitted`, `Snapshot` and `Unspecified` are not allowed. Outbox relies on pessimistic locking to prevent concurrent more-than-once invocation.

--- a/persistence/nhibernate/outbox_transactionisolation_nhibernate_[8.5,).partial.md
+++ b/persistence/nhibernate/outbox_transactionisolation_nhibernate_[8.5,).partial.md
@@ -4,4 +4,4 @@ The transaction isolation level for the outbox operation can be specified:
 
 snippet: OutboxTransactionIsolation
 
-Note: The default isolation level is `Serializable`. The isolation level values of `Chaos`, `ReadUncommitted`, `Snapshot` and `Unspecified` are not allowed.
+Note: The default isolation level is `Serializable`. The isolation level values of `Chaos`, `ReadUncommitted`, `Snapshot` (outbox relies on pessimistic locking to prevent more-than-once invocation) and `Unspecified` are not allowed.


### PR DESCRIPTION
I noticed a new section https://github.com/Particular/docs.particular.net/pull/5395 and I think it could use a little argumentation.