### PR TITLE
Document throttling retry configuration for CosmosDB

### DIFF
--- a/Snippets/ASP/ASTP_3/Usage.cs
+++ b/Snippets/ASP/ASTP_3/Usage.cs
@@ -164,6 +164,23 @@ class Usage
 
         #endregion
     }
+
+    void ConfigureThrottlingSettingsOnStorageTableClient(EndpointConfiguration endpointConfiguration, CloudStorageAccount storageAccount)
+    {
+        #region StorageTableClientConfigureThrottlingWithClientOptions
+
+        endpointConfiguration.UsePersistence<AzureTablePersistence>()
+            .UseCloudTableClient(storageAccount.CreateCloudTableClient(new TableClientConfiguration
+        {
+            CosmosExecutorConfiguration = new CosmosExecutorConfiguration
+            {
+                MaxRetryAttemptsOnThrottledRequests = 9,
+                MaxRetryWaitTimeOnThrottledRequests = 30
+            }
+        }));
+
+        #endregion
+    }
 }
 
 // to avoid host reference

--- a/Snippets/ASP/ASTP_4/Usage.cs
+++ b/Snippets/ASP/ASTP_4/Usage.cs
@@ -164,6 +164,23 @@ class Usage
 
         #endregion
     }
+
+    void ConfigureThrottlingSettingsOnStorageTableClient(EndpointConfiguration endpointConfiguration, CloudStorageAccount storageAccount)
+    {
+        #region StorageTableClientConfigureThrottlingWithClientOptions
+
+        endpointConfiguration.UsePersistence<AzureTablePersistence>()
+            .UseCloudTableClient(storageAccount.CreateCloudTableClient(new TableClientConfiguration
+            {
+                CosmosExecutorConfiguration = new CosmosExecutorConfiguration
+                {
+                    MaxRetryAttemptsOnThrottledRequests = 9,
+                    MaxRetryWaitTimeOnThrottledRequests = 30
+                }
+            }));
+
+        #endregion
+    }
 }
 
 // to avoid host reference

--- a/Snippets/CosmosDB/CosmosDB_1/Usage.cs
+++ b/Snippets/CosmosDB/CosmosDB_1/Usage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Fluent;
 using NServiceBus;
 
 class Usage
@@ -59,6 +60,30 @@ class Usage
         #region CosmosDBRegisterLogicalBehavior
 
         endpointConfiguration.Pipeline.Register(new RegisterMyBehavior());
+
+        #endregion
+
+        #region CosmosDBConfigureThrottlingWithClientOptions
+
+        endpointConfiguration.UsePersistence<CosmosPersistence>()
+            .CosmosClient(new CosmosClient("ConnectionString", new CosmosClientOptions
+            {
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(30),
+                MaxRetryAttemptsOnRateLimitedRequests = 9
+            }));
+
+        #endregion
+
+        #region CosmosDBConfigureThrottlingWithBuilder
+
+        var cosmosClientBuilder = new CosmosClientBuilder("ConnectionString")
+           .WithThrottlingRetryOptions(
+               maxRetryWaitTimeOnThrottledRequests: TimeSpan.FromSeconds(30),
+               maxRetryAttemptsOnThrottledRequests: 9
+           );
+
+        endpointConfiguration.UsePersistence<CosmosPersistence>()
+            .CosmosClient(cosmosClientBuilder.Build());
 
         #endregion
     }

--- a/persistence/azure-table/index.md
+++ b/persistence/azure-table/index.md
@@ -35,6 +35,8 @@ For a description of each feature, see the [persistence at a glance legend](/per
 
 partial: config
 
+partial: ratelimiting
+
 partial: transaction
 
 partial: correlation

--- a/persistence/azure-table/index_ratelimiting_astp_[3,].partial.md
+++ b/persistence/azure-table/index_ratelimiting_astp_[3,].partial.md
@@ -1,0 +1,13 @@
+## Provisioned throughput rate-limiting with Azure Cosmos DB
+
+When using provisioned throughput it is possible for the CosmosDB service to rate-limit usage, resulting in request rate too large `StorageException`s indicated by a 429 status code.
+
+WARN: When using the Azure Table persistence with Outbox enabled, request rate too large errors may result in handler re-execution and/or duplicate message dispatches depending on which operation is throttled.
+
+INFO: Microsoft provides [guidance](https://docs.microsoft.com/en-us/azure/cosmos-db/monitor-request-unit-usage) on how to monitor request rate usage.
+
+The Cosmos DB SDK provides a mechanism to automatically retry collection operations when rate-limiting occurs. Besides changing the provisioned RUs or switching to the serverless tier, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
+
+These settings may be set when initializing the `CloudTableClient` via the `TableClientConfiguration.CosmosExecutorConfiguration` [`MaxRetryAttemptsOnThrottledRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.cosmosexecutorconfiguration.maxretryattemptsonthrottledrequests?view=azure-dotnet) and [`MaxRetryWaitTimeOnThrottledRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.cosmosexecutorconfiguration.maxretrywaittimeonthrottledrequests?view=azure-dotnet) properties:
+
+snippet: CosmosDBConfigureThrottlingWithClientOptions

--- a/persistence/azure-table/index_ratelimiting_astp_[3,].partial.md
+++ b/persistence/azure-table/index_ratelimiting_astp_[3,].partial.md
@@ -10,4 +10,4 @@ The Cosmos DB SDK provides a mechanism to automatically retry collection operati
 
 These settings may be set when initializing the `CloudTableClient` via the `TableClientConfiguration.CosmosExecutorConfiguration` [`MaxRetryAttemptsOnThrottledRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.cosmosexecutorconfiguration.maxretryattemptsonthrottledrequests?view=azure-dotnet) and [`MaxRetryWaitTimeOnThrottledRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.cosmosexecutorconfiguration.maxretrywaittimeonthrottledrequests?view=azure-dotnet) properties:
 
-snippet: CosmosDBConfigureThrottlingWithClientOptions
+snippet: StorageTableClientConfigureThrottlingWithClientOptions

--- a/persistence/cosmosdb/index.md
+++ b/persistence/cosmosdb/index.md
@@ -83,7 +83,7 @@ WARN: When using the Cosmos DB persistence with Outbox enabled, throttling error
 
 INFO: Microsoft provides [guidance](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-request-rate-too-large) on how to diagnose and troubleshoot throttling exceptions.
 
-The Cosmos DB SDK provides a mechanism to automatically retry collection operations when throttling concerns. Besides changing the provisioned RUs, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
+The Cosmos DB SDK provides a mechanism to automatically retry collection operations when throttling occurs. Besides changing the provisioned RUs or switching to the serverless tier, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
 
 These settings may be set when initializing the `CosmosClient` via the `CosmosClientOptions` [`MaxRetryAttemptsOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretryattemptsonratelimitedrequests?view=azure-dotnet) and [`MaxRetryWaitTimeOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretrywaittimeonratelimitedrequests?view=azure-dotnet) properties:
 

--- a/persistence/cosmosdb/index.md
+++ b/persistence/cosmosdb/index.md
@@ -77,7 +77,7 @@ snippet: CosmosDBCustomClientProviderRegistration
 
 ## Provisioned throughput throttling
 
-When using provisioned throughput it is possible for the CosmosDB service to throttle usage, resulting in status code 429 throttling errors.
+When using provisioned throughput it is possible for the CosmosDB service to throttle usage, resulting request rate too large exceptions indicated by the 429 status code .
 
 WARN: When using the Cosmos DB persistence with Outbox enabled, throttling errors may result in handler re-execution and / or duplicate message dispatches depending on which operation is throttled.
 

--- a/persistence/cosmosdb/index.md
+++ b/persistence/cosmosdb/index.md
@@ -75,6 +75,24 @@ and registered on the container
 
 snippet: CosmosDBCustomClientProviderRegistration
 
+## Provisioned throughput throttling
+
+When using provisioned throughput it is possible for the CosmosDB service to throttle usage, resulting in status code 429 throttling errors.
+
+WARN: When using the Cosmos DB persistence with Outbox enabled, throttling errors may result in handler re-execution and / or duplicate message dispatches depending on which operation is throttled.
+
+INFO: Microsoft provides [guidance](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-request-rate-too-large) on how to diagnose and troubleshoot throttling exceptions.
+
+The Cosmos DB SDK provides a mechanism to automatically retry collection operations when throttling concerns. Besides changing the provisioned RUs, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
+
+These settings may be set when initializing the `CosmosClient` via the `CosmosClientOptions` [`MaxRetryAttemptsOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretryattemptsonratelimitedrequests?view=azure-dotnet) and [`MaxRetryWaitTimeOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretrywaittimeonratelimitedrequests?view=azure-dotnet) properties:
+
+snippet: CosmosDBConfigureThrottlingWithClientOptions
+
+They may also be set when using a `CosmosClientBuilder` via the [`WithThrottlingRetryOptions`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.fluent.cosmosclientbuilder.withthrottlingretryoptions?view=azure-dotnet) method:
+
+snippet: CosmosDBConfigureThrottlingWithBuilder
+
 ## Transactions
 
 The Cosmos DB persister supports using the [Cosmos DB transactional batch API](https://devblogs.microsoft.com/cosmosdb/introducing-transactionalbatch-in-the-net-sdk/). However, Cosmos DB only allows operations to be batched if all operations are performed within the same logical partition key. This is due to the distributed nature of the Cosmos DB service, which [does not support distributed transactions](/nservicebus/azure/understanding-transactionality-in-azure.md).

--- a/persistence/cosmosdb/index.md
+++ b/persistence/cosmosdb/index.md
@@ -75,15 +75,15 @@ and registered on the container
 
 snippet: CosmosDBCustomClientProviderRegistration
 
-## Provisioned throughput throttling
+## Provisioned throughput rate-limiting
 
-When using provisioned throughput it is possible for the CosmosDB service to throttle usage, resulting request rate too large exceptions indicated by the 429 status code .
+When using provisioned throughput it is possible for the CosmosDB service to rate-limit usage, resulting request rate too large exceptions indicated by the 429 status code.
 
-WARN: When using the Cosmos DB persistence with Outbox enabled, throttling errors may result in handler re-execution and / or duplicate message dispatches depending on which operation is throttled.
+WARN: When using the Cosmos DB persistence with Outbox enabled, request rate too large errors may result in handler re-execution and/or duplicate message dispatches depending on which operation is throttled.
 
-INFO: Microsoft provides [guidance](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-request-rate-too-large) on how to diagnose and troubleshoot throttling exceptions.
+INFO: Microsoft provides [guidance](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-request-rate-too-large) on how to diagnose and troubleshoot request rate too large exceptions.
 
-The Cosmos DB SDK provides a mechanism to automatically retry collection operations when throttling occurs. Besides changing the provisioned RUs or switching to the serverless tier, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
+The Cosmos DB SDK provides a mechanism to automatically retry collection operations when rate-limiting occurs. Besides changing the provisioned RUs or switching to the serverless tier, those settings can be adjusted to help prevent messages from failing during spikes in message volume.
 
 These settings may be set when initializing the `CosmosClient` via the `CosmosClientOptions` [`MaxRetryAttemptsOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretryattemptsonratelimitedrequests?view=azure-dotnet) and [`MaxRetryWaitTimeOnRateLimitedRequests`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions.maxretrywaittimeonratelimitedrequests?view=azure-dotnet) properties:
 


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/170

This PR adds documentation about provisioned throughput throttling and how to configure the SDK throttling settings using the CosmosClient and provides a link to Microsoft's troubleshooting guide as well as a sample.

- [x] Cosmos DB persistence index section
- [x] Cosmos DB persistence snippets
- [x] Azure Table persistence index section
- [x] Azure Table persistence snippets