### PR TITLE
Fix mutator registration for Newtonsoft sample

### DIFF
--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
@@ -28,7 +28,7 @@ static class Program
         endpointConfiguration.RegisterComponents(
             registration: components =>
             {
-                components.AddTransient<MessageBodyWriter>();
+                components.AddTransient<IMutateIncomingTransportMessages, MessageBodyWriter>();
             });
 
         #endregion

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using NServiceBus;
+using NServiceBus.MessageMutator;
 
 static class Program
 {

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
@@ -23,19 +23,15 @@ static class Program
 
         #endregion
 
-        #region registermutator
-        
-        endpointConfiguration.RegisterComponents(
-            registration: components =>
-            {
-                components.AddTransient<IMutateIncomingTransportMessages, MessageBodyWriter>();
-            });
-
-        #endregion
-
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());
 
+        #region registermutator
+
+        endpointConfiguration.RegisterMessageMutator(new MessageBodyWriter());
+
+        #endregion
+        
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
 


### PR DESCRIPTION
The mutator registration is using the MS DI API which doesn't register the interface type of the mutator, causing it to not be registered and invoked correctly. The correct registration would be to use `components.AddTransient<IMutateIncomingTransportMessage, MessageBodyWriter>();` but by default, the sample should rather use the explicit mutator registration API