### PR TITLE
Regular diagnostics docs do not apply to azure functions

### DIFF
--- a/nservicebus/hosting/startup-diagnostics.md
+++ b/nservicebus/hosting/startup-diagnostics.md
@@ -6,7 +6,7 @@ versions: '[7,)'
 reviewed: 2023-01-03
 ---
 
-INFO: Does not apply to Azure Function hosts. For Azure Function hosts check [Azure Function In-process diagnostics](/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) or [Azure Function Isolated Worker diagnostics](/nservicebus/hosting/azure-functions-service-bus/isolated-worker#custom-triggers-custom-diagnostics)
+INFO: Does not apply to Azure Function hosts. For Azure Function hosts check [Azure Function In-process diagnostics](/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) or [Azure Function Isolated Worker diagnostics](/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md#custom-triggers-custom-diagnostics)
 
 To make troubleshooting easier, diagnostic information is collected during endpoint startup and written to a `.diagnostics` sub-folder in the host output directory.
 

--- a/nservicebus/hosting/startup-diagnostics.md
+++ b/nservicebus/hosting/startup-diagnostics.md
@@ -6,7 +6,7 @@ versions: '[7,)'
 reviewed: 2023-01-03
 ---
 
-INFO: Does not apply to Azure Function hosts. For Azure Function hosts check [Azure Function In-process diagnostics](/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) or [Azure Function Isolated Worker diagnostics](/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md#custom-triggers-custom-diagnostics)
+INFO: This document does not apply to Azure Function hosts. For Azure Function hosts, see [Azure Function In-process diagnostics](/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) or [Azure Function Isolated Worker diagnostics](/nservicebus/hosting/azure-functions-service-bus/isolated-worker.md#custom-triggers-custom-diagnostics)
 
 To make troubleshooting easier, diagnostic information is collected during endpoint startup and written to a `.diagnostics` sub-folder in the host output directory.
 

--- a/nservicebus/hosting/startup-diagnostics.md
+++ b/nservicebus/hosting/startup-diagnostics.md
@@ -6,6 +6,8 @@ versions: '[7,)'
 reviewed: 2023-01-03
 ---
 
+INFO: Does not apply to Azure Function hosts. For Azure Function hosts check [Azure Function In-process diagnostics](/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) or [Azure Function Isolated Worker diagnostics](/nservicebus/hosting/azure-functions-service-bus/isolated-worker#custom-triggers-custom-diagnostics)
+
 To make troubleshooting easier, diagnostic information is collected during endpoint startup and written to a `.diagnostics` sub-folder in the host output directory.
 
 NOTE: By default, the output directory is called `AppDomain.CurrentDomain.BaseDirectory`, except for web applications where `App_Data` is used instead.


### PR DESCRIPTION
Based on a support case where a customer was not guided to the azure function pages.