### PR TITLE
dotnet-support-policy-issue-1475

### DIFF
--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -14,8 +14,9 @@ related:
 | .NET Core | 2.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET | 5.0 | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md) | Supported | macOS is supported only for development purposes. |
+| .NET | 6.0 Preview | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md) | [Current Status](Link to discourse announcement goes here)  |  |
 
-Supported frameworks can be used for production workloads with technical support available from Particular Software. Language features in target frameworks newer than NServiceBus is compiled against are not guaranteed to work.
+Supported frameworks can be used for production workloads with technical support available from Particular Software.
 
 ### Packages not supporting .NET Core/ .NET 5
 

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -15,7 +15,7 @@ related:
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET | 5.0 | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md) | Supported | macOS is supported only for development purposes. |
 
-**Supported:** It means that automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Submit suggestions or feature requests to https://discuss.particular.net
+Supported frameworks can be used for production workloads with technical support available from Particular Software. Language features in target frameworks newer than NServiceBus is compiled against are not guaranteed to work.
 
 ### Packages not supporting .NET Core/ .NET 5
 

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -15,7 +15,7 @@ related:
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET | 5.0 | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md) | Supported | macOS is supported only for development purposes. |
 
-**Supported:** It means that our automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Please contact us if you have any suggestions of feature requests.
+**Supported:** It means that our automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Submit suggestions or feature requests to https://discuss.particular.net
 
 ### Packages not supporting .NET Core/ .NET 5
 

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -15,6 +15,8 @@ related:
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET | 5.0 | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md) | Supported | macOS is supported only for development purposes. |
 
+**Supported:** It means that our automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Please contact us if you have any suggestions of feature requests.
+
 ### Packages not supporting .NET Core/ .NET 5
 
 Some packages do not currently support .NET Core or running on non-Windows platforms:

--- a/nservicebus/upgrades/supported-platforms.md
+++ b/nservicebus/upgrades/supported-platforms.md
@@ -15,7 +15,7 @@ related:
 | .NET Core | 3.1 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) | Supported | macOS is supported only for development purposes. |
 | .NET | 5.0 | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md) | Supported | macOS is supported only for development purposes. |
 
-**Supported:** It means that our automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Submit suggestions or feature requests to https://discuss.particular.net
+**Supported:** It means that automated tests are passing and that customer support is available. Not necessarily all new types and language features added in the new version of .NET are supported. Submit suggestions or feature requests to https://discuss.particular.net
 
 ### Packages not supporting .NET Core/ .NET 5
 


### PR DESCRIPTION
Adding text to https://docs.particular.net/nservicebus/upgrades/supported-platforms clarifying the meaning of "supported". Work done as part of issue https://github.com/Particular/DeveloperExperience/issues/1475