### PR TITLE
Adding documentation related to raven 5 persistence for Audit

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1335,6 +1335,8 @@
         Url: servicecontrol/audit-instances/installation-powershell
       - Title: Settings
         Url: servicecontrol/audit-instances/creating-config-file
+      - Title: Persistence
+        Url: servicecontrol/audit-instances/persistence
       - Title: Maintenance Mode
         Url: servicecontrol/audit-instances/maintenance-mode
   - Title: Monitoring instances

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1323,6 +1323,8 @@
       Articles:
       - Title: ServiceControl troubleshooting
         Url: servicecontrol/troubleshooting
+      - Title: Persistence
+        Url: servicecontrol/persistence
       - Title: Maintenance mode
         Url: servicecontrol/maintenance-mode
       - Title: Retry importing messages

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -1,0 +1,14 @@
+---
+title: ServiceControl Audit persistence
+summary: Information about ServiceControl Audit persistence options.
+reviewed: 2022-10-17
+---
+
+ServiceControl audit instances store their data in an RavenDB embedded database. In the ServiceControl.Audit version 4.26 and up, new instances store their data in RavenDB version 5. Instances less than version 4.26 use RavenDB version 3.5.
+
+Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that uses RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
+
+WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.
+
+## Document expiration
+

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -4,7 +4,7 @@ summary: Information about ServiceControl Audit persistence options.
 reviewed: 2022-10-17
 ---
 
-ServiceControl audit instances store their data in an RavenDB embedded database. In the ServiceControl.Audit version 4.26 and up, new instances store their data in RavenDB version 5. Instances less than version 4.26 use RavenDB version 3.5.
+ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above, new instances store their data in RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
 Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that uses RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
 

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -6,6 +6,6 @@ reviewed: 2022-10-17
 
 ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above new instances use RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
-Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5. For more details see [upgrade guide to new persistence format](servicecontrol/upgrades/new-persistence.md)
+Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5. For more details see [upgrade guide to new persistence format](/servicecontrol/upgrades/new-persistence.md)
 
 WARNING: The ServiceControl Audit RavenDB embedded database is used exclusively by ServiceControl and is not intended for external manipulation or modifications.

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -6,6 +6,6 @@ reviewed: 2022-10-17
 
 ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above, new instances store their data in RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
-Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that use RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
+Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5.
 
 WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -4,8 +4,8 @@ summary: Information about ServiceControl Audit persistence options.
 reviewed: 2022-10-17
 ---
 
-ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above, new instances store their data in RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
+ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above new instances use RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
 Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5.
 
-WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.
+WARNING: The ServiceControl Audit RavenDB embedded database is used exclusively by ServiceControl and is not intended for external manipulation or modifications.

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -6,6 +6,6 @@ reviewed: 2022-10-17
 
 ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above new instances use RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
-Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5.
+Upgrading ServiceControl.Audit instances to version 4.26 or higher does not change the database version. Instances using RavenDB version 3.5, when upgraded to the newest version, will still be using RavenDB version 3.5. For more details see [upgrade guide to new persistence format](servicecontrol/upgrades/new-persistence.md)
 
 WARNING: The ServiceControl Audit RavenDB embedded database is used exclusively by ServiceControl and is not intended for external manipulation or modifications.

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -6,7 +6,7 @@ reviewed: 2022-10-17
 
 ServiceControl audit instances store their data in a RavenDB embedded database. In ServiceControl.Audit version 4.26 and above, new instances store their data in RavenDB version 5. Instances created by version 4.25 and below use RavenDB version 3.5.
 
-Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that uses RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
+Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that use RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
 
 WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.
 

--- a/servicecontrol/audit-instances/persistence.md
+++ b/servicecontrol/audit-instances/persistence.md
@@ -9,6 +9,3 @@ ServiceControl audit instances store their data in a RavenDB embedded database. 
 Upgrading ServiceControl.Audit instances into version 4.26 or higher does not change the database version. So instance that use RavenDB version 3.5 upgraded to the newest version will still be using RavenDB version 3.5.
 
 WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.
-
-## Document expiration
-

--- a/servicecontrol/how-purge-expired-data.md
+++ b/servicecontrol/how-purge-expired-data.md
@@ -16,5 +16,5 @@ Warning: The database will not automatically shrink in size after reducing the r
 
 ## Differences in purge implementations
 
-Expiration of error and audit data is implemented by runnig a reccuring task that checks the documents for old data and deleting the rows that should be deleted. Changing the expiration setting results in it being picked up during the next time the service is run. 
-In the ServiceControl.Audit version 4.26 and up expiration is done using the persistance mechanisms, that results in metadata key to be stored with every message. Thanks to that, purging of the data can be handled fully by database itself. The drawback is that changing of expiration setting is only applied to new rows. 
+Expiration of error and audit data is implemented by a reccuring task that checks the documents for old data and deletes documents that have expired. Changing the expiration setting results in it being picked up during the next time the service is run. 
+In ServiceControl.Audit version 4.26 and above expiration is handled by the database automatically. Each audited message contains a metadata key that tells the database when to remove it. When the expiration setting changes, the new value is only applied to new audit data. Existing audit meta is not changed. Messages already in the database are not affected by the change to the expiration setting.

--- a/servicecontrol/how-purge-expired-data.md
+++ b/servicecontrol/how-purge-expired-data.md
@@ -4,7 +4,8 @@ summary: Configuring ServiceControl's data retention policy
 related:
  - nservicebus/recoverability
  - nservicebus/operations/auditing
-reviewed: 2020-06-23
+ - servicecontrol/audit-instances/persistence
+reviewed: 2022-10-18
 ---
 
 ServiceControl stores audit and error data. Any audit and error data that is older than the specified thresholds is deleted from the embedded RavenDB. The expiration thresholds for both faulted and audited messages must be set during installation. These values can be modified later by launching ServiceControl Management and editing the configuration settings for the instance.
@@ -12,3 +13,8 @@ ServiceControl stores audit and error data. Any audit and error data that is old
 Note: The expiration process curates only the data in the embedded RavenDB. Audit and error forwarding queues are not curated or managed by ServiceControl. To turn these settings off, launch ServiceControl Management and edit the configuration settings for the instance.
 
 Warning: The database will not automatically shrink in size after reducing the retention period. Ensure ServiceControl had time to purge all expired messages and then [Compact the database](db-compaction.md).
+
+## Differences in purge implementations
+
+Expiration of error and audit data is implemented by runnig a reccuring task that checks the documents for old data and deleting the rows that should be deleted. Changing the expiration setting results in it being picked up during the next time the service is run. 
+In the ServiceControl.Audit version 4.26 and up expiration is done using the persistance mechanisms, that results in metadata key to be stored with every message. Thanks to that, purging of the data can be handled fully by database itself. The drawback is that changing of expiration setting is only applied to new rows. 

--- a/servicecontrol/how-purge-expired-data.md
+++ b/servicecontrol/how-purge-expired-data.md
@@ -14,7 +14,7 @@ Note: The expiration process curates only the data in the embedded RavenDB. Audi
 
 Warning: The database will not automatically shrink in size after reducing the retention period. Ensure ServiceControl had time to purge all expired messages and then [Compact the database](db-compaction.md).
 
-## Differences in purge implementations
+## Differences in message retention implementations
 
-Expiration of error and audit data is implemented by a reccuring task that checks the documents for old data and deletes documents that have expired. Changing the expiration setting results in it being picked up during the next time the service is run. 
-In ServiceControl.Audit version 4.26 and above expiration is handled by the database automatically. Each audited message contains a metadata key that tells the database when to remove it. When the expiration setting changes, the new value is only applied to new audit data. Existing audit meta is not changed. Messages already in the database are not affected by the change to the expiration setting.
+The expiration of error and audit data is implemented by a recurring task that checks and deletes expired documents. Changing the expiration setting results in it being picked up the next time the service is run. 
+In ServiceControl.Audit version 4.26 and above expiration is handled by the database automatically. Each audited message contains a metadata key that tells the database when to remove it. When the expiration setting changes, the new value is only applied to new audit data. Metadata for already ingested messages is not changed. Only new audited messages are affected by the change to the expiration setting.

--- a/servicecontrol/persistence.md
+++ b/servicecontrol/persistence.md
@@ -6,4 +6,4 @@ reviewed: 2022-10-17
 
 ServiceControl error instances store their data in a RavenDB embedded database. All instances use RavenDB version 3.5.
 
-WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.
+WARNING: The ServiceControl RavenDB embedded database is used exclusively by ServiceControl and is not intended for external manipulation or modifications.

--- a/servicecontrol/persistence.md
+++ b/servicecontrol/persistence.md
@@ -1,0 +1,9 @@
+---
+title: ServiceControl persistence
+summary: Information about ServiceControl persistence.
+reviewed: 2022-10-17
+---
+
+ServiceControl error instances store their data in a RavenDB embedded database. All instances use RavenDB version 3.5.
+
+WARNING: The ServiceControl Audit RavenDB embedded instance is used exclusively by ServiceControl and is not intended for external manipulation or modifications.


### PR DESCRIPTION
Added the following pages:
 - persistence page for SC.Audit
 - Modified the page defining expiration

When we agree on the wording we should create a page describing persistence for the error instance