### PR TITLE
Set default culture for integrity tests

### DIFF
--- a/tests/IntegrityTests/Global.cs
+++ b/tests/IntegrityTests/Global.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+[SetUpFixture]
+public static class Global
+{
+    [OneTimeSetUp]
+    public static void SetupInvariantCulture()
+    {
+        var current = Thread.CurrentThread;
+        current.CurrentCulture = CultureInfo.InvariantCulture;
+        current.CurrentUICulture = CultureInfo.InvariantCulture;
+    }
+}

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -78,7 +78,7 @@ namespace IntegrityTests
 
                     solutionLangVersion ??= fallbackLangVersion;
 
-                    var solutionLangVersionString = solutionLangVersion.Value.ToString("N1", CultureInfo.InvariantCulture);
+                    var solutionLangVersionString = solutionLangVersion.Value.ToString("N1");
                     bool valid = true;
 
                     foreach (var projectFile in projectFiles)


### PR DESCRIPTION
A small improvement over 9ac89b8 to prevent issues in the future by initializing global culture.