### PR TITLE
Suppress broken CA2252 warning

### DIFF
--- a/samples/ravendb/simple/Raven_8/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_8/Server/Server.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
+    <NoWarn>$(NoWarn);CA2252</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />


### PR DESCRIPTION
The CA2252 code analyzer currently triggers on the `DocumentStore` APIs and also seems to fail with a NRE:

> CSC : error AD0001: Analyzer 'Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.

Disables the CA2252 warning temporarily since it's breaking the builds and preventing deployments.

If merged, an issue should be raised to further investigate or validate the problem at a later point in time and to remove the workaround again.