### PR TITLE
Fixing Lambda+DynamoDB Sagas sample

### DIFF
--- a/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
+++ b/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
@@ -58,6 +58,20 @@
         "DisplayName": "OrderReceived"
       }
     },
+    "CustomerBilledTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": "CustomerBilled",
+        "DisplayName": "CustomerBilled"
+      }
+    },
+    "InventoryStagedTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": "InventoryStaged",
+        "DisplayName": "InventoryStaged"
+      }
+    },
     "DynamoTable": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {


### PR DESCRIPTION
[Using NServiceBus Sagas with AWS Lambda, SQS, and DynamoDB](https://docs.particular.net/samples/aws/sagas/) sample was not working correctly, the following error was being logged in Cloudwatch. 

`NServiceBus.Features.AutoSubscribe. Error. AutoSubscribe was unable to subscribe to an event:. Exception: System.Exception: Topic CustomerBilled not found. Call endpointConfiguration.EnableInstallers() to create the topic at startup, or create them manually`