### PR TITLE
ServiceControl troubleshooting - Low on storage

### DIFF
--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -359,3 +359,23 @@ Folder `C:\DBRecoverFolder` will now contain RavenDB recovery files. Rename the 
 9. Select all of the recovery files to import them
 
 Contact [Particular support](https://particular.net/support) for assistance.
+
+
+## Low on storage space
+
+ServiceControl will halt ingestion when low on storage. This can happen if incorrect or no [capacity planning](https://docs.particular.net/servicecontrol/capacity-and-planning) was done or that the system has grown and capacity planning wasn't re-evaluated.
+
+To mitigate growth or not having enough storage:
+
+a. Mount a new disk that is larger, stop instance, [move database](https://docs.particular.net/servicecontrol/configure-ravendb-location), adjust drive letter or update location in configuration, start instance
+b. Lower retention, optionally compact database
+  - https://docs.particular.net/servicecontrol/creating-config-file#data-retention-servicecontrolerrorretentionperiod
+  - https://docs.particular.net/servicecontrol/creating-config-file#data-retention-servicecontroleventretentionperiod
+  - https://docs.particular.net/servicecontrol/audit-instances/creating-config-file#data-retention-servicecontrol-auditauditretentionperiod
+c. Disable auditing on selecting endpoints if not all endpoint need auditing
+  - https://docs.particular.net/nservicebus/operations/auditing#configuring-auditing
+d. Filter which messages will be send to the audit queue using [NServiceBus.AuditFilter](https://github.com/NServiceBusExtensions/NServiceBus.AuditFilter)
+e. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
+  - https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes#overview-sharding-audit-messages-with-split-audit-queues
+f. Scale-out audit storage over multiple disks and/or machines
+  - https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes#overview-sharding-audit-messages-with-split-audit-queues

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -363,19 +363,22 @@ Contact [Particular support](https://particular.net/support) for assistance.
 
 ## Low on storage space
 
-ServiceControl will halt ingestion when low on storage. This can happen if incorrect or no [capacity planning](https://docs.particular.net/servicecontrol/capacity-and-planning) was done or that the system has grown and capacity planning wasn't re-evaluated.
+ServiceControl will halt ingestion when low on storage. This can happen if incorrect or no [capacity planning](/servicecontrol/capacity-and-planning.md) was done or that the system has grown and capacity planning wasn't re-evaluated.
 
 To mitigate growth or not having enough storage:
 
-a. Mount a new disk that is larger, stop instance, [move database](https://docs.particular.net/servicecontrol/configure-ravendb-location), adjust drive letter or update location in configuration, start instance
-b. Lower retention, optionally compact database
-  - https://docs.particular.net/servicecontrol/creating-config-file#data-retention-servicecontrolerrorretentionperiod
-  - https://docs.particular.net/servicecontrol/creating-config-file#data-retention-servicecontroleventretentionperiod
-  - https://docs.particular.net/servicecontrol/audit-instances/creating-config-file#data-retention-servicecontrol-auditauditretentionperiod
+a. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
+b. Lower retention, optionally compact database:
+
+  - [ServiceControl - Error instance setting `ServiceControl/ErrorRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontrolerrorretentionperiod)
+  - [ServiceControl - Error instance setting `ServiceControl/EventRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontroleventretentionperiod)
+  - [ServiceControl - Audit instance setting `ServiceControl.Audit/AuditRetentionPeriod`](/servicecontrol/audit-instances/creating-config-file.md#data-retention-servicecontrol-auditauditretentionperiod)
+  - [ServiceControl - How to compact database](/servicecontrol/db-compaction.md)
+  - [ServiceControl - How to purge expired data](/servicecontrol/how-purge-expired-data.md)
 c. Disable auditing on selecting endpoints if not all endpoint need auditing
-  - https://docs.particular.net/nservicebus/operations/auditing#configuring-auditing
+  - [NServiceBus - Message auditing](/nservicebus/operations/auditing.md#configuring-auditing)
 d. Filter which messages will be send to the audit queue using [NServiceBus.AuditFilter](https://github.com/NServiceBusExtensions/NServiceBus.AuditFilter)
 e. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
-  - https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes#overview-sharding-audit-messages-with-split-audit-queues
+  - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)
 f. Scale-out audit storage over multiple disks and/or machines
-  - https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes#overview-sharding-audit-messages-with-split-audit-queues
+  - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -360,24 +360,33 @@ Folder `C:\DBRecoverFolder` will now contain RavenDB recovery files. Rename the 
 
 Contact [Particular support](https://particular.net/support) for assistance.
 
-
 ## Low on storage space
 
 ServiceControl will halt ingestion when low on storage. This can happen if incorrect or no [capacity planning](/servicecontrol/capacity-and-planning.md) was done or that the system has grown and capacity planning wasn't re-evaluated.
 
 To mitigate growth or not having enough storage:
 
-a. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
-b. Lower retention, optionally compact database:
-  - [ServiceControl - Error instance setting `ServiceControl/ErrorRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontrolerrorretentionperiod)
-  - [ServiceControl - Error instance setting `ServiceControl/EventRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontroleventretentionperiod)
-  - [ServiceControl - Audit instance setting `ServiceControl.Audit/AuditRetentionPeriod`](/servicecontrol/audit-instances/creating-config-file.md#data-retention-servicecontrol-auditauditretentionperiod)
-  - [ServiceControl - How to compact database](/servicecontrol/db-compaction.md)
-  - [ServiceControl - How to purge expired data](/servicecontrol/how-purge-expired-data.md)
-c. Disable auditing on selecting endpoints if not all endpoint need auditing
-  - [NServiceBus - Message auditing](/nservicebus/operations/auditing.md#configuring-auditing)
-d. Filter which messages will be send to the audit queue using [NServiceBus.AuditFilter](https://github.com/NServiceBusExtensions/NServiceBus.AuditFilter)
-e. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
-  - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)
-f. Scale-out audit storage over multiple disks and/or machines
-  - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)
+1. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
+2. Lower retention, optionally compact database:
+
+   - [ServiceControl - Error instance setting `ServiceControl/ErrorRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontrolerrorretentionperiod)
+   - [ServiceControl - Error instance setting `ServiceControl/EventRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontroleventretentionperiod)
+   - [ServiceControl - Audit instance setting `ServiceControl.Audit/AuditRetentionPeriod`](/servicecontrol/audit-instances/creating-config-file.md#data-retention-servicecontrol-auditauditretentionperiod)
+   - [ServiceControl - How to compact database](/servicecontrol/db-compaction.md)
+   - [ServiceControl - How to purge expired data](/servicecontrol/how-purge-expired-data.md)
+
+3. Disable auditing on selecting endpoints if not all endpoint need auditing
+
+   - [NServiceBus - Message auditing](/nservicebus/operations/auditing.md#configuring-auditing)
+
+4. Filter which messages will be send to the audit queue using
+
+   - [NServiceBus.AuditFilter](https://github.com/NServiceBusExtensions/NServiceBus.AuditFilter)
+
+5. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
+
+   - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)
+
+6. Scale-out audit storage over multiple disks and/or machines
+
+   - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -369,7 +369,6 @@ To mitigate growth or not having enough storage:
 
 a. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
 b. Lower retention, optionally compact database:
-
   - [ServiceControl - Error instance setting `ServiceControl/ErrorRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontrolerrorretentionperiod)
   - [ServiceControl - Error instance setting `ServiceControl/EventRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontroleventretentionperiod)
   - [ServiceControl - Audit instance setting `ServiceControl.Audit/AuditRetentionPeriod`](/servicecontrol/audit-instances/creating-config-file.md#data-retention-servicecontrol-auditauditretentionperiod)

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -367,7 +367,12 @@ ServiceControl will halt ingestion when low on storage. This can happen if incor
 To mitigate growth or not having enough storage:
 
 1. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
-2. Lower retention, optionally compact database:
+2. Enlarge parition if your environment supports this:
+
+   - Expand the partition if the drive has enough storage
+   - Mount a new disk and join these with the existing disk ([JBOD](https://en.wikipedia.org/wiki/Non-RAID_drive_architectures#JBOD))
+
+5. Lower retention, optionally compact database:
 
    - [ServiceControl - Error instance setting `ServiceControl/ErrorRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontrolerrorretentionperiod)
    - [ServiceControl - Error instance setting `ServiceControl/EventRetentionPeriod`](/servicecontrol/creating-config-file.md#data-retention-servicecontroleventretentionperiod)
@@ -375,18 +380,18 @@ To mitigate growth or not having enough storage:
    - [ServiceControl - How to compact database](/servicecontrol/db-compaction.md)
    - [ServiceControl - How to purge expired data](/servicecontrol/how-purge-expired-data.md)
 
-3. Disable auditing on selecting endpoints if not all endpoint need auditing
+6. Disable auditing on selecting endpoints if not all endpoint need auditing
 
    - [NServiceBus - Message auditing](/nservicebus/operations/auditing.md#configuring-auditing)
 
-4. Filter which messages will be send to the audit queue using
+7. Filter which messages will be send to the audit queue using
 
    - [NServiceBus.AuditFilter](https://github.com/NServiceBusExtensions/NServiceBus.AuditFilter)
 
-5. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
+8. Setup multiple audit instance with different retension periods if retension requirements can vary between endpoints
 
    - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)
 
-6. Scale-out audit storage over multiple disks and/or machines
+9. Scale-out audit storage over multiple disks and/or machines
 
    - [ServiceControl remote instances  Sharding audit messages with split audit queues](/servicecontrol/servicecontrol-instances/remotes.md#overview-sharding-audit-messages-with-split-audit-queues)

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -367,7 +367,7 @@ ServiceControl will halt ingestion when low on storage. This can happen if incor
 To mitigate growth or not having enough storage:
 
 1. Mount a new disk that is larger, stop instance, [move database](/servicecontrol/configure-ravendb-location.md), adjust drive letter or update location in configuration, start instance
-2. Enlarge parition if your environment supports this:
+2. Enlarge storage partition if the environment supports this:
 
    - Expand the partition if the drive has enough storage
    - Mount a new disk and join these with the existing disk ([JBOD](https://en.wikipedia.org/wiki/Non-RAID_drive_architectures#JBOD))


### PR DESCRIPTION
Based on a support case. Guidance on what options there are when the database expands too much or when on a drive that is not provisioned with enough storage.

