### PR TITLE
Documentation for new installers API

### DIFF
--- a/Snippets/Core/Core_8.1/Core_8.1.csproj
+++ b/Snippets/Core/Core_8.1/Core_8.1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>

--- a/Snippets/Core/Core_8.1/Installers.cs
+++ b/Snippets/Core/Core_8.1/Installers.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using NServiceBus.Installation;
+
+namespace Core_8._1
+{
+    public class InstallerSetup
+    {
+        #region installer-setup
+        public static async Task Main()
+        {
+            var endpointConfiguration = new EndpointConfiguration("my-endpoint");
+            // configure endpoint
+
+            await Installer.Setup(endpointConfiguration);
+        }
+        #endregion
+    }
+
+    public class InstallerSetupExternallyManagedContainer
+    {
+        #region installer-setup-externally-managed-container
+        public static async Task Main()
+        {
+            var endpointConfiguration = new EndpointConfiguration("my-endpoint");
+            // configure endpoint
+
+            var serviceCollection = new ServiceCollection();
+            // custom registrations
+
+            var installer = Installer.CreateInstallerWithExternallyManagedContainer(endpointConfiguration, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            await installer.Setup(serviceProvider);
+        }
+        #endregion
+    }
+}

--- a/Snippets/Core/Core_8.1/Installers.cs
+++ b/Snippets/Core/Core_8.1/Installers.cs
@@ -1,4 +1,4 @@
-﻿namespace Core_8._1
+﻿namespace Core_8
 {
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.Installation;

--- a/Snippets/Core/Core_8.1/Installers.cs
+++ b/Snippets/Core/Core_8.1/Installers.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using NServiceBus.Installation;
-
-namespace Core_8._1
+﻿namespace Core_8._1
 {
+    using Microsoft.Extensions.DependencyInjection;
+    using NServiceBus.Installation;
+    using System.Threading.Tasks;
+    using NServiceBus;
+
     public class InstallerSetup
     {
         #region installer-setup

--- a/nservicebus/operations/installers.md
+++ b/nservicebus/operations/installers.md
@@ -15,11 +15,11 @@ Installers ensure that endpoint-specific artifacts (e.g. database tables, queues
 
 Installers require permissions to administer resources such as database tables, queues, or directories. Following the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), it is recommended to run an endpoint with these elevated permissions only during initial deployment.
 
-For example, an endpoint can be started manually as an administrator or elevated user to allow installers to run. The required resources will be ready as soon as the endpoint has successfully started. The endpoint can then be shut down and installed as a service, which can run as a regular user that does not have permission to modify resources.
-
 The alternative to using installers is to create the required resources before the endpoint is run. The method of doing this varies for each transport or persistence package. For more information, see [operations](/nservicebus/operations).
 
-## Running installers
+partial: installer-api
+
+## Running installers during endpoint startup
 
 partial: default-behavior
 

--- a/nservicebus/operations/installers_installer-api_core_[8.1,).partial.md
+++ b/nservicebus/operations/installers_installer-api_core_[8.1,).partial.md
@@ -1,0 +1,14 @@
+## Running installers
+
+When requiring special privileges to setup the endpoint, the installer API can be used to run all necessary installation steps:
+
+snippet: installer-setup
+
+When the setup requires access to services that are provided via an externally managed dependency injection container, provide the configured `IServiceProvider` to the installer API:
+
+snippet: installer-setup-externally-managed-container
+
+Note: The installer APIs always run installers, regardless whether the endpoint has configured `EnableInstallers`.
+
+The installer APIs are intended to be used when the endpoint host process be run with different privileges after installation. The `EndpointConfiguration` can't be reused in the same process to call `Endpoint.Start`. To setup the endpoint as part of the endpoint host process, use see the [Running installers during endpoint startup](#running-installers-during-endpoint-startup).
+

--- a/nservicebus/operations/installers_installer-api_core_[8.1,).partial.md
+++ b/nservicebus/operations/installers_installer-api_core_[8.1,).partial.md
@@ -8,7 +8,7 @@ When the setup requires access to services that are provided via an externally m
 
 snippet: installer-setup-externally-managed-container
 
-Note: The installer APIs always run installers, regardless whether the endpoint has configured `EnableInstallers`.
+Note: The installer APIs always run installers, regardless of whether the endpoint has configured `EnableInstallers`.
 
-The installer APIs are intended to be used when the endpoint host process be run with different privileges after installation. The `EndpointConfiguration` can't be reused in the same process to call `Endpoint.Start`. To setup the endpoint as part of the endpoint host process, use see the [Running installers during endpoint startup](#running-installers-during-endpoint-startup).
+The installer APIs are intended to be used when resources required by the endpoint must be set up with different privileges than the endpoint itself requires. `EndpointConfiguration` can't be reused in the same process to call `Endpoint.Start`. To setup the endpoint as part of the endpoint host process, see the [Running installers during endpoint startup](#running-installers-during-endpoint-startup) article.
 

--- a/persistence/upgrades/nhibernate-8to8.1.md
+++ b/persistence/upgrades/nhibernate-8to8.1.md
@@ -72,7 +72,7 @@ NHibernate persistence has an option to use an [explicit version column](/persis
 
 This requires adding a version property to the saga code, as well as altering the database saga table schema by adding a column.
 
-NHibernate adds this column if the [endpoint is started or created with EnableInstallers enabled](/nservicebus/operations/installers.md#running-installers). 
+NHibernate adds this column if the [endpoint is started or created with installers enabled](/nservicebus/operations/installers.md).
 
 
 ### Enforce NHibernate 4 backward-compatibility


### PR DESCRIPTION
Adds documentation for the new installer APIs introduced via https://github.com/Particular/NServiceBus/pull/6563 in NServiceBus 8.1.

The core reference in the 8.1 csproj file is a reference to a local build since we don't have any 8.1 builds available yet.