### PR TITLE
ASB Upgrade Guide - Match existing API name

### DIFF
--- a/transports/upgrades/asbs-2to3.md
+++ b/transports/upgrades/asbs-2to3.md
@@ -48,7 +48,7 @@ The Azure Service Bus transport configuration options have been moved to the `Az
 | RuleNameShortener | SubscriptionRuleNamingConvention |
 | SubscriptionRuleNamingConvention | SubscriptionRuleNamingConvention |
 | UseWebSockets | UseWebSockets |
-| CustomTokenProvider | TokenProvider |
+| CustomTokenCredential | TokenCredential |
 | CustomRetryPolicy | RetryPolicy |
 
 ## Accessing the native incoming message


### PR DESCRIPTION
There is no `CustomTokenProvider` API in v7 and no `TokenProvider` property in v8. This changes things to match the public API

- [V8](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/blob/master/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt#L16)
- [V7](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/blob/release-2.0/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt#L13)