### PR TITLE
Move Powershell page into MSMQ transport

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -705,8 +705,6 @@
       Title: .NET Framework requirements
     - Url: nservicebus/operations/installers
       Title: Installers
-    - Url: nservicebus/operations/management-using-powershell
-      Title: PowerShell
     - Url: nservicebus/operations/tuning
       Title: Tuning endpoint message processing
     - Url: nservicebus/endpoints/decommissioning-endpoints
@@ -989,6 +987,8 @@
       Title: Troubleshooting
     - Url: transports/msmq/subscription-authorisation
       Title: Subscription Authorization
+    - Url: transports/msmq/management-using-powershell
+      Title: PowerShell
     - Url: transports/msmq/native-integration
       Title: Native integration
     - Url: transports/msmq/operations-scripting

--- a/monitoring/metrics/performance-counters-install-powershell.include.md
+++ b/monitoring/metrics/performance-counters-install-powershell.include.md
@@ -1,6 +1,6 @@
 ## Installing Counters
 
-The NServiceBus performance counters can be installed using the [NServiceBus PowerShell tools](/nservicebus/operations/management-using-powershell.md).
+The NServiceBus performance counters can be installed using the [NServiceBus PowerShell tools](/transports/msmq/management-using-powershell.md).
 
 ```ps
 Import-Module NServiceBus.PowerShell

--- a/monitoring/metrics/performance-counters.md
+++ b/monitoring/metrics/performance-counters.md
@@ -12,7 +12,7 @@ related:
  - nservicebus/operations
  - nservicebus/recoverability
  - nservicebus/operations/auditing
- - nservicebus/operations/management-using-powershell
+ - transports/msmq/management-using-powershell
  - samples/performance-counters
 ---
 

--- a/nservicebus/operations/transactions-message-processing.md
+++ b/nservicebus/operations/transactions-message-processing.md
@@ -22,7 +22,7 @@ The default [`TransactionScope`](https://msdn.microsoft.com/en-us/library/system
 
 In Windows, the Distributed Transaction Coordinator (DTC) is an OS-level service which manages transactions that span multiple resources, e.g. queues and databases.
 
-The easiest way to configure DTC for NServiceBus is to follow the [installation guide](https://support.microsoft.com/en-us/help/817064/how-to-enable-network-dtc-access-in-windows-server-2003), or to use the dedicated [PowerShell commandlets](/nservicebus/operations/management-using-powershell.md).
+The easiest way to configure DTC for NServiceBus is to follow the [installation guide](https://support.microsoft.com/en-us/help/817064/how-to-enable-network-dtc-access-in-windows-server-2003), or to use the dedicated [PowerShell commandlets](/transports/msmq/management-using-powershell.md).
 
 
 ### Troubleshooting Distributed Transaction Coordinator

--- a/nservicebus/upgrades/3to4.md
+++ b/nservicebus/upgrades/3to4.md
@@ -223,7 +223,7 @@ The `MsmqTransportConfig` section has been deprecated in favor of `TransportConf
 
 ## PowerShell cmdlet updates
 
-[NServiceBus PowerShell cmdlets](/nservicebus/operations/management-using-powershell.md) have moved to NServiceBus.PowerShell.dll.
+[NServiceBus PowerShell cmdlets](/transports/msmq/management-using-powershell.md) have moved to NServiceBus.PowerShell.dll.
 
 
 ## [Serialization](/nservicebus/serialization/)
@@ -282,4 +282,4 @@ unicastBus.RunHandlersUnderIncomingPrincipal(true);
 
 ## INeedToInstallInfrastructure
 
-The `INeedToInstallInfrastructure` interface is obsolete and will be removed in NServiceBus version 5.0. Use [PowerShell commandlets](/nservicebus/operations/management-using-powershell.md) as an alternative.
+The `INeedToInstallInfrastructure` interface is obsolete and will be removed in NServiceBus version 5.0.

--- a/nservicebus/upgrades/4to5.md
+++ b/nservicebus/upgrades/4to5.md
@@ -826,4 +826,4 @@ Another option is to use a custom header as illustrated in the [Appending userna
 
 ## INeedToInstallInfrastructure
 
-The interface `INeedToInstallInfrastructure<T>` has been removed. Use [PowerShell commandlets](/nservicebus/operations/management-using-powershell.md) as an alternative.
+The interface `INeedToInstallInfrastructure<T>` has been removed.

--- a/samples/performance-counters/sample.md
+++ b/samples/performance-counters/sample.md
@@ -5,7 +5,7 @@ reviewed: 2024-01-26
 component: PerfCounters
 related:
 - monitoring/metrics/performance-counters
-- nservicebus/operations/management-using-powershell
+- transports/msmq/management-using-powershell
 ---
 
 

--- a/transports/msmq/index.md
+++ b/transports/msmq/index.md
@@ -52,7 +52,7 @@ partial: default
 
 NServiceBus requires a specific MSMQ configuration to operate.
 
-The supported configuration is to have only the base MSMQ service installed with no optional features. To enable the supported configuration, use the `Install-NServiceBusMSMQ` cmdlet from the [NServiceBus PowerShell Module](/nservicebus/operations/management-using-powershell.md).
+The supported configuration is to have only the base MSMQ service installed with no optional features. To enable the supported configuration, use the `Install-NServiceBusMSMQ` cmdlet from the [NServiceBus PowerShell Module](management-using-powershell.md).
 
 Alternatively, the MSMQ service can be installed manually. When installing manually **do not** enable the following components:
 
@@ -157,7 +157,7 @@ See also [Message Queuing Security Overview](https://docs.microsoft.com/en-us/pr
 
 ## Distributed Transaction Coordinator
 
-NServiceBus makes use of the Microsoft Distributed Transaction Coordinator (MSDTC) to synchronize transactions between MSMQ and the database in order to support [guaranteed once delivery of messages](/nservicebus/operations/transactions-message-processing.md). For this to work, MSDTC must be started and configured correctly. This can be done manually or using the [NServiceBus PowerShell module](/nservicebus/operations/management-using-powershell.md).
+NServiceBus makes use of the Microsoft Distributed Transaction Coordinator (MSDTC) to synchronize transactions between MSMQ and the database in order to support [guaranteed once delivery of messages](/nservicebus/operations/transactions-message-processing.md). For this to work, MSDTC must be started and configured correctly. This can be done manually or using the [NServiceBus PowerShell module](management-using-powershell.md).
 
 Alternatively, there is a _non-MSDTC mode of operation available. In this mode NServiceBus uses the _outbox_, a message store backed by the same database as the user code, to temporarily store messages that must be sent as a result of processing an incoming message. To read more about this subject see [Outbox](/nservicebus/outbox/).
 

--- a/transports/msmq/management-using-powershell.md
+++ b/transports/msmq/management-using-powershell.md
@@ -2,14 +2,14 @@
 title: Management using PowerShell
 summary: Install the infrastructure for NServiceBus on servers using PowerShell.
 reviewed: 2023-10-11
-isLearningPath: true
 related:
  - nservicebus/operations
 redirects:
 - nservicebus/managing-nservicebus-using-powershell
+- nservicebus/operations/management-using-powershell
 ---
 
-A PowerShell module that sets up a computer to run NServiceBus.
+A PowerShell module that sets up a computer to run NServiceBus with the MSMQ transport.
 
 The PowerShell module provides cmdlets to assist with:
 

--- a/transports/msmq/uninstalling-msmq.md
+++ b/transports/msmq/uninstalling-msmq.md
@@ -7,7 +7,7 @@ redirects:
 ---
 
 
-The [NServiceBus.PowerShell modules](/nservicebus/operations/management-using-powershell.md) provide a simple mechanism for installing and configuring the MSMQ service to suit NServiceBus. Particular does not provide an uninstall for this as there are built-in removal options within the Windows operating system.
+The [NServiceBus.PowerShell modules](management-using-powershell.md) provide a simple mechanism for installing and configuring the MSMQ service to suit NServiceBus. Particular does not provide an uninstall for this as there are built-in removal options within the Windows operating system.
 
 The removal instructions vary depending on the operating system and are detailed below.
 


### PR DESCRIPTION
NServiceBus.PowerShell package is for Windows-only and only has cmdlets for managing MSMQ infrastructure and Windows performance counters, and so is more at home under the MSMQ transport than as a general NServiceBus topic.