### PR TITLE
Remove TypenameHandling.Auto from the example configuration

### DIFF
--- a/Snippets/ASP/ASTP_3/Usage.cs
+++ b/Snippets/ASP/ASTP_3/Usage.cs
@@ -82,7 +82,6 @@ class Usage
 
         persistence.JsonSettings(new JsonSerializerSettings
         {
-            TypeNameHandling = TypeNameHandling.Auto,
             Converters =
                 {
                     new IsoDateTimeConverter

--- a/Snippets/ASP/ASTP_4/Usage.cs
+++ b/Snippets/ASP/ASTP_4/Usage.cs
@@ -82,7 +82,6 @@ class Usage
 
         persistence.JsonSettings(new JsonSerializerSettings
         {
-            TypeNameHandling = TypeNameHandling.Auto,
             Converters =
                 {
                     new IsoDateTimeConverter


### PR DESCRIPTION
This is a snippet for [this page](https://docs.particular.net/persistence/azure-table/#enable-azure-table-persistence-supported-saga-properties-types-customization) on how to configure the JSON serializer but there is no direct need to configure TypeNameHandling.Auto so we can also just remove it here.