### PR TITLE
Remove unnecessary naming of problems as "ghost" or "phantom"

### DIFF
--- a/nservicebus/best-practices.md
+++ b/nservicebus/best-practices.md
@@ -93,7 +93,7 @@ In production, the creation of queues, database tables, and other tables should 
 
 :heavy_check_mark: **DO use the [Outbox feature](/nservicebus/outbox/) to provide consistency between business data modifications and messaging operations**
 
-Because message queues generally do not support any form of transactions, message handlers that modify business data in a database run into problems when the messages that are sent become inconsistent with the changes made to business data, resulting in ghost messages or phantom records.
+Because message queues generally do not support any form of transactions, message handlers that modify business data in a database run into problems when the messages that are sent become inconsistent with the changes made to business data.
 
 Using the outbox guarantees exactly-once message processing by taking advantage of the local database transaction used to store business data.
 

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -18,7 +18,7 @@ related:
 - persistence/mongodb
 ---
 
-Most message queues, and some data stores, do not support distributed transactions. This may cause problems when message handlers modify business data. Business data and messages may become inconsistent in the form of **phantom records** or **ghost messages** (see below).
+Most message queues, and some data stores, do not support distributed transactions. This may cause problems when message handlers modify business data. Business data and messages may become inconsistent (see below).
 
 The NServiceBus **outbox** feature ensures consistency between business data and messages. It simulates an atomic transaction, distributed across both the data store used for business data and the message queue used for messaging.
 
@@ -32,10 +32,10 @@ Note: Messages sent using `IMessageSession` won't be handled by the outbox. The 
 
 Consider a message handler that creates a `User` in the business database, and also publishes a `UserCreated` event. If a failure occurs during the execution of the message handler, two scenarios may occur, depending on the order of operations.
 
-1. **Phantom record**: The message handler creates the `User` in the database first, then publishes the `UserCreated` event. If a failure occurs between these two operations:
+1. The message handler creates the `User` in the database first, then publishes the `UserCreated` event. If a failure occurs between these two operations:
    * The `User` is created in the database, but the `UserCreated` event is not published.
-   * The message handler does not complete, so the message is retried, and both operations are repeated. This results in a duplicate `User` in the database, known as a phantom record, which is never announced to the rest of the system.
-2. **Ghost message**: The message handler publishes the `UserCreated` event first, then creates the `User` in the database. If a failure occurs between these two operations:
+   * The message handler does not complete, so the message is retried, and both operations are repeated. This results in a duplicate `User` in the database which is never announced to the rest of the system.
+2. The message handler publishes the `UserCreated` event first, then creates the `User` in the database. If a failure occurs between these two operations:
    * The `UserCreated` event is published, but the `User` is not created in the database.
    * The rest of the system is notified about the creation of the `User`, but the `User` does not exist in the database. This causes further errors in other message handlers which expect the `User` to exist in the database.
 

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -12,10 +12,10 @@ related:
 
 Consider an ASP.NET Core controller that creates a user in the business database and publishes a `UserCreated` event. If a failure occurs during the execution of the request, two scenarios may occur, depending on the order of operations.
 
-1. **Phantom record**: The controller creates the `User` in the database first, then publishes the `UserCreated` event. If a failure occurs between these two operations:
+1. The controller creates the `User` in the database first, then publishes the `UserCreated` event. If a failure occurs between these two operations:
     * The user is created in the database, but the `UserCreated` event is not published.
-    * This results is a user in the database, known as a phantom record, which is never announced to the rest of the system.
-2. **Ghost message**: The controller publishes the `UserCreated` event first, then creates the user in the database. If a failure occurs between these two operations:
+    * This results in a user in the database which is never announced to the rest of the system.
+2. The controller publishes the `UserCreated` event first, then creates the user in the database. If a failure occurs between these two operations:
     * The `UserCreated` event is published, but the user is not created in the database.
     * The rest of the system is notified about the creation of the user, but the user record is never created. This inconsistency causes errors, as parts of the system expect the record to exist in the database.
 
@@ -103,7 +103,7 @@ To guarantee atomic consistency across database and message operations, the tran
 
 NOTE: The outbox has to be [enabled explicitly](/nservicebus/outbox/#enabling-the-outbox) on the endpoint configuration.
 
-With the Outbox disabled, database and message operations are not applied until the session is committed. All database operations share the same database transaction and are committed first. When the database operations complete successfully, the message operations are [batch-dispatched by the transport](/nservicebus/messaging/batched-dispatch.md). The message operations and the database changes are not guaranteed to be atomic. This might lead to phantom records or ghost messages in case of a failure during the commit phase.
+With the Outbox disabled, database and message operations are not applied until the session is committed. All database operations share the same database transaction and are committed first. When the database operations complete successfully, the message operations are [batch-dispatched by the transport](/nservicebus/messaging/batched-dispatch.md). The message operations and the database changes are not guaranteed to be atomic. This might lead to inconsistencies in case of a failure during the commit phase.
 
 ## How it works
 


### PR DESCRIPTION
There have been a bunch of slack communications about the inaccuracy of these terms during the Transactional Session TF. Those can be found here: https://particularsoftware.slack.com/archives/C03Q3FRPTLL/p1663785368329989