### PR TITLE
Fix LangVersion test for Jetbrains Rider users

### DIFF
--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                     var firstLangVersionElement = xdoc.XPathSelectElement("/Project/PropertyGroup/LangVersion");
                     var value = firstLangVersionElement?.Value;
 
-                    return value == "10.0";
+                    return value is "10.0" or "10";
                 });
         }
     }


### PR DESCRIPTION
JetBrains Rider does "10" instead of "10.0" when you select version in the UI