### PR TITLE
Update sample target framework recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,13 +271,7 @@ Samples can be targeted to multiple [target frameworks](https://docs.microsoft.c
 The currently recommended set of frameworks is:
 
 ```xml
-<TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
-```
-
-Shared/messages projects should not be multi-targeted but use a standard framework that works with all targets:
-
-```xml
-<TargetFramework>netstandard2.0</TargetFramework>
+<TargetFrameworks>net6.0;net48</TargetFrameworks>
 ```
 
 Some things to keep in mind:


### PR DESCRIPTION
This seems to be a bit outdated since most samples have been updated to use `net6.0` already. 3.1 shouldn't be required anymore, I left .NET Framework 4.8 in there for now.

Also removed the recommendation to use `.netstandard` for shared message contracts projects since this doesn't really work anymore with NServiceBus v8 since we don't target .NET Standard anymore and shared message contracts now need to use multi-targeting as well (see [existing docs](https://docs.particular.net/nservicebus/messaging/sharing-contracts#sharing-contracts-nservicebus-dependency) on this).