### PR TITLE
Do not overwrite other queue details (ASB Sample)

### DIFF
--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/Program.cs
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/Program.cs
@@ -50,10 +50,8 @@ class Program
     private static async Task OverrideQueueLockDuration(string queuePath, string connectionString)
     {
         var managementClient = new ManagementClient(connectionString);
-        var queueDescription = new QueueDescription(queuePath)
-        {
-            LockDuration = TimeSpan.FromSeconds(30)
-        };
+        var queueDescription = await managementClient.GetQueueAsync(queuePath).ConfigureAwait(false);
+        queueDescription.LockDuration = TimeSpan.FromSeconds(30);
 
         await managementClient.UpdateQueueAsync(queueDescription).ConfigureAwait(false);
     }


### PR DESCRIPTION
Fixes #5568

Prevents the sample from overwiting unaffected queue details (such as description).