### PR TITLE
Scheduling samples for Core9

### DIFF
--- a/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_7/Scheduler/Scheduler.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="FluentScheduler" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_8/Scheduler/Scheduler.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="FluentScheduler" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/fluentscheduler/Core_9/FluentScheduler.sln
+++ b/samples/scheduling/fluentscheduler/Core_9/FluentScheduler.sln
@@ -1,0 +1,27 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "Scheduler\Scheduler.csproj", "{B58159EB-9EFD-443F-A80E-8C90B0AF1907}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{BF92D39E-42F6-44E9-8F7F-819993235621}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/scheduling/fluentscheduler/Core_9/Receiver/MyHandler.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Receiver/MyHandler.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+public class MyHandler :
+    IHandleMessages<MyMessage>
+{
+    static ILog log = LogManager.GetLogger<MyHandler>();
+
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        log.Info("Hello from MyHandler");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/scheduling/fluentscheduler/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Receiver/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Samples.FluentScheduler.Receiver";
+        var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Receiver");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+        Console.WriteLine("Press any key to exit");
+        Console.WriteLine("Waiting for messages from the Scheduler");
+        Console.ReadKey();
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+    }
+}

--- a/samples/scheduling/fluentscheduler/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/fluentscheduler/Core_9/Receiver/Receiver.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/fluentscheduler/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Scheduler/Program.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentScheduler;
+using NServiceBus;
+using NServiceBus.Logging;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Samples.FluentScheduler.Scheduler";
+        var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Scheduler");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        #region logging
+
+        var logger = LogManager.GetLogger(typeof(JobManager).FullName);
+        JobManager.JobException += info =>
+        {
+            logger.Error($"Error occurred in job: {info.Name}", info.Exception);
+        };
+        JobManager.JobStart += info =>
+        {
+            logger.Info($"Start job: {info.Name}. Duration: {info.StartTime}");
+        };
+        JobManager.JobEnd += info =>
+        {
+            logger.Info($"End job: {info.Name}. Duration: {info.Duration}. NextRun: {info.NextRun}.");
+        };
+
+        #endregion
+
+        #region Configuration
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        JobManager.AddJob(
+            new SendMessageJob(endpointInstance),
+            schedule =>
+            {
+                schedule
+                    .ToRunNow()
+                    .AndEvery(3).Seconds();
+            });
+
+        #endregion
+
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+
+        #region shutdown
+
+        JobManager.StopAndBlock();
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+
+        #endregion
+    }
+}

--- a/samples/scheduling/fluentscheduler/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/fluentscheduler/Core_9/Scheduler/Scheduler.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentScheduler" Version="5.*" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/fluentscheduler/Core_9/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Scheduler/SendMessageJob.cs
@@ -1,0 +1,20 @@
+﻿using FluentScheduler;
+using NServiceBus;
+
+#region SendMessageJob
+public class SendMessageJob : IJob
+{
+    IEndpointInstance endpoint;
+
+    public SendMessageJob(IEndpointInstance endpoint)
+    {
+        this.endpoint = endpoint;
+    }
+
+    public void Execute()
+    {
+        endpoint.Send("Samples.FluentScheduler.Receiver", new MyMessage())
+            .GetAwaiter().GetResult();
+    }
+}
+#endregion

--- a/samples/scheduling/fluentscheduler/Core_9/Shared/MyMessage.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Shared/MyMessage.cs
@@ -1,0 +1,6 @@
+﻿using NServiceBus;
+
+public class MyMessage :
+    IMessage
+{
+}

--- a/samples/scheduling/fluentscheduler/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/fluentscheduler/Core_9/Shared/Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.0.0-alpha.10" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/hangfire/Core_7/Receiver/MyHandler.cs
+++ b/samples/scheduling/hangfire/Core_7/Receiver/MyHandler.cs
@@ -1,15 +1,13 @@
+using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using Serilog;
 
 public class MyHandler :
     IHandleMessages<MyMessage>
 {
-    static ILogger log = Log.ForContext<MyHandler>();
-
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        log.Information("Hello from MyHandler");
+        Console.WriteLine("Hello from MyHandler");
         return Task.CompletedTask;
     }
 }

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="Serilog" Version="2.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
@@ -7,7 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.*" />
-  </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
@@ -6,6 +6,7 @@ using NServiceBus;
 using NServiceBus.Logging;
 using NServiceBus.Serilog;
 using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
@@ -14,7 +15,7 @@ class Program
         #region serilog
 
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.ColoredConsole()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
             .CreateLogger();
         LogManager.Use<SerilogFactory>();
 

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
@@ -3,24 +3,11 @@ using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.HangfireScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport<LearningTransport>();
@@ -36,6 +23,8 @@ class Program
         // use in memory storage. Production should use more robust alternatives:
         // SqlServer, Msmq, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
+
+        GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();
 
         // create and start scheduler instance
         var scheduler = new BackgroundJobServer();
@@ -57,7 +46,6 @@ class Program
         scheduler.Dispose();
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
@@ -6,11 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.*" />
-    <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.*" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.*" />
-    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
@@ -10,9 +10,5 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.*" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_8/Receiver/MyHandler.cs
+++ b/samples/scheduling/hangfire/Core_8/Receiver/MyHandler.cs
@@ -1,15 +1,13 @@
+using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using Serilog;
 
 public class MyHandler :
     IHandleMessages<MyMessage>
 {
-    static ILogger log = Log.ForContext<MyHandler>();
-
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        log.Information("Hello from MyHandler");
+        Console.WriteLine("Hello from MyHandler");
         return Task.CompletedTask;
     }
 }

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="Serilog" Version="2.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -7,7 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.*" />
-  </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
@@ -3,24 +3,11 @@ using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.HangfireScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
@@ -36,6 +23,8 @@ class Program
         // use in memory storage. Production should use more robust alternatives:
         // SqlServer, Msmq, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
+
+        GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();
 
         // create and start scheduler instance
         var scheduler = new BackgroundJobServer();
@@ -57,7 +46,6 @@ class Program
         scheduler.Dispose();
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
@@ -6,6 +6,7 @@ using NServiceBus;
 using NServiceBus.Logging;
 using NServiceBus.Serilog;
 using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
@@ -14,7 +15,7 @@ class Program
         #region serilog
 
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.ColoredConsole()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
             .CreateLogger();
         LogManager.Use<SerilogFactory>();
 

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -6,11 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.*" />
-    <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.*" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.*" />
-    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -10,9 +10,5 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.*" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_9/HangfireScheduler.sln
+++ b/samples/scheduling/hangfire/Core_9/HangfireScheduler.sln
@@ -1,0 +1,27 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "Scheduler\Scheduler.csproj", "{B58159EB-9EFD-443F-A80E-8C90B0AF1907}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{BF92D39E-42F6-44E9-8F7F-819993235621}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/scheduling/hangfire/Core_9/Receiver/MyHandler.cs
+++ b/samples/scheduling/hangfire/Core_9/Receiver/MyHandler.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using Serilog;
+
+public class MyHandler :
+    IHandleMessages<MyMessage>
+{
+    static ILogger log = Log.ForContext<MyHandler>();
+
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        log.Information("Hello from MyHandler");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/scheduling/hangfire/Core_9/Receiver/MyHandler.cs
+++ b/samples/scheduling/hangfire/Core_9/Receiver/MyHandler.cs
@@ -1,15 +1,13 @@
+using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using Serilog;
 
 public class MyHandler :
     IHandleMessages<MyMessage>
 {
-    static ILogger log = Log.ForContext<MyHandler>();
-
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        log.Information("Hello from MyHandler");
+        Console.WriteLine("Hello from MyHandler");
         return Task.CompletedTask;
     }
 }

--- a/samples/scheduling/hangfire/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Receiver/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Samples.HangfireScheduler.Receiver";
+        var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Receiver");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+        Console.WriteLine("Press any key to exit");
+        Console.WriteLine("Waiting for messages from the Scheduler");
+        Console.ReadKey();
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+    }
+}

--- a/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.*" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
@@ -7,7 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.*" />
-  </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_9/Scheduler/EndpointHelper.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/EndpointHelper.cs
@@ -1,0 +1,10 @@
+﻿using NServiceBus;
+
+#region EndpointInstance
+
+public static class EndpointHelper
+{
+    public static IEndpointInstance Instance { get; set; }
+}
+
+#endregion

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.MemoryStorage;
+using NServiceBus;
+using NServiceBus.Logging;
+using NServiceBus.Serilog;
+using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
+
+class Program
+{
+    static async Task Main()
+    {
+        #region serilog
+
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
+            .CreateLogger();
+        LogManager.Use<SerilogFactory>();
+
+        #endregion
+
+        Console.Title = "Samples.HangfireScheduler.Scheduler";
+        var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        #region Configuration
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        // store the endpointInstance in a static helper class
+        EndpointHelper.Instance = endpointInstance;
+
+        // use in memory storage. Production should use more robust alternatives:
+        // SqlServer, Msmq, Redis etc
+        GlobalConfiguration.Configuration.UseMemoryStorage();
+
+        // create and start scheduler instance
+        var scheduler = new BackgroundJobServer();
+
+        #endregion
+
+        #region scheduleJob
+
+        // Tell Hangfire to schedule the job and trigger every minute
+        RecurringJob.AddOrUpdate("myJob", () => SendMessageJob.Run(), Cron.Minutely);
+
+        #endregion
+
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+
+        #region shutdown
+
+        scheduler.Dispose();
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+        Log.CloseAndFlush();
+
+        #endregion
+    }
+}

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
@@ -3,24 +3,11 @@ using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.HangfireScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
@@ -37,6 +24,8 @@ class Program
         // use in memory storage. Production should use more robust alternatives:
         // SqlServer, Msmq, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
+
+        GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();
 
         // create and start scheduler instance
         var scheduler = new BackgroundJobServer();
@@ -58,7 +47,6 @@ class Program
         scheduler.Dispose();
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Hangfire.Core" Version="1.*" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
+    <PackageReference Include="NServiceBus.Serilog" Version="11.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
@@ -10,9 +10,5 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="1.*" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="11.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/hangfire/Core_9/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/SendMessageJob.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+
+#region SendMessageJob
+public static class SendMessageJob
+{
+    public static Task Run()
+    {
+        var endpoint = EndpointHelper.Instance;
+        return endpoint.Send("Samples.HangfireScheduler.Receiver", new MyMessage());
+    }
+}
+#endregion

--- a/samples/scheduling/hangfire/Core_9/Shared/MyMessage.cs
+++ b/samples/scheduling/hangfire/Core_9/Shared/MyMessage.cs
@@ -1,0 +1,6 @@
+﻿using NServiceBus;
+
+public class MyMessage :
+    IMessage
+{
+}

--- a/samples/scheduling/hangfire/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_9/Shared/Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.0.0-alpha.10" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/hangfire/sample.md
+++ b/samples/scheduling/hangfire/sample.md
@@ -74,15 +74,6 @@ snippet: shutdown
 The Hangfire scheduler implements the `IDisposable` interface. For cleanup purposes, keep a reference to the scheduler instance and call `Dispose()` at shutdown. Alternatively, use [dependency injection](/nservicebus/dependency-injection/), and let cleanup be automatically be managed.
 
 
-### Logging
-
-Hangfire uses [LibLog](https://github.com/damianh/LibLog). Since LibLog supports the detection and utilization of [Serilog](https://serilog.net/), this sample uses the NServiceBus Serilog integration.
-
-snippet: serilog
-
-LibLog [supports many other common logging libraries](https://github.com/damianh/LibLog/wiki#transparent-logging-support). Hangfire can also be configured to use a custom logger. See [Adding logging in Hangfire](https://docs.hangfire.io/en/latest/configuration/configuring-logging.html).
-
-
 ## Scale Out
 
 Note that in this sample, an instance of the Hangfire scheduler is configured to run in every endpoint's instance. If an endpoint is [scaled out](/nservicebus/scaling.md), then the configured jobs will be executed by each of the running instances. A persistent [job storage](https://docs.hangfire.io/en/latest/configuration/index.html) can help to manage the Hangfire scheduler shared state, including jobs, triggers, calendars, etc.

--- a/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
@@ -1,26 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
 using Quartz;
 using Quartz.Impl;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
+using Quartz.Logging;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.QuartzScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport<LearningTransport>();
@@ -29,6 +17,8 @@ class Program
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
+
+        LogProvider.SetCurrentLogProvider(new QuartzConsoleLogProvider());
 
         var schedulerFactory = new StdSchedulerFactory();
 
@@ -77,7 +67,6 @@ class Program
             .ConfigureAwait(false);
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
@@ -6,6 +6,7 @@ using NServiceBus.Serilog;
 using Quartz;
 using Quartz.Impl;
 using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
@@ -14,7 +15,7 @@ class Program
         #region serilog
 
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.ColoredConsole()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
             .CreateLogger();
         LogManager.Use<SerilogFactory>();
 

--- a/samples/scheduling/quartz/Core_7/Scheduler/QuartzConsoleLogProvider.cs
+++ b/samples/scheduling/quartz/Core_7/Scheduler/QuartzConsoleLogProvider.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Quartz.Logging;
+
+class QuartzConsoleLogProvider : ILogProvider
+{
+    public Logger GetLogger(string name)
+    {
+        return (level, func, exception, parameters) =>
+        {
+            if (level >= LogLevel.Info && func != null)
+            {
+                Console.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] [" + level + "] " + func(), parameters);
+            }
+            return true;
+        };
+    }
+
+    public IDisposable OpenNestedContext(string message)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
@@ -6,9 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
     <PackageReference Include="Quartz" Version="3.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.*" />
-    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
@@ -8,9 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
     <PackageReference Include="Quartz" Version="3.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/quartz/Core_7/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/quartz/Core_7/Scheduler/SendMessageJob.cs
@@ -2,15 +2,12 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using Quartz;
-using Serilog;
 
 #region SendMessageJob
 
 public class SendMessageJob :
     IJob
 {
-    static ILogger log = Log.ForContext<SendMessageJob>();
-
     public async Task Execute(IJobExecutionContext context)
     {
         try
@@ -22,7 +19,7 @@ public class SendMessageJob :
         }
         catch (Exception exception)
         {
-            log.Fatal(exception, "Execution Failed");
+            Console.WriteLine($"Execution Failed: {exception.Message}");
             // TODO: handle exception and dont throw.
             // consider implementing a circuit breaker
             throw;

--- a/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
@@ -1,26 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
 using Quartz;
 using Quartz.Impl;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
+using Quartz.Logging;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.QuartzScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
@@ -29,6 +17,8 @@ class Program
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
+
+        LogProvider.SetCurrentLogProvider(new QuartzConsoleLogProvider());
 
         var schedulerFactory = new StdSchedulerFactory();
 
@@ -77,7 +67,6 @@ class Program
             .ConfigureAwait(false);
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
@@ -6,6 +6,7 @@ using NServiceBus.Serilog;
 using Quartz;
 using Quartz.Impl;
 using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
 
 class Program
 {
@@ -14,7 +15,7 @@ class Program
         #region serilog
 
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.ColoredConsole()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
             .CreateLogger();
         LogManager.Use<SerilogFactory>();
 

--- a/samples/scheduling/quartz/Core_8/Scheduler/QuartzConsoleLogProvider.cs
+++ b/samples/scheduling/quartz/Core_8/Scheduler/QuartzConsoleLogProvider.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Quartz.Logging;
+
+class QuartzConsoleLogProvider : ILogProvider
+{
+    public Logger GetLogger(string name)
+    {
+        return (level, func, exception, parameters) =>
+        {
+            if (level >= LogLevel.Info && func != null)
+            {
+                Console.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] [" + level + "] " + func(), parameters);
+            }
+            return true;
+        };
+    }
+
+    public IDisposable OpenNestedContext(string message)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -6,9 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
     <PackageReference Include="Quartz" Version="3.*" />
-    <PackageReference Include="NServiceBus.Serilog" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.*" />
-    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -8,9 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Serilog" Version="9.*" />
     <PackageReference Include="Quartz" Version="3.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/quartz/Core_8/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/quartz/Core_8/Scheduler/SendMessageJob.cs
@@ -2,15 +2,12 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using Quartz;
-using Serilog;
 
 #region SendMessageJob
 
 public class SendMessageJob :
     IJob
 {
-    static ILogger log = Log.ForContext<SendMessageJob>();
-
     public async Task Execute(IJobExecutionContext context)
     {
         try
@@ -22,7 +19,7 @@ public class SendMessageJob :
         }
         catch (Exception exception)
         {
-            log.Fatal(exception, "Execution Failed");
+            Console.WriteLine($"Execution Failed: {exception.Message}");
             // TODO: handle exception and dont throw.
             // consider implementing a circuit breaker
             throw;

--- a/samples/scheduling/quartz/Core_9/QuartzScheduler.sln
+++ b/samples/scheduling/quartz/Core_9/QuartzScheduler.sln
@@ -1,0 +1,27 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "Scheduler\Scheduler.csproj", "{B58159EB-9EFD-443F-A80E-8C90B0AF1907}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{BF92D39E-42F6-44E9-8F7F-819993235621}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B58159EB-9EFD-443F-A80E-8C90B0AF1907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEC6A8C-DB3C-4F20-93CE-5004BF16AD7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF92D39E-42F6-44E9-8F7F-819993235621}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/scheduling/quartz/Core_9/Receiver/MyHandler.cs
+++ b/samples/scheduling/quartz/Core_9/Receiver/MyHandler.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+public class MyHandler :
+    IHandleMessages<MyMessage>
+{
+    static ILog log = LogManager.GetLogger<MyHandler>();
+
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        log.Info("Hello from MyHandler");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/scheduling/quartz/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/quartz/Core_9/Receiver/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Samples.QuartzScheduler.Receiver";
+        var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Receiver");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+        Console.WriteLine("Press any key to exit");
+        Console.WriteLine("Waiting for messages from the Sender");
+        Console.ReadKey();
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+    }
+}

--- a/samples/scheduling/quartz/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_9/Receiver/Receiver.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
@@ -1,26 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NServiceBus;
-using NServiceBus.Logging;
-using NServiceBus.Serilog;
 using Quartz;
 using Quartz.Impl;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
+using Quartz.Logging;
 
 class Program
 {
     static async Task Main()
     {
-        #region serilog
-
-        Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
-            .CreateLogger();
-        LogManager.Use<SerilogFactory>();
-
-        #endregion
-
         Console.Title = "Samples.QuartzScheduler.Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
@@ -30,6 +18,8 @@ class Program
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
+
+        LogProvider.SetCurrentLogProvider(new QuartzConsoleLogProvider());
 
         var schedulerFactory = new StdSchedulerFactory();
 
@@ -78,7 +68,6 @@ class Program
             .ConfigureAwait(false);
         await endpointInstance.Stop()
             .ConfigureAwait(false);
-        Log.CloseAndFlush();
 
         #endregion
     }

--- a/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+using NServiceBus.Serilog;
+using Quartz;
+using Quartz.Impl;
+using Serilog;
+using Serilog.Sinks.SystemConsole.Themes;
+
+class Program
+{
+    static async Task Main()
+    {
+        #region serilog
+
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {Message}{NewLine}{Exception}", theme: AnsiConsoleTheme.Sixteen)
+            .CreateLogger();
+        LogManager.Use<SerilogFactory>();
+
+        #endregion
+
+        Console.Title = "Samples.QuartzScheduler.Scheduler";
+        var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
+        endpointConfiguration.UseTransport(new LearningTransport());
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+        #region Configuration
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        var schedulerFactory = new StdSchedulerFactory();
+
+        var scheduler = await schedulerFactory.GetScheduler()
+            .ConfigureAwait(false);
+
+        // inject the endpointInstance into the scheduler context
+        scheduler.SetEndpointInstance(endpointInstance);
+
+        await scheduler.Start()
+            .ConfigureAwait(false);
+        #endregion
+
+        #region scheduleJob
+
+        // define the job and tie it to the SendMessageJob class
+        var job = JobBuilder.Create<SendMessageJob>()
+            .WithIdentity("job1", "group1")
+            .Build();
+
+        // Trigger the job to run now, and then repeat every 3 seconds
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .StartNow()
+            .WithSimpleSchedule(
+                action: builder =>
+                {
+                    builder
+                        .WithIntervalInSeconds(3)
+                        .RepeatForever();
+                })
+            .Build();
+
+        // Tell quartz to schedule the job using the trigger
+        await scheduler.ScheduleJob(job, trigger)
+            .ConfigureAwait(false);
+
+        #endregion
+
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+
+        #region shutdown
+
+        await scheduler.Shutdown()
+            .ConfigureAwait(false);
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+        Log.CloseAndFlush();
+
+        #endregion
+    }
+}

--- a/samples/scheduling/quartz/Core_9/Scheduler/QuartzConsoleLogProvider.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/QuartzConsoleLogProvider.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Quartz.Logging;
+
+class QuartzConsoleLogProvider : ILogProvider
+{
+    public Logger GetLogger(string name)
+    {
+        return (level, func, exception, parameters) =>
+        {
+            if (level >= LogLevel.Info && func != null)
+            {
+                Console.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] [" + level + "] " + func(), parameters);
+            }
+            return true;
+        };
+    }
+
+    public IDisposable OpenNestedContext(string message)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/samples/scheduling/quartz/Core_9/Scheduler/QuartzContextExtensions.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/QuartzContextExtensions.cs
@@ -1,0 +1,19 @@
+﻿using NServiceBus;
+using Quartz;
+
+#region QuartzContextExtensions
+
+public static class QuartzContextExtensions
+{
+    public static IEndpointInstance EndpointInstance(this IJobExecutionContext context)
+    {
+        return (IEndpointInstance) context.Scheduler.Context["EndpointInstance"];
+    }
+
+    public static void SetEndpointInstance(this IScheduler scheduler, IEndpointInstance instance)
+    {
+        scheduler.Context["EndpointInstance"] = instance;
+    }
+}
+
+#endregion

--- a/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
@@ -8,9 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Serilog" Version="11.*" />
     <PackageReference Include="Quartz" Version="3.*" />
-    <PackageReference Include="Serilog" Version="3.*" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Serilog" Version="11.*" />
+    <PackageReference Include="Quartz" Version="3.*" />
+    <PackageReference Include="Serilog" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.*" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/quartz/Core_9/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/SendMessageJob.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using Quartz;
+using Serilog;
+
+#region SendMessageJob
+
+public class SendMessageJob :
+    IJob
+{
+    static ILogger log = Log.ForContext<SendMessageJob>();
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        try
+        {
+            var endpointInstance = context.EndpointInstance();
+            var message = new MyMessage();
+            await endpointInstance.Send("Samples.QuartzScheduler.Receiver", message)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            log.Fatal(exception, "Execution Failed");
+            // TODO: handle exception and dont throw.
+            // consider implementing a circuit breaker
+            throw;
+        }
+    }
+}
+
+#endregion

--- a/samples/scheduling/quartz/Core_9/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/SendMessageJob.cs
@@ -2,15 +2,12 @@
 using System.Threading.Tasks;
 using NServiceBus;
 using Quartz;
-using Serilog;
 
 #region SendMessageJob
 
 public class SendMessageJob :
     IJob
 {
-    static ILogger log = Log.ForContext<SendMessageJob>();
-
     public async Task Execute(IJobExecutionContext context)
     {
         try
@@ -22,7 +19,7 @@ public class SendMessageJob :
         }
         catch (Exception exception)
         {
-            log.Fatal(exception, "Execution Failed");
+            Console.WriteLine($"Execution Failed: {exception.Message}");
             // TODO: handle exception and dont throw.
             // consider implementing a circuit breaker
             throw;

--- a/samples/scheduling/quartz/Core_9/Shared/MyMessage.cs
+++ b/samples/scheduling/quartz/Core_9/Shared/MyMessage.cs
@@ -1,0 +1,6 @@
+﻿using NServiceBus;
+
+public class MyMessage :
+    IMessage
+{
+}

--- a/samples/scheduling/quartz/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_9/Shared/Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.0.0-alpha.10" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/quartz/sample.md
+++ b/samples/scheduling/quartz/sample.md
@@ -63,15 +63,6 @@ The Quartz scheduler should be shut down when the endpoint is stopped.
 snippet: shutdown
 
 
-### Logging
-
-Quartz.NET uses [LibLog](https://github.com/damianh/LibLog). Since LibLog supports the detection and utilization of [Serilog](https://serilog.net/), this sample use the NServiceBus Serilog integration.
-
-snippet: serilog
-
-LibLog [supports many other common logging libraries](https://github.com/damianh/LibLog/wiki#transparent-logging-support). Quartz can also be configured to use a custom logger. See [Adding logging in Quartz.NET](https://www.quartz-scheduler.net/documentation/quartz-3.x/quick-start.html#adding-logging).
-
-
 ### Exception Handling
 
 Quartz recommendations for [Handling Exceptions](https://www.quartz-scheduler.net/documentation/best-practices.html#throwing-exceptions):

--- a/samples/scheduling/timer/Core_9/Sample/MyHandler.cs
+++ b/samples/scheduling/timer/Core_9/Sample/MyHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+public class MyHandler :
+    IHandleMessages<MyMessage>
+{
+    static ILog log = LogManager.GetLogger<MyHandler>();
+
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        log.Info("Hello from MyHandler");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/scheduling/timer/Core_9/Sample/MyMessage.cs
+++ b/samples/scheduling/timer/Core_9/Sample/MyMessage.cs
@@ -1,0 +1,6 @@
+﻿using NServiceBus;
+
+public class MyMessage :
+    IMessage
+{
+}

--- a/samples/scheduling/timer/Core_9/Sample/MyScheduledTask.cs
+++ b/samples/scheduling/timer/Core_9/Sample/MyScheduledTask.cs
@@ -1,0 +1,8 @@
+﻿using NServiceBus;
+
+partial class Program
+{
+    public class MyScheduledTask : IMessage
+    {
+    }
+}

--- a/samples/scheduling/timer/Core_9/Sample/MyScheduledTaskHandler.cs
+++ b/samples/scheduling/timer/Core_9/Sample/MyScheduledTaskHandler.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+partial class Program
+{
+    public class MyScheduledTaskHandler : IHandleMessages<MyScheduledTask>
+    {
+        static ILog log = LogManager.GetLogger<MyHandler>();
+
+        public Task Handle(MyScheduledTask message, IMessageHandlerContext context)
+        {
+            log.Info(nameof(MyScheduledTask) + " invoked");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/samples/scheduling/timer/Core_9/Sample/Program.cs
+++ b/samples/scheduling/timer/Core_9/Sample/Program.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+partial class Program
+{
+    static ILog log = LogManager.GetLogger<Program>();
+
+    static async Task Main()
+    {
+        Console.Title = "Samples.Scheduling.Timer";
+        var endpointConfiguration = new EndpointConfiguration("Samples.Scheduling.Timer");
+        endpointConfiguration.UsePersistence<LearningPersistence>();
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseTransport(new LearningTransport());
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration)
+            .ConfigureAwait(false);
+
+        #region ScheduleUsingTimer
+        var interval = TimeSpan.FromSeconds(5);
+
+        var timer = new Timer(async state =>
+        {
+            try
+            {
+                await endpointInstance.SendLocal(new MyScheduledTask());
+                log.Info(nameof(MyScheduledTask) + " scheduled");
+            }
+            catch (Exception ex)
+            {
+                log.Error(nameof(MyScheduledTask) + " could not be scheduled", ex);
+            }
+        }, null, interval, interval);
+
+        #endregion
+
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+
+        timer.Dispose();
+
+        await endpointInstance.Stop()
+            .ConfigureAwait(false);
+    }
+}

--- a/samples/scheduling/timer/Core_9/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_9/Sample/Sample.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.0.0-alpha.10" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/timer/Core_9/Timer.sln
+++ b/samples/scheduling/timer/Core_9/Timer.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.csproj", "{48F718EE-6C45-41BA-80EC-81BF34D4A623}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48F718EE-6C45-41BA-80EC-81BF34D4A623}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR updates the scheduling samples.

- FluentScheduler
  - Added core9 sample
- Hangfire
  - Updated Core7 & core8 samples
    - Bump NServiceBus.Serilog to version version 9
    - Fixed deprecated dependencies
      - Hangfire.MemoryStorage.Core -> Hangfire.MemoryStorage
      - Serilog.Sinks.ColoredConsole -> Serilog.Sinks.Console
  - Add core9 sample
    - Bump NServiceBus.Serilog to version 11
- Quartz
  - Updated Core7 & core8 samples
    - Bump NServiceBus.Serilog to version version 9
    - Fixed deprecated dependencies
      - Hangfire.MemoryStorage.Core -> Hangfire.MemoryStorage
      - Serilog.Sinks.ColoredConsole -> Serilog.Sinks.Console
  - Add core9 sample 
    - Bump NServiceBus.Serilog to version 11
- [NSB scheduler deprecated](https://docs.particular.net/nservicebus/upgrades/7to8/#nservicebus-scheduler) (No core9 sample added) 
- Timers
  -  Add core9 sample 