### PR TITLE
Warn against UseTransport for ASB Functions

### DIFF
--- a/nservicebus/hosting/azure-functions-service-bus/index.md
+++ b/nservicebus/hosting/azure-functions-service-bus/index.md
@@ -43,6 +43,8 @@ Any setting that is related to the configuration of the transport (e.g. the conc
 
 Concurrency-related settings are controlled via the Azure Function `host.json` configuration file. See [Concurrency in Azure Functions](https://docs.microsoft.com/en-us/azure/azure-functions/functions-concurrency#service-bus) for details.
 
+partial: no-use-transport
+
 ## Message consistency
 
 partial: message-consistency

--- a/nservicebus/hosting/azure-functions-service-bus/index_no-use-transport_ASBFunctions_[,4.1].partial.md
+++ b/nservicebus/hosting/azure-functions-service-bus/index_no-use-transport_ASBFunctions_[,4.1].partial.md
@@ -1,0 +1,1 @@
+WARN: Calling `AdvancedConfiguration.UseTransport(..)` is not supported and may prevent the endpoint from processing messages. Use the `.Transport` property to configure the transport. Use the `.Routing` property to configure transport routing.

--- a/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md
+++ b/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md
@@ -67,6 +67,8 @@ snippet: asb-function-isolated-configure-error-queue
 
 The configuration API exposes NServiceBus transport configuration options via the `configuration.Transport` property to allow customization. However, not all of the options will be applicable to execution within Azure Functions.
 
+partial: no-use-transport
+
 ## Preparing the Azure Service Bus namespace
 
 Function endpoints cannot create their own queues or other infrastructure in the Azure Service Bus namespace.

--- a/nservicebus/hosting/azure-functions-service-bus/isolated-worker_no-use-transport_ASBFunctionsWorker_[,4.1].partial.md
+++ b/nservicebus/hosting/azure-functions-service-bus/isolated-worker_no-use-transport_ASBFunctionsWorker_[,4.1].partial.md
@@ -1,0 +1,1 @@
+WARN: Calling `AdvancedConfiguration.UseTransport(..)` is not supported and may prevent the endpoint from processing messages. Use the `.Transport` property to configure the transport. Use the `.Routing` property to configure transport routing.


### PR DESCRIPTION
Calling `UseTransport` in the Azure functions host may cause the endpoint to be unable to process messages successfully. This explicitly calls it out as unsupported for the affected versions. Newer versions are able to handle `UseTransport` gracefully.

## Related issues

### In Process
- https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/pull/614
- https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/issues/615

### Worker
- https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/pull/263
- https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/issues/264