### PR TITLE
Adding AWS preview to hosting menu

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -410,6 +410,8 @@
         Title: Custom triggers
       - Url: nservicebus/hosting/azure-functions-service-bus/isolated-worker
         Title: Isolated worker
+    - Url: previews/aws-lambda-simple-queue-service
+      Title: AWS Lambda with SQS
     - Url: nservicebus/hosting/service-fabric-hosting
       Title: Service Fabric
       Articles:


### PR DESCRIPTION
based on the additions to the docs-menu for previews made by Travis, we can add AWS Lambda to the hosting menu entry with some nice indication of it's preview status.