### PR TITLE
Outbox handling of deduplication and transaction

### DIFF
--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -1,7 +1,7 @@
 ---
 title: Outbox
 summary: Reliable messaging without distributed transactions
-reviewed: 2022-05-12
+reviewed: 2023-06-30
 component: Core
 isLearningPath: true
 versions: "[5,)"

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -4,7 +4,7 @@ summary: Reliable messaging without distributed transactions
 reviewed: 2023-06-30
 component: Core
 isLearningPath: true
-versions: "[5,)"
+versions: "[6,)"
 redirects:
 - nservicebus/no-dtc
 related:


### PR DESCRIPTION
Modify the chart and text to match the way the code handles the outbox where the check for deduplication happens first and begin transaction is invoked only if no entry is found.


Reference: https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs#L25
