### PR TITLE
Outbox tweaks

### DIFF
--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -124,7 +124,6 @@ In phase 2, outgoing messages are sent to the messaging infrastructure and outbo
 * Because deduplication is done using `MessageId`, messages sent outside of an NServiceBus message handler (i.e. from a Web API) cannot be deduplicated unless they are sent with the same `MessageId`.
 * The outbox is _expected_ to generate duplicate messages from time to time, especially if there is unreliable communication between the endpoint and the message broker.
 * Endpoints using the outbox feature should not send messages to endpoints using DTC (see below) as the DTC-enabled endpoints treat duplicates coming from outbox-enabled endpoints as multiple messages.
-* Messages dispatched to the transport as part of the [outgoing pipeline stages](/nservicebus/pipeline/steps-stages-connectors#stages-outgoing-pipeline-stages.md) may not be batched and each message is sent in isolation.
 
 ### Transaction scope
 


### PR DESCRIPTION
Minor wording tweaks on the outbox, with two "major" changes:

* Removed the note about sending messages in the outbox dispatch phase.
  * This note was very prominently placed at the beginning of the document but touches an extreme edge case that seems to be related to extending the pipeline in very specific stages to do message dispatches. This note should be further down, probably in the `Important design considerations` section. However:
  * "outbox dispatch phase" is not something that is defined or documented anywhere. Afaik, there is no dispatch stage which even allows sending messages. So I'm not even sure what this tries to say.
* Added a link to the TX session in the note about using the outbox without an incoming message as this is exactly what the tx session is designed for.