### PR TITLE
Clarification on type inference - Receiving messages from external systems

### DIFF
--- a/nservicebus/messaging/message-type-detection.md
+++ b/nservicebus/messaging/message-type-detection.md
@@ -22,3 +22,9 @@ The mapping rules are as follows:
 1. If the header is missing, some serializers can optionally [infer the message type](/nservicebus/serialization/#security-message-type-inference) based on the message payload. Serializers that support message type inference:
    - [XML](/nservicebus/serialization/xml.md#inferring-message-type-from-root-node-name) via the root node name
    - [JSON.NET](/nservicebus/serialization/newtonsoft.md#inferring-message-type-from-type) via a custom `$type` property
+
+NOTE: Message type inference based on the message body content if the `NServiceBus.EnclosedMessageTypes` header is missing is only supported from NServiceBus version 7.4 or higher
+
+## Custom type inference
+
+A custom type inference behavior can be created when type inferences cannot be done using the incoming `NServiceBus.EnclosedMessageTypes` header and the serializer is not able to infer type information using the embedded message body.  The custom behavior needs to be executed in the `IncomingPhysicalMessageContext` stage. It can infer the message type by inspecting any message header of body data using custom logic and add the `NServiceBus.EnclosedMessageTypes` header with the custom resolved message type.

--- a/nservicebus/messaging/third-party-integration.md
+++ b/nservicebus/messaging/third-party-integration.md
@@ -14,7 +14,7 @@ Endpoints can receive messages from external systems (such as BizTalk, TIBCO, et
 
 In order to [deserialize](/nservicebus/serialization/) a message coming from a third party system, NServiceBus needs to know the .NET type to use.
 
-Starting from NServiceBus version 7.4, the [NServiceBus.EnclosedMessageTypes header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) is automatically populated when missing. When using NServiceBus version 7.3 and below, the sender should set that header.
+Starting from NServiceBus version 7.4, the [NServiceBus.EnclosedMessageTypes header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) is automatically added when missing and populated with the message type fullname. When using NServiceBus version 7.3 and below, the sender should set that header.
 
 Some serializers can infer the message type from information embedded in the message body.
 

--- a/nservicebus/messaging/third-party-integration.md
+++ b/nservicebus/messaging/third-party-integration.md
@@ -14,7 +14,7 @@ Endpoints can receive messages from external systems (such as BizTalk, TIBCO, et
 
 In order to [deserialize](/nservicebus/serialization/) a message coming from a third party system, NServiceBus needs to know the .NET type to use.
 
-Starting from NServiceBus version 7.4, the [NServiceBus.EnclosedMessageTypes header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) is automatically added when missing and populated with the message type fullname. When using NServiceBus version 7.3 and below, the sender should set that header.
+Starting from NServiceBus version 7.4, the [NServiceBus.EnclosedMessageTypes header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) is automatically added when missing and populated with the message type full name. When using NServiceBus version 7.3 and below, the sender should set that header.
 
 Some serializers can infer the message type from information embedded in the message body.
 

--- a/nservicebus/messaging/third-party-integration.md
+++ b/nservicebus/messaging/third-party-integration.md
@@ -14,12 +14,7 @@ Endpoints can receive messages from external systems (such as BizTalk, TIBCO, et
 
 In order to [deserialize](/nservicebus/serialization/) a message coming from a third party system, NServiceBus needs to know the .NET type to use.
 
-Starting from NServiceBus version 7.4, the [NServiceBus.EnclosedMessageTypes header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes) is automatically added when missing and populated with the message type full name. When using NServiceBus version 7.3 and below, the sender should set that header.
-
-Some serializers can infer the message type from information embedded in the message body.
-
- * [XML](/nservicebus/serialization/xml.md)
- * [Newtonsoft](/nservicebus/serialization/newtonsoft.md)
+See [Message type detection](/nservicebus/messaging/message-type-detection.md) for details.
 
 The [RabbitMQ](/samples/rabbitmq/native-integration/), [SQL](/samples/sqltransport/native-integration/), and [Azure Service Bus](/samples/azure-service-bus-netstandard/native-integration/) native integration samples demonstrate inferring message type from the message body.
 


### PR DESCRIPTION
Clarifying [how](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Pipeline/Incoming/InferredMessageTypeEnricherBehavior.cs#L13C59-L13C59) NServiceBus.EnclosedMessageTypes header is automatically populated when missing. Feedback from 
- https://github.com/Particular/docs.particular.net/issues/6246