### PR TITLE
Change the word "plumbing" with something more literal

### DIFF
--- a/tutorials/quickstart/tutorial.md
+++ b/tutorials/quickstart/tutorial.md
@@ -15,7 +15,7 @@ abTestName: Quickstart intro 2022 01
 
 It is **very difficult** to build a distributed software system correctly from scratch. You _could_ read all 736 pages of the [Enterprise Integration Patterns](https://www.enterpriseintegrationpatterns.com/) book (an excellent though very dry reference) and then spend months creating, testing, and documenting a communication framework so that different services can talk to each other. Or instead, you could use a framework that incorporates all those design patterns and guides you straight into the [pit of success](https://blog.codinghorror.com/falling-into-the-pit-of-success/).
 
-NServiceBus combines decades of distributed systems design experience and expertise and distills it into one easy-to-use framework. In this tutorial, you'll see how NServiceBus takes all the grunt work out of system design by handling all of the plumbing for you, taking system design best practices like reliability, failure recovery, and extensibility and baking them right into the software, guiding you toward the pit of success.
+NServiceBus combines decades of distributed systems design experience and expertise and distills it into one easy-to-use framework. In this tutorial, you'll see how NServiceBus takes all the grunt work out of system design by handling all of the infrastructure complexity for you, taking system design best practices like reliability, failure recovery, and extensibility and baking them right into the software, guiding you toward the pit of success.
 
 You'll also see how the additional tools in the Particular Service Platform make it easy to manage, monitor, and debug.
 


### PR DESCRIPTION
Based on this feedback that I got:

> I would swap out the word “plumbing” here for something more literal. Metaphors in tutorials can be confusing for the reader.