### PR TITLE
Removing leading space from front-matter headers

### DIFF
--- a/transports/azure-storage-queues/transaction-support.md
+++ b/transports/azure-storage-queues/transaction-support.md
@@ -6,7 +6,7 @@ versions: '[6,]'
 reviewed: 2022-12-23
 redirects:
  - nservicebus/azure-storage-queues/transaction-support
- ---
+---
 
 The following [`TransportTransactionMode` levels](/transports/transactions.md) are supported
 

--- a/transports/upgrades/asb-9to10.md
+++ b/transports/upgrades/asb-9to10.md
@@ -8,8 +8,8 @@ related:
 isUpgradeGuide: true
 upgradeGuideCoreVersions:
  - 7
- ---
 
+---
 
 ## .NET Framework 4.6.2.
 

--- a/transports/upgrades/asb-9to10.md
+++ b/transports/upgrades/asb-9to10.md
@@ -8,7 +8,6 @@ related:
 isUpgradeGuide: true
 upgradeGuideCoreVersions:
  - 7
-
 ---
 
 ## .NET Framework 4.6.2.


### PR DESCRIPTION
There was a leading space on the closing `---` of these front-matter blocks that prevented them from being parsed properly.

This probably does not matter as [the code to read header info](https://github.com/Particular/DocsEngine/blob/master/src/ParticularDocsCore/YamlHeader/YamlHeaderExtractor.cs#L350-L353) trims the line.