### PR TITLE
Add SQS snippets for v7

### DIFF
--- a/Snippets/Sqs/Sqs.sln
+++ b/Snippets/Sqs/Sqs.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sqs_6.1", "Sqs_6.1\Sqs_6.1.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sqs_5.7", "Sqs_5.7\Sqs_5.7.csproj", "{24556030-316D-4887-B20F-F84BAF51A2FF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sqs_7", "Sqs_7\Sqs_7.csproj", "{F9F47D1F-4301-4799-BB7F-98AFCFD3D7C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{24556030-316D-4887-B20F-F84BAF51A2FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24556030-316D-4887-B20F-F84BAF51A2FF}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{24556030-316D-4887-B20F-F84BAF51A2FF}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{F9F47D1F-4301-4799-BB7F-98AFCFD3D7C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9F47D1F-4301-4799-BB7F-98AFCFD3D7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9F47D1F-4301-4799-BB7F-98AFCFD3D7C0}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9F47D1F-4301-4799-BB7F-98AFCFD3D7C0}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Snippets/Sqs/Sqs_7/AccessToAmazonSqsNativeMessage.cs
+++ b/Snippets/Sqs/Sqs_7/AccessToAmazonSqsNativeMessage.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using NServiceBus.Pipeline;
+
+#region sqs-access-to-native-message
+class AccessToAmazonSqsNativeMessage : Behavior<IIncomingContext>
+{
+    public override Task Invoke(IIncomingContext context, Func<Task> next)
+    {
+        // get the native Amazon SQS message
+        var message = context.Extensions.Get<Message>();
+
+        //do something useful
+
+        return next();
+    }
+}
+#endregion

--- a/Snippets/Sqs/Sqs_7/Sqs_7.csproj
+++ b/Snippets/Sqs/Sqs_7/Sqs_7.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="NServiceBus.AmazonSQS" Version="7.0.0-alpha.1" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="7.0.0-alpha.1" />
+  </ItemGroup>
 </Project>

--- a/Snippets/Sqs/Sqs_7/Sqs_7.csproj
+++ b/Snippets/Sqs/Sqs_7/Sqs_7.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="NServiceBus.AmazonSQS" Version="7.0.0-alpha.1" />
+	</ItemGroup>
+</Project>

--- a/Snippets/Sqs/Sqs_7/Usage.cs
+++ b/Snippets/Sqs/Sqs_7/Usage.cs
@@ -1,0 +1,443 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using NServiceBus;
+using NServiceBus.Transport.SQS;
+
+
+class Usage
+{
+    void AssumePermissionsOnPolicy(EndpointConfiguration config)
+    {
+        #region assume-permissions
+
+        var transport = new SqsTransport();
+
+        transport.Policies.SetupTopicPoliciesWhenSubscribing = false;
+
+        config.UseTransport(transport);
+
+        #endregion
+    }
+
+    void WildcardsAccount(EndpointConfiguration config)
+    {
+        #region wildcard-account-condition
+
+        var transport = new SqsTransport();
+
+        transport.Policies.AccountCondition = true;
+
+        config.UseTransport(transport);
+
+        #endregion
+    }
+
+    void WildcardsPrefix(EndpointConfiguration config)
+    {
+        #region wildcard-prefix-condition
+
+        var transport = new SqsTransport();
+
+        transport.Policies.TopicNamePrefixCondition = true;
+
+        config.UseTransport(transport);
+
+        #endregion
+    }
+
+    void WildcardsNamespace(EndpointConfiguration config)
+    {
+        #region wildcard-namespace-condition
+
+        var transport = new SqsTransport();
+
+        transport.Policies.TopicNamespaceConditions
+            .Add("Sales.");
+        transport.Policies.TopicNamespaceConditions
+            .Add("Shipping.HighValueOrders.");
+
+        config.UseTransport(transport);
+
+        #endregion
+    }
+
+    Usage(EndpointConfiguration endpointConfiguration)
+    {
+        #region SqsTransport
+
+        // S3 bucket only required for messages larger than 256KB
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings("myBucketName", "my/key/prefix")
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void CredentialSource(EndpointConfiguration endpointConfiguration)
+    {
+        #region CredentialSource
+
+        var transport = new SqsTransport(
+            new AmazonSQSClient(new InstanceProfileAWSCredentials()),
+            new AmazonSimpleNotificationServiceClient());
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3CredentialSource(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix)
+    {
+        #region S3CredentialSource
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix,
+                new AmazonS3Client(new InstanceProfileAWSCredentials()))
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void MaxTTL(EndpointConfiguration endpointConfiguration)
+    {
+        #region MaxTTL
+
+        var transport = new SqsTransport
+        {
+            MaxTimeToLive = TimeSpan.FromDays(10)
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void QueueNamePrefix(EndpointConfiguration endpointConfiguration)
+    {
+        #region QueueNamePrefix
+
+        var transport = new SqsTransport
+        {
+            QueueNamePrefix = "DEV-"
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void Region(EndpointConfiguration endpointConfiguration)
+    {
+        #region Region
+
+        var transport = new SqsTransport(new AmazonSQSClient(
+            new AmazonSQSConfig
+            {
+                RegionEndpoint = RegionEndpoint.APSoutheast2
+            }),
+            new AmazonSimpleNotificationServiceClient());
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3Region(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix)
+    {
+        #region S3Region
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix,
+                new AmazonS3Client(new AmazonS3Config
+                {
+                    RegionEndpoint = RegionEndpoint.APSoutheast2
+                }))
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void ClientFactory(EndpointConfiguration endpointConfiguration)
+    {
+        #region ClientFactory
+
+        var transport = new SqsTransport(
+            new AmazonSQSClient(new AmazonSQSConfig()),
+            new AmazonSimpleNotificationServiceClient());
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void SnsClientFactory(EndpointConfiguration endpointConfiguration)
+    {
+        #region SnsClientFactory
+
+        var transport = new SqsTransport(
+            new AmazonSQSClient(new AmazonSQSConfig()),
+            new AmazonSimpleNotificationServiceClient());
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3BucketForLargeMessages(EndpointConfiguration endpointConfiguration)
+    {
+        #region S3BucketForLargeMessages
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(
+                bucketForLargeMessages: "nsb-sqs-messages",
+                keyPrefix: "my/sample/path")
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3ClientFactory(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix)
+    {
+        #region S3ClientFactory
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix,
+                new AmazonS3Client(new AmazonS3Config()))
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3ServerSideEncryption(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix)
+    {
+        #region S3ServerSideEncryption
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix)
+            {
+                Encryption = new S3EncryptionWithManagedKey(ServerSideEncryptionMethod.AES256, "keyId")
+            }
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3ServerSideCustomerEncryption(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix)
+    {
+        #region S3ServerSideCustomerEncryption
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix)
+            {
+                Encryption = new S3EncryptionWithCustomerProvidedKey(ServerSideEncryptionCustomerMethod.AES256, "key", "keyMD5")
+            }
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void Proxy(EndpointConfiguration endpointConfiguration, string userName, string password)
+    {
+        #region Proxy
+
+        var transport = new SqsTransport(new AmazonSQSClient(
+                new AmazonSQSConfig
+                {
+                    ProxyCredentials = new NetworkCredential(userName, password),
+                    ProxyHost = "127.0.0.1",
+                    ProxyPort = 8888
+                }),
+            new AmazonSimpleNotificationServiceClient());
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void S3Proxy(EndpointConfiguration endpointConfiguration, string bucketName, string keyPrefix, string userName, string password)
+    {
+        #region S3Proxy
+
+        var transport = new SqsTransport
+        {
+            S3 = new S3Settings(bucketName, keyPrefix,
+                new AmazonS3Client(new AmazonS3Config
+                {
+                    ProxyCredentials = new NetworkCredential(userName, password),
+                    ProxyHost = "127.0.0.1",
+                    ProxyPort = 8888
+                }))
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void CustomTopicsMappingsTypeToType(EndpointConfiguration endpointConfiguration)
+    {
+        #region CustomTopicsMappingsTypeToType
+
+        var transport = new SqsTransport();
+
+        transport.MapEvent<SubscribedEvent, PublishedEvent>();
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void CustomTopicsMappingsTypeToTopic(EndpointConfiguration endpointConfiguration)
+    {
+        #region CustomTopicsMappingsTypeToTopic
+
+        var transport = new SqsTransport();
+
+        transport.MapEvent<SubscribedEvent>("topic-used-by-the-publisher");
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void CustomTopicsMappingsTypeToTopicForTopology(EndpointConfiguration endpointConfiguration)
+    {
+        #region CustomTopicsMappingsTypeToTopicForTopology
+
+        var transport = new SqsTransport();
+
+        transport.MapEvent<IOrderAccepted>("namespace-OrderAccepted");
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+
+    void TopicNamePrefix(EndpointConfiguration endpointConfiguration)
+    {
+        #region TopicNamePrefix
+
+        var transport = new SqsTransport
+        {
+            TopicNamePrefix = "DEV-"
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void TopicNameGenerator(EndpointConfiguration endpointConfiguration)
+    {
+        #region TopicNameGenerator
+
+        var transport = new SqsTransport
+        {
+            TopicNameGenerator = (eventType, topicNamePrefix) => $"{topicNamePrefix}{eventType.Name}"
+        };
+
+        endpointConfiguration.UseTransport(transport);
+
+        #endregion
+    }
+
+    void EnableMessageDrivenPubSubCompatibilityMode(EndpointConfiguration endpointConfiguration)
+    {
+#pragma warning disable 618
+        #region EnableMessageDrivenPubSubCompatibilityMode
+
+        var routing = endpointConfiguration.UseTransport(new SqsTransport());
+
+        routing.EnableMessageDrivenPubSubCompatibilityMode();
+
+        #endregion
+#pragma warning restore 618
+    }
+
+    void SubscriptionCacheTtl(EndpointConfiguration endpointConfiguration)
+    {
+#pragma warning disable 618
+        var routing = endpointConfiguration.UseTransport(new SqsTransport());
+        #region SubscriptionsCacheTTL
+
+        var migrationSettings = routing.EnableMessageDrivenPubSubCompatibilityMode();
+        migrationSettings.SubscriptionsCacheTTL(TimeSpan.FromSeconds(30));
+
+        #endregion
+#pragma warning restore 618
+    }
+
+    void TopicCacheTtl(EndpointConfiguration endpointConfiguration)
+    {
+#pragma warning disable 618
+        var routing = endpointConfiguration.UseTransport(new SqsTransport());
+        #region TopicCacheTtl
+
+        var migrationSettings = routing.EnableMessageDrivenPubSubCompatibilityMode();
+        migrationSettings.TopicCacheTTL(TimeSpan.FromSeconds(30));
+
+        #endregion
+#pragma warning restore 618
+    }
+
+    void MessageVisibilityTimeout(EndpointConfiguration endpointConfiguration)
+    {
+#pragma warning disable 618
+        var routing = endpointConfiguration.UseTransport(new SqsTransport());
+        #region MessageVisibilityTimeout
+
+        var migrationSettings = routing.EnableMessageDrivenPubSubCompatibilityMode();
+        migrationSettings.MessageVisibilityTimeout(timeoutInSeconds: 10);
+
+        #endregion
+#pragma warning restore 618
+    }
+
+    void DoNotWrapOutgoingMessages(EndpointConfiguration endpointConfiguration)
+    {
+        #region DoNotWrapOutgoingMessages [6.1,)
+        var transport = new SqsTransport
+        {
+            DoNotWrapOutgoingMessages = true
+        };
+
+        endpointConfiguration.UseTransport(transport);
+        #endregion
+    }
+
+    class SubscribedEvent { }
+
+    class PublishedEvent { }
+
+    interface IOrderAccepted { }
+
+    class OrderAccepted : IOrderAccepted { }
+}

--- a/Snippets/Sqs/Sqs_7/Usage.cs
+++ b/Snippets/Sqs/Sqs_7/Usage.cs
@@ -423,7 +423,7 @@ class Usage
 
     void DoNotWrapOutgoingMessages(EndpointConfiguration endpointConfiguration)
     {
-        #region DoNotWrapOutgoingMessages [6.1,)
+        #region DoNotWrapOutgoingMessages
         var transport = new SqsTransport
         {
             DoNotWrapOutgoingMessages = true

--- a/Snippets/Sqs/Sqs_7/Usage.cs
+++ b/Snippets/Sqs/Sqs_7/Usage.cs
@@ -67,7 +67,7 @@ class Usage
         #endregion
     }
 
-    Usage(EndpointConfiguration endpointConfiguration)
+    void S3Settings(EndpointConfiguration endpointConfiguration)
     {
         #region SqsTransport
 
@@ -371,7 +371,6 @@ class Usage
 
     void EnableMessageDrivenPubSubCompatibilityMode(EndpointConfiguration endpointConfiguration)
     {
-#pragma warning disable 618
         #region EnableMessageDrivenPubSubCompatibilityMode
 
         var routing = endpointConfiguration.UseTransport(new SqsTransport());
@@ -379,12 +378,10 @@ class Usage
         routing.EnableMessageDrivenPubSubCompatibilityMode();
 
         #endregion
-#pragma warning restore 618
     }
 
     void SubscriptionCacheTtl(EndpointConfiguration endpointConfiguration)
     {
-#pragma warning disable 618
         var routing = endpointConfiguration.UseTransport(new SqsTransport());
         #region SubscriptionsCacheTTL
 
@@ -392,12 +389,10 @@ class Usage
         migrationSettings.SubscriptionsCacheTTL(TimeSpan.FromSeconds(30));
 
         #endregion
-#pragma warning restore 618
     }
 
     void TopicCacheTtl(EndpointConfiguration endpointConfiguration)
     {
-#pragma warning disable 618
         var routing = endpointConfiguration.UseTransport(new SqsTransport());
         #region TopicCacheTtl
 
@@ -405,12 +400,10 @@ class Usage
         migrationSettings.TopicCacheTTL(TimeSpan.FromSeconds(30));
 
         #endregion
-#pragma warning restore 618
     }
 
     void MessageVisibilityTimeout(EndpointConfiguration endpointConfiguration)
     {
-#pragma warning disable 618
         var routing = endpointConfiguration.UseTransport(new SqsTransport());
         #region MessageVisibilityTimeout
 
@@ -418,7 +411,6 @@ class Usage
         migrationSettings.MessageVisibilityTimeout(timeoutInSeconds: 10);
 
         #endregion
-#pragma warning restore 618
     }
 
     void DoNotWrapOutgoingMessages(EndpointConfiguration endpointConfiguration)

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -498,7 +498,7 @@
         Title: Roslyn analyzers
     - Url: nservicebus/hosting/azure-functions-service-bus/in-process
       Title: Azure Functions with Service Bus (In Process)
-      Articles:        
+      Articles:
       - Url: nservicebus/hosting/azure-functions-service-bus/in-process/custom-triggers
         Title: Custom triggers
       - Url: nservicebus/hosting/azure-functions-service-bus/in-process/analyzers
@@ -853,6 +853,8 @@
         Title: Version 1.x to 1.2.5
     - Title: Amazon SQS
       Articles:
+      - Url: transports/upgrades/amazonsqs-6to7
+        Title: Version 6 to 7
       - Url: transports/upgrades/amazonsqs-5to6
         Title: Version 5 to 6
       - Url: transports/upgrades/amazonsqs-4to5

--- a/transports/upgrades/amazonsqs-5to6.md
+++ b/transports/upgrades/amazonsqs-5to6.md
@@ -67,3 +67,7 @@ The SQS transport configuration options that have not changed have been moved to
 | Policies.AddTopicNamePrefixCondition | Policies.TopicNamePrefixCondition |
 | Policies.AddNamespaceCondition | Policies.TopicNamespaceConditions |
 | Policies.AssumePolicyHasAppropriatePermissions | Policies.SetupTopicPoliciesWhenSubscribing |
+
+## V1 Compatibility Mode
+
+The V1 Compatibility mode is marked as deprecated in Version 6 and will be no longer be available in Version 7, see the [Version 7 upgrade guide for more details](/transports/upgrades/amazonsqs-6to7.md).

--- a/transports/upgrades/amazonsqs-6to7.md
+++ b/transports/upgrades/amazonsqs-6to7.md
@@ -1,0 +1,16 @@
+---
+title: Upgrade AmazonSQS Transport Version 6 to 7
+summary: Instructions on how to upgrade the AmazonSQS transport from version 6 to 7
+component: SQS
+isUpgradeGuide: true
+reviewed: 2023-10-18
+upgradeGuideCoreVersions:
+ - 8
+ - 9
+---
+
+## V1 Compatibility Mode
+
+The option to serialize the `TimeToBeReceived` and `ReplyToAddress` message headers in the message envelope for compatibility with endpoints using version 1 of the transport is no longer available.
+
+Make sure that all V1 endpoints are upgraded to a supported version and remove the `transport.EnableV1CompatibilityMode();` configuration option.


### PR DESCRIPTION
There is no upgrade guide for v7 and there is a breaking change that is documented [here](https://docs.particular.net/transports/sqs/configuration-options#v1-compatibility-mode), should we create one?