### PR TITLE
Clarify CriticalErrorContext.Stop behavior

### DIFF
--- a/Snippets/Core/Core_7/CriticalErrors.cs
+++ b/Snippets/Core/Core_7/CriticalErrors.cs
@@ -38,6 +38,15 @@ namespace Core7
 
         #endregion
 
+        async Task CriticalErrorHandler(ICriticalErrorContext criticalErrorContext)
+        {
+            #region StopEndpointInCriticalError
+
+            await criticalErrorContext.Stop();
+
+            #endregion
+        }
+
 
         void InvokeCriticalError(CriticalError criticalError, string errorMessage, Exception exception)
         {

--- a/Snippets/Core/Core_8/CriticalErrors.cs
+++ b/Snippets/Core/Core_8/CriticalErrors.cs
@@ -39,6 +39,14 @@ namespace Core8
 
         #endregion
 
+        async Task CriticalErrorHandler(ICriticalErrorContext criticalErrorContext, CancellationToken cancellationToken)
+        {
+            #region StopEndpointInCriticalError
+
+            await criticalErrorContext.Stop(cancellationToken);
+
+            #endregion
+        }
 
         void InvokeCriticalError(CriticalError criticalError, string errorMessage, Exception exception)
         {

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -31,11 +31,13 @@ Define a custom handler using the following code.
 
 snippet: DefiningCustomHostErrorHandlingAction
 
-### Terminating the process
+### Stopping the endpoint
 
-It is often unknown if the issue is recoverable when a critical error occurs. A sound strategy is to terminate the process when a critical error occurs and rely on the process hosting environment to restart the process as a recovery mechanism, resulting in a resilient way to deal with critical errors.
+It is often unknown if the issue is recoverable when a critical error occurs. A sound strategy is to terminate the process (e.g. via `Environment.FailFast` or `IHostApplicationLifetime.Stop`) when a critical error occurs and rely on the process hosting environment to restart the process as a recovery mechanism, resulting in a resilient way to deal with critical errors.
 
-However, this strategy only works when the endpoint instance is hosted in isolation and does not have another component. For example, when co-hosting NServiceBus with a web-service or website, terminating the process would result in these components becoming unavailable to users or other systems.
+However, this strategy only works when the endpoint instance is hosted in isolation and does not have another component. For example, when co-hosting NServiceBus with a web-service or website, terminating the process would result in these components becoming unavailable to users or other systems. When the host process should not be affected, the NServiceBus endpoint can be stopped without affecting other components or the host process:
+
+snippet: StopEndpointInCriticalError
 
 ### Host OS recoverability
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -35,7 +35,7 @@ snippet: DefiningCustomHostErrorHandlingAction
 
 It is often unknown if the issue is recoverable when a critical error occurs. A sound strategy is to terminate the process (e.g. via `Environment.FailFast` or `IHostApplicationLifetime.Stop`) when a critical error occurs and rely on the process hosting environment to restart the process as a recovery mechanism, resulting in a resilient way to deal with critical errors.
 
-Before terminating the process, the NServiceBus endpoint can attempt a graceful shutdown:
+Before terminating the process, the NServiceBus endpoint can attempt a graceful shutdown which can be useful in non-transactional processing environments:
 
 snippet: StopEndpointInCriticalError
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -35,7 +35,9 @@ snippet: DefiningCustomHostErrorHandlingAction
 
 It is often unknown if the issue is recoverable when a critical error occurs. A sound strategy is to terminate the process (e.g. via `Environment.FailFast` or `IHostApplicationLifetime.Stop`) when a critical error occurs and rely on the process hosting environment to restart the process as a recovery mechanism, resulting in a resilient way to deal with critical errors.
 
-However, this strategy only works when the endpoint instance is hosted in isolation and does not have another component. For example, when co-hosting NServiceBus with a web-service or website, terminating the process would result in these components becoming unavailable to users or other systems. When the host process should not be affected, the NServiceBus endpoint can be stopped without affecting other components or the host process:
+Note: [The Microsoft Generic Host's](/nservicebus/hosting/extensions-hosting.md) `IHostApplicationLifetime.Stop` method also stops the NServiceBus endpoint gracefully.
+
+However, this strategy only works when the endpoint instance is hosted in isolation and does not have another component. For example, when co-hosting NServiceBus with a web-service or website, terminating the process would result in these components becoming unavailable too. When the host process should not be affected, the NServiceBus endpoint can be stopped without affecting other components or the host process:
 
 snippet: StopEndpointInCriticalError
 

--- a/nservicebus/hosting/critical-errors.md
+++ b/nservicebus/hosting/critical-errors.md
@@ -35,11 +35,14 @@ snippet: DefiningCustomHostErrorHandlingAction
 
 It is often unknown if the issue is recoverable when a critical error occurs. A sound strategy is to terminate the process (e.g. via `Environment.FailFast` or `IHostApplicationLifetime.Stop`) when a critical error occurs and rely on the process hosting environment to restart the process as a recovery mechanism, resulting in a resilient way to deal with critical errors.
 
-Note: [The Microsoft Generic Host's](/nservicebus/hosting/extensions-hosting.md) `IHostApplicationLifetime.Stop` method also stops the NServiceBus endpoint gracefully.
-
-However, this strategy only works when the endpoint instance is hosted in isolation and does not have another component. For example, when co-hosting NServiceBus with a web-service or website, terminating the process would result in these components becoming unavailable too. When the host process should not be affected, the NServiceBus endpoint can be stopped without affecting other components or the host process:
+Before terminating the process, the NServiceBus endpoint can attempt a graceful shutdown:
 
 snippet: StopEndpointInCriticalError
+
+Note: [The Microsoft Generic Host's](/nservicebus/hosting/extensions-hosting.md) `IHostApplicationLifetime.Stop` method also stops the NServiceBus endpoint gracefully.
+
+Warn: Calling `criticalErrorContext.Stop` without terminating the host process will only stop the NServiceBus endpoint without affecting the host process and other components running within the same process. It is generally recommended to restart the process after stopping the endpoint.
+
 
 ### Host OS recoverability
 


### PR DESCRIPTION
be more clear that this does never impact the host process. Also adds a snippet for the Stop method.