### PR TITLE
Update LangVersion from 7.3 to 8.0

### DIFF
--- a/Snippets/ABSDataBus/ABSDataBus_3.1/ABSDataBus_3.1.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_3.1/ABSDataBus_3.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="3.1.*" />

--- a/Snippets/ABSDataBus/ABSDataBus_4/ABSDataBus_4.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_4/ABSDataBus_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="4.*" />

--- a/Snippets/ABSDataBus/ABSDataBus_5/ABSDataBus_5.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_5/ABSDataBus_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="5.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.0.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.1.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.2.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBS/ASBS_1.9/ASBS_1.9.csproj
+++ b/Snippets/ASBS/ASBS_1.9/ASBS_1.9.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Testing" Version="7.*" />

--- a/Snippets/ASBS/ASBS_1/ASBS_1.csproj
+++ b/Snippets/ASBS/ASBS_1/ASBS_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.7.*" />

--- a/Snippets/ASBS/ASBS_2/ASBS_2.csproj
+++ b/Snippets/ASBS/ASBS_2/ASBS_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Testing" Version="7.*" />

--- a/Snippets/ASBS/ASBS_3/ASBS_3.csproj
+++ b/Snippets/ASBS/ASBS_3/ASBS_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />

--- a/Snippets/ASP/ASTP_3/ASTP_3.csproj
+++ b/Snippets/ASP/ASTP_3/ASTP_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>ASP_3</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASP/ASTP_4/ASTP_4.csproj
+++ b/Snippets/ASP/ASTP_4/ASTP_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>ASTP_4</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASP/ASTP_5/ASTP_5.csproj
+++ b/Snippets/ASP/ASTP_5/ASTP_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>ASTP_5</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASQ/ASQN_10/ASQN_10.csproj
+++ b/Snippets/ASQ/ASQN_10/ASQN_10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="10.*" />

--- a/Snippets/ASQ/ASQN_11/ASQN_11.csproj
+++ b/Snippets/ASQ/ASQN_11/ASQN_11.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="11.*" />

--- a/Snippets/ASQ/ASQN_12/ASQN_12.csproj
+++ b/Snippets/ASQ/ASQN_12/ASQN_12.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="12.*" />

--- a/Snippets/ASQ/ASQN_9/ASQN_9.csproj
+++ b/Snippets/ASQ/ASQN_9/ASQN_9.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="9.*" />

--- a/Snippets/ASQ/ASQ_8/ASQ_8.csproj
+++ b/Snippets/ASQ/ASQ_8/ASQ_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" Version="8.*" />

--- a/Snippets/Autofac/Autofac_7/Autofac_7.csproj
+++ b/Snippets/Autofac/Autofac_7/Autofac_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />

--- a/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
+++ b/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.BinarySerializer" Version="1.*" />

--- a/Snippets/Callbacks/Callbacks_3/Callbacks_3.csproj
+++ b/Snippets/Callbacks/Callbacks_3/Callbacks_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />

--- a/Snippets/Callbacks/Callbacks_4/Callbacks_4.csproj
+++ b/Snippets/Callbacks/Callbacks_4/Callbacks_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="4.*" />

--- a/Snippets/CallbacksTesting/CallbacksTesting_3/CallbacksTesting_3.csproj
+++ b/Snippets/CallbacksTesting/CallbacksTesting_3/CallbacksTesting_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks.Testing" Version="3.*" />

--- a/Snippets/CallbacksTesting/CallbacksTesting_4/CallbacksTesting_4.csproj
+++ b/Snippets/CallbacksTesting/CallbacksTesting_4/CallbacksTesting_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks.Testing" Version="4.*" />

--- a/Snippets/Castle/Castle_7/Castle_7.csproj
+++ b/Snippets/Castle/Castle_7/Castle_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CastleWindsor" Version="7.*" />

--- a/Snippets/Common/Common.csproj
+++ b/Snippets/Common/Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/CommonLogging/CommonLogging_5/CommonLogging_5.csproj
+++ b/Snippets/CommonLogging/CommonLogging_5/CommonLogging_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CommonLogging" Version="5.0.*" />

--- a/Snippets/Core/Core_7.2/Core_7.2.csproj
+++ b/Snippets/Core/Core_7.2/Core_7.2.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.*" />

--- a/Snippets/Core/Core_7.4/Core_7.4.csproj
+++ b/Snippets/Core/Core_7.4/Core_7.4.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.4.0" />

--- a/Snippets/Core/Core_7.6/Core_7.6.csproj
+++ b/Snippets/Core/Core_7.6/Core_7.6.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.6.0" />

--- a/Snippets/Core/Core_7.7/Core_7.7.csproj
+++ b/Snippets/Core/Core_7.7/Core_7.7.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.7.2" />

--- a/Snippets/Core/Core_7/Core_7.csproj
+++ b/Snippets/Core/Core_7/Core_7.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.*" />

--- a/Snippets/Core/Core_8/Core_8.csproj
+++ b/Snippets/Core/Core_8/Core_8.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />

--- a/Snippets/Core/Core_All/Core_All.csproj
+++ b/Snippets/Core/Core_All/Core_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
+++ b/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
+++ b/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
+++ b/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.*" />

--- a/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
+++ b/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="4.*" />

--- a/Snippets/Extensions.DependencyInjection/Extensions.DependencyInjection_1/Extensions.DependencyInjection_1.csproj
+++ b/Snippets/Extensions.DependencyInjection/Extensions.DependencyInjection_1/Extensions.DependencyInjection_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.*" />

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_1/Extensions.Logging_1.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_1/Extensions.Logging_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.*" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/Snippets/FileShareDataBus/Core_7/Core_7.csproj
+++ b/Snippets/FileShareDataBus/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/FileShareDataBus/Core_8/Core_8.csproj
+++ b/Snippets/FileShareDataBus/Core_8/Core_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
+++ b/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_3.2/Gateway_3.2.csproj
+++ b/Snippets/Gateway/Gateway_3.2/Gateway_3.2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_3/Gateway_3.csproj
+++ b/Snippets/Gateway/Gateway_3/Gateway_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_4/Gateway_4.csproj
+++ b/Snippets/Gateway/Gateway_4/Gateway_4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Gateway_3.2</RootNamespace>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_1/GatewayRavenDB_1.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_1/GatewayRavenDB_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_2/GatewayRavenDB_2.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_2/GatewayRavenDB_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_3/GatewayRavenDB_3.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_3/GatewayRavenDB_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/GatewaySql/GatewaySql_1/GatewaySql_1.csproj
+++ b/Snippets/GatewaySql/GatewaySql_1/GatewaySql_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewaySql/GatewaySql_2/GatewaySql_2.csproj
+++ b/Snippets/GatewaySql/GatewaySql_2/GatewaySql_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
+++ b/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="3.*" />

--- a/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
+++ b/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="4.*" />

--- a/Snippets/Host/Host_8/Host_8.csproj
+++ b/Snippets/Host/Host_8/Host_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningPersistence/Core_7/Core_7.csproj
+++ b/Snippets/LearningPersistence/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningPersistence/Core_8/Core_8.csproj
+++ b/Snippets/LearningPersistence/Core_8/Core_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/LearningTransport/Core_7/Core_7.csproj
+++ b/Snippets/LearningTransport/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningTransport/Core_8/Core_8.csproj
+++ b/Snippets/LearningTransport/Core_8/Core_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/Log4Net/Log4Net_3/Log4Net_3.csproj
+++ b/Snippets/Log4Net/Log4Net_3/Log4Net_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Log4Net" Version="3.*" />

--- a/Snippets/Metrics/Metrics_3/Metrics_3.csproj
+++ b/Snippets/Metrics/Metrics_3/Metrics_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Metrics/Metrics_4/Metrics_4.csproj
+++ b/Snippets/Metrics/Metrics_4/Metrics_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_3/MetricsServiceControl_3.csproj
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_3/MetricsServiceControl_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.*" />

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_4/MetricsServiceControl_4.csproj
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_4/MetricsServiceControl_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="4.*" />

--- a/Snippets/MsmqPersistence/MsmqTransport_1/MsmqTransport_1.csproj
+++ b/Snippets/MsmqPersistence/MsmqTransport_1/MsmqTransport_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqPersistence/MsmqTransport_2/MsmqTransport_2.csproj
+++ b/Snippets/MsmqPersistence/MsmqTransport_2/MsmqTransport_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_1.2/MsmqTransport_1.2.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_1.2/MsmqTransport_1.2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_1/MsmqTransport_1.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_1/MsmqTransport_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_2/MsmqTransport_2.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_2/MsmqTransport_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_All/MsmqTransport_All.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_All/MsmqTransport_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.*" />

--- a/Snippets/NHibernate/NHibernate_8.4/NHibernate_8.4.csproj
+++ b/Snippets/NHibernate/NHibernate_8.4/NHibernate_8.4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.4.*" />

--- a/Snippets/NHibernate/NHibernate_8.5/NHibernate_8.5.csproj
+++ b/Snippets/NHibernate/NHibernate_8.5/NHibernate_8.5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.5.*" />

--- a/Snippets/NHibernate/NHibernate_8/NHibernate_8.csproj
+++ b/Snippets/NHibernate/NHibernate_8/NHibernate_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/Snippets/NHibernate/NHibernate_9/NHibernate_9.csproj
+++ b/Snippets/NHibernate/NHibernate_9/NHibernate_9.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="9.*" />

--- a/Snippets/NLog/Extensions.Logging_1/Extensions.Logging_1.csproj
+++ b/Snippets/NLog/Extensions.Logging_1/Extensions.Logging_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.*" />

--- a/Snippets/NLog/Extensions.Logging_2/Extensions.Logging_2.csproj
+++ b/Snippets/NLog/Extensions.Logging_2/Extensions.Logging_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/Snippets/NLog/NLog_3/NLog_3.csproj
+++ b/Snippets/NLog/NLog_3/NLog_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NLog" Version="3.*" />

--- a/Snippets/Newtonsoft/Newtonsoft_2.4/Newtonsoft_2.4.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_2.4/Newtonsoft_2.4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Newtonsoft/Newtonsoft_2/Newtonsoft_2.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_2/Newtonsoft_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Newtonsoft/Newtonsoft_3/Newtonsoft_3.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_3/Newtonsoft_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Ninject/Ninject_7/Ninject_7.csproj
+++ b/Snippets/Ninject/Ninject_7/Ninject_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/NonDurablePersistence/Core_7.2/Core_7.2.csproj
+++ b/Snippets/NonDurablePersistence/Core_7.2/Core_7.2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.2.0" />

--- a/Snippets/NonDurablePersistence/Core_7/Core_7.csproj
+++ b/Snippets/NonDurablePersistence/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/NonDurablePersistence/NonDurablePersistence_1/NonDurablePersistence_1.csproj
+++ b/Snippets/NonDurablePersistence/NonDurablePersistence_1/NonDurablePersistence_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Core_8</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/PerfCounters/PerfCounters_3/PerfCounters_3.csproj
+++ b/Snippets/PerfCounters/PerfCounters_3/PerfCounters_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="3.0.0" />

--- a/Snippets/PerfCounters/PerfCounters_4/PerfCounters_4.csproj
+++ b/Snippets/PerfCounters/PerfCounters_4/PerfCounters_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="4.0.0" />

--- a/Snippets/PerfCounters/PerfCounters_5/PerfCounters_5.csproj
+++ b/Snippets/PerfCounters/PerfCounters_5/PerfCounters_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="5.*" />

--- a/Snippets/PlatformConnector/PlatformConnector_1/PlatformConnector_1.csproj
+++ b/Snippets/PlatformConnector/PlatformConnector_1/PlatformConnector_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ServicePlatform.Connector" Version="1.0.0" />

--- a/Snippets/PlatformConnector/PlatformConnector_2/PlatformConnector_2.csproj
+++ b/Snippets/PlatformConnector/PlatformConnector_2/PlatformConnector_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ServicePlatform.Connector" Version="2.*" />

--- a/Snippets/PlatformSample/PlatformSample_2/PlatformSample_2.csproj
+++ b/Snippets/PlatformSample/PlatformSample_2/PlatformSample_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_2/PropertyEncryption_2.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_2/PropertyEncryption_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_3/PropertyEncryption_3.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_3/PropertyEncryption_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_All/PropertyEncryption_All.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_All/PropertyEncryption_All.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Rabbit/Rabbit_6/Rabbit_6.csproj
+++ b/Snippets/Rabbit/Rabbit_6/Rabbit_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="6.*" />

--- a/Snippets/Rabbit/Rabbit_7/Rabbit_7.csproj
+++ b/Snippets/Rabbit/Rabbit_7/Rabbit_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="7.*" />

--- a/Snippets/Rabbit/Rabbit_8/Rabbit_8.csproj
+++ b/Snippets/Rabbit/Rabbit_8/Rabbit_8.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />

--- a/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
+++ b/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/Raven/Raven_5/Raven_5.csproj
+++ b/Snippets/Raven/Raven_5/Raven_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="5.*" />

--- a/Snippets/Raven/Raven_6.1/Raven_6.1.csproj
+++ b/Snippets/Raven/Raven_6.1/Raven_6.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.1.0" />

--- a/Snippets/Raven/Raven_6.3/Raven_6.3.csproj
+++ b/Snippets/Raven/Raven_6.3/Raven_6.3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.3.0" />

--- a/Snippets/Raven/Raven_6.4/Raven_6.4.csproj
+++ b/Snippets/Raven/Raven_6.4/Raven_6.4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.4.0" />

--- a/Snippets/Raven/Raven_6.5/Raven_6.5.csproj
+++ b/Snippets/Raven/Raven_6.5/Raven_6.5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.5.0" />

--- a/Snippets/Raven/Raven_6/Raven_6.csproj
+++ b/Snippets/Raven/Raven_6/Raven_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.0.0" />

--- a/Snippets/Raven/Raven_7/Raven_7.csproj
+++ b/Snippets/Raven/Raven_7/Raven_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="7.*" />

--- a/Snippets/Raven/Raven_8/Raven_8.csproj
+++ b/Snippets/Raven/Raven_8/Raven_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="8.*" />

--- a/Snippets/Raven/Raven_All/Raven_All.csproj
+++ b/Snippets/Raven/Raven_All/Raven_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.*" />

--- a/Snippets/RawMessaging/Core_8/Core_8.csproj
+++ b/Snippets/RawMessaging/Core_8/Core_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/RawMessaging/RawMessaging_3/RawMessaging_3.csproj
+++ b/Snippets/RawMessaging/RawMessaging_3/RawMessaging_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Raw" Version="3.*" />

--- a/Snippets/Router/Router_2/Router_2.csproj
+++ b/Snippets/Router/Router_2/Router_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Router" Version="2.*" />

--- a/Snippets/SCTransportAdapter/SCTransportAdapter_2/SCTransportAdapter_2.csproj
+++ b/Snippets/SCTransportAdapter/SCTransportAdapter_2/SCTransportAdapter_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.*" />

--- a/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
+++ b/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
+++ b/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="3.*" />

--- a/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
+++ b/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="4.*" />

--- a/Snippets/ServiceControl/ServiceControl_All/ServiceControl_All.csproj
+++ b/Snippets/ServiceControl/ServiceControl_All/ServiceControl_All.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/ServiceControlContracts/ServiceControlContracts_1/ServiceControlContracts_1.csproj
+++ b/Snippets/ServiceControlContracts/ServiceControlContracts_1/ServiceControlContracts_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.*" />

--- a/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_2/ServiceFabricPersistence_2.csproj
+++ b/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_2/ServiceFabricPersistence_2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.ServiceFabric" Version="2.*" />

--- a/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_3/ServiceFabricPersistence_3.csproj
+++ b/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_3/ServiceFabricPersistence_3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.ServiceFabric" Version="3.*" />

--- a/Snippets/ServiceInsight/ServiceInsight_All/ServiceInsight_All.csproj
+++ b/Snippets/ServiceInsight/ServiceInsight_All/ServiceInsight_All.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/ServicePulse/ServicePulse_All/ServicePulse_All.csproj
+++ b/Snippets/ServicePulse/ServicePulse_All/ServicePulse_All.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Spring/Spring_7/Spring_7.csproj
+++ b/Snippets/Spring/Spring_7/Spring_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Spring" Version="7.*" />

--- a/Snippets/Spring/Spring_8/Spring_8.csproj
+++ b/Snippets/Spring/Spring_8/Spring_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Spring" Version="8.*" />

--- a/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_5/SqlPersistence_5.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_5/SqlPersistence_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_6/SqlPersistence_6.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_6/SqlPersistence_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_7/SqlPersistence_7.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_7/SqlPersistence_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MySql.Data" Version="6.*" />

--- a/Snippets/SqlTransport/SqlTransportLegacySystemClient_4/SqlTransportLegacySystemClient_4.csproj
+++ b/Snippets/SqlTransport/SqlTransportLegacySystemClient_4/SqlTransportLegacySystemClient_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SqlServer" Version="4.1.0" />

--- a/Snippets/SqlTransport/SqlTransportLegacySystemClient_5/SqlTransportLegacySystemClient_5.csproj
+++ b/Snippets/SqlTransport/SqlTransportLegacySystemClient_5/SqlTransportLegacySystemClient_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SqlServer" Version="5.*" />

--- a/Snippets/SqlTransport/SqlTransport_6.1/SqlTransport_6.1.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6.1/SqlTransport_6.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.1.*" />

--- a/Snippets/SqlTransport/SqlTransport_6.2/SqlTransport_6.2.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6.2/SqlTransport_6.2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.2.*" />

--- a/Snippets/SqlTransport/SqlTransport_6/SqlTransport_6.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6/SqlTransport_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.0.*" />

--- a/Snippets/SqlTransport/SqlTransport_7/SqlTransport_7.csproj
+++ b/Snippets/SqlTransport/SqlTransport_7/SqlTransport_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="7.*" />

--- a/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
+++ b/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/Sqs/Sqs_4/Sqs_4.csproj
+++ b/Snippets/Sqs/Sqs_4/Sqs_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AmazonSQS" Version="4.*" />

--- a/Snippets/Sqs/Sqs_5.3/Sqs_5.3.csproj
+++ b/Snippets/Sqs/Sqs_5.3/Sqs_5.3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_5/Sqs_5.csproj
+++ b/Snippets/Sqs/Sqs_5/Sqs_5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_6/Sqs_6.csproj
+++ b/Snippets/Sqs/Sqs_6/Sqs_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_All/Sqs_All.csproj
+++ b/Snippets/Sqs/Sqs_All/Sqs_All.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/StructureMap/StructureMap_7/StructureMap_7.csproj
+++ b/Snippets/StructureMap/StructureMap_7/StructureMap_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.StructureMap" Version="7.*" />

--- a/Snippets/Templates/Templates_1/Templates_1.csproj
+++ b/Snippets/Templates/Templates_1/Templates_1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Templates/Templates_2/Templates_2.csproj
+++ b/Snippets/Templates/Templates_2/Templates_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/Snippets/Templates/Templates_3/Templates_3.csproj
+++ b/Snippets/Templates/Templates_3/Templates_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/Snippets/Templates/Templates_4/Templates_4.csproj
+++ b/Snippets/Templates/Templates_4/Templates_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/Snippets/Testing/Testing_7.4/Testing_7.4.csproj
+++ b/Snippets/Testing/Testing_7.4/Testing_7.4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/Snippets/Testing/Testing_7/Testing_7.csproj
+++ b/Snippets/Testing/Testing_7/Testing_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Testing/Testing_8/Testing_8.csproj
+++ b/Snippets/Testing/Testing_8/Testing_8.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/Snippets/UniformSession/UniformSession_2/UniformSession_2.csproj
+++ b/Snippets/UniformSession/UniformSession_2/UniformSession_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="2.*" />

--- a/Snippets/UniformSession/UniformSession_3/UniformSession_3.csproj
+++ b/Snippets/UniformSession/UniformSession_3/UniformSession_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="3.*" />

--- a/Snippets/UniformSessionTesting/UniformSessionTesting_2/UniformSessionTesting_2.csproj
+++ b/Snippets/UniformSessionTesting/UniformSessionTesting_2/UniformSessionTesting_2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="2.*" />

--- a/Snippets/UniformSessionTesting/UniformSessionTesting_3/UniformSessionTesting_3.csproj
+++ b/Snippets/UniformSessionTesting/UniformSessionTesting_3/UniformSessionTesting_3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="3.*" />

--- a/Snippets/Unity/Unity_10/Unity_10.csproj
+++ b/Snippets/Unity/Unity_10/Unity_10.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Unity" Version="10.*" />

--- a/Snippets/Unity/Unity_9/Unity_9.csproj
+++ b/Snippets/Unity/Unity_9/Unity_9.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Unity" Version="9.*" />

--- a/Snippets/Wcf/Wcf_2/Wcf_2.csproj
+++ b/Snippets/Wcf/Wcf_2/Wcf_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />

--- a/Snippets/Wormhole/Wormhole_2/Wormhole_2.csproj
+++ b/Snippets/Wormhole/Wormhole_2/Wormhole_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/Xml/Core_7/Core_7.csproj
+++ b/Snippets/Xml/Core_7/Core_7.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/Xml/Core_8/Core_8.csproj
+++ b/Snippets/Xml/Core_8/Core_8.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/mongodb/MongoDB_2/MongoDB_2.csproj
+++ b/Snippets/mongodb/MongoDB_2/MongoDB_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Storage.MongoDB" Version="2.*" />

--- a/Snippets/mongodb/MongoDB_3/MongoDB_3.csproj
+++ b/Snippets/mongodb/MongoDB_3/MongoDB_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Storage.MongoDB" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_1/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_2/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_1/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_1/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_1/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_1/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="2.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_2/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_3/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_3/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="3.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="4.*" />

--- a/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure-service-bus-netstandard/asbs-asb-side-by-side/ASBS_1/asbs-asb-side-by-side/asbs-asb-side-by-side.csproj
+++ b/samples/azure-service-bus-netstandard/asbs-asb-side-by-side/ASBS_1/asbs-asb-side-by-side/asbs-asb-side-by-side.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="10.*" />

--- a/samples/azure-service-bus-netstandard/asbs-asb-side-by-side/ASBS_2/asbs-asb-side-by-side/asbs-asb-side-by-side.csproj
+++ b/samples/azure-service-bus-netstandard/asbs-asb-side-by-side/ASBS_2/asbs-asb-side-by-side/asbs-asb-side-by-side.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="10.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Client/Client.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Processor/Processor.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Processor/Processor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Server/Server.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Client/Client.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Processor/Processor.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Processor/Processor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Server/Server.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.*" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Client/Client.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Processor/Processor.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Processor/Processor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Server/Server.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/azure-service-bus-long-running/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_1/LockRenewal/LockRenewal.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Endpoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_2/LockRenewal/LockRenewal.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Transitive dependencies">

--- a/samples/azure-service-bus-netstandard/lock-renewal/ASBS_3/LockRenewal/LockRenewal.csproj
+++ b/samples/azure-service-bus-netstandard/lock-renewal/ASBS_3/LockRenewal/LockRenewal.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeShared/NativeShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberA/NativeSubscriberA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/NativeSubscriberB/NativeSubscriberB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.*" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeShared/NativeShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeShared/NativeShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.*" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.*" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_1/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_7/CandidateVoteCount/CandidateVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/CandidateVoteCount/CandidateVoteCount.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Contracts\Contracts.csproj" />

--- a/samples/azure/azure-service-fabric-routing/Core_7/Contracts/Contracts.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Contracts/Contracts.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_7/Shared/Shared.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Shared/Shared.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_7/Voter/Voter.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/Voter/Voter.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Contracts\Contracts.csproj" />

--- a/samples/azure/azure-service-fabric-routing/Core_7/ZipCodeVoteCount/ZipCodeVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_7/ZipCodeVoteCount/ZipCodeVoteCount.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Contracts\Contracts.csproj" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVoteCount.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="6.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/Contracts/Contracts.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/Contracts/Contracts.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/Shared/Shared.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/Shared/Shared.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/Voter/Voter.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/Voter/Voter.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ZipCodeVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ZipCodeVoteCount.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="6.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASP_2/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASP_2/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureStorage" Version="2.*" />

--- a/samples/azure/azure-table/simple/ASP_2/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASP_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.*" />

--- a/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.*" />

--- a/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.*" />

--- a/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="4.*" />

--- a/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="5.*" />

--- a/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.5.0" />

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_2/SenderAndReceiver/SenderAndReceiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.*" />

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_4/SenderAndReceiver/SenderAndReceiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/azure/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_3/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
+++ b/samples/azure/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />

--- a/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />

--- a/samples/azure/storage-queues/ASQN_9/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_9/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/storage-queues/ASQN_9/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_9/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />

--- a/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/azure/storage-queues/ASQ_8/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQ_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQ_8/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.*" />

--- a/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.*" />

--- a/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>    
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.*" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Bridge/Bridge.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net48</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/MsmqEndpoint/MsmqEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/MsmqEndpoint/MsmqEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/bridge/simple/Bridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_1/Bridge/Bridge.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/simple/Bridge_1/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_1/LeftReceiver/LeftReceiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/simple/Bridge_1/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_1/LeftSender/LeftSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/simple/Bridge_1/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_1/RightReceiver/RightReceiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/simple/Bridge_1/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/bridge/sql-multi-instance/Bridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_1/Bridge/Bridge.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_1/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_1/Helpers/Helpers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.*" />

--- a/samples/bridge/sql-multi-instance/Bridge_1/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_1/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_1/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_1/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_1/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_3/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_3/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_3/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_4/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_4/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_4/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Consumer1\Contracts\Consumer1Contract.cs" />

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Consumer1\Contracts\Consumer1Contract.cs" />

--- a/samples/cooperative-cancellation/Core_8/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />

--- a/samples/delayed-delivery/Core_7/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_7/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_7/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/delayed-delivery/Core_8/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_8/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_8/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/dependency-injection/aspnetcore/Core_7.2/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7.2/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/samples/dependency-injection/aspnetcore/Core_7.2/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7.2/SampleAutofac/SampleAutofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.*" />

--- a/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.*" />

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/spring/Spring_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/spring/Spring_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/elsa/Core_7/Billing/Billing.csproj
+++ b/samples/elsa/Core_7/Billing/Billing.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_7/ClientUI/ClientUI.csproj
+++ b/samples/elsa/Core_7/ClientUI/ClientUI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_7/ElsaDesigner/ElsaDesigner.csproj
+++ b/samples/elsa/Core_7/ElsaDesigner/ElsaDesigner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_7/Messages/Messages.csproj
+++ b/samples/elsa/Core_7/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_7/NServiceBus.Elsa.Activities/NServiceBus.Activities.csproj
+++ b/samples/elsa/Core_7/NServiceBus.Elsa.Activities/NServiceBus.Activities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_7/Sales/Sales.csproj
+++ b/samples/elsa/Core_7/Sales/Sales.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/Billing/Billing.csproj
+++ b/samples/elsa/Core_8/Billing/Billing.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/ClientUI/ClientUI.csproj
+++ b/samples/elsa/Core_8/ClientUI/ClientUI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/ElsaDesigner/ElsaDesigner.csproj
+++ b/samples/elsa/Core_8/ElsaDesigner/ElsaDesigner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/Messages/Messages.csproj
+++ b/samples/elsa/Core_8/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/NServiceBus.Elsa.Activities/NServiceBus.Activities.csproj
+++ b/samples/elsa/Core_8/NServiceBus.Elsa.Activities/NServiceBus.Activities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/elsa/Core_8/Sales/Sales.csproj
+++ b/samples/elsa/Core_8/Sales/Sales.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/endpoint-configuration/Core_7/Sample/Sample.csproj
+++ b/samples/endpoint-configuration/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework-core/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework-core/SqlPersistence_5/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_5/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework-core/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_6/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/entity-framework/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_5/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_5/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_5/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/errorhandling/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/errorhandling/Core_7/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/errorhandling/Core_8/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_7/Client/Client.csproj
+++ b/samples/faulttolerance/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_7/Server/Server.csproj
+++ b/samples/faulttolerance/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_7/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/faulttolerance/Core_8/Client/Client.csproj
+++ b/samples/faulttolerance/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_8/Server/Server.csproj
+++ b/samples/faulttolerance/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_8/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/feature/Core_7/Sample/Sample.csproj
+++ b/samples/feature/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />

--- a/samples/feature/Core_8/Sample/Sample.csproj
+++ b/samples/feature/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />

--- a/samples/file-share-databus/Core_7/Receiver/Receiver.csproj
+++ b/samples/file-share-databus/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/file-share-databus/Core_7/Sender/Sender.csproj
+++ b/samples/file-share-databus/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/file-share-databus/Core_7/Shared/Shared.csproj
+++ b/samples/file-share-databus/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/file-share-databus/Core_8/Receiver/Receiver.csproj
+++ b/samples/file-share-databus/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/file-share-databus/Core_8/Sender/Sender.csproj
+++ b/samples/file-share-databus/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/file-share-databus/Core_8/Shared/Shared.csproj
+++ b/samples/file-share-databus/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/fullduplex/Core_7/Client/Client.csproj
+++ b/samples/fullduplex/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_7/Server/Server.csproj
+++ b/samples/fullduplex/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_7/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/gateway/Gateway_3/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/header-manipulation/Core_7/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/header-manipulation/Core_8/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_7/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_7/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	  <TargetFrameworks>net6.0;net48</TargetFrameworks>
 	  <OutputType>Exe</OutputType>
-	  <LangVersion>7.3</LangVersion>
+	  <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_8/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	  <TargetFrameworks>net6.0;net48</TargetFrameworks>
 	  <OutputType>Exe</OutputType>
-	  <LangVersion>7.3</LangVersion>
+	  <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/hosting/generic-host/Core_7/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_7/GenericHost/GenericHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.*" />

--- a/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/generic-multi-hosting/Core_7/Instance1/Instance1.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Instance1/Instance1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/generic-multi-hosting/Core_7/Instance2/Instance2.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Instance2/Instance2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/generic-multi-hosting/Core_7/Sample.MultiHosting/Sample.MultiHosting.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Sample.MultiHosting/Sample.MultiHosting.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Instance1\Instance1.csproj" />

--- a/samples/hosting/generic-multi-hosting/Core_7/Sample.Sender/Sample.Sender.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Sample.Sender/Sample.Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/samples/hosting/generic-multi-hosting/Core_7/Shared/Shared.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/hosting/generic-multi-hosting/Core_8/Instance1/Instance1.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Instance1/Instance1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/generic-multi-hosting/Core_8/Instance2/Instance2.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Instance2/Instance2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/generic-multi-hosting/Core_8/Sample.MultiHosting/Sample.MultiHosting.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Sample.MultiHosting/Sample.MultiHosting.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/samples/hosting/generic-multi-hosting/Core_8/Sample.Sender/Sample.Sender.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Sample.Sender/Sample.Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/hosting/generic-multi-hosting/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/generic-multi-hosting/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/hosting/nservicebus-host/Host_8/Sample/Sample.csproj
+++ b/samples/hosting/nservicebus-host/Host_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <StartAction>Program</StartAction>
     <StartProgram>.\NServiceBus.Host.exe</StartProgram>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_7/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_7/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_8/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_8/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/index.md
+++ b/samples/index.md
@@ -42,7 +42,7 @@ Most samples are made available for multiple frameworks, available through a dro
 
 ### C# language level
 
-All samples target **C# 7.3** to take advantage of the new language features. If any help is required in converting to earlier versions of C#, [raise an issue](https://github.com/Particular/docs.particular.net/issues).
+All samples target **C# 8.0** to take advantage of the new language features. If any help is required in converting to earlier versions of C#, [raise an issue](https://github.com/Particular/docs.particular.net/issues).
 
 ### ConfigureAwait
 

--- a/samples/index.md
+++ b/samples/index.md
@@ -14,31 +14,25 @@ The samples are designed to highlight how various features of NServiceBus work a
 
 Samples are not meant to be production-ready code or to be used as-is with Particular Platform tools. They are meant to illustrate the use of an API or feature in the simplest way possible. For this reason, these samples make certain assumptions on transport, hosting, etc. See [Technology choices](#technology-choices) for more details.
 
-
 ## Samples are not "endpoint drop in" projects
 
 Since the endpoint in samples have to choose specific technologies (transport, serializer, persistence, etc.), before using this code in production ensure the code conforms with any specific [technology choices](./endpoint-configuration/).
-
 
 ## Samples are downloadable and runnable
 
 All samples have a download link that allows the sample solution to be downloaded as a zip file. Once opened in Visual Studio, the samples are then runnable. Note some samples may have certain infrastructure requirements, for example a database existing in a local SQL Server.
 
-
 ## The full GitHub Repository
 
 The samples are located in GitHub at [Particular/docs.particular.net/samples](https://github.com/Particular/docs.particular.net/tree/master/samples) and both [issues](https://github.com/Particular/docs.particular.net/issues) and [pull requests](https://help.github.com/articles/using-pull-requests/) are accepted.
-
 
 ## Samples targeting non-supported versions of the platform
 
 Samples that target non-supported versions of NServiceBus have been archived, according to the [support policy](/nservicebus/upgrades/support-policy.md). Customers with an extended support agreement can request archived samples by [contacting support](mailto:support@particular.net).
 
-
 ## Technology choices
 
 Unless otherwise specified (by an individual sample) the following are the default technology choices.
-
 
 ### Visual Studio and .NET
 
@@ -46,11 +40,9 @@ Unless otherwise specified (by an individual sample) the following are the defau
 
 Most samples are made available for multiple frameworks, available through a dropdown menu on the download button. Each framework has its own requirements for what version of Visual Studio is supported. For instance, .NET Core 3.1 requires at least Visual Studio 2019.
 
-
 ### C# language level
 
 All samples target **C# 7.3** to take advantage of the new language features. If any help is required in converting to earlier versions of C#, [raise an issue](https://github.com/Particular/docs.particular.net/issues).
-
 
 ### ConfigureAwait
 
@@ -60,36 +52,29 @@ For example, to help avoid deadlocks and improve performance, it is [recommended
 
 _<sup>1</sup> For more detail, see the [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/)._
 
-
 ### [Transport](/transports/)
 
 Samples default to the [learning transport](/transports/learning/) as it has the least friction for experimentation. **The [learning transport](/transports/learning/) is not for production use**.
-
 
 ### [Persistence](/persistence/)
 
 Samples default to either the [learning persistence](/persistence/learning/) or the [Non-Durable persistence](/persistence/non-durable/) since both have no requirement on installed infrastructure. **The [learning persistence](/persistence/learning/) is not for production use**.
 
-
 ### Console hosting
 
 Samples default to [self-hosting](/nservicebus/hosting/) in a console since it is the most explicit and contains fewer moving pieces. This would not be a suitable choice for a production system and other [hosting options](/nservicebus/hosting/) should be considered.
-
 
 ### [Logging](/nservicebus/logging/)
 
 Samples default to logging at the `Info` level to the console. In production, the preferred approach is some combination of `Warning` and `Error` with a combination of targets.
 
-
 ### [Messages definitions](/nservicebus/messaging/messages-events-commands.md)
 
 In many samples, messages are defined in a shared project along with reusable helper and configuration classes. This is done to reduce the number of projects in a solution. In a production solution, message definitions are usually isolated in their own projects.
 
-
 ### [Message destinations](/nservicebus/messaging/routing.md)
 
 Many samples make use of `SendLocal` and send to an endpoint directly by specify the destination using a string in code. This is done to simplify the amount of configuration in samples. In a production solution, most message destinations should be defined via [routing configuration](/nservicebus/messaging/routing.md).
-
 
 ### [Dependency injection](/nservicebus/dependency-injection/)
 

--- a/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/application-insights/Metrics_3/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.*" />

--- a/samples/logging/application-insights/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/application-insights/Metrics_4/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.*" />

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.*" />

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.*" />

--- a/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.*" />

--- a/samples/logging/default/Core_7/Sample/Sample.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/logging/default/Core_8/Sample/Sample.csproj
+++ b/samples/logging/default/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.*" />

--- a/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/samples/logging/hostcustom/Host_8/Sample/Sample.csproj
+++ b/samples/logging/hostcustom/Host_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net48</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NewRelic.Agent.Api" Version="6.*" />

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.*" />

--- a/samples/logging/notifications/Core_7/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/logging/notifications/Core_8/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/prometheus-grafana/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/prometheus-grafana/Metrics_3/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/logging/prometheus-grafana/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/prometheus-grafana/Metrics_4/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithClean/SampleWithClean.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />

--- a/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_7/SampleWithoutClean/SampleWithoutClean.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.*" />

--- a/samples/logging/stack-trace-cleaning/Core_8/SampleWithClean/SampleWithClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_8/SampleWithClean/SampleWithClean.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFriendlyStackTrace" Version="1.*" />

--- a/samples/logging/stack-trace-cleaning/Core_8/SampleWithoutClean/SampleWithoutClean.csproj
+++ b/samples/logging/stack-trace-cleaning/Core_8/SampleWithoutClean/SampleWithoutClean.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.*" />

--- a/samples/manual-unsubscribe/Core_7/Messages/Messages.csproj
+++ b/samples/manual-unsubscribe/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/manual-unsubscribe/Core_7/Publisher/Publisher.csproj
+++ b/samples/manual-unsubscribe/Core_7/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/manual-unsubscribe/Core_7/Subscriber/Subscriber.csproj
+++ b/samples/manual-unsubscribe/Core_7/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/manual-unsubscribe/Core_7/SubscriptionManager/SubscriptionManager.csproj
+++ b/samples/manual-unsubscribe/Core_7/SubscriptionManager/SubscriptionManager.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/manual-unsubscribe/Core_8/Messages/Messages.csproj
+++ b/samples/manual-unsubscribe/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/manual-unsubscribe/Core_8/Publisher/Publisher.csproj
+++ b/samples/manual-unsubscribe/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/manual-unsubscribe/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/manual-unsubscribe/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/manual-unsubscribe/Core_8/SubscriptionManager/SubscriptionManager.csproj
+++ b/samples/manual-unsubscribe/Core_8/SubscriptionManager/SubscriptionManager.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.csproj
+++ b/samples/message-error-handling/Core_7/CustomErrorHandling/CustomErrorHandling.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/message-error-handling/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/message-error-handling/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/message-error-handling/Core_8/CustomErrorHandling/CustomErrorHandling.csproj
+++ b/samples/message-error-handling/Core_8/CustomErrorHandling/CustomErrorHandling.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/message-error-handling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/message-error-handling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/messagemutators/Core_7/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/samples/messagemutators/Core_8/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/msmq/dlq-customcheck/MsmqTransport_1/SampleEndpoint/SampleEndpoint.csproj
+++ b/samples/msmq/dlq-customcheck/MsmqTransport_1/SampleEndpoint/SampleEndpoint.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
     <StartupObject>Program</StartupObject>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/msmq/dlq-customcheck/MsmqTransport_2/SampleEndpoint/SampleEndpoint.csproj
+++ b/samples/msmq/dlq-customcheck/MsmqTransport_2/SampleEndpoint/SampleEndpoint.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
     <StartupObject>Program</StartupObject>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/MsmqPublisher.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/MsmqPublisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/NativeMsmqToSql/NativeMsmqToSql.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/NativeMsmqToSql/NativeMsmqToSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Messaging" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/Shared/Shared.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/SqlRelay.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/SqlRelay.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/MsmqPublisher/MsmqPublisher.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/MsmqPublisher/MsmqPublisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/NativeMsmqToSql/NativeMsmqToSql.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/NativeMsmqToSql/NativeMsmqToSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Messaging" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/Shared/Shared.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/SqlRelay/SqlRelay.csproj
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/SqlRelay/SqlRelay.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/msmq/persistence/MsmqTransport_1/Sample/Sample.csproj
+++ b/samples/msmq/persistence/MsmqTransport_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/msmq/persistence/MsmqTransport_2/Sample/Sample.csproj
+++ b/samples/msmq/persistence/MsmqTransport_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/msmq/simple/MsmqTransport_1/Sample/Sample.csproj
+++ b/samples/msmq/simple/MsmqTransport_1/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/msmq/simple/MsmqTransport_2/Sample/Sample.csproj
+++ b/samples/msmq/simple/MsmqTransport_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/ravendb/Core_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/near-realtime-clients/Core_7/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_7/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_7/ClientHub/ClientHub.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_7/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_7/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_7/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_7/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/near-realtime-clients/Core_8/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/netcore-reference/Core_7/BackEnd/BackEnd.csproj
+++ b/samples/netcore-reference/Core_7/BackEnd/BackEnd.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="3.*" />

--- a/samples/netcore-reference/Core_7/FrontEnd/FrontEnd.csproj
+++ b/samples/netcore-reference/Core_7/FrontEnd/FrontEnd.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.*" />

--- a/samples/netcore-reference/Core_7/Messages/Messages.csproj
+++ b/samples/netcore-reference/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/netcore-reference/Core_8/BackEnd/BackEnd.csproj
+++ b/samples/netcore-reference/Core_8/BackEnd/BackEnd.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="6.*" />

--- a/samples/netcore-reference/Core_8/FrontEnd/FrontEnd.csproj
+++ b/samples/netcore-reference/Core_8/FrontEnd/FrontEnd.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.*" />

--- a/samples/netcore-reference/Core_8/Messages/Messages.csproj
+++ b/samples/netcore-reference/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="OrderSagaDataXml.hbm.xml">

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="OrderSagaDataXml.hbm.xml">

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/open-telemetry/customizing/Core_8/CustomizingTelemetry/Sample/Sample.csproj
+++ b/samples/open-telemetry/customizing/Core_8/CustomizingTelemetry/Sample/Sample.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/open-telemetry/logging/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/open-telemetry/logging/Core_8/GenericHost/GenericHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="6.*" />

--- a/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_7/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_8/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_8/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/performance-counters/PerfCounters_3/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_3/Sample/Sample.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="3.*" />

--- a/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="4.*" />

--- a/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="5.*" />

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/header-propagation/Core_7/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/header-propagation/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/header-propagation/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Sender/Sender.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net6.0;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net6.0;net48</TargetFrameworks>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MassTransit.AspNetCore" Version="7.*" />

--- a/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MassTransit.AspNetCore" Version="7.*" />

--- a/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/multi-serializer/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/multi-serializer/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/multi-serializer/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/pipeline/multi-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/multi-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/multi-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/multi-serializer/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/stream-properties/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="FileToSend.txt">

--- a/samples/pipeline/stream-properties/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/stream-properties/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/stream-properties/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/stream-properties/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="FileToSend.txt">

--- a/samples/pipeline/stream-properties/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/stream-properties/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/platform-connector/json/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="platformConnection.json" />

--- a/samples/platform-connector/json/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/json/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="platformConnection.json" />

--- a/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/platform-connector/ms-config/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="appsettings.json" />

--- a/samples/platform-connector/ms-config/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_1/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="appsettings.json" />

--- a/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\CustomExtensionEndpoint\bin\Debug\</OutputPath>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Composition" Version="1.*" />

--- a/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputPath>..\MefExtensionEndpoint\bin\Debug\</OutputPath>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_7/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputPath>..\CustomExtensionEndpoint\bin\Debug\</OutputPath>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Composition" Version="1.*" />

--- a/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputPath>..\MefExtensionEndpoint\bin\Debug\</OutputPath>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/plugin-based-config/Core_8/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.Messages/AwsLambda.Messages.csproj
+++ b/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.Messages/AwsLambda.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.SQSTrigger/AwsLambda.SQSTrigger.csproj
+++ b/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.SQSTrigger/AwsLambda.SQSTrigger.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.Sender/AwsLambda.Sender.csproj
+++ b/samples/previews/aws-lambda/sqs/SQSLambda_0/AwsLambda.Sender/AwsLambda.Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/message-driven/Core_7/Publisher/Publisher.csproj
+++ b/samples/pubsub/message-driven/Core_7/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/message-driven/Core_7/Shared/Shared.csproj
+++ b/samples/pubsub/message-driven/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pubsub/message-driven/Core_7/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/message-driven/Core_7/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/message-driven/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/message-driven/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/message-driven/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/message-driven/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pubsub/message-driven/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/message-driven/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_7/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/rabbitmq/native-integration/Rabbit_6/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_6/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/rabbitmq/simple/Rabbit_6/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="6.*" />

--- a/samples/rabbitmq/simple/Rabbit_6/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="6.*" />

--- a/samples/rabbitmq/simple/Rabbit_6/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="7.*" />

--- a/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="7.*" />

--- a/samples/rabbitmq/simple/Rabbit_7/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />

--- a/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />

--- a/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/ravendb/simple/Raven_6/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_6/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_6/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_6/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_6/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/ravendb/simple/Raven_7/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_7/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/ravendb/simple/Raven_8/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_8/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/recoverabilitypolicytesting/Core_7/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/router/backplane/Router_3/Blue.Client/Blue.Client.csproj
+++ b/samples/router/backplane/Router_3/Blue.Client/Blue.Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/backplane/Router_3/Blue.Router/Blue.Router.csproj
+++ b/samples/router/backplane/Router_3/Blue.Router/Blue.Router.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Router.Shared\Router.Shared.csproj" />

--- a/samples/router/backplane/Router_3/Green.Billing/Green.Billing.csproj
+++ b/samples/router/backplane/Router_3/Green.Billing/Green.Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/backplane/Router_3/Green.Router/Green.Router.csproj
+++ b/samples/router/backplane/Router_3/Green.Router/Green.Router.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Router.Shared\Router.Shared.csproj" />

--- a/samples/router/backplane/Router_3/Red.Router/Red.Router.csproj
+++ b/samples/router/backplane/Router_3/Red.Router/Red.Router.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Router.Shared\Router.Shared.csproj" />

--- a/samples/router/backplane/Router_3/Red.Sales/Red.Sales.csproj
+++ b/samples/router/backplane/Router_3/Red.Sales/Red.Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/backplane/Router_3/Red.Shipping/Red.Shipping.csproj
+++ b/samples/router/backplane/Router_3/Red.Shipping/Red.Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/backplane/Router_3/Router.Shared/Router.Shared.csproj
+++ b/samples/router/backplane/Router_3/Router.Shared/Router.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/backplane/Router_3/Shared/Shared.csproj
+++ b/samples/router/backplane/Router_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/mixed-transports/Router_3/Client/Client.csproj
+++ b/samples/router/mixed-transports/Router_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/mixed-transports/Router_3/Router/Router.csproj
+++ b/samples/router/mixed-transports/Router_3/Router/Router.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/mixed-transports/Router_3/Server/Server.csproj
+++ b/samples/router/mixed-transports/Router_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/mixed-transports/Router_3/Shared/Shared.csproj
+++ b/samples/router/mixed-transports/Router_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sites/Router_3/Client/Client.csproj
+++ b/samples/router/sites/Router_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sites/Router_3/RouterA/RouterA.csproj
+++ b/samples/router/sites/Router_3/RouterA/RouterA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sites/Router_3/RouterB/RouterB.csproj
+++ b/samples/router/sites/Router_3/RouterB/RouterB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sites/Router_3/Server/Server.csproj
+++ b/samples/router/sites/Router_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sites/Router_3/Shared/Shared.csproj
+++ b/samples/router/sites/Router_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.*" />

--- a/samples/router/sql-switch/Router_3/Billing/Billing.csproj
+++ b/samples/router/sql-switch/Router_3/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/sql-switch/Router_3/Client/Client.csproj
+++ b/samples/router/sql-switch/Router_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/sql-switch/Router_3/Sales/Sales.csproj
+++ b/samples/router/sql-switch/Router_3/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/sql-switch/Router_3/Shared/Shared.csproj
+++ b/samples/router/sql-switch/Router_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/sql-switch/Router_3/Shipping/Shipping.csproj
+++ b/samples/router/sql-switch/Router_3/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/sql-switch/Router_3/Switch/Switch.csproj
+++ b/samples/router/sql-switch/Router_3/Switch/Switch.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/router/update-and-publish/Router_3/Backend/Backend.csproj
+++ b/samples/router/update-and-publish/Router_3/Backend/Backend.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/router/update-and-publish/Router_3/Client/Client.csproj
+++ b/samples/router/update-and-publish/Router_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/router/update-and-publish/Router_3/Frontend/Frontend.csproj
+++ b/samples/router/update-and-publish/Router_3/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />

--- a/samples/router/update-and-publish/Router_3/Router/Router.csproj
+++ b/samples/router/update-and-publish/Router_3/Router/Router.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Router" Version="3.*" />

--- a/samples/router/update-and-publish/Router_3/Shared/Shared.csproj
+++ b/samples/router/update-and-publish/Router_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_3/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_3/ResultHost/ResultHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_3/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepA/StepA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepB/StepB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_3/StepC/StepC.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_7/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_7/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_8/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_8/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/fair-distribution/Core_7/Client/Client.csproj
+++ b/samples/routing/fair-distribution/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="instance-mapping.xml">

--- a/samples/routing/fair-distribution/Core_7/Server/Server.csproj
+++ b/samples/routing/fair-distribution/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/routing/fair-distribution/Core_7/Server2/Server2.csproj
+++ b/samples/routing/fair-distribution/Core_7/Server2/Server2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/routing/fair-distribution/Core_7/Shared/Shared.csproj
+++ b/samples/routing/fair-distribution/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/fair-distribution/Core_8/Client/Client.csproj
+++ b/samples/routing/fair-distribution/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="instance-mapping.xml">

--- a/samples/routing/fair-distribution/Core_8/Server/Server.csproj
+++ b/samples/routing/fair-distribution/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/routing/fair-distribution/Core_8/Server2/Server2.csproj
+++ b/samples/routing/fair-distribution/Core_8/Server2/Server2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/routing/fair-distribution/Core_8/Shared/Shared.csproj
+++ b/samples/routing/fair-distribution/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/fowarding-address/Core_7/Messages/Messages.csproj
+++ b/samples/routing/fowarding-address/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/fowarding-address/Core_7/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
+++ b/samples/routing/fowarding-address/Core_7/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.csproj
+++ b/samples/routing/fowarding-address/Core_7/NewDestination/NewDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/fowarding-address/Core_7/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_7/Sender/Sender.csproj
+++ b/samples/routing/fowarding-address/Core_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_8/Messages/Messages.csproj
+++ b/samples/routing/fowarding-address/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/fowarding-address/Core_8/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
+++ b/samples/routing/fowarding-address/Core_8/NServiceBus.ForwardingAddress/NServiceBus.ForwardingAddress.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/fowarding-address/Core_8/NewDestination/NewDestination.csproj
+++ b/samples/routing/fowarding-address/Core_8/NewDestination/NewDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/fowarding-address/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/fowarding-address/Core_8/Sender/Sender.csproj
+++ b/samples/routing/fowarding-address/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/instance-mapping-file/Core_7/Billing/Billing.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_7/Client/Client.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_7/Sales/Sales.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_7/Sales2/Sales2.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Sales2/Sales2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_7/Shared/Shared.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/instance-mapping-file/Core_7/Shipping/Shipping.csproj
+++ b/samples/routing/instance-mapping-file/Core_7/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_8/Billing/Billing.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_8/Client/Client.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_8/Sales/Sales.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_8/Sales2/Sales2.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Sales2/Sales2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/instance-mapping-file/Core_8/Shared/Shared.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/instance-mapping-file/Core_8/Shipping/Shipping.csproj
+++ b/samples/routing/instance-mapping-file/Core_8/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/saga/batching/Core_7/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_7/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/batching/Core_7/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_7/WorkGenerator/WorkGenerator.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/batching/Core_7/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_7/WorkProcessor/WorkProcessor.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/saga/migration/Core_7/Client/Client.csproj
+++ b/samples/saga/migration/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_7/Server.New/Server.New.csproj
+++ b/samples/saga/migration/Core_7/Server.New/Server.New.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_7/Server/Server.csproj
+++ b/samples/saga/migration/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_7/Shared/Shared.csproj
+++ b/samples/saga/migration/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/saga/migration/Core_8/Client/Client.csproj
+++ b/samples/saga/migration/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_8/Server.New/Server.New.csproj
+++ b/samples/saga/migration/Core_8/Server.New/Server.New.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_8/Server/Server.csproj
+++ b/samples/saga/migration/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/migration/Core_8/Shared/Shared.csproj
+++ b/samples/saga/migration/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.*" />

--- a/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.*" />

--- a/samples/saga/simple/Core_7/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/saga/simple/Core_8/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scaleout/senderside/Core_7/Client/Client.csproj
+++ b/samples/scaleout/senderside/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/scaleout/senderside/Core_7/Messages/Messages.csproj
+++ b/samples/scaleout/senderside/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/scaleout/senderside/Core_7/Server1/Server1.csproj
+++ b/samples/scaleout/senderside/Core_7/Server1/Server1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/scaleout/senderside/Core_7/Server2/Server2.csproj
+++ b/samples/scaleout/senderside/Core_7/Server2/Server2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/scaleout/senderside/Core_8/Client/Client.csproj
+++ b/samples/scaleout/senderside/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/scaleout/senderside/Core_8/Messages/Messages.csproj
+++ b/samples/scaleout/senderside/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scaleout/senderside/Core_8/Server1/Server1.csproj
+++ b/samples/scaleout/senderside/Core_8/Server1/Server1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/scaleout/senderside/Core_8/Server2/Server2.csproj
+++ b/samples/scaleout/senderside/Core_8/Server2/Server2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/scheduling/fluentscheduler/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/fluentscheduler/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
+++ b/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/scheduling/scheduler/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/scheduler/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/timer/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/serializers/xml/Core_7/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/serializers/xml/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Adapter/Adapter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shared/Shared.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.csproj
+++ b/samples/servicecontrol/adapter-asq-multi-storage-account/SCTransportAdapter_2/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/Adapter/Adapter.csproj
+++ b/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/Adapter/Adapter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/Endpoint/Endpoint.csproj
+++ b/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/adapter-mixed-transports/SCTransportAdapter_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/EndpointsMonitor/EndpointsMonitor.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	<OutputType>Exe</OutputType>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/fix-messages/Core_7/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_7/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/fix-messages/Core_7/Receiver/Receiver.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_7/Sender/Sender.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_7/Shared/Shared.csproj
+++ b/samples/servicecontrol/fix-messages/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/servicecontrol/fix-messages/Core_8/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/fix-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_8/Sender/Sender.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/servicecontrol/fix-messages/Core_8/Shared/Shared.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/3rdPartySystem.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
         <OutputType>Exe</OutputType>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/3rdPartySystem/3rdPartySystem.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/3rdPartySystem/3rdPartySystem.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/Sample/Sample.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/Sample/Sample.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<OutputType>Exe</OutputType>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Endpoint.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Endpoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
@@ -6,7 +6,7 @@
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <RootNamespace>ServiceInsight.CustomViewer.Plugin</RootNamespace>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Shared/Shared.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Endpoint.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Endpoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
@@ -6,7 +6,7 @@
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<RootNamespace>ServiceInsight.CustomViewer.Plugin</RootNamespace>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/Shared.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/showcase/cloud-azure/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/cloud-azure/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/cloud-azure/Core_7/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.Messages/Store.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/showcase/cloud-azure/Core_7/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.Operations/Store.Operations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/cloud-azure/Core_7/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.Sales/Store.Sales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/cloud-azure/Core_7/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/cloud-azure/Core_7/Store.Shared/Store.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_7/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ECommerce/Store.ECommerce.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.*" />

--- a/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.*" />

--- a/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.*" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion1/EndpointVersion1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/EndpointVersion2/EndpointVersion2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion1/EndpointVersion1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/EndpointVersion2/EndpointVersion2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_5/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.*" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointOracle/EndpointOracle.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointOracle/EndpointOracle.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_5/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerShared\ServerShared.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_4/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_5/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase1.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase2.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\SharedPhase3.csproj" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_7/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.*" />

--- a/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.*" />

--- a/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.*" />

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.*" />

--- a/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.*" />

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.NHibernate/Endpoint.NHibernate.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.NHibernate/Endpoint.NHibernate.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.Native/Endpoint.Native.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.Native/Endpoint.Native.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
+++ b/samples/sqltransport/native-timeout-migration/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransportLegacySystemClient_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Sender/Sender.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Shared/Shared.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/startup-purge-behavior/SqlTransport_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqs/native-integration/Sqs_5/Receiver/Receiver.csproj
+++ b/samples/sqs/native-integration/Sqs_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/native-integration/Sqs_5/Sender/Sender.csproj
+++ b/samples/sqs/native-integration/Sqs_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.*" />

--- a/samples/sqs/native-integration/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/sqs/native-integration/Sqs_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/native-integration/Sqs_6/Sender/Sender.csproj
+++ b/samples/sqs/native-integration/Sqs_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.*" />

--- a/samples/sqs/simple/Sqs_4/Sample/Sample.csproj
+++ b/samples/sqs/simple/Sqs_4/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.3.*" />

--- a/samples/sqs/simple/Sqs_5/Receiver/Receiver.csproj
+++ b/samples/sqs/simple/Sqs_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/simple/Sqs_5/Sender/Sender.csproj
+++ b/samples/sqs/simple/Sqs_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/simple/Sqs_5/Shared/Shared.csproj
+++ b/samples/sqs/simple/Sqs_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/sqs/simple/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/sqs/simple/Sqs_6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/simple/Sqs_6/Sender/Sender.csproj
+++ b/samples/sqs/simple/Sqs_6/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/sqs/simple/Sqs_6/Shared/Shared.csproj
+++ b/samples/sqs/simple/Sqs_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/throttling/Core_7/Limited/Limited.csproj
+++ b/samples/throttling/Core_7/Limited/Limited.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_7/Sender/Sender.csproj
+++ b/samples/throttling/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_7/Shared/Shared.csproj
+++ b/samples/throttling/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/throttling/Core_8/Limited/Limited.csproj
+++ b/samples/throttling/Core_8/Limited/Limited.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_8/Sender/Sender.csproj
+++ b/samples/throttling/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_8/Shared/Shared.csproj
+++ b/samples/throttling/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/tracing/Core_7/Tracing/Tracing.csproj
+++ b/samples/tracing/Core_7/Tracing/Tracing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/tracing/Core_8/Tracing/Tracing.csproj
+++ b/samples/tracing/Core_8/Tracing/Tracing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/unit-of-work/Core_7/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/unit-of-work/Core_8/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/unit-testing/Testing_7/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/samples/unit-testing/Testing_8/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/samples/unobtrusive/Core_7/Client/Client.csproj
+++ b/samples/unobtrusive/Core_7/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/unobtrusive/Core_7/Server/Server.csproj
+++ b/samples/unobtrusive/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/unobtrusive/Core_7/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/unobtrusive/Core_8/Client/Client.csproj
+++ b/samples/unobtrusive/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/unobtrusive/Core_8/Server/Server.csproj
+++ b/samples/unobtrusive/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/unobtrusive/Core_8/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_7/Shared/Shared.csproj
+++ b/samples/username-header/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_8/Shared/Shared.csproj
+++ b/samples/username-header/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/versioning/Core_7/V1.Contracts/Versioning.Contracts.csproj
+++ b/samples/versioning/Core_7/V1.Contracts/Versioning.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/versioning/Core_7/V1.Publisher/V1.Publisher.csproj
+++ b/samples/versioning/Core_7/V1.Publisher/V1.Publisher.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_7/V1.Receiver/V1.Receiver.csproj
+++ b/samples/versioning/Core_7/V1.Receiver/V1.Receiver.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_7/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_7/V1.Subscriber/V1.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V1.Contracts\Versioning.Contracts.csproj" />

--- a/samples/versioning/Core_7/V2.Contracts/Versioning.Contracts.csproj
+++ b/samples/versioning/Core_7/V2.Contracts/Versioning.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/versioning/Core_7/V2.Publisher/V2.Publisher.csproj
+++ b/samples/versioning/Core_7/V2.Publisher/V2.Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Versioning.Contracts.csproj" />

--- a/samples/versioning/Core_7/V2.Receiver/V2.Receiver.csproj
+++ b/samples/versioning/Core_7/V2.Receiver/V2.Receiver.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_7/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_7/V2.Subscriber/V2.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Versioning.Contracts.csproj" />

--- a/samples/versioning/Core_8/V1.Contracts/Versioning.Contracts.csproj
+++ b/samples/versioning/Core_8/V1.Contracts/Versioning.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/versioning/Core_8/V1.Publisher/V1.Publisher.csproj
+++ b/samples/versioning/Core_8/V1.Publisher/V1.Publisher.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_8/V1.Receiver/V1.Receiver.csproj
+++ b/samples/versioning/Core_8/V1.Receiver/V1.Receiver.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V1.Contracts\Versioning.Contracts.csproj" />

--- a/samples/versioning/Core_8/V2.Contracts/Versioning.Contracts.csproj
+++ b/samples/versioning/Core_8/V2.Contracts/Versioning.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/versioning/Core_8/V2.Publisher/V2.Publisher.csproj
+++ b/samples/versioning/Core_8/V2.Publisher/V2.Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Versioning.Contracts.csproj" />

--- a/samples/versioning/Core_8/V2.Receiver/V2.Receiver.csproj
+++ b/samples/versioning/Core_8/V2.Receiver/V2.Receiver.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Versioning.Contracts.csproj" />

--- a/samples/wcf/Wcf_2/Wcf/Wcf.csproj
+++ b/samples/wcf/Wcf_2/Wcf/Wcf.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/wcf/Wcf_3/Wcf/Wcf.csproj
+++ b/samples/wcf/Wcf_3/Wcf/Wcf.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />

--- a/samples/web/asp-mvc-application/Core_7/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="4.*" />

--- a/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/asp-web-application/Core_7/Server/Server.csproj
+++ b/samples/web/asp-web-application/Core_7/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/asp-web-application/Core_7/Shared/Shared.csproj
+++ b/samples/web/asp-web-application/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/web/asp-web-application/Core_7/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_7/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/asp-web-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-web-application/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/asp-web-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-web-application/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/asp-web-application/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_8/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/websocket-gateway/Gateway_3/Messages/Messages.csproj
+++ b/samples/websocket-gateway/Gateway_3/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/websocket-gateway/Gateway_3/SiteA/SiteA.csproj
+++ b/samples/websocket-gateway/Gateway_3/SiteA/SiteA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/websocket-gateway/Gateway_3/SiteB/SiteB.csproj
+++ b/samples/websocket-gateway/Gateway_3/SiteB/SiteB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/websocket-gateway/Gateway_3/WebSocketGateway/WebSocketGateway.csproj
+++ b/samples/websocket-gateway/Gateway_3/WebSocketGateway/WebSocketGateway.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/websocket-gateway/Gateway_4/Messages/Messages.csproj
+++ b/samples/websocket-gateway/Gateway_4/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/websocket-gateway/Gateway_4/SiteA/SiteA.csproj
+++ b/samples/websocket-gateway/Gateway_4/SiteA/SiteA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/websocket-gateway/Gateway_4/SiteB/SiteB.csproj
+++ b/samples/websocket-gateway/Gateway_4/SiteB/SiteB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/websocket-gateway/Gateway_4/WebSocketGateway/WebSocketGateway.csproj
+++ b/samples/websocket-gateway/Gateway_4/WebSocketGateway/WebSocketGateway.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -12,7 +12,7 @@ namespace IntegrityTests
             // Also reflected in https://docs.particular.net/samples/#technology-choices-c-language-level
             // And in /tools/projectStandards.linq
 
-            new TestRunner("*.csproj", "SDK-style project files (VS2017+) must specify LangVersion=7.3 - Provides the best balance between users between samples for netcoreapp3.1 and samples built by the user likely without LangVersion element.")
+            new TestRunner("*.csproj", "SDK-style project files (VS2017+) must specify LangVersion=8.0 - Provides the best balance between users between samples for net48 and net6 and samples built by the user likely without LangVersion element.")
                 .IgnoreSnippets()
                 .Run(projectFilePath =>
                 {
@@ -37,7 +37,7 @@ namespace IntegrityTests
                     var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/LangVersion");
                     var value = firstTargetFrameworksElement?.Value;
 
-                    return value == "7.3";
+                    return value == "8.0";
                 });
         }
     }

--- a/tools/projectStandards.linq
+++ b/tools/projectStandards.linq
@@ -76,11 +76,11 @@ void CleanUpProjects()
 
 			if (langVersion == null)
 			{
-				propertyGroup.Add(new XElement("LangVersion", "7.3"));
+				propertyGroup.Add(new XElement("LangVersion", "8.0"));
 			}
 			else
 			{
-				langVersion.Value = "7.3";
+				langVersion.Value = "8.0";
 			}
 
             var targetFrameworks = propertyGroup.Element("TargetFrameworks");

--- a/tutorials/message-replay/Solution/Billing/Billing.csproj
+++ b/tutorials/message-replay/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/message-replay/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/message-replay/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/message-replay/Solution/Messages/Messages.csproj
+++ b/tutorials/message-replay/Solution/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/message-replay/Solution/PlatformTools/PlatformTools.csproj
+++ b/tutorials/message-replay/Solution/PlatformTools/PlatformTools.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/tutorials/message-replay/Solution/Sales/Sales.csproj
+++ b/tutorials/message-replay/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/message-replay/Solution/Shipping/Shipping.csproj
+++ b/tutorials/message-replay/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Solution/Messages/Messages.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Solution/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/1-saga-basics/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-sagas/1-saga-basics/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Solution/Messages/Messages.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Solution/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/2-timeouts/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-sagas/2-timeouts/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Solution/Messages/Messages.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Solution/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-sagas/3-integration/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-sagas/3-integration/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/1-getting-started/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/1-getting-started/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/Messages/Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing.Messages/Billing.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing.Messages/Billing.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing.Messages/Billing.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing.Messages/Billing.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Shipping/Shipping.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/tutorials/quickstart/Snippets/Core_7/Core_7.csproj
+++ b/tutorials/quickstart/Snippets/Core_7/Core_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.*" />

--- a/tutorials/quickstart/Solution/Billing/Billing.csproj
+++ b/tutorials/quickstart/Solution/Billing/Billing.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tutorials/quickstart/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/quickstart/Solution/ClientUI/ClientUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tutorials/quickstart/Solution/Messages/Messages.csproj
+++ b/tutorials/quickstart/Solution/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tutorials/quickstart/Solution/Platform/Platform.csproj
+++ b/tutorials/quickstart/Solution/Platform/Platform.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tutorials/quickstart/Solution/Sales/Sales.csproj
+++ b/tutorials/quickstart/Solution/Sales/Sales.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the samples to allow using the `LanguageVersion` `8.0`. This gives us at least the possibility to use slightly more modern CSharp features while striving for a good balance of supporting older versions of tooling.

This PR deliberately does not yet remove `netcoreapp3.1`