### PR TITLE
Fix fair distribution sample for v7

### DIFF
--- a/samples/routing/fair-distribution/Core_7/Shared/FairDistribution/FairDistribution.cs
+++ b/samples/routing/fair-distribution/Core_7/Shared/FairDistribution/FairDistribution.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NServiceBus;
 using NServiceBus.Features;
-using NServiceBus.Transport;
 
 public class FairDistribution :
     Feature
@@ -16,8 +15,6 @@ public class FairDistribution :
         var sessionId = Guid.NewGuid().ToString();
         var flowManager = context.Settings.Get<FlowManager>();
         var controlAddress = context.Settings.InstanceSpecificQueue() ?? context.Settings.LocalAddress();
-
-        var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
 
         var pipeline = context.Pipeline;
         pipeline.Register(

--- a/samples/routing/fair-distribution/Core_7/Shared/FairDistribution/FairDistributionStrategy.cs
+++ b/samples/routing/fair-distribution/Core_7/Shared/FairDistribution/FairDistributionStrategy.cs
@@ -1,23 +1,23 @@
-﻿using NServiceBus;
+﻿using System;
+using NServiceBus;
 using NServiceBus.Routing;
 using NServiceBus.Settings;
 
 public class FairDistributionStrategy :
     DistributionStrategy
 {
-    ReadOnlySettings settings;
-    FlowManager flowManager;
+    Lazy<FlowManager> flowManager;
 
     public FairDistributionStrategy(ReadOnlySettings settings, string endpoint, DistributionStrategyScope scope)
         : base(endpoint, scope)
     {
-        this.settings = settings;
-        flowManager = settings.Get<FlowManager>();
+        // FlowManager is created by the FairDistribution feature at endpoint start time
+        flowManager = new Lazy<FlowManager>(settings.Get<FlowManager>);
     }
 
     public override string SelectDestination(DistributionContext context)
     {
-        return flowManager
+        return flowManager.Value
             .FindShortestQueue(context.ReceiverAddresses);
     }
 }

--- a/samples/routing/fair-distribution/Core_8/Shared/FairDistribution/FairDistributionStrategy.cs
+++ b/samples/routing/fair-distribution/Core_8/Shared/FairDistribution/FairDistributionStrategy.cs
@@ -6,14 +6,13 @@ using System;
 public class FairDistributionStrategy :
     DistributionStrategy
 {
-    IReadOnlySettings settings;
     Lazy<FlowManager> flowManager;
 
     public FairDistributionStrategy(IReadOnlySettings settings, string endpoint, DistributionStrategyScope scope)
         : base(endpoint, scope)
     {
-        this.settings = settings;
-        flowManager = new Lazy<FlowManager>(() => settings.Get<FlowManager>());
+        // FlowManager is created by the FairDistribution feature at endpoint start time
+        flowManager = new Lazy<FlowManager>(settings.Get<FlowManager>);
     }
 
     public override string SelectDestination(DistributionContext context)


### PR DESCRIPTION
The sample is currently broken on v7 because access to the `FlowManager` created by a `Feature` happens too early. It seems this has already been addressed for the v8 sample and I went with the same approach using a `Lazy` to delay access until the feature has ran its default configuration. Not ideal but there is currently no better way to share settings from a Feature with outside code. Also added a small comment for clarity.