### PR TITLE
Fix stream properties sample

### DIFF
--- a/samples/pipeline/stream-properties/Core_7/Receiver/Program.cs
+++ b/samples/pipeline/stream-properties/Core_7/Receiver/Program.cs
@@ -1,6 +1,6 @@
+using NServiceBus;
 using System;
 using System.Threading.Tasks;
-using NServiceBus;
 
 class Program
 {
@@ -10,6 +10,9 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineStream.Receiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();
+
+        endpointConfiguration.Pipeline.Register<StreamSendBehavior.Registration>();
+        endpointConfiguration.Pipeline.Register(typeof(StreamReceiveBehavior), "Copies the shared data back to the logical messages");
         endpointConfiguration.SetStreamStorageLocation(@"..\..\..\..\storage");
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)


### PR DESCRIPTION
This didn't work anyway (behavior was not registered on the receiver) and this gets it ready for .NET 6 when WebClient is obsolete.