### PR TITLE
Remove the DataBus  property type restriction and add other alternates for large data

### DIFF
--- a/nservicebus/community/index.md
+++ b/nservicebus/community/index.md
@@ -150,5 +150,6 @@ These serializer packages are part of the [NServiceBusExtensions](https://github
 * [MsgPack](https://github.com/NServiceBusExtensions/NServiceBus.MsgPack)
 * [ProtoBuf-Google](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufGoogle)
 * [ProtoBuf-Net](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
+  * Fork: [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet)
 * [Utf8Json](https://github.com/NServiceBusExtensions/NServiceBus.Utf8Json)
 * [ZeroFormatter](https://github.com/NServiceBusExtensions/NServiceBus.ZeroFormatter)

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -19,6 +19,35 @@ Instead of serializing the payload along with the rest of the message, the `Data
 
 If the location is not available upon sending, the send operation will fail. When a message is received and the payload location is not available, the receive operation will fail as well, resulting in the standard NServiceBus retry behavior, possibly resulting in the message being moved to the error queue if the error could not be resolved.
 
+## Transport message size limits
+
+Using the Data Bus if often only required if the message size can exceed the transport message size limit.
+
+| Transport                  | Maximum size |
+| -------------------------- | ------------:|
+| Amazon SQS                 | Unknown      |
+| Azure Storage Queues       | 128KB ?      |
+| Azure Service Bus Standard | 256KB        |
+| Azure Service Bus Premium  | 100MB        |
+| RabbitMQ                   | No limit     |
+| SQL Server                 | No limit     |
+| Learning                   | No limit     |
+| MSMQ                       | 4MB          |
+
+## Alternatives
+
+1. Use a different transport or a different transport tier
+  - Not all transports have very restrictive message size limits and Azure Service Bus has increased their size limits over the years
+1. Use message body encryption to which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+1. Use a binary serializer
+   - In the past some ready to use packages were available via https://github.com/NServiceBusExtensions but none of the binary serializers are available for NServiceBus 8+.
+   - [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
+   - Implementation a binary serializer is simple and just requires a few lines of code
+1. If you are dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+  - Read on demand: Will only retrieve attachment data when the consumer reads it
+  - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
+1. Use any of the above in combination with compression
+
 ## Alternative
 
 The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -49,10 +49,7 @@ Using the Data Bus is required when the message size can exceed the transport me
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
 1. Use any of the above in combination with compression
-
-## Alternative
-
-The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
+1. Stream-based: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
 
 ## Enabling the data bus
 

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -27,8 +27,9 @@ Note: Not all transports have very restrictive message size limits and Azure Ser
 
 | Transport                  | Maximum size |
 | -------------------------- | ------------:|
-| Amazon SQS                 | Unknown      |
-| Azure Storage Queues       |64KB     |
+| Amazon SQS                 | 256KB        |
+| Amazon SQS + S3            | 2GB          |
+| Azure Storage Queues       | 64KB         |
 | Azure Service Bus Standard | 256KB        |
 | Azure Service Bus Premium  | 100MB        |
 | RabbitMQ                   | No limit     |

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -26,7 +26,7 @@ Using the Data Bus is required when the message size can exceed the transport me
 | Transport                  | Maximum size |
 | -------------------------- | ------------:|
 | Amazon SQS                 | Unknown      |
-| Azure Storage Queues       | 128KB ?      |
+| Azure Storage Queues       |64KB     |
 | Azure Service Bus Standard | 256KB        |
 | Azure Service Bus Premium  | 100MB        |
 | RabbitMQ                   | No limit     |

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -21,7 +21,7 @@ If the location is not available upon sending, the send operation will fail. Whe
 
 ## Transport message size limits
 
-Using the Data Bus if often only required if the message size can exceed the transport message size limit.
+Using the Data Bus is required when the message size can exceed the transport message size limit.
 
 | Transport                  | Maximum size |
 | -------------------------- | ------------:|
@@ -37,14 +37,14 @@ Using the Data Bus if often only required if the message size can exceed the tra
 ## Alternatives
 
 1. Use a different transport or a different transport tier
-  - Not all transports have very restrictive message size limits and Azure Service Bus has increased their size limits over the years
-1. Use message body compression to which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+  - Not all transports have very restrictive message size limits and Azure Service Bus has increased its size limits over the years
+1. Use message body compression which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
   - [Message mutator example demonstrating message body compression](https://docs.particular.net/samples/messagemutators/)
   - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
 1. Use a binary serializer
-   - In the past some ready to use packages were available via https://github.com/NServiceBusExtensions but none of the binary serializers are available for NServiceBus 8+.
+   - Implementing a binary serializer requires a few lines of code
    - [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
-   - Implementating a binary serializer is simple and just requires a few lines of code
+     - ProtoBuf is the default for [gRPC](https://grpc.io/)
 1. When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
@@ -84,7 +84,7 @@ snippet: MessageWithLargePayload
 
 ### Using message conventions
 
-NServiceBus also supports defining data bus properties via convention. This allows data properties to be sent using the data bus without using `DataBusProperty<T>`, thus removing the need for having a dependency on NServiceBus from the message types.
+NServiceBus also supports defining data bus properties via a convention. This allows data properties to be sent using the data bus without using `DataBusProperty<T>`, thus removing the need for having a dependency on NServiceBus from the message types.
 
 In the configuration of the endpoint include:
 

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -95,16 +95,13 @@ Automatically removing these attachments can cause problems in many situations. 
 
 ## Alternatives
 
-WARNING: Alternatives marked with ⚠️ are community project and are not maintained or supported by Particular Software.
-
 - Use a different transport or a different transport tier
 - Message Compression: Use message body compression which works well on text-based payloads like XML and Json or any payload (text or binary) that contains repetitive data
   - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
-  - Community maintained [NServiceBus.Comression ⚠️](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
 - Stream-based properties: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
 - Binary Serializer: A binary serializer is more efficient and most serializers can be added with a few lines of code
-   - ProtoBuf is commonly used and is the default for [gRPC](https://grpc.io/). An implementation for NServiceBus is [ramonsmits/NServiceBus.ProtoBufNet ⚠️](https://github.com/ramonsmits/NServiceBus.ProtoBufNet)
-- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments ⚠️](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+   - Some binary [serializers are maintained by the community](/nservicebus/community/#serializers)
+- Attachments: When dealing with unbounded binary payloads consider the [community maintained NServiceBus.Attachments](/nservicebus/community/#nservicebus-attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
 - Use any of the above in combination with compression

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -43,9 +43,9 @@ There are two ways to specify the message properties to be sent using the data b
  1. Using the `DataBusProperty<T>` type
  1. Message conventions
 
-Note: Data bus properties must be of type `byte[]` and be top-level properties on the message class.
+Note: Data bus properties must be top-level properties on the message class.
 
-### Using DataBusProperty<T>
+### Using `DataBusProperty<T>`
 
 Set the type of the property to be sent over the data bus as `DataBusProperty<byte[]>`:
 

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -36,20 +36,20 @@ Using the Data Bus is required when the message size can exceed the transport me
 
 ## Alternatives
 
-1. Use a different transport or a different transport tier
+-  Use a different transport or a different transport tier
   - Not all transports have very restrictive message size limits and Azure Service Bus has increased its size limits over the years
-1. Use message body compression which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
-  - [Message mutator example demonstrating message body compression](https://docs.particular.net/samples/messagemutators/)
+-  Use message body compression which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+  - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
   - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
-1. Use a binary serializer
+-  Use a binary serializer
    - Implementing a binary serializer requires a few lines of code
    - [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
      - ProtoBuf is the default for [gRPC](https://grpc.io/)
-1. When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+-  When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
-1. Use any of the above in combination with compression
-1. Stream-based: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
+- Use any of the above in combination with compression
+- Stream-based: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
 
 ## Enabling the data bus
 

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -39,15 +39,15 @@ Note: Not all transports have very restrictive message size limits and Azure Ser
 
 ## Alternatives
 
--  Use a different transport or a different transport tier
+- Use a different transport or a different transport tier
   
--  Use message body compression which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+- Message Compression: Use message body compression which works well on text-based payloads like XML and Json or any payload (text or binary) that contains repetitive data
   - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
   - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
--  Use a binary serializer
+- Binary Serializer: Implementing a binary serializer requires a few lines of code.
    - ProtoBuf is the default for [gRPC](https://grpc.io/). [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
     
--  When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
 - Use any of the above in combination with compression

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -23,6 +23,8 @@ If the location is not available upon sending, the send operation will fail. Whe
 
 Using the Data Bus is required when the message size can exceed the transport message size limit.
 
+Note: Not all transports have very restrictive message size limits and Azure Service Bus has increased its size limits over the years. Check the respective transport website documentation for the latest maximum limit of the message size.
+
 | Transport                  | Maximum size |
 | -------------------------- | ------------:|
 | Amazon SQS                 | Unknown      |
@@ -37,14 +39,13 @@ Using the Data Bus is required when the message size can exceed the transport me
 ## Alternatives
 
 -  Use a different transport or a different transport tier
-  - Not all transports have very restrictive message size limits and Azure Service Bus has increased its size limits over the years
+  
 -  Use message body compression which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
   - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
   - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
 -  Use a binary serializer
-   - Implementing a binary serializer requires a few lines of code
-   - [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
-     - ProtoBuf is the default for [gRPC](https://grpc.io/)
+   - ProtoBuf is the default for [gRPC](https://grpc.io/). [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
+    
 -  When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -39,19 +39,19 @@ Note: Not all transports have very restrictive message size limits and Azure Ser
 
 ## Alternatives
 
+WARNING: Alternatives marked with ⚠️ are community project and are not maintained or supported by Particular Software.
+
 - Use a different transport or a different transport tier
-  
 - Message Compression: Use message body compression which works well on text-based payloads like XML and Json or any payload (text or binary) that contains repetitive data
   - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
-  - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
-- Binary Serializer: Implementing a binary serializer requires a few lines of code.
-   - ProtoBuf is the default for [gRPC](https://grpc.io/). [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
-    
-- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+  - Community maintained [NServiceBus.Comression ⚠️](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
+- Stream-based properties: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
+- Binary Serializer: A binary serializer is more efficient and most serializers can be added with a few lines of code
+   - ProtoBuf is commonly used and is the default for [gRPC](https://grpc.io/). An implementation for NServiceBus is [ramonsmits/NServiceBus.ProtoBufNet ⚠️](https://github.com/ramonsmits/NServiceBus.ProtoBufNet)
+- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments ⚠️](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
 - Use any of the above in combination with compression
-- Stream-based: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
 
 ## Enabling the data bus
 

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -38,12 +38,14 @@ Using the Data Bus if often only required if the message size can exceed the tra
 
 1. Use a different transport or a different transport tier
   - Not all transports have very restrictive message size limits and Azure Service Bus has increased their size limits over the years
-1. Use message body encryption to which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+1. Use message body compression to which works well on text-based payloads like XML and Json any payload (text or binary) that contains repetitive data
+  - [Message mutator example demonstrating message body compression](https://docs.particular.net/samples/messagemutators/)
+  - Community maintained [NServiceBus.Comression](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
 1. Use a binary serializer
    - In the past some ready to use packages were available via https://github.com/NServiceBusExtensions but none of the binary serializers are available for NServiceBus 8+.
    - [ramonsmits/NServiceBus.ProtoBufNet](https://github.com/ramonsmits/NServiceBus.ProtoBufNet) (original archived at [NServiceBusExtensions/NServiceBus.ProtoBufNet](https://github.com/NServiceBusExtensions/NServiceBus.ProtoBufNet)
-   - Implementation a binary serializer is simple and just requires a few lines of code
-1. If you are dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+   - Implementating a binary serializer is simple and just requires a few lines of code
+1. When dealing with unbounded binary payloads consider [NServiceBus.Attachments](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
   - Read on demand: Will only retrieve attachment data when the consumer reads it
   - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
 1. Use any of the above in combination with compression

--- a/nservicebus/messaging/databus/index.md
+++ b/nservicebus/messaging/databus/index.md
@@ -37,22 +37,6 @@ Note: Not all transports have very restrictive message size limits and Azure Ser
 | Learning                   | No limit     |
 | MSMQ                       | 4MB          |
 
-## Alternatives
-
-WARNING: Alternatives marked with ⚠️ are community project and are not maintained or supported by Particular Software.
-
-- Use a different transport or a different transport tier
-- Message Compression: Use message body compression which works well on text-based payloads like XML and Json or any payload (text or binary) that contains repetitive data
-  - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
-  - Community maintained [NServiceBus.Comression ⚠️](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
-- Stream-based properties: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
-- Binary Serializer: A binary serializer is more efficient and most serializers can be added with a few lines of code
-   - ProtoBuf is commonly used and is the default for [gRPC](https://grpc.io/). An implementation for NServiceBus is [ramonsmits/NServiceBus.ProtoBufNet ⚠️](https://github.com/ramonsmits/NServiceBus.ProtoBufNet)
-- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments ⚠️](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
-  - Read on demand: Will only retrieve attachment data when the consumer reads it
-  - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
-- Use any of the above in combination with compression
-
 ## Enabling the data bus
 
 See the individual data bus implementations for details on enabling and configuring the data bus.
@@ -108,6 +92,22 @@ Automatically removing these attachments can cause problems in many situations. 
 * Functional requirements might dictate the message to be available for a longer duration.
 * If the data bus feature is used when publishing an event to multiple subscribers, neither the publisher nor any specific subscribing endpoint can determine when all subscribers have successfully processed the message allowing the file to be cleaned up.
 * If message processing fails, it will be handled by the [recoverability feature](/nservicebus/recoverability/). This message can then be retried some period after that failure. The data bus files need to exist for that message to be re-processed correctly.
+
+## Alternatives
+
+WARNING: Alternatives marked with ⚠️ are community project and are not maintained or supported by Particular Software.
+
+- Use a different transport or a different transport tier
+- Message Compression: Use message body compression which works well on text-based payloads like XML and Json or any payload (text or binary) that contains repetitive data
+  - [Message mutator example demonstrating message body compression](/samples/messagemutators/)
+  - Community maintained [NServiceBus.Comression ⚠️](https://github.com/ramonsmits/NServiceBus.Compression) with configurable compression thresholds
+- Stream-based properties: The [Handling large stream properties via pipeline](/samples/pipeline/stream-properties/) sample demonstrates a purely stream-based approach (rather than loading the full payload into memory) implemented by leveraging the NServiceBus pipeline.
+- Binary Serializer: A binary serializer is more efficient and most serializers can be added with a few lines of code
+   - ProtoBuf is commonly used and is the default for [gRPC](https://grpc.io/). An implementation for NServiceBus is [ramonsmits/NServiceBus.ProtoBufNet ⚠️](https://github.com/ramonsmits/NServiceBus.ProtoBufNet)
+- Attachments: When dealing with unbounded binary payloads consider [NServiceBus.Attachments ⚠️](https://github.com/NServiceBusExtensions/NServiceBus.Attachments)
+  - Read on demand: Will only retrieve attachment data when the consumer reads it
+  - Reduced Memory usage: No base64 serializer overhead resulting in a significant reduction in resource utilization
+- Use any of the above in combination with compression
 
 ## Other considerations
 


### PR DESCRIPTION
As the [DataBusProperty](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/DataBus/DataBusProperty.cs) does not restrict the databus property to be only a `byte[]` and there are other samples in the docs site that use other types, this PR removes that restriction.

This PR also adds in other alternatives for sending messages with large data as listed below

- [x] Mention compression
- [x] Mention storage limits
- [x] Mention NServiceBus.Attachments