### PR TITLE
Spike workaround for ASB functions timeout problem

### DIFF
--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/RerouteDelayedMessagesBehavior.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/RerouteDelayedMessagesBehavior.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.DelayedDelivery;
+using NServiceBus.DeliveryConstraints;
+using NServiceBus.Extensibility;
+using NServiceBus.Pipeline;
+using NServiceBus.Routing;
+using NServiceBus.Settings;
+
+public class RerouteDelayedMessagesBehavior : Behavior<IRoutingContext>
+{
+    string delayQueue;
+    string localAddress;
+
+    public RerouteDelayedMessagesBehavior(ReadOnlySettings settings)
+    {
+        delayQueue = settings.Get<string>("ASBDelayQueue");
+        localAddress = settings.LocalAddress();
+    }
+
+    public override Task Invoke(IRoutingContext context, Func<Task> next)
+    {
+        if (!IsDeferred(context))
+        {
+            return next();
+        }
+
+        var newRoutingStrategies = context.RoutingStrategies.Select(s => RerouteToDelayQueue(s, context));
+        context.RoutingStrategies = newRoutingStrategies.ToArray();
+
+        return next();
+    }
+
+    RoutingStrategy RerouteToDelayQueue(RoutingStrategy routingStrategy, IRoutingContext context)
+    {
+        var headers = new Dictionary<string, string>(context.Message.Headers);
+        var originalTag = routingStrategy.Apply(headers);
+        if (!(originalTag is UnicastAddressTag unicastTag))
+        {
+            return routingStrategy;
+        }
+        if (unicastTag.Destination != localAddress)
+        {
+            return routingStrategy;
+        }
+        return new UnicastRoutingStrategy(delayQueue);
+    }
+
+    static bool IsDeferred(IExtendable context)
+    {
+        if (context.Extensions.TryGetDeliveryConstraint(out DoNotDeliverBefore _)
+            || context.Extensions.TryGetDeliveryConstraint(out DelayDeliveryWith _))
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Logging;
 
@@ -12,7 +13,11 @@ public class TriggerMessageHandler : IHandleMessages<TriggerMessage>
     {
         Log.Warn($"Handling {nameof(TriggerMessage)} in {nameof(TriggerMessageHandler)}");
 
-        return context.SendLocal(new FollowupMessage());
+        var options = new SendOptions();
+        options.RouteToThisEndpoint();
+        options.DelayDeliveryWith(TimeSpan.FromSeconds(10));
+
+        return context.Send(new FollowupMessage(), options);
     }
 }
 


### PR DESCRIPTION
Shows a possible workaround for the [issue in the Azure Functions scale controller](https://github.com/Azure/azure-functions-host/issues/7767) that causes overprovisioning of instances when there are delayed messages in the function's input queue. Uses an intermediary queue to store delayed messages.