### PR TITLE
Document RavenDB pessimistic locking support

### DIFF
--- a/nservicebus/sagas/concurrency.md
+++ b/nservicebus/sagas/concurrency.md
@@ -77,6 +77,7 @@ The following saga persisters use pessimistic locking:
 - [MongoDB](/persistence/mongodb/) (since version 2.2.0)
 - [Service Fabric](/persistence/service-fabric/) (since version 2.2.0)
 - [SQL](/persistence/sql/) (since version 4.1.1)
+- [RavenDB](/persistence/ravendb/) (available since version 6.4.0, default since version 7.0.0)
 
 #### Optimistic concurrency control
 
@@ -89,7 +90,7 @@ The following saga persisters use OCC:
 - [Azure Storage](/persistence/azure-table/)
 - [Non-Durable](/persistence/non-durable/)
 - [MongoDB](/persistence/mongodb/) (prior to 2.2.0)
-- [RavenDB](/persistence/ravendb/)
+- [RavenDB](/persistence/ravendb/) (prior to 7.0.0)
 - [Service Fabric](/persistence/service-fabric/) (prior to 2.2.0)
 - [SQL](/persistence/sql/) (prior to 4.1.1)
 


### PR DESCRIPTION
The documentation seems incorrect/outdated given RavenDB is supporting "pessimistic locking"