### PR TITLE
Document .NET SDK version requirements

### DIFF
--- a/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md
+++ b/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md
@@ -90,3 +90,11 @@ asb-transport endpoint subscribe <queue name> <eventtype>
 See the [full documentation](/transports/azure-service-bus/operational-scripting.md#operational-scripting-asb-transport-endpoint-subscribe) for the `asb-transport endpoint subscribe` command for more details.
 
 partial: assembly-scanner
+
+## Package requirements
+
+`NServiceBus.AzureFunctions.Worker.ServiceBus` requires Visual Studio 2019 and .NET SDK version `5.0.300` or higher. Older versions of the .NET SDK might cause the following warning which prevents the trigger definition from being auto-generated:
+
+```
+CSC : warning CS8032: An instance of analyzer NServiceBus.AzureFunctions.SourceGenerator.TriggerFunctionGenerator cannot be created from ServiceBus.AzureFunctions.Worker.SourceGenerator.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=3.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified..
+```


### PR DESCRIPTION
Documents the minimum required version of the .NET SDK and Visual Studio for the source generator to be able to load correctly. Failure to do so will cause the trigger to not be generated.