### PR TITLE
Removing reference to 'NServiceBus.MicrosoftLogging' in 'Endpoint hosting with the Generic Host' sample

### DIFF
--- a/samples/hosting/generic-host/Core_7/GenericHost/Program.cs
+++ b/samples/hosting/generic-host/Core_7/GenericHost/Program.cs
@@ -31,18 +31,6 @@ internal class Program
         #endregion
         */
 
-        #region generic-host-logging
-
-        builder.ConfigureLogging((ctx, logging) =>
-        {
-            logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-
-            logging.AddEventLog();
-            logging.AddConsole();
-        });
-
-        #endregion
-
         #region generic-host-nservicebus
 
         builder.UseNServiceBus(ctx =>

--- a/samples/hosting/generic-host/Core_8/GenericHost/Program.cs
+++ b/samples/hosting/generic-host/Core_8/GenericHost/Program.cs
@@ -32,18 +32,6 @@ internal class Program
         #endregion
         */
 
-        #region generic-host-logging
-
-        builder.ConfigureLogging((ctx, logging) =>
-        {
-            logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-
-            logging.AddEventLog();
-            logging.AddConsole();
-        });
-
-        #endregion
-
         #region generic-host-nservicebus
 
         builder.UseNServiceBus(ctx =>

--- a/samples/hosting/generic-host/sample.md
+++ b/samples/hosting/generic-host/sample.md
@@ -48,11 +48,6 @@ The snippet above shows how the host builder runs by default as a Windows Servic
 
 snippet: generic-host-console-lifetime
 
-
-snippet: generic-host-logging
-
-To enable integration with Microsoft.Extensions.Logging, the [`NServiceBus.MicrosoftLogging.Hosting`](https://www.nuget.org/packages/NServiceBus.MicrosoftLogging.Hosting/) community package is used and configured in combination with the standard logging.
-
 Next, the builder configures NServiceBus using the [`NServiceBus.Extensions.Hosting`](/nservicebus/hosting/extensions-hosting.md) package, including the [critical error](/nservicebus/hosting/critical-errors.md) action that will shut down the application or service in case of a critical error.
 
 snippet: generic-host-nservicebus


### PR DESCRIPTION
Applying the same [changes](https://github.com/Particular/docs.particular.net/pull/6247) made to ASP.NET core sample 