### PR TITLE
Update integrity tests

### DIFF
--- a/Snippets/ABSDataBus/ABSDataBus_3.1/ABSDataBus_3.1.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_3.1/ABSDataBus_3.1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="3.1.*" />

--- a/Snippets/ABSDataBus/ABSDataBus_4/ABSDataBus_4.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_4/ABSDataBus_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="4.*" />

--- a/Snippets/ABSDataBus/ABSDataBus_5/ABSDataBus_5.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_5/ABSDataBus_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="5.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.0.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.1.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.2.*" />

--- a/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="1.3.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="2.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="3.*" />
   </ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
@@ -5,8 +5,6 @@
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="4.*" />
   </ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/ASBS/ASBS_1.9/ASBS_1.9.csproj
+++ b/Snippets/ASBS/ASBS_1.9/ASBS_1.9.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Testing" Version="7.*" />

--- a/Snippets/ASBS/ASBS_1/ASBS_1.csproj
+++ b/Snippets/ASBS/ASBS_1/ASBS_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.7.*" />

--- a/Snippets/ASBS/ASBS_2/ASBS_2.csproj
+++ b/Snippets/ASBS/ASBS_2/ASBS_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Testing" Version="7.*" />

--- a/Snippets/ASBS/ASBS_3.2/ASBS_3.2.csproj
+++ b/Snippets/ASBS/ASBS_3.2/ASBS_3.2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />

--- a/Snippets/ASBS/ASBS_3/ASBS_3.csproj
+++ b/Snippets/ASBS/ASBS_3/ASBS_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />

--- a/Snippets/ASP/ASTP_3/ASTP_3.csproj
+++ b/Snippets/ASP/ASTP_3/ASTP_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace>ASP_3</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASP/ASTP_4/ASTP_4.csproj
+++ b/Snippets/ASP/ASTP_4/ASTP_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace>ASTP_4</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASP/ASTP_5/ASTP_5.csproj
+++ b/Snippets/ASP/ASTP_5/ASTP_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace>ASTP_5</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/ASQ/ASQN_10/ASQN_10.csproj
+++ b/Snippets/ASQ/ASQN_10/ASQN_10.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="10.*" />

--- a/Snippets/ASQ/ASQN_11/ASQN_11.csproj
+++ b/Snippets/ASQ/ASQN_11/ASQN_11.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="11.*" />

--- a/Snippets/ASQ/ASQN_12/ASQN_12.csproj
+++ b/Snippets/ASQ/ASQN_12/ASQN_12.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="12.*" />

--- a/Snippets/ASQ/ASQN_9/ASQN_9.csproj
+++ b/Snippets/ASQ/ASQN_9/ASQN_9.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="9.*" />

--- a/Snippets/ASQ/ASQ_8/ASQ_8.csproj
+++ b/Snippets/ASQ/ASQ_8/ASQ_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" Version="8.*" />

--- a/Snippets/Autofac/Autofac_7/Autofac_7.csproj
+++ b/Snippets/Autofac/Autofac_7/Autofac_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Autofac" Version="7.*" />

--- a/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
+++ b/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.BinarySerializer" Version="1.*" />

--- a/Snippets/Bridge/Bridge_2.1/Bridge_2.1.csproj
+++ b/Snippets/Bridge/Bridge_2.1/Bridge_2.1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Bridge/Bridge_2/Bridge_2.csproj
+++ b/Snippets/Bridge/Bridge_2/Bridge_2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Bridge/Bridge_2/DummyMessages.cs
+++ b/Snippets/Bridge/Bridge_2/DummyMessages.cs
@@ -1,13 +1,14 @@
-﻿namespace Messages;
-
-public class OrderPlaced
+﻿namespace Messages
 {
-}
+    public class OrderPlaced
+    {
+    }
 
-public class OrderBilled
-{
-}
+    public class OrderBilled
+    {
+    }
 
-public class OrderShipped
-{
+    public class OrderShipped
+    {
+    }
 }

--- a/Snippets/Bridge/TransportBridge_1/DummyMessages.cs
+++ b/Snippets/Bridge/TransportBridge_1/DummyMessages.cs
@@ -1,13 +1,14 @@
-﻿namespace Messages;
-
-public class OrderPlaced
+﻿namespace Messages
 {
-}
+    public class OrderPlaced
+    {
+    }
 
-public class OrderBilled
-{
-}
+    public class OrderBilled
+    {
+    }
 
-public class OrderShipped
-{
+    public class OrderShipped
+    {
+    }
 }

--- a/Snippets/Bridge/TransportBridge_1/TransportBridge_1.csproj
+++ b/Snippets/Bridge/TransportBridge_1/TransportBridge_1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Callbacks/Callbacks_3/Callbacks_3.csproj
+++ b/Snippets/Callbacks/Callbacks_3/Callbacks_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />

--- a/Snippets/Callbacks/Callbacks_4/Callbacks_4.csproj
+++ b/Snippets/Callbacks/Callbacks_4/Callbacks_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="4.*" />

--- a/Snippets/CallbacksTesting/CallbacksTesting_3/CallbacksTesting_3.csproj
+++ b/Snippets/CallbacksTesting/CallbacksTesting_3/CallbacksTesting_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks.Testing" Version="3.*" />

--- a/Snippets/CallbacksTesting/CallbacksTesting_4/CallbacksTesting_4.csproj
+++ b/Snippets/CallbacksTesting/CallbacksTesting_4/CallbacksTesting_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks.Testing" Version="4.*" />

--- a/Snippets/Castle/Castle_7/Castle_7.csproj
+++ b/Snippets/Castle/Castle_7/Castle_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CastleWindsor" Version="7.*" />

--- a/Snippets/Common/Common.csproj
+++ b/Snippets/Common/Common.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Common/Common.csproj
+++ b/Snippets/Common/Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/Snippets/CommonLogging/CommonLogging_5/CommonLogging_5.csproj
+++ b/Snippets/CommonLogging/CommonLogging_5/CommonLogging_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CommonLogging" Version="5.0.*" />

--- a/Snippets/Core/Core_7/Core_7.csproj
+++ b/Snippets/Core/Core_7/Core_7.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="2.*" />

--- a/Snippets/Core/Core_8.1/Core_8.1.csproj
+++ b/Snippets/Core/Core_8.1/Core_8.1.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />

--- a/Snippets/Core/Core_8/Core_8.csproj
+++ b/Snippets/Core/Core_8/Core_8.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />

--- a/Snippets/Core/Core_All/Core_All.csproj
+++ b/Snippets/Core/Core_All/Core_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
+++ b/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
+++ b/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
+++ b/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
+++ b/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
+++ b/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.*" />

--- a/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
+++ b/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="4.*" />

--- a/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
+++ b/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Extensions.DependencyInjection/Extensions.DependencyInjection_1/Extensions.DependencyInjection_1.csproj
+++ b/Snippets/Extensions.DependencyInjection/Extensions.DependencyInjection_1/Extensions.DependencyInjection_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.*" />

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_1/Extensions.Logging_1.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_1/Extensions.Logging_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.*" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/Snippets/FileShareDataBus/Core_7/Core_7.csproj
+++ b/Snippets/FileShareDataBus/Core_7/Core_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/FileShareDataBus/Core_8/Core_8.csproj
+++ b/Snippets/FileShareDataBus/Core_8/Core_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
+++ b/Snippets/Gateway/Gateway_3.1/Gateway_3.1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_3.2/Gateway_3.2.csproj
+++ b/Snippets/Gateway/Gateway_3.2/Gateway_3.2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_3/Gateway_3.csproj
+++ b/Snippets/Gateway/Gateway_3/Gateway_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Gateway/Gateway_4/Gateway_4.csproj
+++ b/Snippets/Gateway/Gateway_4/Gateway_4.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace>Gateway_3.2</RootNamespace>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_1/GatewayRavenDB_1.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_1/GatewayRavenDB_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_2/GatewayRavenDB_2.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_2/GatewayRavenDB_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_3/GatewayRavenDB_3.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_3/GatewayRavenDB_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway.RavenDB" Version="3.*" />

--- a/Snippets/GatewaySql/GatewaySql_1/GatewaySql_1.csproj
+++ b/Snippets/GatewaySql/GatewaySql_1/GatewaySql_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/GatewaySql/GatewaySql_2/GatewaySql_2.csproj
+++ b/Snippets/GatewaySql/GatewaySql_2/GatewaySql_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway.Sql" Version="2.*" />

--- a/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
+++ b/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
+++ b/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="3.*" />

--- a/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
+++ b/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="4.*" />

--- a/Snippets/Host/Host_8/Host_8.csproj
+++ b/Snippets/Host/Host_8/Host_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningPersistence/Core_7/Core_7.csproj
+++ b/Snippets/LearningPersistence/Core_7/Core_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningPersistence/Core_8/Core_8.csproj
+++ b/Snippets/LearningPersistence/Core_8/Core_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/LearningTransport/Core_7/Core_7.csproj
+++ b/Snippets/LearningTransport/Core_7/Core_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/LearningTransport/Core_8/Core_8.csproj
+++ b/Snippets/LearningTransport/Core_8/Core_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/Log4Net/Log4Net_3/Log4Net_3.csproj
+++ b/Snippets/Log4Net/Log4Net_3/Log4Net_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Log4Net" Version="3.*" />

--- a/Snippets/Metrics/Metrics_3/Metrics_3.csproj
+++ b/Snippets/Metrics/Metrics_3/Metrics_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Metrics/Metrics_4/Metrics_4.csproj
+++ b/Snippets/Metrics/Metrics_4/Metrics_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace />
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_3/MetricsServiceControl_3.csproj
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_3/MetricsServiceControl_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.*" />

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_4/MetricsServiceControl_4.csproj
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_4/MetricsServiceControl_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="4.*" />

--- a/Snippets/MsmqPersistence/MsmqTransport_1/MsmqTransport_1.csproj
+++ b/Snippets/MsmqPersistence/MsmqTransport_1/MsmqTransport_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqPersistence/MsmqTransport_2/MsmqTransport_2.csproj
+++ b/Snippets/MsmqPersistence/MsmqTransport_2/MsmqTransport_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_1.2/MsmqTransport_1.2.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_1.2/MsmqTransport_1.2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_1/MsmqTransport_1.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_1/MsmqTransport_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_2/MsmqTransport_2.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_2/MsmqTransport_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />

--- a/Snippets/MsmqTransport/MsmqTransport_All/MsmqTransport_All.csproj
+++ b/Snippets/MsmqTransport/MsmqTransport_All/MsmqTransport_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.*" />

--- a/Snippets/NHibernate/NHibernate_8.4/NHibernate_8.4.csproj
+++ b/Snippets/NHibernate/NHibernate_8.4/NHibernate_8.4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.4.*" />

--- a/Snippets/NHibernate/NHibernate_8.5/NHibernate_8.5.csproj
+++ b/Snippets/NHibernate/NHibernate_8.5/NHibernate_8.5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.5.*" />

--- a/Snippets/NHibernate/NHibernate_8/NHibernate_8.csproj
+++ b/Snippets/NHibernate/NHibernate_8/NHibernate_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="8.*" />

--- a/Snippets/NHibernate/NHibernate_9/NHibernate_9.csproj
+++ b/Snippets/NHibernate/NHibernate_9/NHibernate_9.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="9.*" />

--- a/Snippets/NLog/Extensions.Logging_1/Extensions.Logging_1.csproj
+++ b/Snippets/NLog/Extensions.Logging_1/Extensions.Logging_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.*" />

--- a/Snippets/NLog/Extensions.Logging_2/Extensions.Logging_2.csproj
+++ b/Snippets/NLog/Extensions.Logging_2/Extensions.Logging_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/Snippets/NLog/NLog_3/NLog_3.csproj
+++ b/Snippets/NLog/NLog_3/NLog_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NLog" Version="3.*" />

--- a/Snippets/Newtonsoft/Newtonsoft_2.4/Newtonsoft_2.4.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_2.4/Newtonsoft_2.4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Newtonsoft/Newtonsoft_2/Newtonsoft_2.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_2/Newtonsoft_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Newtonsoft/Newtonsoft_3/Newtonsoft_3.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_3/Newtonsoft_3.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />

--- a/Snippets/Ninject/Ninject_7/Ninject_7.csproj
+++ b/Snippets/Ninject/Ninject_7/Ninject_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/NonDurablePersistence/Core_7.2/Core_7.2.csproj
+++ b/Snippets/NonDurablePersistence/Core_7.2/Core_7.2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.2.0" />

--- a/Snippets/NonDurablePersistence/Core_7/Core_7.csproj
+++ b/Snippets/NonDurablePersistence/Core_7/Core_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/NonDurablePersistence/NonDurablePersistence_1/NonDurablePersistence_1.csproj
+++ b/Snippets/NonDurablePersistence/NonDurablePersistence_1/NonDurablePersistence_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <RootNamespace>Core_8</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/PerfCounters/PerfCounters_3/PerfCounters_3.csproj
+++ b/Snippets/PerfCounters/PerfCounters_3/PerfCounters_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="3.0.0" />

--- a/Snippets/PerfCounters/PerfCounters_4/PerfCounters_4.csproj
+++ b/Snippets/PerfCounters/PerfCounters_4/PerfCounters_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="4.0.0" />

--- a/Snippets/PerfCounters/PerfCounters_5/PerfCounters_5.csproj
+++ b/Snippets/PerfCounters/PerfCounters_5/PerfCounters_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="5.*" />

--- a/Snippets/PlatformConnector/PlatformConnector_1/PlatformConnector_1.csproj
+++ b/Snippets/PlatformConnector/PlatformConnector_1/PlatformConnector_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ServicePlatform.Connector" Version="1.0.0" />

--- a/Snippets/PlatformConnector/PlatformConnector_2/PlatformConnector_2.csproj
+++ b/Snippets/PlatformConnector/PlatformConnector_2/PlatformConnector_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ServicePlatform.Connector" Version="2.*" />

--- a/Snippets/PlatformSample/PlatformSample_2/PlatformSample_2.csproj
+++ b/Snippets/PlatformSample/PlatformSample_2/PlatformSample_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_2/PropertyEncryption_2.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_2/PropertyEncryption_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_3/PropertyEncryption_3.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_3/PropertyEncryption_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="3.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_4/PropertyEncryption_4.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_4/PropertyEncryption_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="4.*" />

--- a/Snippets/PropertyEncryption/PropertyEncryption_All/PropertyEncryption_All.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_All/PropertyEncryption_All.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Rabbit/Rabbit_6/Rabbit_6.csproj
+++ b/Snippets/Rabbit/Rabbit_6/Rabbit_6.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="6.*" />

--- a/Snippets/Rabbit/Rabbit_7/Rabbit_7.csproj
+++ b/Snippets/Rabbit/Rabbit_7/Rabbit_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="7.*" />

--- a/Snippets/Rabbit/Rabbit_8/Rabbit_8.csproj
+++ b/Snippets/Rabbit/Rabbit_8/Rabbit_8.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />

--- a/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
+++ b/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/Raven/Raven_5/Raven_5.csproj
+++ b/Snippets/Raven/Raven_5/Raven_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="5.*" />

--- a/Snippets/Raven/Raven_6.1/Raven_6.1.csproj
+++ b/Snippets/Raven/Raven_6.1/Raven_6.1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.1.0" />

--- a/Snippets/Raven/Raven_6.3/Raven_6.3.csproj
+++ b/Snippets/Raven/Raven_6.3/Raven_6.3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.3.0" />

--- a/Snippets/Raven/Raven_6.4/Raven_6.4.csproj
+++ b/Snippets/Raven/Raven_6.4/Raven_6.4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.4.0" />

--- a/Snippets/Raven/Raven_6.5/Raven_6.5.csproj
+++ b/Snippets/Raven/Raven_6.5/Raven_6.5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.5.0" />

--- a/Snippets/Raven/Raven_6/Raven_6.csproj
+++ b/Snippets/Raven/Raven_6/Raven_6.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="6.0.0" />

--- a/Snippets/Raven/Raven_7/Raven_7.csproj
+++ b/Snippets/Raven/Raven_7/Raven_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="7.*" />

--- a/Snippets/Raven/Raven_8/Raven_8.csproj
+++ b/Snippets/Raven/Raven_8/Raven_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="8.*" />

--- a/Snippets/Raven/Raven_All/Raven_All.csproj
+++ b/Snippets/Raven/Raven_All/Raven_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.*" />

--- a/Snippets/RawMessaging/Core_8/Core_8.csproj
+++ b/Snippets/RawMessaging/Core_8/Core_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/RawMessaging/RawMessaging_3/RawMessaging_3.csproj
+++ b/Snippets/RawMessaging/RawMessaging_3/RawMessaging_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Raw" Version="3.*" />

--- a/Snippets/Router/Router_2/Router_2.csproj
+++ b/Snippets/Router/Router_2/Router_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Router" Version="2.*" />

--- a/Snippets/SCTransportAdapter/SCTransportAdapter_2/SCTransportAdapter_2.csproj
+++ b/Snippets/SCTransportAdapter/SCTransportAdapter_2/SCTransportAdapter_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.*" />

--- a/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
+++ b/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
@@ -4,7 +4,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <RootNamespace />
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="0.6.0" />

--- a/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
+++ b/Snippets/SQSLambda/SQSLambda_0/SQSLambda_0.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <RootNamespace />
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="0.6.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>

--- a/Snippets/SQSLambda/SQSLambda_0/Usage.cs
+++ b/Snippets/SQSLambda/SQSLambda_0/Usage.cs
@@ -12,7 +12,7 @@ class Usage
     static readonly AwsLambdaSQSEndpoint endpoint = new AwsLambdaSQSEndpoint(context =>
     {
         var endpointConfiguration = new AwsLambdaSQSEndpointConfiguration("AwsLambdaSQSTrigger");
-        
+
         //customize configuration here
 
         return endpointConfiguration;
@@ -92,7 +92,7 @@ class Usage
         #region aws-custom-serializer
 
         endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
-        
+
         #endregion
     }
 
@@ -103,7 +103,7 @@ class Usage
         var transport = endpointConfiguration.Transport;
         var routing = transport.Routing();
         routing.RouteToEndpoint(typeof(ACommand), "<destination>");
-        
+
         #endregion
     }
 

--- a/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
+++ b/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <RootNamespace />
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.*" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.*" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.*" />
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="1.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.*" />
   </ItemGroup>

--- a/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
+++ b/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
@@ -4,7 +4,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <RootNamespace />
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="1.*" />

--- a/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
+++ b/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="3.*" />

--- a/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
+++ b/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
+++ b/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="4.*" />

--- a/Snippets/ServiceControl/ServiceControl_All/ServiceControl_All.csproj
+++ b/Snippets/ServiceControl/ServiceControl_All/ServiceControl_All.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/ServiceControlContracts/ServiceControlContracts_1/ServiceControlContracts_1.csproj
+++ b/Snippets/ServiceControlContracts/ServiceControlContracts_1/ServiceControlContracts_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.*" />

--- a/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_2/ServiceFabricPersistence_2.csproj
+++ b/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_2/ServiceFabricPersistence_2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.ServiceFabric" Version="2.*" />

--- a/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_3/ServiceFabricPersistence_3.csproj
+++ b/Snippets/ServiceFabricPersistence/ServiceFabricPersistence_3/ServiceFabricPersistence_3.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.ServiceFabric" Version="3.*" />

--- a/Snippets/ServiceInsight/ServiceInsight_All/ServiceInsight_All.csproj
+++ b/Snippets/ServiceInsight/ServiceInsight_All/ServiceInsight_All.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/ServicePulse/ServicePulse_All/ServicePulse_All.csproj
+++ b/Snippets/ServicePulse/ServicePulse_All/ServicePulse_All.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Spring/Spring_7/Spring_7.csproj
+++ b/Snippets/Spring/Spring_7/Spring_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Spring" Version="7.*" />

--- a/Snippets/Spring/Spring_8/Spring_8.csproj
+++ b/Snippets/Spring/Spring_8/Spring_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Spring" Version="8.*" />

--- a/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_4/SqlPersistence_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_5/SqlPersistence_5.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_5/SqlPersistence_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_6/SqlPersistence_6.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_6/SqlPersistence_6.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_7/SqlPersistence_7.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_7/SqlPersistence_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MySql.Data" Version="6.*" />

--- a/Snippets/SqlTransport/SqlTransport_6.1/SqlTransport_6.1.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6.1/SqlTransport_6.1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.1.*" />

--- a/Snippets/SqlTransport/SqlTransport_6.2/SqlTransport_6.2.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6.2/SqlTransport_6.2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.2.*" />

--- a/Snippets/SqlTransport/SqlTransport_6.3/SqlTransport_6.3.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6.3/SqlTransport_6.3.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>SqlTransport_6._3</RootNamespace>
-    <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Snippets/SqlTransport/SqlTransport_6/SqlTransport_6.csproj
+++ b/Snippets/SqlTransport/SqlTransport_6/SqlTransport_6.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.0.*" />

--- a/Snippets/SqlTransport/SqlTransport_7/SqlTransport_7.csproj
+++ b/Snippets/SqlTransport/SqlTransport_7/SqlTransport_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="7.*" />

--- a/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
+++ b/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/Sqs/Sqs_4/Sqs_4.csproj
+++ b/Snippets/Sqs/Sqs_4/Sqs_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AmazonSQS" Version="4.*" />

--- a/Snippets/Sqs/Sqs_5.3/Sqs_5.3.csproj
+++ b/Snippets/Sqs/Sqs_5.3/Sqs_5.3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_5.7/Sqs_5.7.csproj
+++ b/Snippets/Sqs/Sqs_5.7/Sqs_5.7.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_5/Sqs_5.csproj
+++ b/Snippets/Sqs/Sqs_5/Sqs_5.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_6.1/Sqs_6.1.csproj
+++ b/Snippets/Sqs/Sqs_6.1/Sqs_6.1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_6/Sqs_6.csproj
+++ b/Snippets/Sqs/Sqs_6/Sqs_6.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Configurations>Debug</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Sqs/Sqs_All/Sqs_All.csproj
+++ b/Snippets/Sqs/Sqs_All/Sqs_All.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.csproj" />

--- a/Snippets/StructureMap/StructureMap_7/StructureMap_7.csproj
+++ b/Snippets/StructureMap/StructureMap_7/StructureMap_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.StructureMap" Version="7.*" />

--- a/Snippets/SystemJson/Core_8.1/Core_8.1.csproj
+++ b/Snippets/SystemJson/Core_8.1/Core_8.1.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.1.*" />

--- a/Snippets/Templates/Templates_1/Templates_1.csproj
+++ b/Snippets/Templates/Templates_1/Templates_1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Templates/Templates_1/Templates_1.csproj
+++ b/Snippets/Templates/Templates_1/Templates_1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Snippets/Templates/Templates_2/Templates_2.csproj
+++ b/Snippets/Templates/Templates_2/Templates_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Templates/Templates_2/Templates_2.csproj
+++ b/Snippets/Templates/Templates_2/Templates_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/Snippets/Templates/Templates_3/Templates_3.csproj
+++ b/Snippets/Templates/Templates_3/Templates_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Templates/Templates_3/Templates_3.csproj
+++ b/Snippets/Templates/Templates_3/Templates_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/Snippets/Templates/Templates_4/Templates_4.csproj
+++ b/Snippets/Templates/Templates_4/Templates_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />

--- a/Snippets/Templates/Templates_4/Templates_4.csproj
+++ b/Snippets/Templates/Templates_4/Templates_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Testing/Testing_7.4/Testing_7.4.csproj
+++ b/Snippets/Testing/Testing_7.4/Testing_7.4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/Snippets/Testing/Testing_7/Testing_7.csproj
+++ b/Snippets/Testing/Testing_7/Testing_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/Testing/Testing_8/Testing_8.csproj
+++ b/Snippets/Testing/Testing_8/Testing_8.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />

--- a/Snippets/TransactionalSession.AzureTable/AzureTableTS_3/AzureTableTS_3.csproj
+++ b/Snippets/TransactionalSession.AzureTable/AzureTableTS_3/AzureTableTS_3.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.AzureTable/AzureTableTS_4/AzureTableTS_4.csproj
+++ b/Snippets/TransactionalSession.AzureTable/AzureTableTS_4/AzureTableTS_4.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Persistence.AzureTable.TransactionalSession" Version="4.*" />

--- a/Snippets/TransactionalSession.CosmosDB/CosmosTS_1/CosmosTS_1.csproj
+++ b/Snippets/TransactionalSession.CosmosDB/CosmosTS_1/CosmosTS_1.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.CosmosDB/CosmosTS_2/CosmosTS_2.csproj
+++ b/Snippets/TransactionalSession.CosmosDB/CosmosTS_2/CosmosTS_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Persistence.CosmosDB.TransactionalSession" Version="2.*" />

--- a/Snippets/TransactionalSession.DynamoDB/DynamoTS_1/DynamoTS_1.csproj
+++ b/Snippets/TransactionalSession.DynamoDB/DynamoTS_1/DynamoTS_1.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_3/MongoTS_3.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_3/MongoTS_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Storage.MongoDB.TransactionalSession" Version="3.*" />

--- a/Snippets/TransactionalSession.NHibernate/NHibernateTS_8/NHibernateTS_8.csproj
+++ b/Snippets/TransactionalSession.NHibernate/NHibernateTS_8/NHibernateTS_8.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.NHibernate/NHibernateTS_9/NHibernateTS_9.csproj
+++ b/Snippets/TransactionalSession.NHibernate/NHibernateTS_9/NHibernateTS_9.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.NHibernate.TransactionalSession" Version="9.*" />

--- a/Snippets/TransactionalSession.RavenDB/RavenTS_7/RavenTS_7.csproj
+++ b/Snippets/TransactionalSession.RavenDB/RavenTS_7/RavenTS_7.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.RavenDB/RavenTS_8/RavenTS_8.csproj
+++ b/Snippets/TransactionalSession.RavenDB/RavenTS_8/RavenTS_8.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.RavenDB.TransactionalSession" Version="8.*" />

--- a/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_6/SqlPersistenceTS_6.csproj
+++ b/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_6/SqlPersistenceTS_6.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_7/SqlPersistenceTS_7.csproj
+++ b/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_7/SqlPersistenceTS_7.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="7.*" />

--- a/Snippets/TransactionalSession/TransactionalSession_1/TransactionalSession_1.csproj
+++ b/Snippets/TransactionalSession/TransactionalSession_1/TransactionalSession_1.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession/TransactionalSession_2/TransactionalSession_2.csproj
+++ b/Snippets/TransactionalSession/TransactionalSession_2/TransactionalSession_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.TransactionalSession" Version="2.*" />

--- a/Snippets/UniformSession/UniformSession_2/UniformSession_2.csproj
+++ b/Snippets/UniformSession/UniformSession_2/UniformSession_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="2.*" />

--- a/Snippets/UniformSession/UniformSession_3/UniformSession_3.csproj
+++ b/Snippets/UniformSession/UniformSession_3/UniformSession_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="3.*" />

--- a/Snippets/UniformSessionTesting/UniformSessionTesting_2/UniformSessionTesting_2.csproj
+++ b/Snippets/UniformSessionTesting/UniformSessionTesting_2/UniformSessionTesting_2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="2.*" />

--- a/Snippets/UniformSessionTesting/UniformSessionTesting_3/UniformSessionTesting_3.csproj
+++ b/Snippets/UniformSessionTesting/UniformSessionTesting_3/UniformSessionTesting_3.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="3.*" />

--- a/Snippets/Unity/Unity_10/Unity_10.csproj
+++ b/Snippets/Unity/Unity_10/Unity_10.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Unity" Version="10.*" />

--- a/Snippets/Unity/Unity_9/Unity_9.csproj
+++ b/Snippets/Unity/Unity_9/Unity_9.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Unity" Version="9.*" />

--- a/Snippets/Wcf/Wcf_2/Wcf_2.csproj
+++ b/Snippets/Wcf/Wcf_2/Wcf_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="3.*" />

--- a/Snippets/Wormhole/Wormhole_2/Wormhole_2.csproj
+++ b/Snippets/Wormhole/Wormhole_2/Wormhole_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/Xml/Core_7/Core_7.csproj
+++ b/Snippets/Xml/Core_7/Core_7.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core7</RootNamespace>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/Snippets/Xml/Core_8/Core_8.csproj
+++ b/Snippets/Xml/Core_8/Core_8.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <RootNamespace>Core8</RootNamespace>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/Snippets/mongodb/MongoDB_2/MongoDB_2.csproj
+++ b/Snippets/mongodb/MongoDB_2/MongoDB_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Storage.MongoDB" Version="2.*" />

--- a/Snippets/mongodb/MongoDB_3/MongoDB_3.csproj
+++ b/Snippets/mongodb/MongoDB_3/MongoDB_3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Storage.MongoDB" Version="3.*" />

--- a/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_7/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_7/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_8/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/hosting/docker/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/index.md
+++ b/samples/index.md
@@ -40,10 +40,6 @@ Unless otherwise specified (by an individual sample) the following are the defau
 
 Most samples are made available for multiple frameworks, available through a dropdown menu on the download button. Each framework has its own requirements for what version of Visual Studio is supported. For instance, .NET 6 requires at least Visual Studio 2022.
 
-### C# language level
-
-All samples target **C# 10.0** to take advantage of the new language features. If any help is required in converting to earlier versions of C#, [raise an issue](https://github.com/Particular/docs.particular.net/issues).
-
 ### ConfigureAwait
 
 Samples only call `ConfigureAwait(bool)` when it is required. If any code is copied from samples, appropriate calls to `ConfigureAwait(bool)` should be added.

--- a/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/IntegrityTests/Infrastructure/TestRunner.cs
+++ b/tests/IntegrityTests/Infrastructure/TestRunner.cs
@@ -10,15 +10,15 @@ namespace IntegrityTests
 {
     public class TestRunner
     {
-        private string glob;
-        private string errorMessage;
-        private List<Regex> ignoreRegexes;
+        private readonly string glob;
+        private readonly string errorMessage;
+        private readonly List<Regex> ignoreRegexes;
 
         public TestRunner(string glob, string errorMessage)
         {
             this.glob = glob;
             this.errorMessage = errorMessage;
-            ignoreRegexes = new List<Regex>();
+            ignoreRegexes = [];
             IgnoreRegex(@"\\IntegrityTests\\");
         }
 
@@ -54,7 +54,7 @@ namespace IntegrityTests
 
         public TestRunner IgnoreRegex(string pattern, RegexOptions regexOptions = RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)
         {
-            if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 pattern = pattern.Replace("\\\\", "/");
             }

--- a/tests/IntegrityTests/Infrastructure/TestSetup.cs
+++ b/tests/IntegrityTests/Infrastructure/TestSetup.cs
@@ -25,7 +25,7 @@ namespace IntegrityTests
             var currentDirectory = TestContext.CurrentContext.TestDirectory;
             DocsRootPath = Path.GetFullPath(Path.Combine(currentDirectory, "..", "..", "..", "..", ".."));
 
-            RootDirectories = new[] { DocsRootPath };
+            RootDirectories = [DocsRootPath];
 
             var componentsYamlPath = Path.Combine(DocsRootPath, "components", "components.yaml");
             var componentsText = File.ReadAllText(componentsYamlPath);
@@ -36,7 +36,7 @@ namespace IntegrityTests
             var allData = deserializer.Deserialize<List<ComponentMetadata>>(componentsText);
             ComponentMetadata = allData.ToDictionary(m => m.Key, StringComparer.OrdinalIgnoreCase);
 
-            NugetAliases = new Dictionary<string, string>();
+            NugetAliases = [];
             var nugetAliasesPath = Path.Combine(DocsRootPath, "components", "nugetAlias.txt");
             var nugetAliasesText = File.ReadLines(nugetAliasesPath);
             foreach (var aliasLine in nugetAliasesText)

--- a/tests/IntegrityTests/IntegrityTests.csproj
+++ b/tests/IntegrityTests/IntegrityTests.csproj
@@ -1,14 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="9.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.4.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0-release-23468-02" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.7.0" />
+    <PackageReference Include="YamlDotNet" Version="13.7.0" />
   </ItemGroup>
 </Project>

--- a/tests/IntegrityTests/OnlyOneNugetConfig.cs
+++ b/tests/IntegrityTests/OnlyOneNugetConfig.cs
@@ -1,12 +1,6 @@
-﻿using NUnit.Framework;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Xml;
-using System.Xml.Linq;
-using System.Xml.XPath;
+using NUnit.Framework;
 
 namespace IntegrityTests
 {

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net7.0", "net6.0", "net48", "netstandard2.0"];
+        public static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net7.0", "net6.0", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net7.0", "net6.0", "netcoreapp3.1", "net48", "netstandard2.0"];
+        static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net7.0", "net6.0", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -96,5 +96,26 @@ namespace IntegrityTests
                     return true;
                 });
         }
+
+        [Test]
+        public void SnippetsShouldNotBeMultiTargeted()
+        {
+            new TestRunner("*.csproj", "Snippets projects should not be multi-targeted")
+                .IgnoreSamples()
+                .IgnoreTutorials()
+                .Run(projectFilePath =>
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        return true;
+                    }
+
+                    var firstTargetFrameworksElement = xdoc.XPathSelectElement("/Project/PropertyGroup/TargetFrameworks");
+
+                    return firstTargetFrameworksElement is null;
+
+                });
+        }
     }
 }

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -9,6 +9,8 @@ namespace IntegrityTests
 {
     public class ProjectFrameworks
     {
+        static readonly char[] separator = [';'];
+
         [Test]
         public void TargetFrameworkElementShouldAgreeWithFrameworkCount()
         {
@@ -28,14 +30,14 @@ namespace IntegrityTests
                         return true;
                     }
 
-                    var tfmList = firstTargetFrameworksElement.Value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    var tfmList = firstTargetFrameworksElement.Value.Split(separator, StringSplitOptions.RemoveEmptyEntries);
 
                     return tfmList.Length > 1;
                 });
         }
 
-        static readonly string[] sdkProjectAllowedTfmList = new[] { "net8.0", "net7.0", "net6.0", "netcoreapp3.1", "net48", "netstandard2.0" };
-        static readonly string[] nonSdkProjectAllowedFrameworkList = new[] { "v4.8" };
+        static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net7.0", "net6.0", "netcoreapp3.1", "net48", "netstandard2.0"];
+        static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]
         public void RestrictTargetFrameworks()

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -7,6 +7,26 @@ namespace IntegrityTests
     public class ProjectLangVersion
     {
         [Test]
+        public void SnippetsShouldNotHaveLangVersionProperty()
+        {
+            new TestRunner("*.csproj", "Snippets projects should not have a LangVersion property")
+                .IgnoreSamples()
+                .IgnoreTutorials()
+                .Run(projectFilePath =>
+                {
+                    var xdoc = XDocument.Load(projectFilePath);
+                    if (xdoc.Root.Attribute("xmlns") != null)
+                    {
+                        return true;
+                    }
+
+                    var firstLangVersionElement = xdoc.XPathSelectElement("/Project/PropertyGroup/LangVersion");
+
+                    return firstLangVersionElement is null;
+                });
+        }
+
+        [Test]
         public void ShouldUseLangVersion10()
         {
             // Also reflected in https://docs.particular.net/samples/#technology-choices-c-language-level

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -1,6 +1,6 @@
-﻿using NUnit.Framework;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using System.Xml.XPath;
+using NUnit.Framework;
 
 namespace IntegrityTests
 {

--- a/tests/IntegrityTests/ReferenceVersions.cs
+++ b/tests/IntegrityTests/ReferenceVersions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;

--- a/tests/IntegrityTests/SolutionStructure.cs
+++ b/tests/IntegrityTests/SolutionStructure.cs
@@ -8,11 +8,11 @@ namespace IntegrityTests
     public class SolutionStructure
     {
         [Test]
-        [Ignore("Ignored in favor of sample versioning which ships 2 solutions to showcase how contracts may evolve")]
         public void OneSolutionPerDirectory()
         {
             var directoriesWithMoreThanOneSolution = Directory.GetFiles(TestSetup.DocsRootPath, "*.sln", SearchOption.AllDirectories)
-                .Select(slnPath => Path.GetDirectoryName(slnPath))
+                .Select(Path.GetDirectoryName)
+                .Where(dirPath => !dirPath.Contains(Path.Combine("samples", "versioning"))) //Exception for the Versioning sample
                 .GroupBy(dirPath => dirPath, StringComparer.OrdinalIgnoreCase)
                 .Where(group => group.Count() > 1)
                 .Select(group => group.Key)
@@ -28,7 +28,7 @@ namespace IntegrityTests
         public void OneProjectPerDirectory()
         {
             var directoriesWithMoreThanOneProject = Directory.GetFiles(TestSetup.DocsRootPath, "*.*proj", SearchOption.AllDirectories)
-                .Select(projPath => Path.GetDirectoryName(projPath))
+                .Select(Path.GetDirectoryName)
                 .GroupBy(dirPath => dirPath, StringComparer.OrdinalIgnoreCase)
                 .Where(group => group.Count() > 1)
                 .Select(group => group.Key)

--- a/tests/IntegrityTests/SolutionStructure.cs
+++ b/tests/IntegrityTests/SolutionStructure.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Xml;
-using System.Xml.Linq;
-using System.Xml.XPath;
 using NUnit.Framework;
 
 namespace IntegrityTests

--- a/tests/IntegrityTests/UpgradeGuides.cs
+++ b/tests/IntegrityTests/UpgradeGuides.cs
@@ -9,9 +9,9 @@ namespace IntegrityTests
 {
     public class UpgradeGuides
     {
-        static IDeserializer deserializer;
-        static Regex yamlSeparatorRegex = new Regex("---");
-        static string upgradesPathPart = $"{Path.DirectorySeparatorChar}upgrades{Path.DirectorySeparatorChar}";
+        static readonly IDeserializer deserializer;
+        static readonly Regex yamlSeparatorRegex = new("---");
+        static readonly string upgradesPathPart = $"{Path.DirectorySeparatorChar}upgrades{Path.DirectorySeparatorChar}";
 
         static UpgradeGuides()
         {

--- a/tests/IntegrityTests/ValidateAliases.cs
+++ b/tests/IntegrityTests/ValidateAliases.cs
@@ -8,10 +8,10 @@ using NUnit.Framework;
 
 namespace IntegrityTests
 {
-    public class ValidateAliasses
+    public class ValidateAliases
     {
         [Test]
-        public void ValidateAliassesVersionMatchesPackageReferenceVersion()
+        public void ValidateAliasesVersionMatchesPackageReferenceVersion()
         {
             new TestRunner("*.csproj", "Found alias version not matching package reference version. i.e. Project in `Core_8` should reference NServiceBus 8.*, while `Core_8.1` should reference NServiceBus 8.1.*")
                 .Run(projPath =>

--- a/tests/IntegrityTests/ValidateAliasses.cs
+++ b/tests/IntegrityTests/ValidateAliasses.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
@@ -54,7 +52,7 @@ namespace IntegrityTests
                 });
         }
 
-        (string path, string componentName, string version) GetVersionedAliasPath(string path)
+        static (string path, string componentName, string version) GetVersionedAliasPath(string path)
         {
             var dirPath = Path.GetDirectoryName(path);
 
@@ -64,8 +62,8 @@ namespace IntegrityTests
                 if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d+)?)$"))
                 {
                     var underScoreIndex = dirName.LastIndexOf('_');
-                    var componentName = dirName.Substring(0, underScoreIndex);
-                    return (dirPath, componentName, dirName.Substring(underScoreIndex + 1));
+                    var componentName = dirName[..underScoreIndex];
+                    return (dirPath, componentName, dirName[(underScoreIndex + 1)..]);
                 }
 
                 dirPath = Path.GetDirectoryName(dirPath);

--- a/tests/IntegrityTests/ValidatePartialRanges.cs
+++ b/tests/IntegrityTests/ValidatePartialRanges.cs
@@ -1,8 +1,8 @@
-﻿using NuGet.Versioning;
-using NUnit.Framework;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NuGet.Versioning;
+using NUnit.Framework;
 
 
 namespace IntegrityTests

--- a/tests/IntegrityTests/ValidatePrerelease.cs
+++ b/tests/IntegrityTests/ValidatePrerelease.cs
@@ -124,7 +124,7 @@ namespace IntegrityTests
                 });
         }
 
-        private (string path, string componentName) GetVersionedAliasPath(string path)
+        private static (string path, string componentName) GetVersionedAliasPath(string path)
         {
             var dirPath = Path.GetDirectoryName(path);
 
@@ -133,7 +133,7 @@ namespace IntegrityTests
                 var dirName = Path.GetFileName(dirPath);
                 if (Regex.IsMatch(dirName, @"_(All|\d+(\.\d+)?)$"))
                 {
-                    var componentName = dirName.Substring(0, dirName.IndexOf('_'));
+                    var componentName = dirName[..dirName.IndexOf('_')];
                     return (dirPath, componentName);
                 }
 
@@ -149,7 +149,7 @@ namespace IntegrityTests
 
             return packageRefs
                 .Where(pkgRef => packageNames.Contains(pkgRef.Attribute("Include").Value, StringComparer.OrdinalIgnoreCase))
-                .Any(pkgRef => pkgRef.Attribute("Version").Value.Contains("-"));
+                .Any(pkgRef => pkgRef.Attribute("Version").Value.Contains('-'));
         }
 
         private static bool HasPrereleasePackagesNotLockedToSpecificVersion(string projectPath, IEnumerable<string> packageNames)
@@ -157,8 +157,8 @@ namespace IntegrityTests
             var packageRefs = QueryPackageRefs(projectPath);
 
             return packageRefs
-                .Where(pkgRef => packageNames.Contains(pkgRef.Attribute("Include").Value, StringComparer.OrdinalIgnoreCase) && pkgRef.Attribute("Version").Value.Contains("-"))
-                .Any(pkgRef =>  pkgRef.Attribute("Version").Value.Contains("*"));
+                .Where(pkgRef => packageNames.Contains(pkgRef.Attribute("Include").Value, StringComparer.OrdinalIgnoreCase) && pkgRef.Attribute("Version").Value.Contains('-'))
+                .Any(pkgRef => pkgRef.Attribute("Version").Value.Contains('*'));
         }
 
         static IEnumerable<XElement> QueryPackageRefs(string projectPath)

--- a/tests/IntegrityTests/ValidateReferencedPartials.cs
+++ b/tests/IntegrityTests/ValidateReferencedPartials.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.VisualBasic;
-using NUnit.Framework;
-using NUnit.Framework.Internal;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace IntegrityTests
 {
@@ -15,7 +13,7 @@ namespace IntegrityTests
     {
         [Test]
         public void ReferencedPartialsAreUsed()
-        {           
+        {
             var allErrors = new Dictionary<string, List<string>>();
             var allPartials = Directory.GetFiles(TestSetup.DocsRootPath, "*.partial.md", SearchOption.AllDirectories);
             var allArticles = Directory.GetFiles(TestSetup.DocsRootPath, "*.md", SearchOption.AllDirectories).Except(allPartials);
@@ -35,14 +33,14 @@ namespace IntegrityTests
                 var matches = Regex.Matches(text, searchPattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
                 var errors = new List<string>();
 
-                foreach (Match match in matches)
+                foreach (var match in matches.Cast<Match>())
                 {
                     var partialName = Regex.Replace(match.Value, replacePattern, "").Trim();
 
                     if (!allPartials.Any(x => x.Contains(fileName + "_" + partialName, StringComparison.OrdinalIgnoreCase)))
                     {
                         errors.Add($"    - '{match.Value}' at position ({match.Index})");
-                    }                
+                    }
                 }
 
                 if (errors.Count > 0)
@@ -53,7 +51,7 @@ namespace IntegrityTests
 
             if (allErrors.Count > 0)
             {
-                StringBuilder stringBuilder = new StringBuilder();
+                StringBuilder stringBuilder = new();
                 stringBuilder.Append($"Found ({allErrors.Count}) markdown file(s) that had references to partials that do not have a corresponding partial file to be used. Here are the file paths and partial references that were not used.\r\n");
                 foreach (var error in allErrors)
                 {

--- a/tools/projectStandards.linq
+++ b/tools/projectStandards.linq
@@ -72,17 +72,6 @@ void CleanUpProjects()
 
 		if (propertyGroup != null)
 		{
-			var langVersion = propertyGroup.Element("LangVersion");
-
-			if (langVersion == null)
-			{
-				propertyGroup.Add(new XElement("LangVersion", "10.0"));
-			}
-			else
-			{
-				langVersion.Value = "10.0";
-			}
-
             var targetFrameworks = propertyGroup.Element("TargetFrameworks");
 
             if (targetFrameworks != null && !targetFrameworks.Value.Contains(";"))
@@ -113,7 +102,6 @@ string GetRelativePath(string filespec, string folder)
 	Uri folderUri = new Uri(folder);
 	return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', Path.DirectorySeparatorChar));
 }
-
 
 static void CollapseEmptyElements(string file)
 {


### PR DESCRIPTION
With the upcoming NServiceBus 9 release, we need to take a look at how we are enforcing `LangVersion` settings. It no longer makes sense to enforce a single value across the entire repo.

Instead, we are now doing the following:
- Snippets projects (which should always be single targeted, see new test below) should not have a `LangVersion` defined. Instead, each project will use the default language version based on the TFM of the project.
- Samples should define the `LangVersion` property to match the default version of the lowest .NET TFM  used in the solution. This ensures that the samples can take advantage of language features that match the version of .NET that corresponds to the NServiceBus version used in the sample. It also means that as more TFMs are added to the sample over time (as new .NET versions come out), the `LangVersion` for that sample will stay stable and not require a newer version of tooling to use it than what it initially required.

This PR also updates the integrity tests in the following ways:

- .NET Core 3.1 should no no longer be allowed, so the test has been updated and projects still using `netcoreapp3.1` have been updated.
- There is no point to multi-targeting Snippets projects, so I have added a test to verify that they aren't.
- Re-enabled a test that had been incorrectly marked with `Ignore`. It is still generally true that we only want to have a single solution per directory, so an exception was added to the test for the single sample that violates this.
- Miscellaneous cleanup
