### PR TITLE
Add info about mandatory serialization

### DIFF
--- a/nservicebus/serialization/index.md
+++ b/nservicebus/serialization/index.md
@@ -22,17 +22,7 @@ Other serializers are supported in order to enable specific performance or integ
 * [Newtonsoft](newtonsoft.md)
 * [XML](xml.md)
 
-## Configuring a serializer
-
-A serializer can be configured using the `endpointConfiguration.UseSerialization` API. Refer to the dedicated documentation pages for each available serializer for more information about the specific configuration.
-
-The same serializer must be used by the sending endpoint to serialize messages and by the receiving endpoint to deserialize them, unless additional deserializers are specified.
-
-## Using the default serializer
-
-The default serializer used in NServiceBus projects is the custom [XmlSerializer](xml.md). Unless explicitly configured otherwise, NServiceBus will use [XmlSerializer](xml.md) for serializing and deserializing all messages.
-
-WARN: In NServiceBus 8.1 and above, a runtime warning will encourage explicitly selecting a serializer. In a future version of NServiceBus, the XmlSerializer will no longer be selected by default.
+partial: configuring
 
 ## Using a custom serializer
 

--- a/nservicebus/serialization/index_configuring_core_[,9).partial.md
+++ b/nservicebus/serialization/index_configuring_core_[,9).partial.md
@@ -1,0 +1,11 @@
+## Configuring a serializer
+
+A serializer can be configured using the `endpointConfiguration.UseSerialization` API. Refer to the dedicated documentation pages for each available serializer for more information about the specific configuration.
+
+The same serializer must be used by the sending endpoint to serialize messages and by the receiving endpoint to deserialize them, unless additional deserializers are specified.
+
+## Using the default serializer
+
+The default serializer used in NServiceBus projects is the custom [XmlSerializer](xml.md). Unless explicitly configured otherwise, NServiceBus will use [XmlSerializer](xml.md) for serializing and deserializing all messages.
+
+WARN: In NServiceBus 8.1 and above, a runtime warning will encourage explicitly selecting a serializer. In a future version of NServiceBus, the XmlSerializer will no longer be selected by default.

--- a/nservicebus/serialization/index_configuring_core_[9,).partial.md
+++ b/nservicebus/serialization/index_configuring_core_[9,).partial.md
@@ -1,0 +1,6 @@
+## Configuring a serializer
+
+A serializer must be configured using the `endpointConfiguration.UseSerialization` API. Refer to the dedicated documentation pages for each available serializer for more information about the specific configuration.
+
+The same serializer must be used by the sending endpoint to serialize messages and by the receiving endpoint to deserialize them, unless additional deserializers are specified.
+

--- a/nservicebus/upgrades/8to9/index.md
+++ b/nservicebus/upgrades/8to9/index.md
@@ -13,6 +13,10 @@ upgradeGuideCoreVersions:
 
 NServiceBus 9 no longer supports any version of the .NET Framework. Instead, it targets .NET 8 only (Read more about the [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). Any component in NServiceBus 8 that is .NET Framework only (for example, the MSMQ transport)will not have a version that is compatible with NServiceBus 9. NServiceBus 8 will continue to be supported for use on the .NET Framework.
 
+## Serializer choice is now mandatory
+
+The XML serializer is no longer the default serializer, so a [serializer must always be configured](/nservicebus/serialization/#configuring-a-serializer).
+
 ## SendOptions immediate dispatch changes
 
 The method used to determine if [immediate dispatch](/nservicebus/messaging/send-a-message.md#dispatching-a-message-immediately) has been requested for a message has been renamed.


### PR DESCRIPTION
This PR adds a section to the upgrade guide about how choosing a serializer is now mandatory and also updates the relevant docs section for the change.