### PR TITLE
Attempt to use the EOL concept for renamed packages

### DIFF
--- a/nservicebus/upgrades/all-versions.include.md
+++ b/nservicebus/upgrades/all-versions.include.md
@@ -81,9 +81,11 @@
 
 #### [NServiceBus.Azure.Transports.WindowsAzureStorageQueues](/nuget/NServiceBus.Azure.Transports.WindowsAzureStorageQueues)
 
+_Replaced by NServiceBus.Transport.AzureStorageQueues_
+
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [8.2.x](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.2.5) | 2020-03-05     | -                 | -                                 |
+| [~~8.2.x~~](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.2.5) | ~~2020-03-05~~ | ~~2021-07-09~~    | ~~End of life~~                   |
 | [~~8.1.x~~](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.1.5) | ~~2018-09-27~~ | ~~2020-06-05~~    | ~~Superseded by 8.2.x~~           |
 | [~~8.0.x~~](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.0.1) | ~~2018-05-29~~ | ~~2018-12-27~~    | ~~Superseded by 8.1.x~~           |
 | [7.5.x](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/7.5.9) | 2017-12-04     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
@@ -215,9 +217,11 @@
 
 #### [NServiceBus.Persistence.AzureStorage](/nuget/NServiceBus.Persistence.AzureStorage)
 
+_Replaced by NServiceBus.Persistence.AzureTable_
+
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [2.4.x](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.4.2) | 2020-03-04     | -                 | -                                 |
+| [~~2.4.x~~](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.4.2) | ~~2020-03-04~~ | ~~2020-11-05~~    | ~~End of life~~                   |
 | [~~2.3.x~~](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.3.0) | ~~2018-12-12~~ | ~~2020-06-04~~    | ~~Superseded by 2.4.x~~           |
 | [~~2.2.x~~](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.2.0) | ~~2018-09-28~~ | ~~2019-03-12~~    | ~~Superseded by 2.3.x~~           |
 | [~~2.1.x~~](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.1.0) | ~~2018-05-31~~ | ~~2018-12-28~~    | ~~Superseded by 2.2.x~~           |

--- a/nservicebus/upgrades/supported-versions-downstreams.include.md
+++ b/nservicebus/upgrades/supported-versions-downstreams.include.md
@@ -19,9 +19,11 @@
 
 #### [NServiceBus.Azure.Transports.WindowsAzureStorageQueues](/nuget/NServiceBus.Azure.Transports.WindowsAzureStorageQueues)
 
+_Replaced by NServiceBus.Transport.AzureStorageQueues_
+
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [8.2.x](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.2.5) | 2020-03-05     | -                 | -                                 |
+| [~~8.2.x~~](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/8.2.5) | ~~2020-03-05~~ | ~~2021-07-09~~    | ~~End of life~~                   |
 | [7.5.x](https://www.nuget.org/packages/NServiceBus.Azure.Transports.WindowsAzureStorageQueues/7.5.9) | 2017-12-04     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
 #### [NServiceBus.RabbitMQ](/nuget/NServiceBus.RabbitMQ)
@@ -84,9 +86,10 @@
 
 #### [NServiceBus.Persistence.AzureStorage](/nuget/NServiceBus.Persistence.AzureStorage)
 
+_Replaced by NServiceBus.Persistence.AzureTable_
+
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [2.4.x](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/2.4.2) | 2020-03-04     | -                 | -                                 |
 | [1.5.x](https://www.nuget.org/packages/NServiceBus.Persistence.AzureStorage/1.5.2) | 2018-05-17     | 2020-05-29        | [Extended support](/nservicebus/upgrades/support-policy.md#extended-support) until 2022-05-29 |
 
 #### [NServiceBus.Persistence.AzureTable](/nuget/NServiceBus.Persistence.AzureTable)

--- a/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
+++ b/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
@@ -2,14 +2,14 @@
 
 | Version   | Released       | Supported until   | Notes                             |
 |:---------:|:--------------:|:-----------------:|:---------------------------------:|
-| [4.20.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.20.2) | 2021-07-15     | -                 | -                                 |
-| [~~4.19.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.19.0) | ~~2021-06-21~~ | ~~2021-07-15~~    | ~~Superseded by 4.20.x~~          |
+| [4.20.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.20.2) | 2021-07-26     | -                 | -                                 |
+| [~~4.19.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.19.0) | ~~2021-06-21~~ | ~~2021-07-26~~    | ~~Superseded by 4.20.x~~          |
 | [~~4.18.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.18.0) | ~~2021-06-02~~ | ~~2021-06-21~~    | ~~Superseded by 4.19.x~~          |
-| [~~4.17.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.17.2) | ~~2021-05-06~~ | ~~2021-06-02~~    | ~~Superseded by 4.18.x~~          |
-| [~~4.16.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.16.0) | ~~2021-03-18~~ | ~~2021-05-06~~    | ~~Superseded by 4.17.x~~          |
+| [~~4.17.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.17.2) | ~~2021-05-20~~ | ~~2021-06-02~~    | ~~Superseded by 4.18.x~~          |
+| [~~4.16.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.16.0) | ~~2021-03-18~~ | ~~2021-05-20~~    | ~~Superseded by 4.17.x~~          |
 | [~~4.15.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.15.1) | ~~2020-12-23~~ | ~~2021-03-18~~    | ~~Superseded by 4.16.x~~          |
-| [~~4.14.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.14.2) | ~~2020-11-20~~ | ~~2020-12-23~~    | ~~Superseded by 4.15.x~~          |
-| [~~4.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.13.4) | ~~2020-09-28~~ | ~~2020-11-20~~    | ~~Superseded by 4.14.x~~          |
-| [~~4.12.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.12.1) | ~~2020-08-17~~ | ~~2020-09-28~~    | ~~Superseded by 4.13.x~~          |
+| [~~4.14.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.14.2) | ~~2020-12-07~~ | ~~2020-12-23~~    | ~~Superseded by 4.15.x~~          |
+| [~~4.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.13.4) | ~~2020-11-12~~ | ~~2020-12-07~~    | ~~Superseded by 4.14.x~~          |
+| [~~4.12.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.12.1) | ~~2020-08-17~~ | ~~2020-11-12~~    | ~~Superseded by 4.13.x~~          |
 | [~~4.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/4.11.0) | ~~2020-07-30~~ | ~~2020-08-17~~    | ~~Superseded by 4.12.x~~          |
 

--- a/tools/supportedVersions.linq
+++ b/tools/supportedVersions.linq
@@ -14,8 +14,11 @@
 
 async Task Main()
 {
-	var endOfLifePackages = new Dictionary<string, string>
-	{
+    var endOfLifePackages = new Dictionary<string, string>
+    {
+        // Package name => Reason for end-of-life
+        { "NServiceBus.Azure.Transports.WindowsAzureStorageQueues", "Replaced by NServiceBus.Transport.AzureStorageQueues" },
+        { "NServiceBus.Persistence.AzureStorage", "Replaced by NServiceBus.Persistence.AzureTable" }
 	};
 
 	var source = "https://api.nuget.org/v3/index.json";


### PR DESCRIPTION
@adamralph @bording I really think this is wrong, but…

I attempted to deal with the fact that the ASQ and ASP packages got renamed using the endOfLifePackages collection that was currently in the script. This is the result.  I don't think it's right, and what's really boggling my mind is that it's not a PackageA => PackageB, it's PackageA => Reason, and based on that, I can't figure out where this 2021-07-09 expiration date for NServiceBus.Azure.Transports.WindowsAzureStorageQueues 8.2 is coming from.

Do you agree?