### PR TITLE
Rename upgrade guide for Azure Table persistence

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1048,8 +1048,8 @@
     Articles:
     - Title: Azure Table
       Articles:
-      - Url: persistence/upgrades/asp-5to6
-        Title: Version 5 to 6
+      - Url: persistence/upgrades/asp-6to7
+        Title: Version 6 to 7
       - Url: persistence/upgrades/asp-4to5
         Title: Version 4 to 5
       - Url: persistence/upgrades/asp-2to3

--- a/persistence/upgrades/asp-6to7.md
+++ b/persistence/upgrades/asp-6to7.md
@@ -1,7 +1,7 @@
 ---
-title: Azure Storage Persistence Upgrade Version 5 to 6
-summary: Instructions on how to migrate from Azure Table Persistence version 5 to 6
-reviewed: 2023-11-01
+title: Azure Storage Persistence Upgrade Version 6 to 7
+summary: Instructions on how to migrate from Azure Table Persistence version 6 to 7
+reviewed: 2023-12-08
 component: ASP
 related:
 - persistence/azure-table


### PR DESCRIPTION
Since the changes to the compatibility mode is mandatory starting in v7 and not in v6