### PR TITLE
Use correct instance name in script

### DIFF
--- a/servicecontrol/upgrades/zero-downtime.md
+++ b/servicecontrol/upgrades/zero-downtime.md
@@ -156,7 +156,7 @@ The primary instance continues to query both instances but the original Audit in
 As the original audit instance is no longer ingesting messages, it will be empty after the audit retention period has elapsed and can be removed. The following steps describe how to determine when an audit instance is empty:
 
 1. Put the audit instance in [maintenance mode](/servicecontrol/audit-instances/maintenance-mode.md).
-2. Launch RavenDB Management Studio with a browser
+2. Launch RavenDB Management Studio with a browser.
 3. If the instance is using RavenDB 3.5 for persistence, go to the `<system>` database. If the instance is using RavenDB 5, go to the `audit` database.
 4. Check the documents count in the `ProcessedMessages` collection.
 
@@ -165,14 +165,14 @@ When the `ProcessedMessages` collection is empty, the audit instance can be deco
 On the primary instance machine:
 ```ps1
 Remove-ServiceControlRemote `
-  -Name Particular.ServiceControl.OriginalAudit ` 
+  -Name "Particular.ServiceControl" ` 
   -RemoteInstanceAddress "http://localhost:44444/api"
 ```
 
 On the original audit instance machine:
 ```ps1
 Remove-ServiceControlAuditInstance `
-  -Name Particular.ServiceControl.OriginalAudit `
+  -Name "Particular.ServiceControl.OriginalAudit" `
   -RemoveDB `
   -RemoveLogs
 ```


### PR DESCRIPTION
The old audit instance must be removed from the ServiceControl (Primary) instance.