### PR TITLE
Remove saying that we support Amazon MQ

### DIFF
--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[,7).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[,7).partial.md
@@ -1,3 +1,3 @@
-The transport is compatible with RabbitMQ broker version 3.4 or higher either self-hosted or running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) or [CloudAMQP](https://www.cloudamqp.com/).
+The transport is compatible with RabbitMQ broker version 3.4 or higher, either self-hosted or running on [CloudAMQP](https://www.cloudamqp.com/).
 
 WARNING: The transport is not compatible with RabbitMQ broker version 3.3.X and below.

--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[7,).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[7,).partial.md
@@ -1,5 +1,7 @@
-This version of the transport is compatible with RabbitMQ broker version 3.10.0 or higher either self-hosted or running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) or [CloudAMQP](https://www.cloudamqp.com/). For previous versions of RabbitMQ it is recommended to upgrade RabbitMQ or select an earlier version of the transport.
+The transport is compatible with RabbitMQ broker version 3.10.0 or higher either, self-hosted or running on [CloudAMQP](https://www.cloudamqp.com/).
 
  The `stream_queue` and `quorum_queue` [feature flags](https://www.rabbitmq.com/feature-flags.html) must be enabled because the [delay infrastructure](delayed-delivery.md) requires [at-least once dead lettering](https://blog.rabbitmq.com/posts/2022/03/at-least-once-dead-lettering/).
 
  The broker requirements can be verified with the [`delays verify`](operations-scripting.md#delays-verify) command provided by the command line tool.
+
+WARNING: Running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) is not supported because it does not support [quorum queues or streams](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/best-practices-rabbitmq.html).


### PR DESCRIPTION
It turns out that Amazon MO does not support quorum queues or streams, so we should not be saying that the RabbitMQ transport can run on it.