### PR TITLE
Azure Functions v4 and .net6 disposed container

### DIFF
--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Logging;
 
@@ -10,6 +11,12 @@ public class TriggerMessageHandler : IHandleMessages<TriggerMessage>
 
     public Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
+        var rnd = new Random().Next(10);
+        if (rnd % 2 != 0)
+        {
+            throw new Exception("BOOM!");
+        }
+
         Log.Warn($"Handling {nameof(TriggerMessage)} in {nameof(TriggerMessageHandler)}");
 
         return context.SendLocal(new FollowupMessage());

--- a/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="2.*" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.*" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureFunctions.Messages\AzureFunctions.Messages.csproj" />


### PR DESCRIPTION
When running the Azure Functions sample on v4 and .net6 exceptions are thrown.

```
System.Private.CoreLib: Exception while executing function: NServiceBusFunctionEndpointTrigger-ASBTriggerQueue. Microsoft.Azure.WebJobs.Script.WebHost: Scope disposed{no name} is disposed and scoped instances are disposed and no longer available.

Microsoft.Extensions.DependencyInjection: Cannot access a disposed object.
Object name: 'IServiceProvider'.
```

Just hit the http-trigger endpoint to reproduce.