### PR TITLE
remove .net core as taget framework in msmsq bridge sample

### DIFF
--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
 	<LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/AsbEndpoint/AsbEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
 	<LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFramework>net48</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/sample.md
+++ b/samples/bridge/azure-service-bus-msmq-bridge/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Bridge messages between endpoints using MSMQ and Azure Service Bus
 summary: A sample showing how to send messages between endpoints using different transports
-reviewed: 2022-05-19
+reviewed: 2023-06-02
 component: Bridge
 related:
 - transports/azure-service-bus


### PR DESCRIPTION
remove .net core as taget framework in msmsq bridge sample