### PR TITLE
Fix the policy name in CloudFormation template

### DIFF
--- a/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.SQSTrigger/serverless.template
+++ b/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.SQSTrigger/serverless.template
@@ -35,7 +35,7 @@
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
-        "Policies": [ "AWSLambdaFullAccess", "AmazonSQSFullAccess" ],
+        "Policies": [ "AWSLambda_FullAccess", "AmazonSQSFullAccess" ],
 		"Events": {
             "SqsEvent" : {
                 "Type" : "SQS",


### PR DESCRIPTION
The policy name previously used has been [deprecated](https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html)