### PR TITLE
Demo body storage in azure blob container

### DIFF
--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest6231.1127" />
   </ItemGroup>
 </Project>

--- a/samples/fullduplex/Core_8/Server/Program.cs
+++ b/samples/fullduplex/Core_8/Server/Program.cs
@@ -1,7 +1,8 @@
-using System;
-using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Logging;
+using Shared;
+using System;
+using System.Threading.Tasks;
 
 class Program
 {
@@ -13,6 +14,13 @@ class Program
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());
+
+        endpointConfiguration.AuditProcessedMessagesTo("audit");
+
+        var containerClient = await AzureAuditBodyStorageConfiguration.GetContainerClient();
+
+        endpointConfiguration.Pipeline.Register(_ => new StoreAuditBodyInAzureBlobStorageBehavior(containerClient), "Writing the body to azure blobstorage");
+
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest6231.1127" />
   </ItemGroup>
 </Project>

--- a/samples/fullduplex/Core_8/Shared/AzureAuditBodyStorageConfiguration.cs
+++ b/samples/fullduplex/Core_8/Shared/AzureAuditBodyStorageConfiguration.cs
@@ -1,0 +1,19 @@
+﻿namespace Shared
+{
+    using Azure.Storage.Blobs;
+    using System;
+    using System.Threading.Tasks;
+
+    public static class AzureAuditBodyStorageConfiguration
+    {
+        public static async Task<BlobContainerClient> GetContainerClient()
+        {
+            var blobClient = new BlobServiceClient(Environment.GetEnvironmentVariable("AzureBlobAuditStorage"));
+
+            var blobContainerClient = blobClient.GetBlobContainerClient("audit-bodies");
+            await blobContainerClient.CreateIfNotExistsAsync().ConfigureAwait(false);
+
+            return blobContainerClient;
+        }
+    }
+}

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,9 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest6231.1127" />
   </ItemGroup>
 </Project>

--- a/samples/fullduplex/Core_8/Shared/StoreAuditBodyInAzureBlobStorageBehavior.cs
+++ b/samples/fullduplex/Core_8/Shared/StoreAuditBodyInAzureBlobStorageBehavior.cs
@@ -1,0 +1,57 @@
+﻿namespace Shared
+{
+    using Azure.Storage.Blobs;
+    using Azure.Storage.Blobs.Models;
+    using Microsoft.Toolkit.HighPerformance;
+    using NServiceBus;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public class StoreAuditBodyInAzureBlobStorageBehavior : Behavior<IDispatchContext>
+    {
+        public StoreAuditBodyInAzureBlobStorageBehavior(BlobContainerClient blobContainerClient)
+        {
+            this.blobContainerClient = blobContainerClient;
+        }
+
+        public override async Task Invoke(IDispatchContext context, Func<Task> next)
+        {
+            foreach (var operation in context.Operations)
+            {
+                var unicastAddress = operation.AddressTag as UnicastAddressTag;
+
+                if (unicastAddress?.Destination != "audit")
+                {
+                    continue;
+                }
+
+                var message = operation.Message;
+
+                var blob = blobContainerClient.GetBlobClient(message.MessageId);
+                var options = new BlobUploadOptions
+                {
+                    Metadata = new Dictionary<string, string>()
+                        {
+                        { "ContentType", message.Headers[Headers.ContentType] },
+                        { "BodySize", message.Body.Length.ToString()}
+                        }
+                };
+
+                await blob.UploadAsync(
+                    BinaryData.FromStream(message.Body.AsStream()),
+                    options,
+                    context.CancellationToken
+                    ).ConfigureAwait(false);
+
+                operation.Message.UpdateBody(null); //TODO: Would ReadOnlyMemory<byte>.Empty be better?
+            }
+
+            await next();
+        }
+
+        BlobContainerClient blobContainerClient;
+    }
+}


### PR DESCRIPTION
@kentdr use this to demo storing audit bodies in azure.

Steps:

1. Create a storage account
2. Add the conn string to a system env variable called `AzureBlobAuditStorage`
3. Change the container name to match what you have configured in ServiceControl
4. Download the nuget packages from the core spike  - https://github.com/Particular/NServiceBus/actions/runs/1723254199
5. Store the nsericebus nuget in a local folder and create a local nuget source pointing to that folder
6. Run the sample and send some messages => audit bodies should now be stored in blob storage and audit messages should only contain headers