### PR TITLE
Add docker sample

### DIFF
--- a/samples/sql-persistence/injecting-services/sample.md
+++ b/samples/sql-persistence/injecting-services/sample.md
@@ -19,8 +19,6 @@ downloadbutton
 
 ## Prerequisites
 
-This sample requires:
-
 include: sql-prereq
 
 The database created by this sample is `NsbSamplesInjectedServices`.

--- a/samples/sql-prereq.include.md
+++ b/samples/sql-prereq.include.md
@@ -1,4 +1,4 @@
-Ensure an instance of SQL Server (Version 2016 or above for custom saga finders sample, or Version 2012 or above for other samples) is installed and accessible on `localhost` and port `1433`.
+Ensure an instance of SQL Server (Version 2016 or above for custom saga finders sample, or Version 2012 or above for other samples) is installed and accessible on `localhost` and port `1433`. A Docker image can be used to accomplish this by running `docker run -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=yourStrong(!)Password' -p 1433:1433 -d mcr.microsoft.com/mssql/server:latest` in a terminal.
 
 Alternatively, change the connection string to point to different SQL Server instance.
 


### PR DESCRIPTION
Docker reference was removed in a [previous editorial PR](https://github.com/Particular/docs.particular.net/commit/4c1dd273cbe1f5d69b03fbec2cca05a02931e5f4). This adds it back with slightly different language.