### PR TITLE
Add note about OperationCanceledException.CancellationToken

### DIFF
--- a/nservicebus/cancellation-and-catching-exceptions.md
+++ b/nservicebus/cancellation-and-catching-exceptions.md
@@ -58,7 +58,7 @@ catch (Exception ex)
 }
 ```
 
-Note: Don't rely on the `OperationCanceledException.CancellationToken` property as it might not be set or a linked token is used further down the call stack. See [this blog post](https://blog.stephencleary.com/2022/03/cancellation-3-detecting-cancellation.html) for more information.
+Note: The `OperationCanceledException.CancellationToken` property is not a reliable reference to the token that caused cancellation. This property may not be set, or it may reference a linked token that was created within the called method. See [this blog post](https://blog.stephencleary.com/2022/03/cancellation-3-detecting-cancellation.html) for more information.
 
 ## Helper methods
 

--- a/nservicebus/cancellation-and-catching-exceptions.md
+++ b/nservicebus/cancellation-and-catching-exceptions.md
@@ -58,6 +58,8 @@ catch (Exception ex)
 }
 ```
 
+Note: Don't rely on the `OperationCanceledException.CancellationToken` property as it might not be set or a linked token is used further down the call stack. See [this blog post](https://blog.stephencleary.com/2022/03/cancellation-3-detecting-cancellation.html) for more information.
+
 ## Helper methods
 
 If exception handling is widespread, it may be helpful to introduce an `IsCausedBy` extension method:


### PR DESCRIPTION
As I stumbled upon this property I had to look up why this isn't being used and it seems this is some information that is worthwhile pointing out because it's not very self-explanatory.

btw. is there a reason this page isn't being linked from anywhere?