### PR TITLE
Add missing .NET7 target option to Azure Functions in-process samples

### DIFF
--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <LangVersion>8.0</LangVersion>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
The Azure Functions worker sample curently shows both .NET 6 and .NET 7 as options in the download menu. However, the .NET 7 version is broken because only the messages project correctly targets both SDKs while the Functions project itself currently only targets .NET 6 which will lead to a compilation error when downloading the sample with .NET 7 (the default)