### PR TITLE
Fix note when configuring outbox on NSB v8

### DIFF
--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -150,7 +150,7 @@ In order to enable the Outbox, use the following code API:
 
 snippet: OutboxEnablineInCode
 
-Note: When Outbox is enabled then NServiceBus automatically lowers the default delivery guarantee level to `ReceiveOnly`. A different level can be explicitly [specified in configuration](/transports/transactions.md).
+partial: configuration
 
 Each NServiceBus persistence package may contain specific configuration options, such as a time to keep deduplication data and a deduplication data cleanup interval. For details, refer to the specific page for each persistence package in the [persistence section](#persistence) below.
 

--- a/nservicebus/outbox/index_configuration_core_[,7].partial.md
+++ b/nservicebus/outbox/index_configuration_core_[,7].partial.md
@@ -1,0 +1,3 @@
+
+Note: When Outbox is enabled then NServiceBus automatically lowers the default delivery guarantee level to `ReceiveOnly`. A different level can be explicitly [specified in configuration](/transports/transactions.md).
+

--- a/nservicebus/outbox/index_configuration_core_[8,).partial.md
+++ b/nservicebus/outbox/index_configuration_core_[8,).partial.md
@@ -1,0 +1,2 @@
+
+Note: When using the Outbox, the [transport transaction level must be explicitly set to `ReceiveOnly`](/transports/transactions.md#transactions-transport-transaction-receive-only). This ensures that messages dispatched via the Outbox cannot be rolled back by the transport after the changes have been persisted to the Outbox storage.


### PR DESCRIPTION
The current documentation still states that enabling the Outbox automatically configured the transport transaction mode to `ReceiveOnly` [which is not true anymore](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Reliability/Outbox/OutboxConfigExtensions.cs) and is also stated in the [upgrade guide](https://docs.particular.net/nservicebus/upgrades/7to8/#outbox-configuration).