### PR TITLE
SC health checks email clarification 

### DIFF
--- a/servicepulse/health-check-notifications.md
+++ b/servicepulse/health-check-notifications.md
@@ -1,12 +1,12 @@
 ---
 title: Health check notifications
-summary: Describes how to setup email notifications for failing ServiceControl health checks
+summary: Describes how to setup email notifications for failing ServiceControl internal health checks
 component: ServicePulse
-reviewed: 2021-05-05
+reviewed: 2022-01-13
 related:
 ---
 
-Every ServiceControl instance performs periodic health checks and raises notifications when they fail. By default, notifications are published as [integration events](/servicecontrol/contracts.md) but it's also possible to deliver them as email messages.
+Every ServiceControl instance performs periodic internal health checks and raises notifications when they fail. By default, notifications are published as [integration events](/servicecontrol/contracts.md) but it's also possible to deliver them as email messages.
 
 NOTE: Email notifications require ServicePulse version 1.29 or later, and ServiceControl version 4.17 or later.
 


### PR DESCRIPTION
The current document confusing, causing users to think SC can email about failed messages.