### PR TITLE
Clarify migration from SubscriptionNameShortener

### DIFF
--- a/transports/upgrades/asbs-1.7to1.8.md
+++ b/transports/upgrades/asbs-1.7to1.8.md
@@ -11,5 +11,9 @@ upgradeGuideCoreVersions:
 
 ## Replacing shorteners with naming conventions
 
-For existing shoteners, the logic has to be moved into appropreate naming conventions.
+For existing shoteners, the logic has to be moved into appropriate naming conventions.
 To retain the same behavior, a length check needs to be added to the naming conventions logic.
+
+### SubscriptionNameShortener
+
+To shorten subscription names without changing the naming convention, apply the shortening logic to `Type.FullName` of the passed event name.

--- a/transports/upgrades/asbs-1.7to1.8.md
+++ b/transports/upgrades/asbs-1.7to1.8.md
@@ -14,6 +14,6 @@ upgradeGuideCoreVersions:
 For existing shoteners, the logic has to be moved into appropriate naming conventions.
 To retain the same behavior, a length check needs to be added to the naming conventions logic.
 
-### SubscriptionNameShortener
+### RuleNameShortener
 
-To shorten subscription names without changing the naming convention, apply the shortening logic to `Type.FullName` of the passed event name.
+To shorten subscription rules without changing the naming convention, apply the shortening logic to `Type.FullName` of the passed event type.


### PR DESCRIPTION
When migrating from `RuleNameShortener` which is a `Func<string, string>` to the recommended `SubscriptionRuleNamingConvention` function, which is `Func<Type, string>` it's not clear what `Type` property to use for shortening. Clarifies the upgrade guide that by default, the naming convention is to use `Type.FullName`