### PR TITLE
Warn about tx session commit exceptions

### DIFF
--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -60,7 +60,7 @@ snippet: committing-transactional-session
 
 Disposing the transactional session without committing will roll back any changes that were made.
 
-Warn: The `Commit` operation may fail and throw an exception for reasons outlined in the [failure scenarios section](#failure-scenarios).
+NOTE: The `Commit` operation may fail and throw an exception for reasons outlined in the [failure scenarios section](#failure-scenarios).
 
 ### Advanced configuration
 

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -60,6 +60,8 @@ snippet: committing-transactional-session
 
 Disposing the transactional session without committing will roll back any changes that were made.
 
+Warn: The `Commit` operation may fail and throw an exception for reasons outlined in the [failure scenarios section](#failure-scenarios).
+
 ### Advanced configuration
 
 #### Maximum commit duration


### PR DESCRIPTION
The transactional session commit operation can fail for various reasons. Users should be aware that an exception is a possible and valid outcome and that this might require additional logic in the user code to determine the appropriate reaction to such a failure. This is currently barely mentioned.