### PR TITLE
Removing reference to 'NServiceBus.MicrosoftLogging' in Building endpoints with ASP.NET Core sample

### DIFF
--- a/samples/netcore-reference/Core_7/BackEnd/BackEnd.csproj
+++ b/samples/netcore-reference/Core_7/BackEnd/BackEnd.csproj
@@ -8,8 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.*" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />
-    <PackageReference Include="NServiceBus.MicrosoftLogging.Hosting" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />    
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/netcore-reference/Core_7/BackEnd/Program.cs
+++ b/samples/netcore-reference/Core_7/BackEnd/Program.cs
@@ -17,14 +17,6 @@ internal class Program
     {
         var builder = Host.CreateDefaultBuilder(args);
         builder.UseConsoleLifetime();
-        
-        builder.ConfigureLogging((ctx, logging) =>
-        {
-            logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-
-            logging.AddEventLog();
-            logging.AddConsole();
-        });
 
         #region back-end-use-nservicebus
 
@@ -55,7 +47,7 @@ internal class Program
         var fatalMessage = $"The following critical error was " +
                            $"encountered: {Environment.NewLine}{context.Error}{Environment.NewLine}Process is shutting down. " +
                            $"StackTrace: {Environment.NewLine}{context.Exception.StackTrace}";
-        
+
         EventLog.WriteEntry(".NET Runtime", fatalMessage, EventLogEntryType.Error);
 
         try

--- a/samples/netcore-reference/Core_7/BackEnd/Program.cs
+++ b/samples/netcore-reference/Core_7/BackEnd/Program.cs
@@ -17,8 +17,7 @@ internal class Program
     {
         var builder = Host.CreateDefaultBuilder(args);
         builder.UseConsoleLifetime();
-
-        builder.UseMicrosoftLogFactoryLogging();
+        
         builder.ConfigureLogging((ctx, logging) =>
         {
             logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));

--- a/samples/netcore-reference/Core_8/BackEnd/BackEnd.csproj
+++ b/samples/netcore-reference/Core_8/BackEnd/BackEnd.csproj
@@ -7,8 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="6.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />
-    <PackageReference Include="NServiceBus.MicrosoftLogging.Hosting" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />    
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/netcore-reference/Core_8/BackEnd/Program.cs
+++ b/samples/netcore-reference/Core_8/BackEnd/Program.cs
@@ -18,14 +18,6 @@ internal class Program
     {
         var builder = Host.CreateDefaultBuilder(args);
         builder.UseConsoleLifetime();
-        
-        builder.ConfigureLogging((ctx, logging) =>
-        {
-            logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-
-            logging.AddEventLog();
-            logging.AddConsole();
-        });
 
         #region back-end-use-nservicebus
 

--- a/samples/netcore-reference/Core_8/BackEnd/Program.cs
+++ b/samples/netcore-reference/Core_8/BackEnd/Program.cs
@@ -18,8 +18,7 @@ internal class Program
     {
         var builder = Host.CreateDefaultBuilder(args);
         builder.UseConsoleLifetime();
-
-        builder.UseMicrosoftLogFactoryLogging();
+        
         builder.ConfigureLogging((ctx, logging) =>
         {
             logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));

--- a/samples/netcore-reference/sample.md
+++ b/samples/netcore-reference/sample.md
@@ -14,8 +14,6 @@ This sample demonstrates:
 - a simple back-end process running in the .NET Core generic host
 - the built-in tools used to inject dependencies into message handler classes
 
-NOTE: The `NServiceBus.MicrosoftLogging` community NuGet package should be installed to use the `Microsoft.Extensions.Logging` library.
-
 ## Front-end
 
 The front-end project hosts a simple web page that contains a form. When the form is submitted, a message is sent to the back-end application via NServiceBus for processing. 


### PR DESCRIPTION
Addresses 
- #6240

Since the sample uses [NServiceBus.Extensions.Hosting](https://docs.particular.net/nservicebus/hosting/extensions-hosting) there is no need to use [NServiceBus.MicrosoftLogging](https://github.com/NServiceBusExtensions/NServiceBus.MicrosoftLogging)