### PR TITLE
Run all integrity tests in parallel

### DIFF
--- a/tests/IntegrityTests/assembly.cs
+++ b/tests/IntegrityTests/assembly.cs
@@ -1,0 +1,4 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.All)]
+[assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]


### PR DESCRIPTION
Improves execution duration from 2.8s to 0.7s