### PR TITLE
Updating AWS Sagas+DynamoDB sample - Adding a missing comma to cloud formation template

### DIFF
--- a/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
+++ b/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
@@ -98,7 +98,7 @@
           }
         ]
       }
-    }
+    },
     "SQSTriggerFunction": {
       "Type": "AWS::Serverless::Function",
       "Properties": {


### PR DESCRIPTION
Adding missing comma to cloud formation template. The sample still works even when this comma is not present. 