### PR TITLE
Update supported platforms for NSB 9

### DIFF
--- a/nservicebus/upgrades/supported-platforms_content_core_[9,10).partial.md
+++ b/nservicebus/upgrades/supported-platforms_content_core_[9,10).partial.md
@@ -1,0 +1,5 @@
+| Framework | Version | Platform | Support |
+|------------------|:-------:|:--------:|:-------:|
+| .NET | 8.0 (LTS) | [Windows / Linux](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md) | [Supported until November 10, 2026](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)  |
+
+macOS is supported for development purposes but not for production workloads.


### PR DESCRIPTION
November 10, 2026 is a guess, but it follows the pattern for the other versions, the second Tuesday of the month where support expires.