### PR TITLE
ServiceControl NServiceBus version compatibility

### DIFF
--- a/servicecontrol/upgrades/supported-versions.md
+++ b/servicecontrol/upgrades/supported-versions.md
@@ -14,3 +14,7 @@ related:
 This page lists both currently and recently supported versions of all ServiceControl according to the [support policy](support-policy.md).
 
 include: supported-versions-servicecontrol
+
+## NServiceBus compatibility
+
+ServiceControl is compatible with older NServiceBus versions as long as the transport is unchanged. However, some of these versions might no longer be supported.


### PR DESCRIPTION
Based on a customer asking if upgrading their SC v1.x version to v4.x would cause compatibility issues with their NServiceBus 4.x and 5.x endpoints.