### PR TITLE
Add formatting defined in RepoStandards .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,12 @@
-root                      = true
+root = true
+
+[*.{csproj,xml}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_style = space
+indent_size = 4
 
 [*]
-trim_trailing_whitespace  = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I've been noticing some inconsistent formatting recently, especially as the TF I'm on has been working on updating snippets, so I've brought over the formatting entries we have defined in our RepoStandards .`editorconfig`.