### PR TITLE
Add how to handle service not started to troubleshoot doc

### DIFF
--- a/nservicebus/hosting/nservicebus-host/troubleshooting.md
+++ b/nservicebus/hosting/nservicebus-host/troubleshooting.md
@@ -33,3 +33,16 @@ Verify that:
 
 1. Assembly binding redirects in the `NServiceBus.Host.exe.config` are correct and match with any entries generated in the `App.config` file.
 2. All files in the deployment (sub)folder are correct and no old files are present from previous deployments.
+
+
+## Service fails to start due to reaching the timeout period
+
+Sometimes when the server hosting  a microservice that uses NServiceBus is started, the following exception is seen in windows event viewer.
+> A timeout was reached (30000 milliseconds) while waiting for the XXX service to connect.
+>The XXX service failed to start due to the following error:
+>The service did not respond to the start or control request in a timely fashion
+
+But service is able to start without any issues after a certain period of time. This happens because during the restart, NServiceBus might still be waiting on some infrastructure to be set up before it is able to initialize. This can be mitigated by
+
+- Letting the dependencies of a service get started and running before the service.
+- Set the service to  "Automatic Delayed Start" so that these services only get the signal to start, when all other “auto” services are running. 


### PR DESCRIPTION
This PR adds another troubleshoot section on how to resolve "Service fails to start due to reaching the timeout period"