### PR TITLE
Use the asb-transport CLI instead of the Azure CLI

### DIFF
--- a/samples/azure-functions/service-bus/sample.md
+++ b/samples/azure-functions/service-bus/sample.md
@@ -23,7 +23,7 @@ downloadbutton
 
 Unlike a traditional NServiceBus endpoint, an endpoint hosted in Azure Functions cannot create its own input queue. In this sample, that queue name is `ASBTriggerQueue`.
 
-To create the endpoint with the [Azure Service Bus Transport CLI](/transports/azure-service-bus/operational-scripting), execute the following command:
+To create the endpoint with the [Azure Service Bus Transport CLI](/transports/azure-service-bus/operational-scripting.md), execute the following command:
 
 ```
 asb-transport endpoint create ASBTriggerQueue

--- a/samples/azure-functions/service-bus/sample.md
+++ b/samples/azure-functions/service-bus/sample.md
@@ -23,16 +23,13 @@ downloadbutton
 
 Unlike a traditional NServiceBus endpoint, an endpoint hosted in Azure Functions cannot create its own input queue. In this sample, that queue name is `ASBTriggerQueue`.
 
-To create the queue with the Azure CLI, execute the following [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) command:
+To create the endpoint with the [Azure Service Bus Transport CLI](/transports/azure-service-bus/operational-scripting), execute the following command:
 
 ```
-az servicebus queue create --name ASBTriggerQueue --namespace-name <asb-namespace-to-use> --resource-group <resource-group-containing-namespace>
+asb-transport endpoint create ASBTriggerQueue
 ```
-### Manually create bundle topic
 
-```
-az servicebus topic create --name bundle-1 --namespace-name <asb-namespace-to-use> --resource-group <resource-group-containing-namespace>
-```
+The command will create the required queue and topic.
 
 ### Configure Connection string
 


### PR DESCRIPTION
It looks like the resources created by the Azure CLI work fine for the example. If the example is modified by adding an event and the corresponding handler, it fails to create the required subscription, even if the `bundle-1` topic exists. Using the `asb-transport` CLI it works as expected.