### PR TITLE
Fix NHibernate simple sample client project had missing reference to System.Data.SqlClient

### DIFF
--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Iesi.Collections" Version="4.*" />
     <PackageReference Include="NHibernate" Version="5.*" />
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NHibernate simple sample client project had missing reference to System.Data.SqlClient which resulted in the following error:

```
Unhandled exception. NHibernate.HibernateException: Could not create the driver from NHibernate.Driver.Sql2008ClientDriver, NHibernate, Version=5.3.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4.
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> NHibernate.HibernateException: The DbCommand and DbConnection implementation in the assembly System.Data.SqlClient could not be found. Ensure that the assembly System.Data.SqlClient is located in the application directory or in the Global Assembly Cache. If the assembly is in the GAC, use <qualifyAssembly/> element in the application configuration file to specify the full name of the assembly.
```