### PR TITLE
Update the web samples to use the new hosting package

### DIFF
--- a/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.2" />
     <PackageReference Include="NServiceBus.Callbacks" Version="5.0.0-alpha.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/Program.cs
+++ b/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/Program.cs
@@ -1,36 +1,27 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using NServiceBus;
+﻿using NServiceBus;
 
-namespace AsyncPagesMVC.Core
+#region ApplicationStart
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseNServiceBus(() =>
 {
-    public class Program
-    {
-        public static void Main()
-        {
-            #region ApplicationStart
-            var builder = WebApplication.CreateBuilder();
+    var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.WebApplication");
+    endpointConfiguration.MakeInstanceUniquelyAddressable("1");
+    endpointConfiguration.EnableCallbacks();
 
-            builder.Host.UseNServiceBus(context =>
-            {
-                var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.WebApplication");
-                endpointConfiguration.MakeInstanceUniquelyAddressable("1");
-                endpointConfiguration.EnableCallbacks();
+    endpointConfiguration.UseTransport(new LearningTransport());
+    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
-                endpointConfiguration.UseTransport(new LearningTransport());
-                endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+    return endpointConfiguration;
+});
+#endregion
 
-                return endpointConfiguration;
-            });
-            #endregion
+builder.Services.AddMvc();
 
-            builder.Services.AddMvc();
+builder.Services.AddControllersWithViews();
 
-            var app = builder.Build();
+var app = builder.Build();
 
-            app.MapControllerRoute("default", "{controller=Home}/{action=SendLinks}/{id?}");
+app.MapControllerRoute("default", "{controller=Home}/{action=SendLinks}/{id?}");
 
-            app.Run();
-        }
-    }
-}
+app.Run();

--- a/samples/web/asp-web-application/Core_9/WebApp/Pages/Index.cshtml.cs
+++ b/samples/web/asp-web-application/Core_9/WebApp/Pages/Index.cshtml.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using NServiceBus;
 

--- a/samples/web/asp-web-application/Core_9/WebApp/Program.cs
+++ b/samples/web/asp-web-application/Core_9/WebApp/Program.cs
@@ -1,32 +1,24 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using NServiceBus;
+﻿using NServiceBus;
 
-class Program
+#region ApplicationStart
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseNServiceBus(() =>
 {
-    public static void Main()
-    {
-        #region ApplicationStart
-        var builder = WebApplication.CreateBuilder();
+    var endpointConfiguration = new EndpointConfiguration("Samples.AsyncPages.WebApplication");
+    endpointConfiguration.MakeInstanceUniquelyAddressable("1");
+    endpointConfiguration.EnableCallbacks();
+    endpointConfiguration.UseTransport(new LearningTransport());
+    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 
-        builder.Host.UseNServiceBus(context =>
-        {
-            var endpointConfiguration = new EndpointConfiguration("Samples.AsyncPages.WebApplication");
-            endpointConfiguration.MakeInstanceUniquelyAddressable("1");
-            endpointConfiguration.EnableCallbacks();
-            endpointConfiguration.UseTransport(new LearningTransport());
-            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+    return endpointConfiguration;
+});
+#endregion
 
-            return endpointConfiguration;
-        });
-        #endregion
+builder.Services.AddRazorPages();
 
-        builder.Services.AddRazorPages();
+var app = builder.Build();
 
-        var app = builder.Build();
+app.MapRazorPages();
 
-        app.MapRazorPages();
-
-        app.Run();
-    }
-}
+app.Run();

--- a/samples/web/asp-web-application/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_9/WebApp/WebApp.csproj
@@ -1,13 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>12.0</LangVersion>
-	</PropertyGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Shared\Shared.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.1" />
-		<PackageReference Include="NServiceBus.Callbacks" Version="5.0.0-alpha.1" />
-	</ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.2" />
+    <PackageReference Include="NServiceBus.Callbacks" Version="5.0.0-alpha.1" />
+  </ItemGroup>
 </Project>

--- a/samples/web/blazor-server-application/Core_9/WebApp/Program.cs
+++ b/samples/web/blazor-server-application/Core_9/WebApp/Program.cs
@@ -1,39 +1,28 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using NServiceBus;
+#region ApplicationStart
 
-class Program
+var builder = WebApplication.CreateBuilder();
+
+builder.UseNServiceBus(() =>
 {
-    public static void Main()
-    {
-        #region ApplicationStart
+    var endpointConfiguration = new EndpointConfiguration("Samples.Blazor.WebApplication");
+    endpointConfiguration.MakeInstanceUniquelyAddressable("1");
+    endpointConfiguration.EnableCallbacks();
+    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+    endpointConfiguration.UseTransport(new LearningTransport());
+    return endpointConfiguration;
+});
 
-        var builder = WebApplication.CreateBuilder();
+#endregion
 
-        builder.Host.UseNServiceBus(context =>
-        {
-            var endpointConfiguration = new EndpointConfiguration("Samples.Blazor.WebApplication");
-            endpointConfiguration.MakeInstanceUniquelyAddressable("1");
-            endpointConfiguration.EnableCallbacks();
-            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
-            endpointConfiguration.UseTransport(new LearningTransport());
-            return endpointConfiguration;
-        });
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
 
-        #endregion
+var app = builder.Build();
 
-        builder.Services.AddRazorPages();
-        builder.Services.AddServerSideBlazor();
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
 
-        var app = builder.Build();
-
-        app.UseHttpsRedirection();
-        app.UseStaticFiles();
-        app.UseRouting();
-        app.MapBlazorHub();
-        app.MapFallbackToPage("/_Host");
-
-        app.Run();
-
-    }
-}
+app.Run();

--- a/samples/web/blazor-server-application/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/blazor-server-application/Core_9/WebApp/WebApp.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.0.0-alpha.9" />
     <PackageReference Include="NServiceBus.Callbacks" Version="5.0.0-alpha.1" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/Program.cs
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/Program.cs
@@ -1,35 +1,26 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using NServiceBus;
+﻿using NServiceBus;
 
-public class Program
+#region EndpointConfiguration
+var builder = WebApplication.CreateBuilder(args);
+builder.UseNServiceBus(() =>
 {
-    public static Task Main()
-    {
-        #region EndpointConfiguration
-        var builder = WebApplication.CreateBuilder();
-        builder.Host.UseNServiceBus(context =>
-        {
-            var endpointConfiguration = new EndpointConfiguration("Samples.ASPNETCore.Sender");
-            var transport = endpointConfiguration.UseTransport(new LearningTransport());
-            transport.RouteToEndpoint(
-                assembly: typeof(MyMessage).Assembly,
-                destination: "Samples.ASPNETCore.Endpoint");
+    var endpointConfiguration = new EndpointConfiguration("Samples.ASPNETCore.Sender");
+    var transport = endpointConfiguration.UseTransport(new LearningTransport());
+    transport.RouteToEndpoint(
+        assembly: typeof(MyMessage).Assembly,
+        destination: "Samples.ASPNETCore.Endpoint");
 
-            endpointConfiguration.UseSerialization<SystemJsonSerializer>();
-            endpointConfiguration.SendOnly();
+    endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+    endpointConfiguration.SendOnly();
 
-            return endpointConfiguration;
-        });
-        #endregion
+    return endpointConfiguration;
+});
+#endregion
 
-        builder.Services.AddControllers();
+builder.Services.AddControllers();
 
-        var app = builder.Build();
+var app = builder.Build();
 
-        app.MapControllers();
+app.MapControllers();
 
-        return app.RunAsync();
-    }
-}
+app.Run();

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/SendMessageController.cs
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/SendMessageController.cs
@@ -1,10 +1,9 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using NServiceBus;
 
 [ApiController]
 [Route("")]
-public class SendMessageController : Controller
+public class SendMessageController : ControllerBase
 {
     IMessageSession messageSession;
 

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/WebApp.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-	<PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.1" />
-		<ProjectReference Include="..\Shared\Shared.csproj" />
-	</ItemGroup>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0-alpha.2" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This gets the web samples closer to the .NET 8 templates for each of these options, and uses the new IApplicationBuilder UseNServiceBus overload in the latest NServiceBus.Extensions.Hosting version.