### PR TITLE
Switch to ServiceControl Error instance naming convention

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1320,7 +1320,7 @@
       Url: servicecontrol/upgrades/1to2
   - Title: Error instances
     Articles:
-    - Title: ServiceControl instances
+    - Title: ServiceControl Error instances
       Url: servicecontrol/servicecontrol-instances
     - Title: Planning
       Articles:

--- a/servicecontrol/audit-instances/creating-config-file.md
+++ b/servicecontrol/audit-instances/creating-config-file.md
@@ -11,7 +11,7 @@ The configuration of a ServiceControl Audit instance can be adjusted via the Ser
 
 Anyone who can access the ServiceControl Audit instance URL has complete access to the audit data stored by the ServiceControl Audit instance. This is why the default is to only respond to `localhost`. Consider carefully the implications of exposing a ServiceControl Audit instance via a custom or wildcard URI.
 
-WARN: Changing the host name or port number of an existing ServiceControl Audit instance will break the link from the primary ServiceControl instance. See [Moving a remote instance](/servicecontrol/servicecontrol-instances/remotes.md) for guidelines on changing these settings.
+WARN: Changing the host name or port number of an existing ServiceControl Audit instance will break the link from the ServiceControl Error instance. See [Moving a remote instance](/servicecontrol/servicecontrol-instances/remotes.md) for guidelines on changing these settings.
 
 ### ServiceControl.Audit/HostName
 

--- a/servicecontrol/audit-instances/index.md
+++ b/servicecontrol/audit-instances/index.md
@@ -5,7 +5,7 @@ reviewed: 2021-08-06
 component: ServiceControl
 ---
 
-In ServiceControl versions 4 and above, a ServiceControl Audit instance manages the audit queue. Data about audit messages is exposed via an HTTP API on a primary ServiceControl instance. This API is used by [ServiceInsight](/serviceinsight/) for visualizing message flows.
+In ServiceControl versions 4 and above, a ServiceControl Audit instance manages the audit queue. Data about audit messages is exposed via an HTTP API on a ServiceControl Error instance. This API is used by [ServiceInsight](/serviceinsight/) for visualizing message flows.
 
 NOTE: The ServiceControl HTTP API is designed for use by ServiceInsight only and may change at any time. Use of this HTTP API for other purposes is discouraged.
 
@@ -32,21 +32,21 @@ Each ServiceControl Audit instance stores data in an embedded database. Audit da
 
 When using ServiceControl Management to create a new ServiceControl instance, a connected ServiceControl Audit instance is automatically created. Using PowerShell, create the ServiceControl instance first, then the ServiceControl Audit instance.
 
-When [auditing](/nservicebus/operations/auditing.md) NServiceBus messages there must be at least one ServiceControl audit instance. ServiceInsight connects directly to the primary ServiceControl instance, which will aggregate the data stored in [all connected ServiceControl Audit instances](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-competing-consumers).
+When [auditing](/nservicebus/operations/auditing.md) NServiceBus messages there must be at least one ServiceControl audit instance. ServiceInsight connects directly to the ServiceControl Error instance, which will aggregate the data stored in [all connected ServiceControl Audit instances](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-competing-consumers).
 
 Connecting ServiceInsight directly to a ServiceControl Audit instance is not supported.
 
 ## Notifications
 
-Each ServiceControl Audit instance sends notification messages to a primary ServiceControl instance.
+Each ServiceControl Audit instance sends notification messages to a ServiceControl Error instance.
 
 ### Endpoint detection
 
-When a ServiceControl Audit instance detects a new endpoint, it sends a notification to the primary ServiceControl instance. The primary instance keeps track of all of the endpoints in the system and can monitor them with heartbeats and custom checks.
+When a ServiceControl Audit instance detects a new endpoint, it sends a notification to the ServiceControl Error instance. The Error instance keeps track of all of the endpoints in the system and can monitor them with heartbeats and custom checks.
 
 ### Successful retry detection
 
-When a ServiceControl Audit instance detects that an audited message is the result of a retry, it sends a notification to the primary ServiceControl instance.
+When a ServiceControl Audit instance detects that an audited message is the result of a retry, it sends a notification to the ServiceControl Error instance.
 
 ### Health monitoring
 

--- a/servicecontrol/audit-instances/installation-powershell.md
+++ b/servicecontrol/audit-instances/installation-powershell.md
@@ -32,7 +32,7 @@ Get-Help Get-ServiceControlAuditInstances
 ### Adding an instance
 
 ```ps
-$primaryInstanceName = "Test.ServiceControl"
+$errorInstanceName = "Test.ServiceControl"
 
 $auditInstance New-ServiceControlAuditInstance `
   -Name Test.ServiceControl.Audit `
@@ -45,23 +45,23 @@ $auditInstance New-ServiceControlAuditInstance `
   -AuditQueue audit1 `
   -AuditRetentionPeriod 10:00:00:00 `
   -ForwardAuditMessages:$false `
-  -ServiceControlQueueAddress $primaryInstanceName
+  -ServiceControlQueueAddress $errorInstanceName
 ```
 
 There are additional parameters available to set configuration options such as hostname and transport connection string.
 
 NOTE: The address of a ServiceControl instance must be provided to send notifications to.
 
-Once a ServiceControl Audit instance is created, it must be added to the primary ServiceControl instance as a remote to be included in results returned to ServiceInsight.
+Once a ServiceControl Audit instance is created, it must be added to the ServiceControl Error instance as a remote to be included in results returned to ServiceInsight.
 
 ```ps
-Add-ServiceControlRemote -Name $primaryInstanceName -RemoteInstanceAddress $auditInstance.Url
+Add-ServiceControlRemote -Name $errorInstanceName -RemoteInstanceAddress $auditInstance.Url
 ```
 
 
 ### Removing an instance
 
-Before removing a ServiceControl Audit instance, it should be removed from the primary ServiceControl instances list of remotes.
+Before removing a ServiceControl Audit instance, it should be removed from the ServiceControl Error instances list of remotes.
 
 ```ps
 Remove-ServiceControlRemote -Name "Test.ServiceControl" -RemoteInstanceAddress "http://localhost:44444/api"

--- a/servicecontrol/db-compaction.md
+++ b/servicecontrol/db-compaction.md
@@ -6,7 +6,7 @@ reviewed: 2022-10-26
 
 INFO: Compact the database only if the retention period, message throughput, or average message size have been reduced. If none of these have changed, compacting may not provide a significant reduction in database size, or it may have only a small, temporary effect.
 
-INFO: The following documentation applies to ServiceControl primary and audit instances using RavenDB 3.5 as storage option. New audit instances created with version 4.26 and onward use by default RavenDB 5 and don't need any compaction.
+INFO: The following documentation applies to ServiceControl Error and Audit instances using RavenDB 3.5 as storage option. New audit instances created with version 4.26 and onward use by default RavenDB 5 and don't need any compaction.
 
 ServiceControl's embedded RavenDB 3.5 database can be compacted in one of two ways: with the  [Extensible Storage Engine Utility (esentutl)](https://technet.microsoft.com/en-us/library/hh875546.aspx), or by using the RavenDB management portal.
 

--- a/servicecontrol/installation-powershell.md
+++ b/servicecontrol/installation-powershell.md
@@ -143,7 +143,7 @@ Remove-AuditInstance `
   -RemoveDB -RemoveLogs
 ```
 
-NOTE: All connected ServiceControl Audit instances should be removed before removing the main ServiceControl instance. Use the `Get-ServiceControlRemotes` cmdlet to find a list of connected ServiceControl Audit instances for a given ServiceControl instance.
+NOTE: All connected ServiceControl Audit instances should be removed before removing the ServiceControl Error instance. Use the `Get-ServiceControlRemotes` cmdlet to find a list of connected ServiceControl Audit instances for a given ServiceControl instance.
 
 ### Upgrading an instance
 
@@ -169,7 +169,7 @@ Additional parameters may be required when upgrading an instance to version 4. S
 
 ```ps
 Invoke-ServiceControlInstanceUpgrade `
-  -Name <Name of main instance> `
+  -Name <Name of Error instance> `
   -InstallPath <Path for Audit instance binaries> `
   -DBPath <Path for the Audit instance database> `
   -LogPath <Path for the Audit instance logs> `

--- a/servicecontrol/monitoring-instances/installation/index.md
+++ b/servicecontrol/monitoring-instances/installation/index.md
@@ -9,7 +9,7 @@ The ServiceControl installation package includes a utility to manage the install
 
 Use a Monitoring instance to vizualize [endpoint performance metrics](/monitoring/#endpoint-performance) in ServicePulse.
 
-Monitoring instances are not as [resource intensive as the error and audit instances](/servicecontrol/servicecontrol-instances/hardware.md) and can be run on the same machine as the Error instance.
+Monitoring instances are not as [resource intensive as the Error and Audit instances](/servicecontrol/servicecontrol-instances/hardware.md) and can be run on the same machine as the Error instance.
 
 ## Transport support
 

--- a/servicecontrol/monitoring-instances/installation/index.md
+++ b/servicecontrol/monitoring-instances/installation/index.md
@@ -9,7 +9,7 @@ The ServiceControl installation package includes a utility to manage the install
 
 Use a Monitoring instance to vizualize [endpoint performance metrics](/monitoring/#endpoint-performance) in ServicePulse.
 
-Monitoring instances are not as [resource intensive as the primary and audit instances](/servicecontrol/servicecontrol-instances/hardware.md) and can be run on the same machine as the primary instance.
+Monitoring instances are not as [resource intensive as the error and audit instances](/servicecontrol/servicecontrol-instances/hardware.md) and can be run on the same machine as the Error instance.
 
 ## Transport support
 

--- a/servicecontrol/servicecontrol-instances/hardware.md
+++ b/servicecontrol/servicecontrol-instances/hardware.md
@@ -8,7 +8,7 @@ This article provides recommendations and performance benchmarks to help select 
 
 ## General recommendations
 
-* A dedicated production server for installing ServiceControl instances (Primary, Audit, and Monitoring).
+* A dedicated production server for installing ServiceControl instances (Error, Audit, and Monitoring).
 * A minimum of 16 GB of RAM (excluding RAM for OS and other services).
 * 2 GHz quad core CPU or better.
 * A dedicated disk for ServiceControl databases (not the disk where the operating system is installed).

--- a/servicecontrol/servicecontrol-instances/index.md
+++ b/servicecontrol/servicecontrol-instances/index.md
@@ -10,11 +10,11 @@ ServiceControl instances collect and analyze data about the endpoints that make 
 
 NOTE: The ServiceControl HTTP API is designed for use by ServicePulse and ServiceInsight only and may change at any time. Use of this HTTP API for other purposes is discouraged.
 
-Note: In versions of ServiceControl prior to 4.13.0, saga audit plugin data can only be processed by the main ServiceControl instance using the input queue. Starting with version 4.13.0, saga audit plugin data can also be processed by a ServiceControl audit instance using the `audit` queue. The latter approach is recommended.
+Note: In versions of ServiceControl prior to 4.13.0, saga audit plugin data can only be processed by the ServiceControl Error instance using the input queue. Starting with version 4.13.0, saga audit plugin data can also be processed by a ServiceControl audit instance using the `audit` queue. The latter approach is recommended.
 
 All endpoints in the system should be [configured to send a copy of every message that is processed to a central audit queue](/nservicebus/operations/auditing.md). A ServiceControl instance consumes the messages from the audit queue and makes them available for visualization in ServiceInsight. If required, the messages may also be forwarded to an [audit log queue](/servicecontrol/errorlog-auditlog-behavior.md) for further processing.
 
-NOTE: In ServiceControl version 4 and above, messages in the audit queue are consumed by one or more separate [ServiceControl Audit](/servicecontrol/audit-instances/) instances. The main ServiceControl instance is configured to aggregate data from all connected ServiceControl Audit instances.
+NOTE: In ServiceControl version 4 and above, messages in the audit queue are consumed by one or more separate [ServiceControl Audit](/servicecontrol/audit-instances/) instances. The ServiceControl Error instance is configured to aggregate data from all connected ServiceControl Audit instances.
 
 All endpoints in the system should be [configured to send failed messages to a central error queue](/nservicebus/recoverability/) after those messages have exhausted immediate and delayed retries. A ServiceControl instance consumes the messages from the error queue and makes them available for manual retries in ServicePulse and ServiceInsight. If required, the messages may also be forwarded to an [error log queue](/servicecontrol/errorlog-auditlog-behavior.md) for further processing.
 

--- a/servicecontrol/servicecontrol-instances/index.md
+++ b/servicecontrol/servicecontrol-instances/index.md
@@ -1,5 +1,5 @@
 ---
-title: ServiceControl instances
+title: ServiceControl Error instances
 reviewed: 2021-04-20
 component: ServiceControl
 related:

--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -10,15 +10,15 @@ redirects:
 
 ## Overview
 
-One ServiceControl instance is designated as the _primary_ instance. All other ServiceControl instances are _remote_ instances. The HTTP API of the primary instance aggregates data from the primary instance and from all the remote instances. ServiceInsight and ServicePulse are configured to connect to the primary instance.
+One ServiceControl Error instance is designated as the _primary_ instance. All other ServiceControl instances are _remote_ instances. The HTTP API of the primary instance aggregates data from the primary instance and from all the remote instances. ServiceInsight and ServicePulse are configured to connect to the primary instance.
 
 NOTE: The term _remote_ refers to the fact that remote instances are run in separate processes. The primary instance and one or more remote instances can run on the same machine.
 
-In ServiceControl version 4 and later, a primary ServiceControl instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
+In ServiceControl version 4 and later, a ServiceControl Error instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
 
 ### Default deployment
 
-In ServiceControl version 4 and above, the ServiceControl Management utility creates a primary ServiceControl instance and a remote ServiceControl Audit instance.
+In ServiceControl version 4 and above, the ServiceControl Management utility creates a primary ServiceControl Error instance and a remote ServiceControl Audit instance.
 
 ```mermaid
 graph TD
@@ -157,9 +157,9 @@ class primaryA,primaryB,crossRegionPrimary ServiceControlPrimary
 class auditA,auditB ServiceControlRemote
 ```
 
-In this deployment, each region has a full ServiceControl installation with a primary instance and an Audit instance. Each region can be managed and controlled via a dedicated ServicePulse.
+In this deployment, each region has a full ServiceControl installation with a primary Error instance and an Audit instance. Each region can be managed and controlled via a dedicated ServicePulse.
 
-A new cross-region primary instance is added to allow ServiceInsight to show messages from both regions. This cross-region instance includes each region-specific primary instance as a remote allowing it to query messages from both. The cross-region instance should disable error queue management by configuring the [error queue](/servicecontrol/creating-config-file.md#transport-servicebuserrorqueue) with the value `!disable`.
+A new cross-region primary instance is added to allow ServiceInsight to show messages from both regions. This cross-region instance includes each region-specific primary Error instance as a remote allowing it to query messages from both. The cross-region instance should disable error queue management by configuring the [error queue](/servicecontrol/creating-config-file.md#transport-servicebuserrorqueue) with the value `!disable`.
 
 ### Zero downtime upgrades
 

--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -14,7 +14,7 @@ One ServiceControl Error instance is designated as the _primary_ instance. All o
 
 NOTE: The term _remote_ refers to the fact that remote instances are run in separate processes. The primary instance and one or more remote instances can run on the same machine.
 
-In ServiceControl version 4 and later, a ServiceControl Error instance can be configured with remote instances that are [ServiceControl instances](/servicecontrol/servicecontrol-instances/) and [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
+In ServiceControl version 4 and later, a ServiceControl Error instance can be configured with remote instances that are also [ServiceControl Error instances](/servicecontrol/servicecontrol-instances/) or are [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
 
 ### Default deployment
 

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -229,7 +229,7 @@ Warning: Disabling *Full-Text Search* causes text search to be unavailable in Se
 
 ## Saga audit data retention custom check failure
 
-Users who have migrated from earlier versions of ServiceControl may have historical saga audit records still in the database. This custom check will fail if there is no audit retention period set on the main instance when saga audit data exists. To resolve this issue a retention period should be configured by adding:
+Users who have migrated from earlier versions of ServiceControl may have historical saga audit records still in the database. This custom check will fail if there is no audit retention period set on the ServiceControl Error instance when saga audit data exists. To resolve this issue a retention period should be configured by adding:
 
   ```xml
   <add key="ServiceControl/AuditRetentionPeriod" value="DD:HH:MM" />

--- a/servicecontrol/upgrades/3to4/index.md
+++ b/servicecontrol/upgrades/3to4/index.md
@@ -41,7 +41,7 @@ ServiceControl version 4 introduces a new separate process to manage the audit q
 
 The original ServiceControl instance will no longer manage the audit queue. It can still contain audit messages that have already been read from the audit queue prior to upgrade. These messages will be retained until the configured audit retention period has lapsed.
 
-This split is transparent to the other components of the Particular Software Platform, which should continue to connect to the main ServiceControl instance. All queries to the main ServiceControl instance will contain results from the Audit instance as well.
+This split is transparent to the other components of the Particular Software Platform, which should continue to connect to the ServiceControl Error instance. All queries to the ServiceControl Error instance will contain results from the Audit instance as well.
 
 When upgrading a ServiceControl instance to version 4, if it is configured to manage an audit queue, a new ServiceControl Audit instance will be created as a part of the upgrade process. A user will need to supply additional information about the new ServiceControl Audit instance.
 
@@ -68,7 +68,7 @@ WARN: The settings specified must not be for the current instance, but for the a
 
 ```ps
 Invoke-ServiceControlInstanceUpgrade `
-  -Name <Name of main instance> `
+  -Name <Name of Error instance> `
   -InstallPath <Path for Audit instance binaries> `
   -DBPath <Path for the Audit instance database> `
   -LogPath <Path for the Audit instance logs> `

--- a/servicecontrol/upgrades/zero-downtime.md
+++ b/servicecontrol/upgrades/zero-downtime.md
@@ -25,7 +25,7 @@ Before doing anything, the deployment looks like this:
 graph TD
 endpoints -- send errors to --> errorQ[Error Queue]
 endpoints -- send audits to --> auditQ[Audit Queue]
-errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+errorQ -- ingested by --> sc[ServiceControl<br/>Error]
 auditQ -- ingested by --> sca[Original<br/>ServiceControl<br/>audit]
 sc -. connected to .-> sca
 sp[ServicePulse] -. connected to .-> sc
@@ -34,19 +34,19 @@ si[ServiceInsight] -. connected to .-> sc
 classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
 classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
 classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
-classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlError fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
 classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
 
 class endpoints Endpoints
 class si ServiceInsight
 class sp ServicePulse
-class sc ServiceControlPrimary
+class sc ServiceControlError
 class sca ServiceControlRemote
 ```
 
 ### Add a new audit instance
 
-Create a new audit instance, and configure it as a remote instance of the primary instance.
+Create a new ServiceControl Audit instance, and configure it as a remote instance of the ServiceControl Error instance.
 
 On the audit instance machine:
 ```ps1
@@ -64,7 +64,7 @@ $auditInstance = New-ServiceControlAuditInstance `
   -ServiceControlQueueAddress "Particular.ServiceControl"
 ```
 
-On the primary instance machine:
+On the ServiceControl Error instance machine:
 ```ps1
 Add-ServiceControlRemote `
   -Name "Particular.ServiceControl" `
@@ -77,7 +77,7 @@ After this step the installation looks like this:
 graph TD
 endpoints -- send errors to --> errorQ[Error Queue]
 endpoints -- send audits to --> auditQ[Audit Queue]
-errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+errorQ -- ingested by --> sc[ServiceControl<br/>Error]
 auditQ -- ingested by --> sca[Original<br/>ServiceControl<br/>audit]
 auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
 sc -. connected to .-> sca
@@ -88,17 +88,17 @@ si[ServiceInsight] -. connected to .-> sc
 classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
 classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
 classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
-classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlError fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
 classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
 
 class endpoints Endpoints
 class si ServiceInsight
 class sp ServicePulse
-class sc ServiceControlPrimary
+class sc ServiceControlError
 class sca,sca2 ServiceControlRemote
 ```
 
-Although both ServiceControl Audit instances ingest messages from the audit queue, each message only ends up in a single instance. The primary instance queries both transparently.
+Although both ServiceControl Audit instances ingest messages from the audit queue, each message only ends up in a single instance. The ServiceControl Error instance queries both transparently.
 
 ### Disable audit queue management on the old instance
 
@@ -129,7 +129,7 @@ After this step the installation looks like this:
 graph TD
 endpoints -- send errors to --> errorQ[Error Queue]
 endpoints -- send audits to --> auditQ[Audit Queue]
-errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+errorQ -- ingested by --> sc[ServiceControl<br/>error]
 auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
 sc -. connected to .-> sca[Original<br/>ServiceControl<br/>audit]
 sc -. connected to .-> sca2
@@ -139,17 +139,17 @@ si[ServiceInsight] -. connected to .-> sc
 classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
 classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
 classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
-classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlError fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
 classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
 
 class endpoints Endpoints
 class si ServiceInsight
 class sp ServicePulse
-class sc ServiceControlPrimary
+class sc ServiceControlError
 class sca,sca2 ServiceControlRemote
 ```
 
-The primary instance continues to query both instances but the original Audit instance no longer reads new messages.
+The ServiceControl Error instance continues to query both instances but the original Audit instance no longer reads new messages.
 
 ### Decommission the old audit instance, when it is empty
 
@@ -162,7 +162,7 @@ As the original audit instance is no longer ingesting messages, it will be empty
 
 When the `ProcessedMessages` collection is empty, the audit instance can be decomissioned.
 
-On the primary instance machine:
+On the ServiceControl Error instance machine:
 ```ps1
 Remove-ServiceControlRemote `
   -Name "Particular.ServiceControl" ` 
@@ -183,7 +183,7 @@ After this step the installation looks like this:
 graph TD
 endpoints -- send errors to --> errorQ[Error Queue]
 endpoints -- send audits to --> auditQ[Audit Queue]
-errorQ -- ingested by --> sc[ServiceControl<br/>primary]
+errorQ -- ingested by --> sc[ServiceControl<br/>error]
 auditQ -- ingested by --> sca2[New<br/>ServiceControl<br/>audit]
 sc -. connected to .-> sca2
 sp[ServicePulse] -. connected to .-> sc
@@ -192,12 +192,12 @@ si[ServiceInsight] -. connected to .-> sc
 classDef Endpoints fill:#00A3C4,stroke:#00729C,color:#FFFFFF
 classDef ServiceInsight fill:#878CAA,stroke:#585D80,color:#FFFFFF
 classDef ServicePulse fill:#409393,stroke:#205B5D,color:#FFFFFF
-classDef ServiceControlPrimary fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
+classDef ServiceControlError fill:#A84198,stroke:#92117E,color:#FFFFFF,stroke-width:4px
 classDef ServiceControlRemote fill:#A84198,stroke:#92117E,color:#FFFFFF
 
 class endpoints Endpoints
 class si ServiceInsight
 class sp ServicePulse
-class sc ServiceControlPrimary
+class sc ServiceControlError
 class sca2 ServiceControlRemote
 ```


### PR DESCRIPTION
The terms "Primary instance",  "Main instance", and "ServiceControl Error instance" all refer to the same thing. This PR aligns the language to always use the term "ServiceControl Error instance" which is consistent with the menu headings.

NOTE: This does not completely remove the use of the term primary from the [ServiceControl remote instances](https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes) page which uses the term with a different meaning.