### PR TITLE
Update operational-scripting.md for clarity about specifying values for certain script command options

### DIFF
--- a/persistence/sql/operational-scripting.md
+++ b/persistence/sql/operational-scripting.md
@@ -36,12 +36,12 @@ sql-persistence script <assembly>
 
 #### Options
  
-`-o` | `--output-dir` : Path to the output directory. If not specified, the current directory will be used.
+`-o=<path>` | `--output-dir=<path>` : Path to the output directory. If not specified, the current directory will be used.
 
 `--clean` : Removes existing files in the output directory
 
 `--overwrite`: Overwrites existing files in the output if they match the files to be generated
 
-`--dialect`: Specifies a dialect to generate. Allowed values are: SqlServer, MySql, Oracle, PostgreSql
+`--dialect=<value>`: Specifies a dialect to generate. Allowed values are: SqlServer, MySql, Oracle, PostgreSql
 
 `--verbose`: Verbose logging


### PR DESCRIPTION
Trying to add clarity that "--dialect" and "--output-dir" require "=value". The parser does not seem to look for arg+1 for the value like some command line tools do.

```sql-persistence script .\bin\...\Endpoint.dll --clean --dialect SqlServer --output-dir C:\Temp\sqlpersistence_out```
> sql-persistence failed: Unrecognized command or argument 'SqlServer'