### PR TITLE
Update the ClientUI web server port to avoid possible conflicts on macOS

### DIFF
--- a/tutorials/quickstart/Solution/ClientUI/Properties/launchSettings.json
+++ b/tutorials/quickstart/Solution/ClientUI/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "ClientUI": {
       "commandName": "Project",
       "launchBrowser": true,      
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:5105",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Related to https://github.com/Particular/docs.particular.net/issues/6381

It looks like port 5000 on macOS might be reserved for AirPlay. On my Mac, the port is bound to the ControlCE App, and that crashes the ClientUI web project when started from the IDE.