### PR TITLE
Document path for .net 8 license location

### DIFF
--- a/nservicebus/licensing/index_license-management_core_[7,8).partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,8).partial.md
@@ -22,7 +22,7 @@ To install a license for all endpoints and Particular Service Platform applicati
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
 * Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
-* macOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
+* macOS (.NET 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
 
 
 ### Machine-wide license location

--- a/nservicebus/licensing/index_license-management_core_[7,8).partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,8).partial.md
@@ -22,6 +22,7 @@ To install a license for all endpoints and Particular Service Platform applicati
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
 * Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
+* macOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
 
 
 ### Machine-wide license location

--- a/nservicebus/licensing/index_license-management_core_[8,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[8,].partial.md
@@ -21,7 +21,8 @@ A license located at `{AppDomain.CurrentDomain.BaseDirectory}/license.xml` will 
 To install a license for all endpoints and Particular Service Platform applications run by a specific user, install the license file in the following location:
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
-* Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
+* Linux/MacOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
+* MacOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
 
 ### Machine-wide license location
 

--- a/nservicebus/licensing/index_license-management_core_[8,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[8,].partial.md
@@ -21,8 +21,8 @@ A license located at `{AppDomain.CurrentDomain.BaseDirectory}/license.xml` will 
 To install a license for all endpoints and Particular Service Platform applications run by a specific user, install the license file in the following location:
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
-* Linux/MacOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
-* MacOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
+* Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
+* macOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
 
 ### Machine-wide license location
 

--- a/nservicebus/licensing/index_license-management_core_[8,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[8,].partial.md
@@ -22,7 +22,7 @@ To install a license for all endpoints and Particular Service Platform applicati
 
 * Windows: `%LOCALAPPDATA%\ParticularSoftware\license.xml`
 * Linux/macOS: `${XDG_DATA_HOME:-$HOME/.local/share}/ParticularSoftware/license.xml`
-* macOS (.net 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
+* macOS (.NET 8): `$HOME/Library/Application Support/ParticularSoftware/license.xml`
 
 ### Machine-wide license location
 


### PR DESCRIPTION
For .net 8 there's a new LocalApplicationData location:

https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix

This appears to change the license location for nservicebus.