### PR TITLE
Tweak compliance documentation

### DIFF
--- a/nservicebus/compliance/gdpr.md
+++ b/nservicebus/compliance/gdpr.md
@@ -1,15 +1,15 @@
 ---
-title: GDPR compliance document
+title: GDPR Compliance
 summary: Information about PII stored by NServiceBus
 versions: "[5,)"
 component: core
 isLearningPath: true
-reviewed: 2020-03-30
+reviewed: 2022-12-02
 ---
 
-When operating an NServiceBus-based application, the platform will collect various pieces of information that are necessary to fulfill its operations. It is possible that some of this information will need to be considered when evaluating the application for GDPR compliance.
+The [General Data Protection Regulation](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) is a data protection and privacy regulation of the European Union. The regulation contains provisions and requirements related to the processing of [personally identifiable information (PII)](https://en.wikipedia.org/wiki/Personal_data) of individuals located in the European Economic Area.
 
-PII stands for personally identifiable information (also know as personal data) which means any information relating to an identifiable person who can be directly or indirectly identified. 
+When operating an NServiceBus-based application, the platform will collect various pieces of information that are necessary to fulfill its operations. It is possible that some of this information will need to be considered when evaluating the application for GDPR compliance.
 
 ## Headers
 

--- a/nservicebus/compliance/index.md
+++ b/nservicebus/compliance/index.md
@@ -1,9 +1,7 @@
 ---
 title: Compliance
 summary: Compliance Table of Contents
-reviewed: 2020-03-16
+reviewed: 2022-12-02
 ---
 
 Systems built using NServiceBus often run in environments requiring high levels of government and/or regulatory compliance.
-
-* [General Data Protection Regulation (GDPR)](/nservicebus/compliance/gdpr.md)


### PR DESCRIPTION
The index page only lists the GDPR document but then repeats the same document with the rest of the documents in this category in the related section which looks weird:

![image](https://user-images.githubusercontent.com/3524870/205346836-39ace1a0-d673-4dc6-9783-c2fe8fcd50fd.png)

This PR changes this to:

![image](https://user-images.githubusercontent.com/3524870/205347056-30ffb80e-5f2f-441e-a381-e07cf1d4e4e9.png)

and also adds a little section introducing the GDPR abbreviations, similar to the FIPS document.