### PR TITLE
Add zero downtime upgrade instructions

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1263,6 +1263,8 @@
     Articles:
     - Title: Upgrade tips
       Url: servicecontrol/upgrades
+    - Title: Zero downtime
+      Url: servicecontrol/upgrades/zero-downtime
     - Title: Support policy
       Url: servicecontrol/upgrades/support-policy
     - Title: Version 3 to 4

--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -161,6 +161,10 @@ In this deployment, each region has a full ServiceControl installation with a pr
 
 A new cross-region primary instance is added to allow ServiceInsight to show messages from both regions. This cross-region instance includes each region-specific primary instance as a remote allowing it to query messages from both. The cross-region instance should disable error queue management by configuring the [error queue](/servicecontrol/creating-config-file.md#transport-servicebuserrorqueue) with the value `!disable`.
 
+### Zero downtime upgrades
+
+The remotes feature can be used to perform [zero downtime upgrades](/servicecontrol/upgrades/zero-downtime.md).
+
 ## Configuration
 
 Remote instances are listed in the `ServiceControl/RemoteInstances` app setting in the primary instance [configuration file](/servicecontrol/creating-config-file.md). The value of this setting is a JSON array of remote instances. Each entry requires an `api_url` property specifying the API URL of the remote instance. For ServiceControl version 3 and earlier, each entry requires a `queue_address` property specifying the queue address of the remote instance.

--- a/servicecontrol/upgrades/zero-downtime.md
+++ b/servicecontrol/upgrades/zero-downtime.md
@@ -1,0 +1,131 @@
+---
+title: Zero downtime upgrades
+summary: Instructions on how to upgrade ServiceControl instances with zero downtime
+isUpgradeGuide: true
+reviewed: 2022-10-20
+---
+
+The [ServiceControl remotes feature](/servicecontrol/servicecontrol-instances/remotes.md) can be used to upgrade a ServiceControl installation without taking it offline.
+
+## Audit instances
+
+The process follows these steps:
+
+1. Add a new audit instance as a remote
+1. Disable audit queue management on the old audit instance
+1. Decommission the old audit instance, when it is empty
+
+### Initial state
+
+Before doing anything, the deployment looks like this:
+
+```mermaid
+graph TD
+endpoints -- send errors to --> errorQ[Error Queue]
+endpoints -- send audits to --> auditQ[Audit Queue]
+errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+auditQ -- ingested by --> sca[Original<br/>ServiceControl<br/>audit]
+sc -. connected to .-> sca
+sp[ServicePulse] -. connected to .-> sc
+si[ServiceInsight] -. connected to .-> sc
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class endpoints Endpoints
+class si ServiceInsight
+class sp ServicePulse
+class sc ServiceControlPrimary
+class sca ServiceControlRemote
+```
+
+### Add a new audit instance
+
+Create a new audit instance, and configure it as a remote instance of the primary instance.
+
+```mermaid
+graph TD
+endpoints -- send errors to --> errorQ[Error Queue]
+endpoints -- send audits to --> auditQ[Audit Queue]
+errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+auditQ -- ingested by --> sca[Original<br/>ServiceControl<br/>audit]
+auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
+sc -. connected to .-> sca
+sc -. connected to .-> sca2
+sp[ServicePulse] -. connected to .-> sc
+si[ServiceInsight] -. connected to .-> sc
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class endpoints Endpoints
+class si ServiceInsight
+class sp ServicePulse
+class sc ServiceControlPrimary
+class sca,sca2 ServiceControlRemote
+```
+
+Although both ServiceControl Audit instances ingest messages from the audit queue, each message only ends up in a single instance. The primary instance queries both transparently.
+
+### Disable audit queue management on the old instance
+
+Update the audit queue configuration on the original Audit instance to the value `!disable`.
+
+```mermaid
+graph TD
+endpoints -- send errors to --> errorQ[Error Queue]
+endpoints -- send audits to --> auditQ[Audit Queue]
+errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
+sc -. connected to .-> sca[Original<br/>ServiceControl<br/>audit]
+sc -. connected to .-> sca2
+sp[ServicePulse] -. connected to .-> sc
+si[ServiceInsight] -. connected to .-> sc
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class endpoints Endpoints
+class si ServiceInsight
+class sp ServicePulse
+class sc ServiceControlPrimary
+class sca,sca2 ServiceControlRemote
+```
+
+The primary instance continues to query both instances but the original Audit instance no longer reads new messages.
+
+### Decommission the old audit instance, when it is empty
+
+As the original audit instance is no longer ingesting messages, it will be empty after the audit retention period has elapsed and can be removed.
+
+```mermaid
+graph TD
+endpoints -- send errors to --> errorQ[Error Queue]
+endpoints -- send audits to --> auditQ[Audit Queue]
+errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
+sc -. connected to .-> sca2
+sp[ServicePulse] -. connected to .-> sc
+si[ServiceInsight] -. connected to .-> sc
+
+classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
+classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
+classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
+classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
+
+class endpoints Endpoints
+class si ServiceInsight
+class sp ServicePulse
+class sc ServiceControlPrimary
+class sca2 ServiceControlRemote
+```


### PR DESCRIPTION
Includes instructions for how to use the remotes feature to perform a zero downtime upgrade of ServiceControl Audit instances