### PR TITLE
Message contracts upgrade guidance

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -127,6 +127,8 @@
         Title: Transport Configuration Changes
       - Url: nservicebus/upgrades/7to8/dependency-injection
         Title: Dependency Injection Changes
+      - Url: nservicebus/upgrades/7to8/message-contracts
+        Title: Upgrading shared message contracts
     - Url: nservicebus/upgrades/6to7
       Title: NServiceBus 6 to 7
       Articles:

--- a/nservicebus/upgrades/7to8/index.md
+++ b/nservicebus/upgrades/7to8/index.md
@@ -17,6 +17,10 @@ NOTE: This is a working document; there is currently no timeline for the release
 
 This document focusses on changes that is affecting general endpoint configuration and message handlers.
 
+## Removed support for .NET Standard
+
+NServiceBus version 8 no longers .NET Standard. Instead, NServiceBus targets .NET Framework 4.5.2 and .NET Core 3.1 directly (read more about our [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). While this should have no direct impact on endpoint executables, shared message contract assemblies target .NET Standard might need to be adjusted. Refer to the [updating message contracts](message-contracts.md) page for more details.
+
 ## Transport configuration
 
 NServiceBus version 8 comes with a new transport configuration API. Instead of the generic-based `UseTransport<TTransport>` method, create an instance of the transport's configuration class and pass it to the the `UseTransport` method. For example, instead of:

--- a/nservicebus/upgrades/7to8/index.md
+++ b/nservicebus/upgrades/7to8/index.md
@@ -19,7 +19,7 @@ This document focusses on changes that is affecting general endpoint configurati
 
 ## Removed support for .NET Standard
 
-NServiceBus version 8 no longers .NET Standard. Instead, NServiceBus targets .NET Framework 4.5.2 and .NET Core 3.1 directly (read more about our [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). While this should have no direct impact on endpoint executables, shared message contract assemblies target .NET Standard might need to be adjusted. Refer to the [updating message contracts](message-contracts.md) page for more details.
+.NET Standard support was removed in NServiceBus version 8. Instead, NServiceBus targets .NET Framework 4.5.2 and .NET Core 3.1 directly (read more about our [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). While this should have no direct impact on endpoint executables, shared message contract assemblies that target .NET Standard might need to be adjusted. Refer to the [updating message contracts](message-contracts.md) page for more details.
 
 ## Transport configuration
 

--- a/nservicebus/upgrades/7to8/index.md
+++ b/nservicebus/upgrades/7to8/index.md
@@ -19,7 +19,7 @@ This document focusses on changes that is affecting general endpoint configurati
 
 ## Removed support for .NET Standard
 
-.NET Standard support was removed in NServiceBus version 8. Instead, NServiceBus targets .NET Framework 4.5.2 and .NET Core 3.1 directly (read more about our [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). While this should have no direct impact on endpoint executables, shared message contract assemblies that target .NET Standard might need to be adjusted. Refer to the [updating message contracts](message-contracts.md) page for more details.
+.NET Standard support was removed in NServiceBus version 8. Instead, NServiceBus targets .NET Framework 4.5.2 and .NET Core 3.1 directly (read more about the [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). While this should have no direct impact on endpoint executables, shared message contract assemblies that target .NET Standard might need to be adjusted. Refer to the [updating message contracts](message-contracts.md) page for more details.
 
 ## Transport configuration
 

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -30,18 +30,4 @@ If endpoints that share a common contracts assembly target different platforms a
 </Project>
 ```
 
-## Migration
-
-When upgrading endpoints one by one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are several ways to handle this.
-
-### Backwards compatiblity
-
-NServiceBus version 8 can reference message contracts referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows all endpoints to use the same message contracts assembly version.
-
-### Release new contracts assembly
-
-When deploying a new version of the contracts assembly (e.g., as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](https://docs.particular.net/nservicebus/messaging/evolving-contracts) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to propagate to endpoints that remain on the old version of the message contract assembly.
-
-Note: It is recommended to maintain a stable assembly version across different message contract versions. Use the NuGet package version or the file-version of the shared contract assembly to indicate the assembly's version number.
-
 ## Need help?

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -9,7 +9,7 @@ upgradeGuideCoreVersions:
  - 8
 ---
 
-NServiceBus version 8 does not support .NET Standard as a framework target. Therefore, message contract assemblies that target `netstandard2.0` and that reference NServiceBus must be updated. This guidance outlines possible approaches.
+NServiceBus version 8 does not support .NET Standard as a target framework. Therefore, message contract assemblies that target `netstandard2.0` and reference NServiceBus must be updated. This guidance outlines possible approaches.
 
 Note: When using [unobtrusive mode](https://docs.particular.net/nservicebus/messaging/unobtrusive-mode), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
 
@@ -19,7 +19,7 @@ If all endpoints are targeting the same platform (e.g. .NET Core 3.1), the messa
 
 ## Multi-targeting
 
-If endpoints that share a common contracts assembly target different platforms and frameworks (e.g. both .NET Framework 4.8 and .NET Core 3.1), the target assembly can use [multi-targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) by replacing the `TargetFramwork` element with the `TargetFrameworks` element in the `.csproj` settings:
+If endpoints that share a common contracts assembly target different platforms and frameworks (e.g. both .NET Framework 4.8 and .NET Core 3.1), the target assembly can use [multi-targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) by replacing the `TargetFramwork` element with the `TargetFrameworks` (note the plural) element in the `.csproj` settings:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -32,11 +32,11 @@ If endpoints that share a common contracts assembly target different platforms a
 
 ## Migration
 
-When upgrading endpoints one-by-one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are several ways to handle this:
+When upgrading endpoints one by one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are several ways to handle this.
 
 ### Backwards compatiblity
 
-NServiceBus version 8 can reference message contracts that are referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows all endpoints to use the same message contracts assembly version.
+NServiceBus version 8 can reference message contracts referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows all endpoints to use the same message contracts assembly version.
 
 ### Release new contracts assembly
 

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -15,7 +15,7 @@ Note: When using [unobtrusive mode](https://docs.particular.net/nservicebus/mess
 
 ## Change to specific target Platform
 
-If all endpoints are targeting the same platform (e.g. .NET Core 3.1), the message contracts assembly can be changed to align with all other endpoint projects.
+If all endpoints target the same platform (e.g., .NET Core 3.1), the message contracts assembly can be changed accordingly to align with all other endpoint projects.
 
 ## Multi-targeting
 

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -31,3 +31,5 @@ If endpoints that share a common contracts assembly target different platforms a
 ```
 
 ## Need help?
+
+For further information and assistance, refer to our [support channels](https://particular.net/support).

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -1,0 +1,47 @@
+---
+title: Upgrading message contracts from Version 7 to 8
+summary: Instructions on how to upgrade shared message contracts from NServiceBus version 7 to version 8.
+reviewed: 2022-02-02
+component: Core
+isUpgradeGuide: true
+upgradeGuideCoreVersions:
+ - 7
+ - 8
+---
+
+Since NServiceBus version 8 no longer supports .NET Standard, message contract assemblies refrencing NServiceBus might need to be updated. This guidance outlines possible approaches.
+
+Note: When using [unobtrusive mode](TODO), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
+
+## Change to specifc target Platform
+
+If all endpoints are targeting the same platform (e.g. .NET Core 3.1), the message contracts assembly can be changed to be aligned with all other endpoint projects.
+
+## Multi-targeting
+
+If endpoints sharing a contracts assembly are targeting different platforms and frameworks (e.g. .NET Framework 4.8 and .NET Core 3.1), the target assembly can be changed to use [multi-targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) by replacing the `TargetFramwork` element with the `TargetFrameworks` element in the `.csproj` settings:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Typically, it is sufficient to only list the lowest version needed for each platform -->
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+</Project>
+```
+
+## Migration
+
+When upgrading endpoints one-by-one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are multiple ways to handle this:
+
+### Backwards compatiblity
+
+NServiceBus version 8 can reference message contracts that are referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows to use the same message contracts assembly version across all endpoints.
+
+### Release new contracts assembly
+
+When creating a new version of the contracts assembly (deploying it as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](TODO) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to be propoagated to endpoints that remain on the old version of the message contract assembly.
+
+Note: It is recommended to maintain a stable assembly-version across different message contract versions. Indicate the contract version information via the NuGet package version or the file-version.
+
+## Need help?

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -40,7 +40,7 @@ NServiceBus version 8 can reference message contracts referencing older versions
 
 ### Release new contracts assembly
 
-When deploying a new version of the contracts assembly (e.g. as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](https://docs.particular.net/nservicebus/messaging/evolving-contracts) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to propagate to endpoints that remain on the old version of the message contract assembly.
+When deploying a new version of the contracts assembly (e.g., as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](https://docs.particular.net/nservicebus/messaging/evolving-contracts) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to propagate to endpoints that remain on the old version of the message contract assembly.
 
 Note: It is recommended to maintain a stable assembly version across different message contract versions. Indicate the contract version information via the NuGet package version or the file-version.
 

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -11,7 +11,7 @@ upgradeGuideCoreVersions:
 
 NServiceBus version 8 does not support .NET Standard as a target framework. Therefore, message contract assemblies that target `netstandard2.0` and reference NServiceBus must be updated. This guidance outlines possible approaches.
 
-Note: When using [unobtrusive mode](https://docs.particular.net/nservicebus/messaging/unobtrusive-mode), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
+Note: When using [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
 
 ## Change to specific target Platform
 
@@ -24,12 +24,12 @@ If endpoints that share a common contracts assembly target different platforms a
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Typically, it is sufficient to only list the lowest version needed for each platform -->
+    <!-- Typically, it is sufficient to list the lowest version needed -->
     <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 </Project>
 ```
 
-## Need help?
+## Get help
 
-For further information and assistance, refer to our [support channels](https://particular.net/support).
+For further information and assistance, refer to the [support channels](https://particular.net/support).

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -42,6 +42,6 @@ NServiceBus version 8 can reference message contracts referencing older versions
 
 When deploying a new version of the contracts assembly (e.g., as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](https://docs.particular.net/nservicebus/messaging/evolving-contracts) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to propagate to endpoints that remain on the old version of the message contract assembly.
 
-Note: It is recommended to maintain a stable assembly version across different message contract versions. Indicate the contract version information via the NuGet package version or the file-version.
+Note: It is recommended to maintain a stable assembly version across different message contract versions. Use the NuGet package version or the file-version of the shared contract assembly to indicate the assembly's version number.
 
 ## Need help?

--- a/nservicebus/upgrades/7to8/message-contracts.md
+++ b/nservicebus/upgrades/7to8/message-contracts.md
@@ -9,17 +9,17 @@ upgradeGuideCoreVersions:
  - 8
 ---
 
-Since NServiceBus version 8 no longer supports .NET Standard, message contract assemblies refrencing NServiceBus might need to be updated. This guidance outlines possible approaches.
+NServiceBus version 8 does not support .NET Standard as a framework target. Therefore, message contract assemblies that target `netstandard2.0` and that reference NServiceBus must be updated. This guidance outlines possible approaches.
 
-Note: When using [unobtrusive mode](TODO), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
+Note: When using [unobtrusive mode](https://docs.particular.net/nservicebus/messaging/unobtrusive-mode), the contracts assembly doesn't require a reference to NServiceBus and therefore is not affected. Unobtrusive message contracts can continue to target .NET Standard.
 
-## Change to specifc target Platform
+## Change to specific target Platform
 
-If all endpoints are targeting the same platform (e.g. .NET Core 3.1), the message contracts assembly can be changed to be aligned with all other endpoint projects.
+If all endpoints are targeting the same platform (e.g. .NET Core 3.1), the message contracts assembly can be changed to align with all other endpoint projects.
 
 ## Multi-targeting
 
-If endpoints sharing a contracts assembly are targeting different platforms and frameworks (e.g. .NET Framework 4.8 and .NET Core 3.1), the target assembly can be changed to use [multi-targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) by replacing the `TargetFramwork` element with the `TargetFrameworks` element in the `.csproj` settings:
+If endpoints that share a common contracts assembly target different platforms and frameworks (e.g. both .NET Framework 4.8 and .NET Core 3.1), the target assembly can use [multi-targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) by replacing the `TargetFramwork` element with the `TargetFrameworks` element in the `.csproj` settings:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -32,16 +32,16 @@ If endpoints sharing a contracts assembly are targeting different platforms and 
 
 ## Migration
 
-When upgrading endpoints one-by-one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are multiple ways to handle this:
+When upgrading endpoints one-by-one, message contracts might need to work across endpoints targeting different versions of NServiceBus. There are several ways to handle this:
 
 ### Backwards compatiblity
 
-NServiceBus version 8 can reference message contracts that are referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows to use the same message contracts assembly version across all endpoints.
+NServiceBus version 8 can reference message contracts that are referencing older versions of NServiceBus. Therefore, message contract assemblies can remain targeting NServiceBus version 7 until all endpoints have been successfully upgraded to version 8. This approach allows all endpoints to use the same message contracts assembly version.
 
 ### Release new contracts assembly
 
-When creating a new version of the contracts assembly (deploying it as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](TODO) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to be propoagated to endpoints that remain on the old version of the message contract assembly.
+When deploying a new version of the contracts assembly (e.g. as a NuGet package or directly as a DLL file), the messages remain wire-level compatible as long as the message contract itself is not changed. See the [evolving message contracts](https://docs.particular.net/nservicebus/messaging/evolving-contracts) documentation for more information on updating message contracts. This approach can be chosen if message contract changes don't need to propagate to endpoints that remain on the old version of the message contract assembly.
 
-Note: It is recommended to maintain a stable assembly-version across different message contract versions. Indicate the contract version information via the NuGet package version or the file-version.
+Note: It is recommended to maintain a stable assembly version across different message contract versions. Indicate the contract version information via the NuGet package version or the file-version.
 
 ## Need help?


### PR DESCRIPTION
Adds more details to the upgrade guide about shared message contract assemblies and how to multi-target