### PR TITLE
ASBS configuration/connectivity restructured regarding usage of `TokenCredential`

### DIFF
--- a/servicecontrol/transports.md
+++ b/servicecontrol/transports.md
@@ -33,7 +33,7 @@ In addition to the [connection string options of the transport](/transports/rabb
 
 #### Azure Service Bus
 
-In addition to the [connection string options of the transport](/transports/azure-service-bus/#configuring-an-endpoint) the following ServiceControl specific options are available in versions 4.4 and above:
+In addition to the [connection string options of the transport](/transports/azure-service-bus/configuration.md#configuring-an-endpoint) the following ServiceControl specific options are available in versions 4.4 and above:
 
 * `TransportType=AmqpWebSockets` - Configures the transport to use [AMQP over websockets](/transports/azure-service-bus/configuration.md#connectivity).
 * `TopicName=<topic-bundle-name>` - Specifies the [topic name](/transports/azure-service-bus/configuration.md#entity-creation) to be used by the instance. The default value is `bundle-1`.

--- a/transports/azure-service-bus/configuration.md
+++ b/transports/azure-service-bus/configuration.md
@@ -5,15 +5,35 @@ component: ASBS
 reviewed: 2020-04-15
 ---
 
+## Configuring an endpoint
+
+To use Azure Service Bus as the underlying transport:
+
+snippet: azure-service-bus-for-dotnet-standard
+
+partial: requires-connectionstring
+partial: v7-usetransport
+
+## Connectivity
+
+These settings control how the transport connects to the broker.
+
+* `UseWebSockets()`: Configures the transport to use AMQP over websockets.
+* `TimeToWaitBeforeTriggeringCircuitBreaker(TimeSpan)`: The time to wait before triggering the circuit breaker after a critical error occurred. Defaults to 2 minutes.
+
+partial: custom-retry-policy
+
+partial: custom-token-credentials
+
 ## Entity creation
 
 These settings control how the transport creates entities in the Azure Service Bus namespace.
 
 WARNING: Entity creation settings are applied only at creation time of the corresponding entities; they are not updated on subsequent startups.
 
- * `TopicName(string)`: The name of the topic used to publish events between endpoints. This topic is shared by all endpoints, so ensure all endpoints configure the same topic name. Defaults to `bundle-1`. Topic names must adhere to the limits outlined in [the Microsoft documentation on topic creation](https://docs.microsoft.com/en-us/rest/api/servicebus/create-topic).
- * `EntityMaximumSize(int)`: The maximum entity size in GB. The value must correspond to a valid value for the namespace type. Defaults to 5. See [the Microsoft documentation on quotas and limits](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas) for valid values.
- * `EnablePartitioning()`: Partitioned entities offer higher availability, reliability, and throughput over conventional non-partitioned queues and topics. For more information about partitioned entities [see the Microsoft documentation on partitioned messaging entities](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning).
+* `TopicName(string)`: The name of the topic used to publish events between endpoints. This topic is shared by all endpoints, so ensure all endpoints configure the same topic name. Defaults to `bundle-1`. Topic names must adhere to the limits outlined in [the Microsoft documentation on topic creation](https://docs.microsoft.com/en-us/rest/api/servicebus/create-topic).
+* `EntityMaximumSize(int)`: The maximum entity size in GB. The value must correspond to a valid value for the namespace type. Defaults to 5. See [the Microsoft documentation on quotas and limits](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas) for valid values.
+* `EnablePartitioning()`: Partitioned entities offer higher availability, reliability, and throughput over conventional non-partitioned queues and topics. For more information about partitioned entities [see the Microsoft documentation on partitioned messaging entities](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning).
 partial: subscription-rule-customization
 
 ## Controlling the prefetch count
@@ -27,14 +47,3 @@ Alternatively, the whole calculation can be overridden by setting the prefetch c
 snippet: custom-prefetch-count
 
 To disable prefetching, prefetch count should be set to zero.
- 
-## Connectivity
-
-These settings control how the transport connects to the broker.
-
- * `UseWebSockets()`: Configures the transport to use AMQP over websockets.
- * `TimeToWaitBeforeTriggeringCircuitBreaker(TimeSpan)`: The time to wait before triggering the circuit breaker after a critical error occurred. Defaults to 2 minutes.
-
-partial: custom-retry-policy
-
-partial: custom-token-credentials

--- a/transports/azure-service-bus/configuration_custom-token-credentials_asbs_[2,].partial.md
+++ b/transports/azure-service-bus/configuration_custom-token-credentials_asbs_[2,].partial.md
@@ -1,3 +1,3 @@
  * `CustomTokenCredential(TokenCredential)`: Enables using Azure Active Directory (AAD) authentication such as [managed identities for Azure resources](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-managed-service-identity) instead of the shared secret in the connection string.
  
-Note: AAD authentication requires a fully-qualified namespace usage (e.g. `<asb-namespace-name>.servicebus.windows.net`) instead of a connection string (e.g. `Endpoint=sb://<asb-namespace-name>.servicebus.windows.net>;[...]`).
+NOTE: **Azure Active Directory (AAD)** authentication requires a fully-qualified namespace usage (e.g. `<asb-namespace-name>.servicebus.windows.net`) instead of a connection string (e.g. `Endpoint=sb://<asb-namespace-name>.servicebus.windows.net>;[...]`).

--- a/transports/azure-service-bus/index.md
+++ b/transports/azure-service-bus/index.md
@@ -27,12 +27,3 @@ The Azure Service Bus transport leverages the [Azure.Messaging.ServiceBus](https
 |Native integration         |[Supported](native-integration.md)
 
 NOTE: The Azure Service Bus transport only supports Standard and Premium tiers of the Microsoft Azure Service Bus service. Premium tier is recommended for production environments.
-
-## Configuring an endpoint
-
-To use Azure Service Bus as the underlying transport:
-
-snippet: azure-service-bus-for-dotnet-standard
-
-partial: requires-connectionstring
-partial: v7-usetransport


### PR DESCRIPTION
Moved ASBS "Configuring an endpoint" from index to configuration page close to connectivity information to improve visibility of Azure Active Directory information on usage of `TokenCredential`.

While smoke testing https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/599 to validate if it resolves https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/588 I discovered that the connection string should only contain the namespace identifier. This was even mentioned in the docs but not very visible.