### PR TITLE
Lock renewal examples explicitly target Azure.Messaging.ServiceBus 7.* due to fixed bug

### DIFF
--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Transitive dependencies">
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.*" />
   </ItemGroup>

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_3/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_3/LockRenewal/LockRenewal.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.0.0-beta.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Explicitly target Azure.Messaging.ServiceBus 7.* due to fixed bug that affected long running handlers.