### PR TITLE
Update to XmlSerializer in endpointConfiguration in databus samples

### DIFF
--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/Program.cs
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/Program.cs
@@ -12,7 +12,7 @@ class Program
         var dataBus = endpointConfiguration.UseDataBus<AzureDataBus, SystemJsonDataBusSerializer>();
         dataBus.ConnectionString("UseDevelopmentStorage=true");
 
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseSerialization<XmlSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.EnableInstallers();
 

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Program.cs
@@ -15,7 +15,7 @@ class Program
             .Container("testcontainer")
             .UseBlobServiceClient(blobServiceClient);
 
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseSerialization<XmlSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.EnableInstallers();
 

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Program.cs
@@ -19,7 +19,7 @@ class Program
 
         #endregion
 
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseSerialization<XmlSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.EnableInstallers();
 

--- a/samples/databus/file-share-databus/Core_8/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_8/Receiver/Program.cs
@@ -1,6 +1,6 @@
+using NServiceBus;
 using System;
 using System.Threading.Tasks;
-using NServiceBus;
 
 class Program
 {
@@ -11,7 +11,7 @@ class Program
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
         dataBus.BasePath(@"..\..\..\..\storage");
         endpointConfiguration.UsePersistence<LearningPersistence>();
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseSerialization<XmlSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/databus/file-share-databus/Core_8/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_8/Sender/Program.cs
@@ -1,6 +1,6 @@
+using NServiceBus;
 using System;
 using System.Threading.Tasks;
-using NServiceBus;
 
 class Program
 {
@@ -17,7 +17,7 @@ class Program
         #endregion
 
         endpointConfiguration.UsePersistence<LearningPersistence>();
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseSerialization<XmlSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);


### PR DESCRIPTION

Change the serialization to " XmlSerializer " so that  message serialization and deserialization does not throw the following exception when using SystemJsonSerializer and sending large message through DataBusProperty<T> in NSB 8

>Unhandled exception. System.NotSupportedException: Serialization and deserialization of 'System.Type' instances are not supported. Path: $.LargePayload.Type.

Sample modified:
- [Azure Blob Storage DataBus ](https://docs.particular.net/samples/databus/blob-storage-databus/)
- [Azure Blob Storage Data Bus Cleanup with Azure Functions](https://docs.particular.net/samples/databus/blob-storage-databus-cleanup-function/)
- [File Share Data Bus Usage](https://docs.particular.net/samples/databus/file-share-databus/)