### PR TITLE
Added NServiceBus's NewRelic quickstart link

### DIFF
--- a/samples/logging/new-relic/sample.md
+++ b/samples/logging/new-relic/sample.md
@@ -22,7 +22,7 @@ This sample reports the following metrics to NewRelic:
 * Processing time seconds
 * Retries in Version 2 and later
 
-For a detailed explanation of these metrics refer to the [metrics captured section in the metrics documentation](/monitoring/metrics/definitions.md) section.
+For a detailed explanation of these metrics refer to the [metrics captured section in the metrics documentation](/monitoring/metrics/definitions.md) section and [New Relic NServiceBus integration](https://newrelic.com/instant-observability/nservicebus/f3f28a00-8cea-41f1-a6fe-ebf5eae5791e).
 
 ## Prerequisites
 


### PR DESCRIPTION
Hi dev team,

We have many users on our platform who are using NServiceBus and would like to instrument it. We’d love to provide a smooth experience for NServiceBus users who need to use commercial monitoring solutions, such as New Relic. Please see our documentation[ here](https://newrelic.com/instant-observability/nservicebus/f3f28a00-8cea-41f1-a6fe-ebf5eae5791e).

Please consider adding a link for your direct users to provide an option for New Relic.  For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.
