### PR TITLE
Cache the docs tool to speed up content verification

### DIFF
--- a/.github/workflows/validate-pull-requests.yml
+++ b/.github/workflows/validate-pull-requests.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   content-verification:
     name: Content verification
-    runs-on: windows-2022
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -14,13 +14,25 @@ jobs:
         uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 7.0.x
+      - name: Check docstool
+        run: |
+           curl https://www.myget.org/F/particular/api/v3/flatcontainer/particular.docstool/index.json >> docstool-versions.json
+      - name: Cache docstool
+        id: cache-docstool
+        uses: actions/cache@v3.3.1
+        with:
+          path: |
+             ~/.dotnet/tools/docstool
+             ~/.dotnet/tools/.store/particular.docstool
+          key: docstool-${{ hashFiles('docstool-versions.json') }}
       - name: Install docstool
-        run: dotnet tool install -g Particular.DocsTool --add-source=https://www.myget.org/F/particular/api/v3/index.json
+        if: steps.cache-docstool.outputs.cache-hit != 'true'
+        run: dotnet tool install Particular.DocsTool --global --add-source=https://www.myget.org/F/particular/api/v3/index.json
       - name: Run docstool
-        run: docstool test
+        run: docstool test --no-version-check
   integrity-tests:
     name: Integrity tests
-    runs-on: windows-2022
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/verify-master.yml
+++ b/.github/workflows/verify-master.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   content-verification:
     name: Content verification
-    runs-on: windows-2022
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,8 +17,20 @@ jobs:
         uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 7.0.x
+      - name: Check docstool
+        run: |
+           curl https://www.myget.org/F/particular/api/v3/flatcontainer/particular.docstool/index.json >> docstool-versions.json
+      - name: Cache docstool
+        id: cache-docstool
+        uses: actions/cache@v3.3.1
+        with:
+          path: |
+             ~/.dotnet/tools/docstool
+             ~/.dotnet/tools/.store/particular.docstool
+          key: docstool-${{ hashFiles('docstool-versions.json') }}
       - name: Install docstool
-        run: dotnet tool install -g Particular.DocsTool --add-source=https://www.myget.org/F/particular/api/v3/index.json
+        if: steps.cache-docstool.outputs.cache-hit != 'true'
+        run: dotnet tool install Particular.DocsTool --global --add-source=https://www.myget.org/F/particular/api/v3/index.json
       - name: Run docstool
         run: docstool test --no-version-check
       - name: Notify Slack on failure
@@ -41,7 +53,7 @@ jobs:
           exit $(If ($result.ok) { 0 } Else { 1 })
   integrity-tests:
     name: Integrity tests
-    runs-on: windows-2022
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/nservicebus/sagas/message-correlation_note_core_[6,7.4).partial.md
+++ b/nservicebus/sagas/message-correlation_note_core_[6,7.4).partial.md
@@ -1,5 +1,0 @@
-{{NOTE:
-All correlated properties must have a non-default value when the saga instance is persisted. This means that all messages starting a saga must have a mapping.
-
-Changing the value of correlated properties for existing instances is **not** supported.
-}}

--- a/persistence/cosmosdb/index_glance_CosmosDB_[,1].partial.md
+++ b/persistence/cosmosdb/index_glance_CosmosDB_[,1].partial.md
@@ -1,7 +1,0 @@
-|Feature                    |   |
-|:---                       |---
-|Supported storage types    |Sagas, Outbox
-|Transactions               |Using TransactionalBatch, [with caveats](transactions.md)
-|Concurrency control        |Optimistic concurrency
-|Scripted deployment        |Not supported
-|Installers                 |Container is created by installers.

--- a/persistence/cosmosdb/saga-concurrency_sagaconcurrency_CosmosDB_[,1].partial.md
+++ b/persistence/cosmosdb/saga-concurrency_sagaconcurrency_CosmosDB_[,1].partial.md
@@ -1,1 +1,0 @@
-Due to the distributed nature of Cosmos DB [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) is always used when updating or deleting saga data. 

--- a/transports/azure-service-bus/configuration_subscription-rule-customization_asbs_[1.0,1.7].partial.md
+++ b/transports/azure-service-bus/configuration_subscription-rule-customization_asbs_[1.0,1.7].partial.md
@@ -1,4 +1,0 @@
- * `SubscriptionNameShortener(Func<string, string>)`: By default subscription names are derived from the endpoint name, which may exceed the maximum length of subscription names. This callback allows for a replacement name for the subscription. Subscription names must adhere to the limits outlined in [the Microsoft documentation on subscription creation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
- * `RuleNameShortener(Func<string, string>)`: By default rule names are derived from the message type's full name, which may exceed the maximum length of rule names. This callback allows for a replacement name for the rule. Rule names must adhere to the limits outlined in [Service Bus quotas](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
- 
-WARN: The shorteners are invoked only when the entity name exceeds the maximum length.


### PR DESCRIPTION
As long as there is no new docstool version pushed this improves the docs tool installation process by 24-25 times.

## Before

![image](https://user-images.githubusercontent.com/174258/234697170-bf6f3a09-6139-4bb7-b51d-4ec1f9bf9729.png)

## After

![image](https://user-images.githubusercontent.com/174258/234697068-115d7fdf-9042-4907-a65d-52ce73639bea.png)

## On cache miss

![image](https://user-images.githubusercontent.com/174258/234696920-ab0ff93b-392f-4484-9989-5ed814125a45.png)
