### PR TITLE
specify docstool port in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	],
 	"postCreateCommand": "dotnet tool install -g Particular.DocsTool --add-source=https://www.myget.org/F/particular/api/v3/index.json",
 	"postStartCommand": "docstool update",
-	"postAttachCommand": "docstool serve",
+	"postAttachCommand": "docstool serve --port 55666",
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/home/vscode/.dotnet/tools"
 	},


### PR DESCRIPTION
Related to #6141, let's specify the port explicitly, to match the container settings. Otherwise, we're effectively spreading the knowledge of what the default port is over this repo and the docstool.