### PR TITLE
Update immutable-messages.md

### DIFF
--- a/nservicebus/messaging/immutable-messages.md
+++ b/nservicebus/messaging/immutable-messages.md
@@ -39,7 +39,7 @@ Using private setters is not supported by all serializers. An alternative is to 
 Note: Not all transport configurations support polymorphic dispatch.
 
 ```c#
-public class CancelOrder : ICreateOrder
+public class CancelOrder : ICancelOrder
 {
     public CancelOrder(int orderId)
     {


### PR DESCRIPTION
Fix assumed incorrect inherited interface on the `CancelOrder` class. Updated inherited interface from `ICreateOrder` to `ICancelOrder`