### PR TITLE
Using 1 minute in the SendMetricDataToServiceControl snippet with guidance to what interval to use

### DIFF
--- a/Snippets/MetricsServiceControl/MetricsServiceControl_3/Configuration.cs
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_3/Configuration.cs
@@ -14,7 +14,7 @@ class Configuration
 
         metrics.SendMetricDataToServiceControl(
             serviceControlMetricsAddress: SERVICE_CONTROL_METRICS_ADDRESS,
-            interval: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMinutes(1),
             instanceId: "INSTANCE_ID_OPTIONAL");
         #endregion
 
@@ -37,7 +37,7 @@ class Configuration
 
         metrics.SendMetricDataToServiceControl(
             serviceControlMetricsAddress: SERVICE_CONTROL_METRICS_ADDRESS,
-            interval: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMinutes(1),
             instanceId: instanceIdentifier);
         #endregion
     }

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_4/Configuration.cs
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_4/Configuration.cs
@@ -14,7 +14,7 @@ class Configuration
 
         metrics.SendMetricDataToServiceControl(
             serviceControlMetricsAddress: SERVICE_CONTROL_METRICS_ADDRESS,
-            interval: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMinutes(1),
             instanceId: "INSTANCE_ID_OPTIONAL");
         #endregion
 
@@ -37,7 +37,7 @@ class Configuration
 
         metrics.SendMetricDataToServiceControl(
             serviceControlMetricsAddress: SERVICE_CONTROL_METRICS_ADDRESS,
-            interval: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMinutes(1),
             instanceId: instanceIdentifier);
         #endregion
     }

--- a/monitoring/metrics/install-plugin.md
+++ b/monitoring/metrics/install-plugin.md
@@ -8,7 +8,6 @@ redirects:
   - nservicebus/operations/metrics/service-control
 ---
 
-
 The `NServiceBus.Metrics.ServiceControl` component enables sending monitoring data gathered with `NServiceBus.Metrics` to a `ServiceControl.Monitoring` service.
 
 ## Configuration
@@ -20,7 +19,6 @@ It can be enabled via:
 snippet: SendMetricDataToServiceControl
 
 Note: The metrics feature can't be used on send-only endpoints
-
 
 ### Service Control Metrics Address
 

--- a/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
+++ b/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
@@ -2,9 +2,9 @@
 
 Specifies the maximum delay between sending metrics report messages.
 
-The metrics plugin has a buffer and when that overflows a metric report message is sent and the buffer is cleared. When an endpoint instance is idle it will send metrics report messages at this interval to indicate it is idle but when the endpoint is under load the interval between metric messages will be much shorter as this buffer fills faster.
+The metrics plugin has a buffer and when that overflows a metric report message is sent and the buffer is cleared. When an endpoint instance is idle it will send metrics report messages at this interval to indicate it is idle. When the endpoint is under load the interval between metric messages will be much shorter as this buffer fills faster.
 
-The size of this buffer cannot be adjusted and uses a value that cannot maximum size limit errors with any of the supported transports.
+The size of this buffer is fixed and cannot be adjusted and uses a value that is compatible with thel maximum message size limits of all supported transports.
 
 The recommended value is between 10 and 60 seconds.
 

--- a/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
+++ b/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
@@ -2,13 +2,17 @@
 
 Specifies the maximum delay between sending metrics report messages.
 
-The metrics plugin has a buffer and when that overflows a metric report message is send and the buffer is cleared. When an endpoint instance is idle it will send metrics report messages at this interval to indicate it is idle but when the endpoint is under load the interval between metric messages will be much shorter as this buffer fills faster.
+The metrics plugin has a buffer and when that overflows a metric report message is sent and the buffer is cleared. When an endpoint instance is idle it will send metrics report messages at this interval to indicate it is idle but when the endpoint is under load the interval between metric messages will be much shorter as this buffer fills faster.
 
 The size of this buffer cannot be adjusted and uses a value that cannot maximum size limit errors with any of the supported transports.
 
 The recommended value is between 10 and 60 seconds.
 
-1. Shorter values result in ServiceControl monitoring to more quickly update especially on the 1 minute timescale but resultsin more metrics messages to be generated
-2. Longer values result in less frequent updates when an instance is not under heavy load but this isn't really affecting the monitoring view with larger timespand like the 10 minutes or more timescales
+1. Smaller values result in ServiceControl monitoring view to be updated faster, especially on the 1-minute timescale
+2. Larger values result in less frequent ServiceControl monitoring view updates only when an instance is not under heavy load. This isn't affecting the monitoring view with 10-minutes or larger timescales
 
-It is recommend to use higher values for systems that can have many instances running or use transports that are might be affected by rate limiting (often cloud based).
+It is recommended to use higher values for systems that can have many endpoint instances or use a transport that might be affected by rate limiting (often cloud-based).
+
+Example:
+
+If the system has 500 instances and the interval is set to 5 seconds an idle system will send on average 6.000 metric messages per minute (500 * 6) / 100 per second.

--- a/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
+++ b/monitoring/metrics/install-plugin_interval_metricsservicecontrol_[1,).partial.md
@@ -1,3 +1,14 @@
 ### Interval
 
-Specifies maximum delay for sending metrics report.
+Specifies the maximum delay between sending metrics report messages.
+
+The metrics plugin has a buffer and when that overflows a metric report message is send and the buffer is cleared. When an endpoint instance is idle it will send metrics report messages at this interval to indicate it is idle but when the endpoint is under load the interval between metric messages will be much shorter as this buffer fills faster.
+
+The size of this buffer cannot be adjusted and uses a value that cannot maximum size limit errors with any of the supported transports.
+
+The recommended value is between 10 and 60 seconds.
+
+1. Shorter values result in ServiceControl monitoring to more quickly update especially on the 1 minute timescale but resultsin more metrics messages to be generated
+2. Longer values result in less frequent updates when an instance is not under heavy load but this isn't really affecting the monitoring view with larger timespand like the 10 minutes or more timescales
+
+It is recommend to use higher values for systems that can have many instances running or use transports that are might be affected by rate limiting (often cloud based).


### PR DESCRIPTION
Based on a support case

Also updated:
- https://github.com/Particular/NServiceBus.Metrics.ServiceControl/pull/454