### PR TITLE
Devcontainer for local development with docstool serve

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:0-6.0-bullseye
+
+# Required dependency for docstool libskiasharp
+RUN sudo apt-get update && sudo apt-get install fontconfig -y
+
+EXPOSE 55555

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "docs.particular.net",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/powershell:1": {}
+	},
+	"forwardPorts": [
+		55555
+	],
+	"postCreateCommand": "dotnet tool install -g Particular.DocsTool --add-source=https://www.myget.org/F/particular/api/v3/index.json",
+	"postStartCommand": "docstool update",
+	"postAttachCommand": "docstool serve",
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/home/vscode/.dotnet/tools"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"yzhang.markdown-all-in-one",
+				"streetsidesoftware.code-spell-checker",
+				"DavidAnson.vscode-markdownlint",
+				"shd101wyy.markdown-preview-enhanced",
+				"bierner.github-markdown-preview"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This creates a devcontainer that installs the docstool on create, updates it on start so that it keeps fresh and when the remote extension attaches it runs `docstool serve`.

![image](https://user-images.githubusercontent.com/174258/227367951-ce785c74-4aef-4103-b1b6-960d76e0db92.png)

It also installs powershell to execute some of the build scripts if required. Furthermore it enables some helpful markdown extensions automatically.

