### PR TITLE
Make New Relic links more prominent

### DIFF
--- a/samples/logging/new-relic/sample.md
+++ b/samples/logging/new-relic/sample.md
@@ -22,7 +22,9 @@ This sample reports the following metrics to NewRelic:
 * Processing time seconds
 * Retries in Version 2 and later
 
-For a detailed explanation of these metrics refer to the [metrics captured section in the metrics documentation](/monitoring/metrics/definitions.md) section and [New Relic NServiceBus integration](https://newrelic.com/instant-observability/nservicebus/f3f28a00-8cea-41f1-a6fe-ebf5eae5791e).
+For a detailed explanation of these metrics refer to the [metrics captured section in the metrics documentation](/monitoring/metrics/definitions.md) section.
+
+The [New Relic NServiceBus integration](https://newrelic.com/instant-observability/nservicebus/f3f28a00-8cea-41f1-a6fe-ebf5eae5791e) can be used to get started quickly.
 
 ## Prerequisites
 
@@ -63,9 +65,11 @@ snippet: newrelic-appname
 
 ## Dashboard
 
-### Create
+A ready-to-use dashboard is available in the [official New Relic NServiceBus integration](https://newrelic.com/instant-observability/nservicebus/f3f28a00-8cea-41f1-a6fe-ebf5eae5791e).
 
-Dashboards can be created by using NewRelic Insights. The following steps have to be performed:
+### Create a custom dashboard
+
+Custom dashboards can be created by using NewRelic Insights. The following steps have to be performed:
 
  * Create a new dashboard by using the `Create a dashboard` button under `All Dashboards`.
  * Open up the Data Explorer, select the corresponding application name and filter for `Custom` metrics.


### PR DESCRIPTION
Split the existing link from the previous paragraph into a dedicated to make it more easily recognizable and repeat the link in the dashboard section.