### PR TITLE
call solutions "solutions"

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -1,9 +1,9 @@
-name: BuildProjects
+name: BuildSolutions
 on:
   schedule:
     - cron: '0 */4 * * 1-5' # Every 4 hours, Monday-Friday
 jobs:
-  build-projects:
+  build-solutions:
     name: Build samples & snippets
     runs-on: windows-latest
     steps:
@@ -38,6 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL_WEBHOOK }}
-      - name: Output failed projects
+      - name: Output failed solutions
         if: ${{ failure() }}
-        run: cat .\failed-projects.log
+        run: cat .\failed-solutions.log

--- a/tools/build-samples-and-snippets.ps1
+++ b/tools/build-samples-and-snippets.ps1
@@ -29,8 +29,8 @@ function Get-BuildSolutions
     if( -not $? ) {
     	throw "Unable to fetch origin/master"
     }
-    Write-Host "::endgroup::"    
- 
+    Write-Host "::endgroup::"
+
     Write-Host "::group::Comparing origin/master to HEAD to get modified files"
     # Comparison with 2 dots does not go back to the common branch ancestor, but GitHub Actions is looking at a pull/####/merge branch
     # which also contains the changes in master, so the comparison is correctly only the changes in the PR
@@ -39,7 +39,7 @@ function Get-BuildSolutions
     	throw "Unable to determine differences between master and current branch"
     }
     Write-Host "::endgroup::"
-    
+
     Write-Host "::group::Determining solutions to build from changed files"
     $result = @()
     foreach($change in $changes)
@@ -63,7 +63,7 @@ function Get-BuildSolutions
                         $item = Get-Item $path
                         $result = $result + $item
                     }
-                    
+
                     # Found solution(s) for change, no need to keep navigating up
                     break;
                 }
@@ -77,39 +77,39 @@ function Get-BuildSolutions
 }
 
 $exitCode = 0
-$failedProjects = New-Object Collections.Generic.List[String]
-$failedProjectsOutput = CombinePaths $pwd.Path "failed-projects.log"
-$executionDirectory = Get-Location 
+$failedSolutions = New-Object Collections.Generic.List[String]
+$failedSolutionsOutput = CombinePaths $pwd.Path "failed-solutions.log"
+$executionDirectory = Get-Location
 
-$samples = Get-BuildSolutions
+$solutions = Get-BuildSolutions
 
-Write-Output "::group::Projects to build"
-$samples | ForEach-Object { Write-Output (" * {0}" -f $_.FullName) }
+Write-Output "::group::Solutions to build"
+$solutions | ForEach-Object { Write-Output (" * {0}" -f $_.FullName) }
 Write-Output "::endgroup::"
 
-foreach($sample in $samples) {
-    Write-Output ("::group::Build Project {0}" -f $sample.FullName)	
-    
-    Set-Location -Path $sample.Directory.FullName
+foreach($solution in $solutions) {
+    Write-Output ("::group::Build Solution {0}" -f $solution.FullName)
+
+    Set-Location -Path $solution.Directory.FullName
     Get-ChildItem -inc bin,obj -rec | Remove-Item -rec -force
-    
-    try 
+
+    try
     {
-        $msBuildMarkerFile = CombinePaths $sample.Directory "msbuild"
+        $msBuildMarkerFile = CombinePaths $solution.Directory "msbuild"
         if(Test-Path $msBuildMarkerFile)
         {
-            Write-Output ("::warning::Using msbuild for sample using legacy csproj format: {0}" -f $sample.FullName)
-            msbuild $sample.Name -verbosity:minimal -restore -property:RestorePackagesConfig=true
+            Write-Output ("::warning::Using msbuild for solution using legacy csproj format: {0}" -f $solution.FullName)
+            msbuild $solution.Name -verbosity:minimal -restore -property:RestorePackagesConfig=true
         }
-        else 
+        else
         {
-            dotnet build $sample.Name --verbosity minimal
+            dotnet build $solution.Name --verbosity minimal
         }
-        
+
         if( -not $? ) {
             $exitCode = 1
-            Write-Output ("::error::Build failed: {0}" -f $sample.FullName)
-            $failedProjects.Add($sample.FullName)
+            Write-Output ("::error::Build failed: {0}" -f $solution.FullName)
+            $failedSolutions.Add($solution.FullName)
         }
     }
     finally 
@@ -122,16 +122,16 @@ foreach($sample in $samples) {
     Write-Output "::endgroup::"
 }
 
-If ( $failedProjects.Count -ne 0 ) {
-    Write-Output ("::group::Failed Projects Summary")
-    
-    $failedProjects | ForEach-Object { 
+If ( $failedSolutions.Count -ne 0 ) {
+    Write-Output ("::group::Failed Solutions Summary")
+
+    $failedSolutions | ForEach-Object {
         Write-Output (" * {0}" -f $_)
     }
 
-	New-Item -ItemType "file" -Path $failedProjectsOutput -Force
-	$failedProjects | ForEach-Object { 
-        Add-Content $failedProjectsOutput $_
+	New-Item -ItemType "file" -Path $failedSolutionsOutput -Force
+	$failedSolutions | ForEach-Object {
+        Add-Content $failedSolutionsOutput $_
     }
 
     Write-Output "::endgroup::"


### PR DESCRIPTION
While reading `build-samples-and-snippets.ps1`, I got confused because I couldn't work out where the snippets were being built, until I realised that `$samples` actually refers to _all_ solutions, whether samples or snippets.

In turn that led me to some more places where we are currently using "solution", "project", and "sample" interchangeably, where all the references actually mean "solution" (which could be a sample or a snippet).