### PR TITLE
Remove 8 to 9 upgrade guide from menu

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -124,8 +124,6 @@
         Title: 2018-01-19
     - Url: nservicebus/upgrades/callbacks-1to2
       Title: Callbacks 1 to 2
-    - Url: nservicebus/upgrades/8to9
-      Title: NServiceBus 8 to 9
     - Url: nservicebus/upgrades/7to8
       Title: NServiceBus 7 to 8
       Articles:


### PR DESCRIPTION
This upgrade guide should not be visible on the menu yet.