### PR TITLE
Extract custom trigger definition docs page

### DIFF
--- a/Snippets/ASBFunctions/ASBFunctions_1.1/FunctionsHostBuilderUsage.cs
+++ b/Snippets/ASBFunctions/ASBFunctions_1.1/FunctionsHostBuilderUsage.cs
@@ -11,6 +11,7 @@ namespace ASBFunctions_1_1
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Extensions.Logging;
     using NServiceBus;
@@ -79,6 +80,28 @@ namespace ASBFunctions_1_1
                 await functionEndpoint.Send(new TriggerMessage(), sendOptions, executionContext, logger);
 
                 return new OkObjectResult($"{nameof(TriggerMessage)} sent.");
+            }
+        }
+        #endregion
+
+        #region custom-trigger-definition
+        class CustomTriggerDefinition
+        {
+            readonly IFunctionEndpoint endpoint;
+
+            public CustomTriggerDefinition(IFunctionEndpoint endpoint)
+            {
+                this.endpoint = endpoint;
+            }
+
+            [FunctionName("MyCustomTrigger")]
+            public async Task Run(
+                [ServiceBusTrigger(queueName: "MyFunctionsEndpoint")]
+                Message message,
+                ILogger logger,
+                ExecutionContext executionContext)
+            {
+                await endpoint.Process(message, executionContext, logger);
             }
         }
         #endregion

--- a/Snippets/ASBFunctions/ASBFunctions_1.2/FunctionsHostBuilderUsage.cs
+++ b/Snippets/ASBFunctions/ASBFunctions_1.2/FunctionsHostBuilderUsage.cs
@@ -11,6 +11,7 @@ namespace ASBFunctions_1_2
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Extensions.Logging;
     using NServiceBus;
@@ -82,5 +83,28 @@ namespace ASBFunctions_1_2
             }
         }
         #endregion
+
+        #region custom-trigger-definition
+        class CustomTriggerDefinition
+        {
+            readonly IFunctionEndpoint endpoint;
+
+            public CustomTriggerDefinition(IFunctionEndpoint endpoint)
+            {
+                this.endpoint = endpoint;
+            }
+
+            [FunctionName("MyCustomTrigger")]
+            public async Task Run(
+                [ServiceBusTrigger(queueName: "MyFunctionsEndpoint")]
+                Message message,
+                ILogger logger,
+                ExecutionContext executionContext)
+            {
+                await endpoint.Process(message, executionContext, logger);
+            }
+        }
+        #endregion
+
     }
 }

--- a/nservicebus/hosting/azure-functions/custom-triggers.md
+++ b/nservicebus/hosting/azure-functions/custom-triggers.md
@@ -1,0 +1,10 @@
+---
+title: Custom Azure Functions triggers
+component: ASBFunctions
+summary: How to write custom triggers to call NServiceBus from Azure Functions
+related:
+ - nservicebus/hosting/azure-functions/service-bus
+reviewed: 2021-08-16
+---
+
+partial: content

--- a/nservicebus/hosting/azure-functions/custom-triggers_content_ASBFunctions_[1.1,1.3).partial.md
+++ b/nservicebus/hosting/azure-functions/custom-triggers_content_ASBFunctions_[1.1,1.3).partial.md
@@ -1,0 +1,3 @@
+If the trigger function needs to be customized, the trigger function generation can be disabled by removing the `NServiceBusEndpointName` attribute. A customized trigger function can then be manually added to the project:
+
+snippet: custom-trigger-definition

--- a/nservicebus/hosting/azure-functions/custom-triggers_content_ASBFunctions_[1.3,).partial.md
+++ b/nservicebus/hosting/azure-functions/custom-triggers_content_ASBFunctions_[1.3,).partial.md
@@ -1,0 +1,21 @@
+If the trigger function needs to be customized, the trigger function generation can be disabled by removing the `NServiceBusTriggerFunction` attribute. A customized trigger function can then be manually added to the project:
+
+snippet: custom-trigger-definition
+
+## Configuring transaction mode
+
+If the `NServiceBusTriggerFunction` attribute is not being used, `IFunctionEndpoint.Process` will determine the transaction mode based on the `ServiceBusTrigger`'s `AutoComplete` property:
+
+If auto-complete is **enabled**, which is the default, then NServiceBus cannot control the receive transaction and the message is processed in `TransportTransactionMode.ReceiveOnly` mode.
+
+snippet: asb-function-message-consistency-process-non-transactionally
+
+If auto-complete is **disabled**, then NServiceBus can fully control incoming and outgoing messages and the message is processed in `TransportTransactionMode.SendsAtomicWithReceive` mode.
+
+snippet: asb-function-message-consistency-process-transactionally
+
+If additional control is required, or the service bus triger is not configured using an attribute, use the concrete `FunctionEndpoint` class:
+
+snippet: asb-function-message-consistency-manual
+
+DANGER: Incorrectly configuring the service bus trigger auto-complete setting can lead to message loss. It is recommended to use the auto-detection mechanism on the function endpoint interface, or to use the trigger function attribute to specify message consistency.

--- a/nservicebus/hosting/azure-functions/service-bus_configuration_ASBFunctions_[1.3,).partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_configuration_ASBFunctions_[1.3,).partial.md
@@ -1,5 +1,5 @@
 snippet: asb-function-default
 
-The default builder method will look up values such as function name, connection string and license information directly from from the `IConfiguration`. Fine-grained configuration is also possible:
+Additional configuration settings are retrieved from environment variables, see the [Configuration section](#configuration) for further details. All configuration settings can also be configured directly via code:
 
 snippet: asb-function-hostbuilder

--- a/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[,1.3).partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[,1.3).partial.md
@@ -1,1 +1,2 @@
-There is no support for the `SendsAtomicWithReceive` [transport transaction mode](/transports/transactions.md#transactions-transport-transaction-sends-atomic-with-receive).
+All transport operations behave equal to [`ReceiveOnly` transport transaction mode](/transports/transactions.md#transactions-transport-transaction-receive-only).
+There is no support for the [`SendsAtomicWithReceive` transport transaction mode](/transports/transactions.md#transactions-transport-transaction-sends-atomic-with-receive) in this version.

--- a/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[1.3,).partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[1.3,).partial.md
@@ -2,17 +2,17 @@ NServiceBus can provide transactional consistency between incoming and outgoing 
 
 snippet: asb-function-enable-sends-atomic-with-receive-with-attribute
 
-This is the equivalent to the [sends atomic with receive](/transports/transactions.md#transactions-transport-transaction-sends-atomic-with-receive) transport transaction mode.
+This is the equivalent to the [`SendsAtomicWithReceive`](/transports/transactions.md#transactions-transport-transaction-sends-atomic-with-receive) transport transaction mode. By default, transactional consistency is disabled, providing the same transport guarantees as the [`ReceiveOnly`](/transports/transactions.md#transactions-transport-transaction-receive-only) transport transaction mode.
 
-### Without trigger function attribute
+### Controlling consistency with custom trigger defintion
 
-If the Azure Function queue trigger attribute is not being used, then NServiceBus will process messages transactionally if it can control the receive transaction. This is done by looking for `ServiceBusTriggerAttribute` in the call stack and checking the `AutoComplete` property.
+If the `NServiceBusTriggerFunction` attribute is not being used, `IFunctionEndpoint.Process` will determine the transaction mode based on the `ServiceBusTrigger`'s `AutoComplete` property:
 
-If auto-complete is enabled, which is the default, then NServiceBus cannot control the receive transaction and the message is processed non-transactionally.
+If auto-complete is **enabled**, which is the default, then NServiceBus cannot control the receive transaction and the message is processed in `TransportTransactionMode.ReceiveOnly` mode.
 
 snippet: asb-function-message-consistency-process-non-transactionally
 
-If auto-complete is not enabled then NServiceBus can control the receive transaction and the message is processed transactionally.
+If auto-complete is **disabled**, then NServiceBus can fully control incoming and outgoing messages and the message is processed in `TransportTransactionMode.SendsAtomicWithReceive` mode.
 
 snippet: asb-function-message-consistency-process-transactionally
 

--- a/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[1.3,).partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_message-consistency_ASBFunctions_[1.3,).partial.md
@@ -4,20 +4,4 @@ snippet: asb-function-enable-sends-atomic-with-receive-with-attribute
 
 This is the equivalent to the [`SendsAtomicWithReceive`](/transports/transactions.md#transactions-transport-transaction-sends-atomic-with-receive) transport transaction mode. By default, transactional consistency is disabled, providing the same transport guarantees as the [`ReceiveOnly`](/transports/transactions.md#transactions-transport-transaction-receive-only) transport transaction mode.
 
-### Controlling consistency with custom trigger defintion
-
-If the `NServiceBusTriggerFunction` attribute is not being used, `IFunctionEndpoint.Process` will determine the transaction mode based on the `ServiceBusTrigger`'s `AutoComplete` property:
-
-If auto-complete is **enabled**, which is the default, then NServiceBus cannot control the receive transaction and the message is processed in `TransportTransactionMode.ReceiveOnly` mode.
-
-snippet: asb-function-message-consistency-process-non-transactionally
-
-If auto-complete is **disabled**, then NServiceBus can fully control incoming and outgoing messages and the message is processed in `TransportTransactionMode.SendsAtomicWithReceive` mode.
-
-snippet: asb-function-message-consistency-process-transactionally
-
-If additional control is required, or the service bus triger is not configured using an attribute, use the concrete function endpoint class.
-
-snippet: asb-function-message-consistency-manual
-
-DANGER: Incorrectly configuring the service bus trigger auto-complete setting can lead to message loss. It is recommended to use the auto-detection mechanism on the function endpoint interface, or to use the trigger function attribute to specify message consistency.
+For more information on configuring message consistency using custom triggers, refer to the [custom Azure Functions triggers](/nservicebus/hosting/azure-functions/custom-triggers.md) documentation.

--- a/nservicebus/hosting/azure-functions/service-bus_queue-trigger-wiring_ASBFunctions_[1.1,1.2].partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_queue-trigger-wiring_ASBFunctions_[1.1,1.2].partial.md
@@ -6,4 +6,4 @@ The attribute will generate the trigger function required for NServiceBus.
 
 Note: An invalid endpoint name will generate an `NSBFUNC001` error with the message `Endpoint name is invalid and cannot be used to generate trigger function`.
 
-If the trigger function needs to be customized, the trigger function generation can be disabled by removing the `NServiceBusEndpointName` attribute. A customized trigger function can then be manually added to the project.
+The Azure Service Bus trigger can be manually declared instead of relying on the auto-generated trigger. See the [custom Azure Functions triggers](/nservicebus/hosting/azure-functions/custom-triggers.md) page for more information.

--- a/nservicebus/hosting/azure-functions/service-bus_queue-trigger-wiring_ASBFunctions_[1.3,).partial.md
+++ b/nservicebus/hosting/azure-functions/service-bus_queue-trigger-wiring_ASBFunctions_[1.3,).partial.md
@@ -16,8 +16,6 @@ snippet: asb-function-override-trigger-function-name
 
 Note: An invalid trigger function name will generate an `NSBFUNC004` error with the message `Trigger function name is invalid and cannot be used to generate trigger function`.
 
-#### Custom trigger definition
+#### Customizing Triggers
 
-If the trigger function needs to be customized, the trigger function generation can be disabled by removing the `NServiceBusTriggerFunction` attribute. A customized trigger function can then be manually added to the project:
-
-snippet: custom-trigger-definition
+The Azure Service Bus trigger can be manually declared instead of relying on the auto-generated trigger. See the [custom Azure Functions triggers](/nservicebus/hosting/azure-functions/custom-triggers.md) page for more information.


### PR DESCRIPTION
Some minor word teaks + extracts the custom trigger documentation into a dedicated page to simplify the main page