### PR TITLE
Add note about interface messages

### DIFF
--- a/samples/unit-testing/sample.md
+++ b/samples/unit-testing/sample.md
@@ -20,6 +20,7 @@ The following test verifies that the handler received a `Reply`:
 
 snippet: HandlerTest
 
+Note: When testing [interface messages](/nservicebus/messaging/messages-as-interfaces.md), an implementation of the interface has to be manually defined.
 
 ## Testing a saga
 


### PR DESCRIPTION
add a note that the interface message has to be manually implemented for testing.

based on the feedback from https://github.com/Particular/docs.particular.net/issues/5538