### PR TITLE
Updating Lambda SQS sample for NSB 7 to  NServiceBus.AmazonSQS 5.*

### DIFF
--- a/samples/aws/lambda-sqs/SQSLambda_0/RegularEndpoint/Program.cs
+++ b/samples/aws/lambda-sqs/SQSLambda_0/RegularEndpoint/Program.cs
@@ -14,7 +14,6 @@ class Program
         {
             var endpointConfiguration = new EndpointConfiguration("RegularEndpoint");
             endpointConfiguration.SendFailedMessagesTo("error");
-            endpointConfiguration.UsePersistence<InMemoryPersistence>();
             endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
             endpointConfiguration.UseTransport<SqsTransport>();
 

--- a/samples/aws/lambda-sqs/SQSLambda_0/RegularEndpoint/RegularEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_0/RegularEndpoint/RegularEndpoint.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>OnPremiseEndpoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="4.*" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="5.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The sample for NSB 7 was referencing NServiceBus.AmazonSQS 4.* instead of NServiceBus.AmazonSQS 5.*, which made it require `endpointConfiguration.UsePersistence<InMemoryPersistence>();`