### PR TITLE
Adds net8.0;net7.0;net6.0;net48 to New Relic samples

### DIFF
--- a/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="6.*" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
     <PackageReference Include="NServiceBus.Metrics" Version="3.*" />
   </ItemGroup>

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net48</TargetFramework>
+		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>


### PR DESCRIPTION
I also bumped the version for NewRelic.Agent.Api as the previous one wasn't compatible with .net6 thru .net8