### PR TITLE
Update framework target for samples

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -13,14 +13,6 @@ jobs:
         uses: actions/setup-dotnet@v1.8.1
         with:
           dotnet-version: 5.0.x
-      - name: Setup .NET Core 3.1 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET Core 2.1 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 2.1.x
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1
       - name: Build affected samples & snippets

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -2,6 +2,9 @@ name: BuildSolutions
 on:
   schedule:
     - cron: '0 */4 * * 1-5' # Every 4 hours, Monday-Friday
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_ROLL_FORWARD: Major
 jobs:
   build-solutions:
     name: Build samples & snippets

--- a/.github/workflows/validate-pull-requests.yml
+++ b/.github/workflows/validate-pull-requests.yml
@@ -2,6 +2,7 @@ name: PullRequest
 on: pull_request
 env:
   DOTNET_NOLOGO: true
+  DOTNET_ROLL_FORWARD: Major
 jobs:
   content-verification:
     name: Content verification

--- a/.github/workflows/validate-pull-requests.yml
+++ b/.github/workflows/validate-pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK
+      - name: Setup .NET 5 SDK
         uses: actions/setup-dotnet@v1.8.1
         with:
           dotnet-version: 5.0.x
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK
+      - name: Setup .NET 5 SDK
         uses: actions/setup-dotnet@v1.8.1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 5.0.x
       - name: Run integrity tests
         run: dotnet test tests/IntegrityTests/IntegrityTests.csproj --configuration Release
   build-projects:
@@ -39,14 +39,6 @@ jobs:
         uses: actions/setup-dotnet@v1.8.1
         with:
           dotnet-version: 5.0.x
-      - name: Setup .NET Core 3.1 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET Core 2.1 SDK
-        uses: actions/setup-dotnet@v1.8.1
-        with:
-          dotnet-version: 2.1.x
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build affected samples & snippets

--- a/.github/workflows/verify-master.yml
+++ b/.github/workflows/verify-master.yml
@@ -5,6 +5,7 @@ on:
       - master
 env:
   DOTNET_NOLOGO: true
+  DOTNET_ROLL_FORWARD: Major
 jobs:
   content-verification:
     name: Content verification

--- a/.github/workflows/verify-master.yml
+++ b/.github/workflows/verify-master.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK
+      - name: Setup .NET 5 SDK
         uses: actions/setup-dotnet@v1.8.1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 5.0.x
       - name: Run integrity tests
         run: dotnet test tests/IntegrityTests/IntegrityTests.csproj --configuration Release
       - name: Notify Slack on failure

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Samples can be targeted to multiple [target frameworks](https://docs.microsoft.c
 The currently recommended set of frameworks is:
 
 ```
-<TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+<TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
 ```
 
 Shared/messages projects should not be multi-targeted but use a standard framework that works with all targets:

--- a/components/tfm-mappings.txt
+++ b/components/tfm-mappings.txt
@@ -11,7 +11,6 @@ net47: .NET Framework 4.7
 net471: .NET Framework 4.7.1
 net472: .NET Framework 4.7.2
 net48: .NET Framework 4.8
-netcoreapp2.1: .NET Core 2.1
 netcoreapp2.2: .NET Core 2.2
 netcoreapp3.1: .NET Core 3.1
 net5.0: .NET 5

--- a/components/tfm-mappings.txt
+++ b/components/tfm-mappings.txt
@@ -11,6 +11,7 @@ net47: .NET Framework 4.7
 net471: .NET Framework 4.7.1
 net472: .NET Framework 4.7.2
 net48: .NET Framework 4.8
+netcoreapp2.1: .NET Core 2.1
 netcoreapp2.2: .NET Core 2.2
 netcoreapp3.1: .NET Core 3.1
 net5.0: .NET 5

--- a/nservicebus/dotnet-templates_target-framework_templates_[3].partial.md
+++ b/nservicebus/dotnet-templates_target-framework_templates_[3].partial.md
@@ -6,4 +6,4 @@ The target framework for the project.
 
 Default: `net462`
 
-Supported: `net472`, `net471`, `net47`, `net462`, `net461`, `net46`, `net452`
+Supported: `netcoreapp2.1`, `net472`, `net471`, `net47`, `net462`, `net461`, `net46`, `net452`

--- a/nservicebus/dotnet-templates_target-framework_templates_[3].partial.md
+++ b/nservicebus/dotnet-templates_target-framework_templates_[3].partial.md
@@ -6,4 +6,4 @@ The target framework for the project.
 
 Default: `net462`
 
-Supported: `netcoreapp2.1`, `net472`, `net471`, `net47`, `net462`, `net461`, `net46`, `net452`
+Supported: `net472`, `net471`, `net47`, `net462`, `net461`, `net46`, `net452`

--- a/nservicebus/dotnet-templates_target-framework_templates_[4,].partial.md
+++ b/nservicebus/dotnet-templates_target-framework_templates_[4,].partial.md
@@ -6,4 +6,4 @@ The target framework for the project.
 
 Default: `net462`
 
-Supported: `netcoreapp3.1`, `net48`, `net472`, `net471`, `net47`, `net462`, `net461`
+Supported: `netcoreapp3.1`, `netcoreapp2.1`, `net48`, `net472`, `net471`, `net47`, `net462`, `net461`

--- a/nservicebus/dotnet-templates_target-framework_templates_[4,].partial.md
+++ b/nservicebus/dotnet-templates_target-framework_templates_[4,].partial.md
@@ -6,4 +6,4 @@ The target framework for the project.
 
 Default: `net462`
 
-Supported: `netcoreapp3.1`, `netcoreapp2.1`, `net48`, `net472`, `net471`, `net47`, `net462`, `net461`
+Supported: `netcoreapp3.1`, `net48`, `net472`, `net471`, `net47`, `net462`, `net461`

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Client/Client.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Processor/Processor.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Processor/Processor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Server/Server.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Client/Client.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Processor/Processor.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Processor/Processor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Server/Server.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/LockRenewal.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>Endpoint</RootNamespace>

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASP_2/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASP_2/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASP_2/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_9/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_9/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_9/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_9/StorageReader/StorageReader.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQ_8/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_3/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_3/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>   
-	<TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+	<TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cooperative-cancellation/Core_8/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/delayed-delivery/Core_7/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/delayed-delivery/Core_8/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/endpoint-configuration/Core_7/Sample/Sample.csproj
+++ b/samples/endpoint-configuration/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <NoWarn>$(NoWarn);NU1605</NoWarn>

--- a/samples/endpoint-configuration/Core_8/Sample/Sample.csproj
+++ b/samples/endpoint-configuration/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <NoWarn>$(NoWarn);NU1605</NoWarn>

--- a/samples/entity-framework-core/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_7/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_8/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Client/Client.csproj
+++ b/samples/faulttolerance/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Server/Server.csproj
+++ b/samples/faulttolerance/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/faulttolerance/Core_8/Client/Client.csproj
+++ b/samples/faulttolerance/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Server/Server.csproj
+++ b/samples/faulttolerance/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/feature/Core_7/Sample/Sample.csproj
+++ b/samples/feature/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/feature/Core_8/Sample/Sample.csproj
+++ b/samples/feature/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Receiver/Receiver.csproj
+++ b/samples/file-share-databus/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Sender/Sender.csproj
+++ b/samples/file-share-databus/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_7/Shared/Shared.csproj
+++ b/samples/file-share-databus/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/file-share-databus/Core_8/Receiver/Receiver.csproj
+++ b/samples/file-share-databus/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_8/Sender/Sender.csproj
+++ b/samples/file-share-databus/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/file-share-databus/Core_8/Shared/Shared.csproj
+++ b/samples/file-share-databus/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/fullduplex/Core_7/Client/Client.csproj
+++ b/samples/fullduplex/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Server/Server.csproj
+++ b/samples/fullduplex/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_3/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/header-manipulation/Core_7/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/header-manipulation/Core_8/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/generic-multi-hosting/Core_7/Shared/Shared.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/generic-multi-hosting/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_7/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_7/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_7/Sample/Sample.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <NoWarn>NU1605</NoWarn>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_7/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_8/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_8/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_8/SampleWithClean/SampleWithClean.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/logging/stack-trace-cleaning/Core_8/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_8/SampleWithoutClean/SampleWithoutClean.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.csproj
+++ b/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/message-error-handling/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/message-error-handling/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/message-error-handling/Core_8/CustomErrorHandling/CustomErrorHandling.csproj
+++ b/samples/message-error-handling/Core_8/CustomErrorHandling/CustomErrorHandling.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/message-error-handling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/message-error-handling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_7/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_8/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_7/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <LangVersion>7.3</LangVersion>

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/multi-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/multi-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/stream-properties/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/stream-properties/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\CustomExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\MefExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\CustomExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\MefExtensionEndpoint\bin\Debug\</OutputPath>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_7/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/cluster/Rabbit_8/MyEndpoint/MyEndpoint.csproj
+++ b/samples/rabbitmq/cluster/Rabbit_8/MyEndpoint/MyEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_5/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_5/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_5/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_5/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_7/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_5/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_5/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_5/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_6/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_6/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_6/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_6/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_6/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_7/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_7/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/Messages/Messages.csproj
+++ b/samples/routing/fowarding-address/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
+++ b/samples/routing/fowarding-address/Core_7/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.csproj
+++ b/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/fowarding-address/Core_7/Sender/Sender.csproj
+++ b/samples/routing/fowarding-address/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/saga/simple/Core_7/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/simple/Core_8/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/fluentscheduler/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/fluentscheduler/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
+++ b/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/timer/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/xml/Core_7/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/xml/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shared/Shared.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_7/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/fix-messages/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_7/Receiver/Receiver.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/fix-messages/Core_7/Sender/Sender.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/fix-messages/Core_7/Shared/Shared.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <LangVersion>7.3</LangVersion>
     </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion1/EndpointVersion1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion2/EndpointVersion2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointOracle/EndpointOracle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/ServerShared/ServerShared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_5/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/Shared/SharedPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/Shared/SharedPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/Shared/SharedPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Sender/Sender.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Shared/Shared.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqs/native-integration/Sqs_5/Receiver/Receiver.csproj
+++ b/samples/sqs/native-integration/Sqs_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/native-integration/Sqs_5/Sender/Sender.csproj
+++ b/samples/sqs/native-integration/Sqs_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/native-integration/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/sqs/native-integration/Sqs_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/native-integration/Sqs_6/Sender/Sender.csproj
+++ b/samples/sqs/native-integration/Sqs_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_4/Sample/Sample.csproj
+++ b/samples/sqs/simple/Sqs_4/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_5/Receiver/Receiver.csproj
+++ b/samples/sqs/simple/Sqs_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_5/Sender/Sender.csproj
+++ b/samples/sqs/simple/Sqs_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/sqs/simple/Sqs_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_6/Sender/Sender.csproj
+++ b/samples/sqs/simple/Sqs_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/sqs/simple/Sqs_6/Shared/Shared.csproj
+++ b/samples/sqs/simple/Sqs_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Limited/Limited.csproj
+++ b/samples/throttling/Core_7/Limited/Limited.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Sender/Sender.csproj
+++ b/samples/throttling/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Shared/Shared.csproj
+++ b/samples/throttling/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/throttling/Core_8/Limited/Limited.csproj
+++ b/samples/throttling/Core_8/Limited/Limited.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Sender/Sender.csproj
+++ b/samples/throttling/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Shared/Shared.csproj
+++ b/samples/throttling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unit-of-work/Core_7/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unit-of-work/Core_8/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unit-testing/Testing_7/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unit-testing/Testing_8/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unobtrusive/Core_7/Client/Client.csproj
+++ b/samples/unobtrusive/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_7/Server/Server.csproj
+++ b/samples/unobtrusive/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_7/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/unobtrusive/Core_8/Client/Client.csproj
+++ b/samples/unobtrusive/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_8/Server/Server.csproj
+++ b/samples/unobtrusive/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/unobtrusive/Core_8/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Shared/Shared.csproj
+++ b/samples/username-header/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Shared/Shared.csproj
+++ b/samples/username-header/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/IntegrityTests/IntegrityTests.csproj
+++ b/tests/IntegrityTests/IntegrityTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="9.1.0" />

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        static readonly string[] sdkProjectAllowedTfmList = new[] { "net5.0", "netcoreapp3.1", "netcoreapp2.1", "net48", "netstandard2.0" };
+        static readonly string[] sdkProjectAllowedTfmList = new[] { "net5.0", "netcoreapp3.1", "net48", "netstandard2.0" };
         static readonly string[] nonSdkProjectAllowedFrameworkList = new[] { "v4.8" };
 
         [Test]

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -12,7 +12,7 @@ namespace IntegrityTests
             // Also reflected in https://docs.particular.net/samples/#technology-choices-c-language-level
             // And in /tools/projectStandards.linq
 
-            new TestRunner("*.csproj", "SDK-style project files (VS2017+) must specify LangVersion=7.3 - Provides the best balance between users between samples for netcoreapp2.1/netcoreapp3.1 and samples built by the user likely without LangVersion element.")
+            new TestRunner("*.csproj", "SDK-style project files (VS2017+) must specify LangVersion=7.3 - Provides the best balance between users between samples for netcoreapp3.1 and samples built by the user likely without LangVersion element.")
                 .IgnoreSnippets()
                 .Run(projectFilePath =>
                 {


### PR DESCRIPTION
We're no longer providing samples for `netcoreapp2.1` because it is now out of support.

Integrity tests have been updated to ensure that `netcoreapp2.1` is not re-introduced.