### PR TITLE
Show usage of using message mapper

### DIFF
--- a/Snippets/Testing/Testing_6/Handlers/InterfaceMessageTests.cs
+++ b/Snippets/Testing/Testing_6/Handlers/InterfaceMessageTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testing_7.Handlers
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Testing;
+
+    public class InterfaceMessageTests
+    {
+        public interface IMyMessage { }
+
+        public async Task TestingInterfaceMessages()
+        {
+            var handler = new MyMessageHandler();
+            var context = new TestableMessageHandlerContext();
+
+            #region InterfaceMessageCreation
+            var messageMapper = new MessageMapper();
+            var myMessage = messageMapper.CreateInstance<IMyMessage>(message => { /* ... */ });
+
+            await handler.Handle(myMessage, context)
+                .ConfigureAwait(false);
+            #endregion
+
+        }
+
+        public class MyMessageHandler : IHandleMessages<IMyMessage>
+        {
+            public Task Handle(IMyMessage message, IMessageHandlerContext context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Snippets/Testing/Testing_7/Handlers/InterfaceMessageTests.cs
+++ b/Snippets/Testing/Testing_7/Handlers/InterfaceMessageTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testing_7.Handlers
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Testing;
+
+    public class InterfaceMessageTests
+    {
+        public interface IMyMessage { }
+
+        public async Task TestingInterfaceMessages()
+        {
+            var handler = new MyMessageHandler();
+            var context = new TestableMessageHandlerContext();
+
+            #region InterfaceMessageCreation
+            var messageMapper = new MessageMapper();
+            var myMessage = messageMapper.CreateInstance<IMyMessage>(message => { /* ... */ });
+
+            await handler.Handle(myMessage, context)
+                .ConfigureAwait(false);
+            #endregion
+
+        }
+
+        public class MyMessageHandler : IHandleMessages<IMyMessage>
+        {
+            public Task Handle(IMyMessage message, IMessageHandlerContext context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Snippets/Testing/Testing_8/Handlers/InterfaceMessageTests.cs
+++ b/Snippets/Testing/Testing_8/Handlers/InterfaceMessageTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Testing_7.Handlers
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Testing;
+
+    public class InterfaceMessageTests
+    {
+        public interface IMyMessage { }
+
+        public async Task TestingInterfaceMessages()
+        {
+            var handler = new MyMessageHandler();
+            var context = new TestableMessageHandlerContext();
+
+            #region InterfaceMessageCreation
+            var messageMapper = new MessageMapper();
+            var myMessage = messageMapper.CreateInstance<IMyMessage>(message => { /* ... */ });
+
+            await handler.Handle(myMessage, context)
+                .ConfigureAwait(false);
+            #endregion
+
+        }
+
+        public class MyMessageHandler : IHandleMessages<IMyMessage>
+        {
+            public Task Handle(IMyMessage message, IMessageHandlerContext context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/nservicebus/testing/index_content_testing_[6,).partial.md
+++ b/nservicebus/testing/index_content_testing_[6,).partial.md
@@ -22,6 +22,12 @@ This test verifies that a `Reply` occurred:
 
 snippet: HandlerTest
 
+### Interface messages
+
+When using [interface messages](/nservicebus/messaging/messages-as-interfaces.md), an instance of the message can be created by either defining a custom implementation of the message interface or by using the `MessageMapper` as shown in the following snippet:
+
+snippet: InterfaceMessageCreation
+
 ## Testing message session operations
 
 Use `TestableMessageSession` to test message operations outside of handlers. The following properties are available:

--- a/samples/unit-testing/sample.md
+++ b/samples/unit-testing/sample.md
@@ -9,7 +9,6 @@ related:
 
 This sample shows how to write unit tests for various NServiceBus components with Arrange-Act-Assert (AAA) style tests. This sample is a test project that uses [NUnit](https://nunit.org/) and testable helper implementations from the `NServiceBus.Testing` package.
 
-
 ## Testing a handler
 
 Given the following handler:
@@ -19,8 +18,6 @@ snippet: SimpleHandler
 The following test verifies that the handler received a `Reply`:
 
 snippet: HandlerTest
-
-Note: When testing [interface messages](/nservicebus/messaging/messages-as-interfaces.md), an implementation of the interface has to be manually defined.
 
 ## Testing a saga
 
@@ -32,7 +29,6 @@ The following unit tests checks that the discount was applied to the total amoun
 
 snippet: SagaTest
 
-
 ## Testing a behavior
 
 The following custom behavior adds a header to an outgoing message when the message is of the type `MyResponse`:
@@ -42,7 +38,6 @@ snippet: SampleBehavior
 The behavior can be tested similar to a message handler or a saga by using a testable representation of the context:
 
 snippet: BehaviorTest
-
 
 ## Testing IEndpointInstance usage
 


### PR DESCRIPTION
followup on #5551 to document using the `MessageMapper` instead, [as suggested by Udi](https://github.com/Particular/docs.particular.net/pull/5551#issuecomment-974793759)

Removed the interface message related note on the sample and instead moved it to the actual docs page.