### PR TITLE
Add note about changing headers via sendoptions

### DIFF
--- a/nservicebus/messaging/header-manipulation.md
+++ b/nservicebus/messaging/header-manipulation.md
@@ -60,7 +60,7 @@ snippet: header-outgoing-mutator
 
 ### From a handler
 
-NOTE: SendOptions is meant for your own headers, and changes to NServiceBus headers may be overwritten.
+NOTE: SendOptions is meant for custom headers - changes to NServiceBus headers may be overwritten.
 
 snippet: header-outgoing-handler
 

--- a/nservicebus/messaging/header-manipulation.md
+++ b/nservicebus/messaging/header-manipulation.md
@@ -60,6 +60,8 @@ snippet: header-outgoing-mutator
 
 ### From a handler
 
+NOTE: SendOptions is meant for your own headers, and changes to NServiceBus headers may be overwritten.
+
 snippet: header-outgoing-handler
 
 


### PR DESCRIPTION
When changing some NServiceBus headers via SendOptions, the changes are overwritten by NServiceBus (ie this applies to CorrelationId). 
Adding a note to make the user aware that this method should be used for their own custom headers.