### PR TITLE
Update ef sql persistence sample

### DIFF
--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8;net7;net6;net48</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />


### PR DESCRIPTION
Adds net8, net7 and net 8 to the samples.
I also unpinned the language version to see if they still compiled, and they do.