### PR TITLE
Fix azure samples

### DIFF
--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="11.0.0-alpha.268" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="11.0.0-alpha.268" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="11.0.0-alpha.268" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Those two samples seem to fail to build due to mismatching dependencies. There is a wildcard dependency on the JSON serializer package of which there seems to be a new PR being pushed to the myget feed that is picked up by the wildcard dependency.