### PR TITLE
Clarify queue length is not monitored via NServiceBus.Metrics

### DIFF
--- a/monitoring/metrics/definitions.md
+++ b/monitoring/metrics/definitions.md
@@ -56,3 +56,5 @@ This metric measures the number of [retries](/nservicebus/recoverability) schedu
 ### Queue length
 
 This metric tracks the number of messages in the main input queue of an endpoint.
+
+NOTE: The queue length metric is measured centrally by the [ServiceControl Monitoring instance](/servicecontrol/monitoring-instances) for all the transports except MSMQ, which uses a [custom plugin installed at the endpoint](/monitoring/metrics/msmq-queue-length.md). As a result, the NServiceBus.Metrics package does not contain a probe for this metric.


### PR DESCRIPTION
Related to https://discuss.particular.net/t/queue-length-metric-is-not-available/2524