### PR TITLE
Fix mermaid syntax

### DIFF
--- a/transports/sqs/delayed-delivery.md
+++ b/transports/sqs/delayed-delivery.md
@@ -128,19 +128,13 @@ sequenceDiagram
 ```mermaid
 graph LR
 
-subgraph 
-
 Sender .-> |DelaySeconds = 845sec| Destination
-
-end
 ```
 
 #### Delay of 32 minutes and 5 seconds
 
 ```mermaid
 graph LR
-
-subgraph 
 
 Sender
 fifo(Destination-delay.fifo)
@@ -149,8 +143,6 @@ Destination
 Sender .-> |T1: NServiceBus.AmazonSQS.DelaySeconds = 1,925sec| fifo
 fifo --> |"T2: NServiceBus.AmazonSQS.DelaySeconds = 1,025sec"| fifo
 fifo .-> |"T3: DelaySeconds = 125sec"| Destination
-
-end
 ```
 
 ## Cost considerations


### PR DESCRIPTION
The mermaid graphs on [this page](https://docs.particular.net/transports/sqs/delayed-delivery?version=sqs_6#how-it-works-examples) are broken. `subgraph` needs to have a name, e.g. `subgraph somethingsomething` but I'm not sure why it needs a subgraph at all, so I just removed that.