### PR TITLE
New test for console titles too long

### DIFF
--- a/samples/aws/dynamodb-simple/DynamoDB_1/Client/Program.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DynamoDB.Simple.Client");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Server/Program.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Simple.Server";
+        Console.Title = "Server";
 
         #region DynamoDBConfig
 

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Client/Program.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DynamoDB.Simple.Client");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Server/Program.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Simple.Server";
+        Console.Title = "Server";
 
         #region DynamoDBConfig
 

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Program.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DynamoDB.Transactions.Client");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Program.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Transactions.Server";
+        Console.Title = "Server";
 
         #region DynamoDBConfig
 

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Client/Program.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DynamoDB.Transactions.Client");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Server/Program.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DynamoDB.Transactions.Server";
+        Console.Title = "Server";
 
         #region DynamoDBConfig
 

--- a/samples/aws/sqs-native-integration/Sqs_6/Receiver/Program.cs
+++ b/samples/aws/sqs-native-integration/Sqs_6/Receiver/Program.cs
@@ -2,7 +2,7 @@ using System;
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleReceiver");
 endpointConfiguration.EnableInstallers();

--- a/samples/aws/sqs-native-integration/Sqs_6/Sender/Program.cs
+++ b/samples/aws/sqs-native-integration/Sqs_6/Sender/Program.cs
@@ -8,7 +8,7 @@ using Amazon.SQS.Model;
 var MessageToSend = @"{""$type"" : ""NativeIntegration.Receiver.SomeNativeMessage, Receiver"", ""ThisIsTheMessage"": ""Hello world!""}";
 #endregion
 
-Console.Title = "Samples.Sqs.NativeIntegration";
+Console.Title = "NativeIntegration";
 
 while (true)
 {

--- a/samples/aws/sqs-native-integration/Sqs_7/Receiver/Program.cs
+++ b/samples/aws/sqs-native-integration/Sqs_7/Receiver/Program.cs
@@ -2,7 +2,7 @@ using System;
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleReceiver");
 endpointConfiguration.EnableInstallers();

--- a/samples/aws/sqs-native-integration/Sqs_7/Sender/Program.cs
+++ b/samples/aws/sqs-native-integration/Sqs_7/Sender/Program.cs
@@ -8,7 +8,7 @@ using Amazon.SQS.Model;
 var MessageToSend = @"{""$type"" : ""NativeIntegration.Receiver.SomeNativeMessage, Receiver"", ""ThisIsTheMessage"": ""Hello world!""}";
 #endregion
 
-Console.Title = "Samples.Sqs.NativeIntegration";
+Console.Title = "NativeIntegration";
 
 while (true)
 {

--- a/samples/aws/sqs-simple/Sqs_5/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_5/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Sqs.SimpleReceiver";
+        Console.Title = "SimpleReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleReceiver");
         endpointConfiguration.EnableInstallers();
         var transport = endpointConfiguration.UseTransport<SqsTransport>();

--- a/samples/aws/sqs-simple/Sqs_5/Sender/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_5/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Sqs.SimpleSender";
+        Console.Title = "SimpleSender";
         #region ConfigureEndpoint
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleSender");

--- a/samples/aws/sqs-simple/Sqs_6/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_6/Receiver/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleReceiver");
 endpointConfiguration.EnableInstallers();
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/aws/sqs-simple/Sqs_6/Sender/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_6/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleSender";
+Console.Title = "SimpleSender";
 #region ConfigureEndpoint
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleSender");

--- a/samples/aws/sqs-simple/Sqs_7/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_7/Receiver/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleReceiver");
 endpointConfiguration.EnableInstallers();
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/aws/sqs-simple/Sqs_7/Sender/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_7/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.Sqs.SimpleSender";
+Console.Title = "SimpleSender";
 #region ConfigureEndpoint
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sqs.SimpleSender");

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.Publisher";
+        Console.Title = "Publisher";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASB.Publisher");
 

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.Publisher";
+        Console.Title = "Publisher";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASB.Publisher");
 

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Publisher/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Publisher/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.Publisher";
+        Console.Title = "Publisher";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASB.Publisher");
 

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration.Sender";
+        Console.Title = "Sender";
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))
         {

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration";
+        Console.Title = "NativeIntegration";
 
         #region EndpointName
 

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration.Sender";
+        Console.Title = "Sender";
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))
         {

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration";
+        Console.Title = "NativeIntegration";
 
         #region EndpointName
 

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_4/NativeSender/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_4/NativeSender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration.Sender";
+        Console.Title = "Sender";
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))
         {

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Receiver/Program.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASB.NativeIntegration";
+        Console.Title = "NativeIntegration";
 
         #region EndpointName
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint1";
+        Console.Title = "Endpoint1";
 
         #region config
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint2";
+        Console.Title = "Endpoint2";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASBS.SendReply.Endpoint2");
         endpointConfiguration.EnableInstallers();

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint1";
+        Console.Title = "Endpoint1";
 
         #region config
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint2";
+        Console.Title = "Endpoint2";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASBS.SendReply.Endpoint2");
         endpointConfiguration.EnableInstallers();

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint1/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint1";
+        Console.Title = "Endpoint1";
 
         #region config
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint2/Program.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASBS.SendReply.Endpoint2";
+        Console.Title = "Endpoint2";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.ASBS.SendReply.Endpoint2");
         endpointConfiguration.EnableInstallers();

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Client/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Client/Program.cs
@@ -2,7 +2,7 @@
 
 using NServiceBus;
 
-Console.Title = "Samples.AzureTable.Transactions.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
 endpointConfiguration.UsePersistence<LearningPersistence>();
 endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Server/Program.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Server/Program.cs
@@ -4,7 +4,7 @@ using Azure.Data.Tables;
 
 using NServiceBus;
 
-Console.Title = "Samples.AzureTable.Transactions.Server";
+Console.Title = "Server";
 
 #region AzureTableConfig
 

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/simple/ASTP_5/Client/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_5/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/simple/ASTP_5/Server/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_5/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Simple.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/simple/ASTP_6/Client/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_6/Client/Program.cs
@@ -3,7 +3,7 @@
 using NServiceBus;
 
 
-Console.Title = "Samples.AzureTable.Simple.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Simple.Client");
 endpointConfiguration.UsePersistence<LearningPersistence>();
 endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/simple/ASTP_6/Server/Program.cs
+++ b/samples/azure/azure-table/simple/ASTP_6/Server/Program.cs
@@ -4,7 +4,7 @@ using Azure.Data.Tables;
 
 using NServiceBus;
 
-Console.Title = "Samples.AzureTable.Simple.Server";
+Console.Title = "Server";
 
 #region AzureTableConfig
 

--- a/samples/azure/azure-table/table/ASTP_3/Client/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Table.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/azure/azure-table/table/ASTP_3/Server/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/table/ASTP_4/Client/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Table.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/table/ASTP_4/Server/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/table/ASTP_5/Client/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_5/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Table.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/table/ASTP_5/Server/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_5/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Table.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/table/ASTP_6/Client/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Client/Program.cs
@@ -2,7 +2,7 @@
 
 using NServiceBus;
 
-Console.Title = "Samples.AzureTable.Table.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Table.Client");
 endpointConfiguration.UsePersistence<LearningPersistence>();
 endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/table/ASTP_6/Server/Program.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Server/Program.cs
@@ -4,7 +4,7 @@ using Azure.Data.Tables;
 
 using NServiceBus;
 
-Console.Title = "Samples.AzureTable.Table.Server";
+Console.Title = "Server";
 
 #region AzureTableConfig
 

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/transactions/ASTP_5/Client/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_5/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/transactions/ASTP_5/Server/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_5/Server/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureTable.Transactions.Server";
+        Console.Title = "Server";
 
         #region AzureTableConfig
 

--- a/samples/azure/azure-table/transactions/ASTP_6/Client/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Client/Program.cs
@@ -3,7 +3,7 @@
 using NServiceBus;
 
 
-Console.Title = "Samples.AzureTable.Transactions.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.AzureTable.Transactions.Client");
 endpointConfiguration.UsePersistence<LearningPersistence>();
 endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/Program.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/Program.cs
@@ -5,7 +5,7 @@ using Azure.Data.Tables;
 using NServiceBus;
 
 
-Console.Title = "Samples.AzureTable.Transactions.Server";
+Console.Title = "Server";
 
 #region AzureTableConfig
 

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/AsbEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/AsbEndpoint/Program.cs
@@ -10,7 +10,7 @@ class Program
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         var random = new Random();
 
-        Console.Title = "Samples.MessagingBridge.AsbEndpoint";
+        Console.Title = "AsbEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.AsbEndpoint");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/Bridge/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/Bridge/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.MessagingBridge.Bridge";
+        Console.Title = "Bridge";
 
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/MsmqEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/MsmqEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessagingBridge.MsmqEndpoint";
+        Console.Title = "MsmqEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.MsmqEndpoint");
         endpointConfiguration.EnableInstallers();

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/AsbEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/AsbEndpoint/Program.cs
@@ -10,7 +10,7 @@ class Program
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         var random = new Random();
 
-        Console.Title = "Samples.MessagingBridge.AsbEndpoint";
+        Console.Title = "AsbEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.AsbEndpoint");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Bridge/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Bridge/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessagingBridge.Bridge";
+        Console.Title = "Bridge";
 
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/MsmqEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/MsmqEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessagingBridge.MsmqEndpoint";
+        Console.Title = "MsmqEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.MsmqEndpoint");
         endpointConfiguration.EnableInstallers();

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/AsbEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/AsbEndpoint/Program.cs
@@ -10,7 +10,7 @@ class Program
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         var random = new Random();
 
-        Console.Title = "Samples.MessagingBridge.AsbEndpoint";
+        Console.Title = "AsbEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.AsbEndpoint");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/Bridge/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/Bridge/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.MessagingBridge.Bridge";
+        Console.Title = "Bridge";
 
         var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/MsmqEndpoint/Program.cs
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/MsmqEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessagingBridge.MsmqEndpoint";
+        Console.Title = "MsmqEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MessagingBridge.MsmqEndpoint");
         endpointConfiguration.EnableInstallers();

--- a/samples/bridge/service-control/Bridge_2/Bridge/Program.cs
+++ b/samples/bridge/service-control/Bridge_2/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/service-control/Bridge_2/Endpoint/Program.cs
+++ b/samples/bridge/service-control/Bridge_2/Endpoint/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.Endpoint";
+        Console.Title = "Endpoint";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration(

--- a/samples/bridge/service-control/Bridge_3/Bridge/Program.cs
+++ b/samples/bridge/service-control/Bridge_3/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/service-control/Bridge_3/Endpoint/Program.cs
+++ b/samples/bridge/service-control/Bridge_3/Endpoint/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.Endpoint";
+        Console.Title = "Endpoint";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration(

--- a/samples/bridge/service-control/TransportBridge_1/Bridge/Program.cs
+++ b/samples/bridge/service-control/TransportBridge_1/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/service-control/TransportBridge_1/Endpoint/Program.cs
+++ b/samples/bridge/service-control/TransportBridge_1/Endpoint/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.Endpoint";
+        Console.Title = "Endpoint";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration(

--- a/samples/bridge/simple/Bridge_2/Bridge/Program.cs
+++ b/samples/bridge/simple/Bridge_2/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/simple/Bridge_2/LeftReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_2/LeftReceiver/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftReceiver";
+        Console.Title = "LeftReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/bridge/simple/Bridge_2/LeftSender/Program.cs
+++ b/samples/bridge/simple/Bridge_2/LeftSender/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftSender";
+        Console.Title = "LeftSender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/simple/Bridge_2/RightReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_2/RightReceiver/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.RightReceiver";
+        Console.Title = "RightReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.RightReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/simple/Bridge_3/Bridge/Program.cs
+++ b/samples/bridge/simple/Bridge_3/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/simple/Bridge_3/LeftReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_3/LeftReceiver/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftReceiver";
+        Console.Title = "LeftReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/bridge/simple/Bridge_3/LeftSender/Program.cs
+++ b/samples/bridge/simple/Bridge_3/LeftSender/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftSender";
+        Console.Title = "LeftSender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/simple/Bridge_3/RightReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_3/RightReceiver/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.RightReceiver";
+        Console.Title = "RightReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.RightReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/simple/TransportBridge_1/Bridge/Program.cs
+++ b/samples/bridge/simple/TransportBridge_1/Bridge/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge";
+        Console.Title = "Bridge";
 
         await Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>

--- a/samples/bridge/simple/TransportBridge_1/LeftReceiver/Program.cs
+++ b/samples/bridge/simple/TransportBridge_1/LeftReceiver/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftReceiver";
+        Console.Title = "LeftReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/bridge/simple/TransportBridge_1/LeftSender/Program.cs
+++ b/samples/bridge/simple/TransportBridge_1/LeftSender/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.LeftSender";
+        Console.Title = "LeftSender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/simple/TransportBridge_1/RightReceiver/Program.cs
+++ b/samples/bridge/simple/TransportBridge_1/RightReceiver/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Bridge.RightReceiver";
+        Console.Title = "RightReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.RightReceiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
 

--- a/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Program.cs
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Program.cs
@@ -10,7 +10,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceReceiver";
+        Console.Title = "MultiInstanceReceiver";
 
         #region ReceiverConfiguration
 

--- a/samples/bridge/sql-multi-instance/Bridge_2/Sender/Program.cs
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Sender/Program.cs
@@ -12,7 +12,7 @@ public class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceSender";
+        Console.Title = "MultiInstanceSender";
 
         #region SenderConfiguration
 

--- a/samples/bridge/sql-multi-instance/Bridge_3/Receiver/Program.cs
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Receiver/Program.cs
@@ -10,7 +10,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceReceiver";
+        Console.Title = "MultiInstanceReceiver";
 
         #region ReceiverConfiguration
 

--- a/samples/bridge/sql-multi-instance/Bridge_3/Sender/Program.cs
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Sender/Program.cs
@@ -12,7 +12,7 @@ public class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceSender";
+        Console.Title = "MultiInstanceSender";
 
         #region SenderConfiguration
 

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/Program.cs
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/Program.cs
@@ -10,7 +10,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceReceiver";
+        Console.Title = "MultiInstanceReceiver";
 
         #region ReceiverConfiguration
 

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/Program.cs
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/Program.cs
@@ -10,7 +10,7 @@ public class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.SqlServer.MultiInstanceSender";
+        Console.Title = "MultiInstanceSender";
 
         #region SenderConfiguration
 

--- a/samples/callbacks/Callbacks_3/Receiver/Program.cs
+++ b/samples/callbacks/Callbacks_3/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Receiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/callbacks/Callbacks_3/Sender/Program.cs
+++ b/samples/callbacks/Callbacks_3/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Sender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/callbacks/Callbacks_4/Receiver/Program.cs
+++ b/samples/callbacks/Callbacks_4/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Receiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/callbacks/Callbacks_4/Sender/Program.cs
+++ b/samples/callbacks/Callbacks_4/Sender/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Sender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/callbacks/Callbacks_5/Receiver/Program.cs
+++ b/samples/callbacks/Callbacks_5/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Receiver");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/callbacks/Callbacks_5/Sender/Program.cs
+++ b/samples/callbacks/Callbacks_5/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Callbacks.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.Callbacks.Sender");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Program.cs
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer1";
+        Console.Title = "Consumer1";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer1");
         var transport = endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Program.cs
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer2";
+        Console.Title = "Consumer2";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer2");
         var transport = endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_7/Producer/Program.cs
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Producer";
+        Console.Title = "Producer";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Producer");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Program.cs
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer1";
+        Console.Title = "Consumer1";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer1");
         var transport = endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Program.cs
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer2";
+        Console.Title = "Consumer2";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer2");
         var transport = endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_8/Producer/Program.cs
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Producer";
+        Console.Title = "Producer";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Producer");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_9/Consumer1/Program.cs
+++ b/samples/consumer-driven-contracts/Core_9/Consumer1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer1";
+        Console.Title = "Consumer1";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer1");
         var transport = endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_9/Consumer2/Program.cs
+++ b/samples/consumer-driven-contracts/Core_9/Consumer2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Consumer2";
+        Console.Title = "Consumer2";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Consumer2");
         var transport = endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/consumer-driven-contracts/Core_9/Producer/Program.cs
+++ b/samples/consumer-driven-contracts/Core_9/Producer/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ConsumerDrivenContracts.Producer";
+        Console.Title = "Producer";
         var endpointConfiguration = new EndpointConfiguration("Samples.ConsumerDrivenContracts.Producer");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/cooperative-cancellation/Core_8/Server/Program.cs
+++ b/samples/cooperative-cancellation/Core_8/Server/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Cooperative.Cancellation";
+        Console.Title = "Cancellation";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.Cooperative.Cancellation");

--- a/samples/cooperative-cancellation/Core_9/Server/Program.cs
+++ b/samples/cooperative-cancellation/Core_9/Server/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Cooperative.Cancellation";
+        Console.Title = "Cancellation";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.Cooperative.Cancellation");

--- a/samples/cosmosdb/container/CosmosDB_1/Client/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_1/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Container.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/cosmosdb/container/CosmosDB_1/Server/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_1/Server/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Container.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/container/CosmosDB_3/Client/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Container.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/container/CosmosDB_3/Server/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_3/Server/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Container.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/simple/CosmosDB_1/Client/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_1/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/cosmosdb/simple/CosmosDB_1/Server/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_1/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/simple/CosmosDB_3/Client/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Simple.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/simple/CosmosDB_3/Server/Program.cs
+++ b/samples/cosmosdb/simple/CosmosDB_3/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Simple.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/transactions/CosmosDB_1/Client/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/cosmosdb/transactions/CosmosDB_1/Server/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Server/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/cosmosdb/transactions/CosmosDB_3/Client/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CosmosDB.Transactions.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/cosmosdb/transactions/CosmosDB_3/Server/Program.cs
+++ b/samples/cosmosdb/transactions/CosmosDB_3/Server/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CosmosDB.Transactions.Server";
+        Console.Title = "Server";
 
         #region CosmosDBConfig
 

--- a/samples/custom-recoverability/Core_7/Client/Program.cs
+++ b/samples/custom-recoverability/Core_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/custom-recoverability/Core_7/Server/Program.cs
+++ b/samples/custom-recoverability/Core_7/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/custom-recoverability/Core_8/Client/Program.cs
+++ b/samples/custom-recoverability/Core_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/custom-recoverability/Core_8/Server/Program.cs
+++ b/samples/custom-recoverability/Core_8/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/custom-recoverability/Core_9/Client/Program.cs
+++ b/samples/custom-recoverability/Core_9/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/custom-recoverability/Core_9/Server/Program.cs
+++ b/samples/custom-recoverability/Core_9/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomRecoverability.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomRecoverability.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/Program.cs
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureDataBusCleanupWithFunctions.SenderAndReceiver";
+        Console.Title = "SenderAndReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureDataBusCleanupWithFunctions.SenderAndReceiver");
 
         var dataBus = endpointConfiguration.UseDataBus<AzureDataBus, SystemJsonDataBusSerializer>();

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/SenderAndReceiver/Program.cs
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/SenderAndReceiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureDataBusCleanupWithFunctions.SenderAndReceiver";
+        Console.Title = "SenderAndReceiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureDataBusCleanupWithFunctions.SenderAndReceiver");
 
         var dataBus = endpointConfiguration.UseDataBus<AzureDataBus, SystemJsonDataBusSerializer>();

--- a/samples/databus/blob-storage-databus/ABSDataBus_4/Receiver/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_4/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Receiver");
 
         var blobServiceClient = new BlobServiceClient("UseDevelopmentStorage=true");

--- a/samples/databus/blob-storage-databus/ABSDataBus_4/Sender/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_4/Sender/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Sender");
 
         #region ConfiguringDataBusLocation

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Receiver");
 
         var blobServiceClient = new BlobServiceClient("UseDevelopmentStorage=true");

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Sender");
 
         #region ConfiguringDataBusLocation

--- a/samples/databus/blob-storage-databus/ABSDataBus_6/Receiver/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_6/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Receiver");
 
         var blobServiceClient = new BlobServiceClient("UseDevelopmentStorage=true");

--- a/samples/databus/blob-storage-databus/ABSDataBus_6/Sender/Program.cs
+++ b/samples/databus/blob-storage-databus/ABSDataBus_6/Sender/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AzureBlobStorageDataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.AzureBlobStorageDataBus.Sender");
 
         #region ConfiguringDataBusLocation

--- a/samples/databus/custom-serializer/Core_7/Receiver/Program.cs
+++ b/samples/databus/custom-serializer/Core_7/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
 
         #region ConfigureReceiverCustomDataBusSerializer

--- a/samples/databus/custom-serializer/Core_7/Sender/Program.cs
+++ b/samples/databus/custom-serializer/Core_7/Sender/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureSenderCustomDataBusSerializer

--- a/samples/databus/custom-serializer/Core_8/Receiver/Program.cs
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
 
         #region ConfigureReceiverCustomDataBusSerializer

--- a/samples/databus/custom-serializer/Core_8/Sender/Program.cs
+++ b/samples/databus/custom-serializer/Core_8/Sender/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureSenderCustomDataBusSerializer

--- a/samples/databus/custom-serializer/Core_9/Receiver/Program.cs
+++ b/samples/databus/custom-serializer/Core_9/Receiver/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
 
         #region ConfigureReceiverCustomDataBusSerializer

--- a/samples/databus/custom-serializer/Core_9/Sender/Program.cs
+++ b/samples/databus/custom-serializer/Core_9/Sender/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureSenderCustomDataBusSerializer

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Program.cs
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
         dataBus.BasePath(@"..\..\..\..\storage");

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Program.cs
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureDataBus

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Program.cs
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
         dataBus.BasePath(@"..\..\..\..\storage");

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Program.cs
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureDataBus

--- a/samples/databus/file-share-databus/Core_7/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus>();
         dataBus.BasePath(@"..\..\..\..\storage");

--- a/samples/databus/file-share-databus/Core_7/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_7/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureDataBus

--- a/samples/databus/file-share-databus/Core_8/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
         dataBus.BasePath(@"..\..\..\..\storage");

--- a/samples/databus/file-share-databus/Core_8/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_8/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureDataBus

--- a/samples/databus/file-share-databus/Core_9/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
         var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
         dataBus.BasePath(@"..\..\..\..\storage");

--- a/samples/databus/file-share-databus/Core_9/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_9/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DataBus.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
 
         #region ConfigureDataBus

--- a/samples/delayed-delivery/Core_7/Client/Program.cs
+++ b/samples/delayed-delivery/Core_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/delayed-delivery/Core_7/Server/Program.cs
+++ b/samples/delayed-delivery/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/delayed-delivery/Core_8/Client/Program.cs
+++ b/samples/delayed-delivery/Core_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/delayed-delivery/Core_8/Server/Program.cs
+++ b/samples/delayed-delivery/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/delayed-delivery/Core_9/Client/Program.cs
+++ b/samples/delayed-delivery/Core_9/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/delayed-delivery/Core_9/Server/Program.cs
+++ b/samples/delayed-delivery/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DelayedDelivery.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.DelayedDelivery.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Program.cs
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Autofac";
+        Console.Title = "Autofac";
 
         #region ContainerConfiguration
 

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Program.cs
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Castle";
+        Console.Title = "Castle";
 
         #region ContainerConfiguration
 

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Program.cs
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NServiceBus.Extensions.DependencyInjection";
+        Console.Title = "DependencyInjection";
 
         var endpointConfiguration = new EndpointConfiguration("Sample");
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Program.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NServiceBus.ExternallyManagedContainer";
+        Console.Title = "ExternallyManagedContainer";
 
         var endpointConfiguration = new EndpointConfiguration("Sample");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/dependency-injection/externally-managed-mode/Core_9/Sample/Program.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NServiceBus.ExternallyManagedContainer";
+        Console.Title = "ExternallyManagedContainer";
 
         var endpointConfiguration = new EndpointConfiguration("Sample");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Program.cs
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Program.cs
@@ -7,7 +7,7 @@ public class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Ninject";
+        Console.Title = "Ninject";
 
         #region ContainerConfiguration
 

--- a/samples/dependency-injection/spring/Spring_8/Sample/Program.cs
+++ b/samples/dependency-injection/spring/Spring_8/Sample/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Spring";
+        Console.Title = "Spring";
 
         #region ContainerConfiguration
 

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Program.cs
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.StructureMap";
+        Console.Title = "StructureMap";
 
         #region ContainerConfiguration
 

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Program.cs
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unity";
+        Console.Title = "Unity";
 
         #region ContainerConfiguration
 

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         #region enableEncryption
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.ConfigurationEncryption();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         #region enableEncryption
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.ConfigurationEncryption();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         #region enableEncryption
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.ConfigurationEncryption();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint1/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         #region enableEncryption
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint2/Program.cs
+++ b/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.ConfigurationEncryption();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         #region enableEncryption

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         #region enableEncryption

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         #region enableEncryption

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint1/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint1");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         #region enableEncryption

--- a/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint2/Program.cs
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Encryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.Encryption.Endpoint2");
         endpointConfiguration.Conventions().DefiningMessagesAs(type => type.Name.Contains("Message"));
         endpointConfiguration.ConfigurationEncryption();

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint1/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint1");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint2/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint2");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.RegisterMessageEncryptor();

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/encryption/message-body-encryption/Core_9/Endpoint1/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_9/Endpoint1/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/encryption/message-body-encryption/Core_9/Endpoint2/Program.cs
+++ b/samples/encryption/message-body-encryption/Core_9/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageBodyEncryption.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageBodyEncryption.Endpoint2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Program.cs
+++ b/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Program.cs
@@ -14,7 +14,7 @@ class Program
     {
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesEfCoreUowSql;Integrated Security=True;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesEfCoreUowSql;User Id=SA;Password=yourStrong(!)Password;Encrypt=false";
-        Console.Title = "Samples.EntityFrameworkUnitOfWork.SQL";
+        Console.Title = "EntityFrameworkUnitOfWork";
 
         using (var receiverDataContext = new ReceiverDataContext(new DbContextOptionsBuilder<ReceiverDataContext>()
             .UseSqlServer(new SqlConnection(connectionString))

--- a/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Program.cs
+++ b/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Program.cs
@@ -12,7 +12,7 @@ class Program
     {
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesEfCoreUowSql;Integrated Security=True;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesEfCoreUowSql;User Id=SA;Password=yourStrong(!)Password;Encrypt=false;Max Pool Size=100";
-        Console.Title = "Samples.EntityFrameworkUnitOfWork.SQL";
+        Console.Title = "EntityFrameworkUnitOfWork";
 
         using (var receiverDataContext = new ReceiverDataContext(new DbContextOptionsBuilder<ReceiverDataContext>()
             .UseSqlServer(connectionString)

--- a/samples/entity-framework-core/SqlPersistence_8/Endpoint.SqlPersistence/Program.cs
+++ b/samples/entity-framework-core/SqlPersistence_8/Endpoint.SqlPersistence/Program.cs
@@ -12,7 +12,7 @@ class Program
     {
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesEfCoreUowSql;Integrated Security=True;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesEfCoreUowSql;User Id=SA;Password=yourStrong(!)Password;Encrypt=false;Max Pool Size=100;TrustServerCertificate=True";
-        Console.Title = "Samples.EntityFrameworkUnitOfWork.SQL";
+        Console.Title = "EntityFrameworkUnitOfWork";
 
         using (var receiverDataContext = new ReceiverDataContext(new DbContextOptionsBuilder<ReceiverDataContext>()
             .UseSqlServer(connectionString)

--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Program.cs
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Program.cs
@@ -11,7 +11,7 @@ class Program
     {
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesEfUowSql;Integrated Security=True;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesEfUowSql;User Id=SA;Password=yourStrong(!)Password;Encrypt=false";
-        Console.Title = "Samples.EntityFrameworkUnitOfWork.SQL";
+        Console.Title = "EntityFrameworkUnitOfWork";
         using (var connection = new SqlConnection(connectionString))
         {
             using (var receiverDataContext = new ReceiverDataContext(connection))

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Program.cs
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Program.cs
@@ -14,7 +14,7 @@ class Program
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesEfUowSql;Integrated Security=True;Encrypt=false;Max Pool Size=100
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesEfUowSql;User Id=SA;Password=yourStrong(!)Password;Encrypt=false;Max Pool Size=100";
 
-        Console.Title = "Samples.EntityFrameworkUnitOfWork.SQL";
+        Console.Title = "EntityFrameworkUnitOfWork";
         using (var connection = new SqlConnection(connectionString))
         {
             using (var receiverDataContext = new ReceiverDataContext(connection))

--- a/samples/errorhandling/Core_7/WithDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_7/WithDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithDelayedRetries";
+        Console.Title = "WithDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/errorhandling/Core_7/WithoutDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_7/WithoutDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithoutDelayedRetries";
+        Console.Title = "WithoutDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/errorhandling/Core_8/WithDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithDelayedRetries";
+        Console.Title = "WithDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithoutDelayedRetries";
+        Console.Title = "WithoutDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/errorhandling/Core_9/WithDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_9/WithDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithDelayedRetries";
+        Console.Title = "WithDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/errorhandling/Core_9/WithoutDelayedRetries/Program.cs
+++ b/samples/errorhandling/Core_9/WithoutDelayedRetries/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ErrorHandling.WithoutDelayedRetries";
+        Console.Title = "WithoutDelayedRetries";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Warn);
 

--- a/samples/faulttolerance/Core_7/Client/Program.cs
+++ b/samples/faulttolerance/Core_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/faulttolerance/Core_7/Server/Program.cs
+++ b/samples/faulttolerance/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/faulttolerance/Core_8/Client/Program.cs
+++ b/samples/faulttolerance/Core_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/faulttolerance/Core_8/Server/Program.cs
+++ b/samples/faulttolerance/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/faulttolerance/Core_9/Client/Program.cs
+++ b/samples/faulttolerance/Core_9/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/faulttolerance/Core_9/Server/Program.cs
+++ b/samples/faulttolerance/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FaultTolerance.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.FaultTolerance.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/feature/Core_7/Sample/Program.cs
+++ b/samples/feature/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Features";
+        Console.Title = "FeaturesSample";
         var endpointConfiguration = new EndpointConfiguration("Samples.Features");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/feature/Core_8/Sample/Program.cs
+++ b/samples/feature/Core_8/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Features";
+        Console.Title = "FeaturesSample";
         var endpointConfiguration = new EndpointConfiguration("Samples.Features");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/feature/Core_9/Sample/Program.cs
+++ b/samples/feature/Core_9/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Features";
+        Console.Title = "FeaturesSample";
         var endpointConfiguration = new EndpointConfiguration("Samples.Features");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/fullduplex/Core_7/Client/Program.cs
+++ b/samples/fullduplex/Core_7/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Client";
+        Console.Title = "Client";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Client");

--- a/samples/fullduplex/Core_7/Server/Program.cs
+++ b/samples/fullduplex/Core_7/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Server";
+        Console.Title = "Server";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Server");

--- a/samples/fullduplex/Core_8/Client/Program.cs
+++ b/samples/fullduplex/Core_8/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Client";
+        Console.Title = "Client";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Client");

--- a/samples/fullduplex/Core_8/Server/Program.cs
+++ b/samples/fullduplex/Core_8/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Server";
+        Console.Title = "Server";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Server");

--- a/samples/fullduplex/Core_9/Client/Program.cs
+++ b/samples/fullduplex/Core_9/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Client";
+        Console.Title = "Client";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Client");

--- a/samples/fullduplex/Core_9/Server/Program.cs
+++ b/samples/fullduplex/Core_9/Server/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FullDuplex.Server";
+        Console.Title = "Server";
         LogManager.Use<DefaultFactory>()
             .Level(LogLevel.Info);
         var endpointConfiguration = new EndpointConfiguration("Samples.FullDuplex.Server");

--- a/samples/gateway/Gateway_3/Headquarters/Program.cs
+++ b/samples/gateway/Gateway_3/Headquarters/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.Headquarters";
+        Console.Title = "Headquarters";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.Headquarters");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/gateway/Gateway_3/RemoteSite/Program.cs
+++ b/samples/gateway/Gateway_3/RemoteSite/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.RemoteSite";
+        Console.Title = "RemoteSite";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.RemoteSite");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/gateway/Gateway_4/Headquarters/Program.cs
+++ b/samples/gateway/Gateway_4/Headquarters/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.Headquarters";
+        Console.Title = "Headquarters";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.Headquarters");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/gateway/Gateway_4/RemoteSite/Program.cs
+++ b/samples/gateway/Gateway_4/RemoteSite/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.RemoteSite";
+        Console.Title = "RemoteSite";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.RemoteSite");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/gateway/Gateway_5/Headquarters/Program.cs
+++ b/samples/gateway/Gateway_5/Headquarters/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.Headquarters";
+        Console.Title = "Headquarters";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.Headquarters");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/gateway/Gateway_5/RemoteSite/Program.cs
+++ b/samples/gateway/Gateway_5/RemoteSite/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Gateway.RemoteSite";
+        Console.Title = "RemoteSite";
         var endpointConfiguration = new EndpointConfiguration("Samples.Gateway.RemoteSite");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/header-manipulation/Core_7/Sample/Program.cs
+++ b/samples/header-manipulation/Core_7/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Headers";
+        Console.Title = "Headers";
         var endpointConfiguration = new EndpointConfiguration("Samples.Headers");
 
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/header-manipulation/Core_8/Sample/Program.cs
+++ b/samples/header-manipulation/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Headers";
+        Console.Title = "Headers";
         var endpointConfiguration = new EndpointConfiguration("Samples.Headers");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/header-manipulation/Core_9/Sample/Program.cs
+++ b/samples/header-manipulation/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Headers";
+        Console.Title = "Headers";
         var endpointConfiguration = new EndpointConfiguration("Samples.Headers");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/immutable-messages/Core_7/Receiver/Program.cs
+++ b/samples/immutable-messages/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Receiver");
         endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/immutable-messages/Core_7/Sender/Program.cs
+++ b/samples/immutable-messages/Core_7/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Sender");
         endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/immutable-messages/Core_8/Receiver/Program.cs
+++ b/samples/immutable-messages/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Receiver");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/immutable-messages/Core_8/Sender/Program.cs
+++ b/samples/immutable-messages/Core_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Sender");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/immutable-messages/Core_9/Receiver/Program.cs
+++ b/samples/immutable-messages/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Receiver");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/immutable-messages/Core_9/Sender/Program.cs
+++ b/samples/immutable-messages/Core_9/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ImmutableMessages.UsingInterfaces.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Sender");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Program.cs
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.CommonLogging";
+        Console.Title = "CommonLogging";
 
         #region ConfigureLogging
 

--- a/samples/logging/custom-factory/Core_7/Sample/Program.cs
+++ b/samples/logging/custom-factory/Core_7/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.CustomFactory";
+        Console.Title = "CustomFactory";
         #region ConfigureLogging
 
         var loggerDefinition = LogManager.Use<ConsoleLoggerDefinition>();

--- a/samples/logging/custom-factory/Core_8/Sample/Program.cs
+++ b/samples/logging/custom-factory/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.CustomFactory";
+        Console.Title = "CustomFactory";
         #region ConfigureLogging
 
         var loggerDefinition = LogManager.Use<ConsoleLoggerDefinition>();

--- a/samples/logging/custom-factory/Core_9/Sample/Program.cs
+++ b/samples/logging/custom-factory/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.CustomFactory";
+        Console.Title = "CustomFactory";
         #region ConfigureLogging
 
         var loggerDefinition = LogManager.Use<ConsoleLoggerDefinition>();

--- a/samples/logging/datadog/Core_7/Endpoint/Program.cs
+++ b/samples/logging/datadog/Core_7/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Metrics.Tracing.Endpoint";
+        Console.Title = "TracingEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.Metrics.Tracing.Endpoint");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/logging/default/Core_7/Sample/Program.cs
+++ b/samples/logging/default/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.Default";
+        Console.Title = "LoggingDefault";
         #region ConfigureLogging
 
         var defaultFactory = NServiceBus.Logging.LogManager.Use<NServiceBus.Logging.DefaultFactory>();

--- a/samples/logging/default/Core_8/Sample/Program.cs
+++ b/samples/logging/default/Core_8/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.Default";
+        Console.Title = "LoggingDefault";
         #region ConfigureLogging
 
         var defaultFactory = NServiceBus.Logging.LogManager.Use<NServiceBus.Logging.DefaultFactory>();

--- a/samples/logging/default/Core_9/Sample/Program.cs
+++ b/samples/logging/default/Core_9/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.Default";
+        Console.Title = "LoggingDefault";
         #region ConfigureLogging
 
         var defaultFactory = NServiceBus.Logging.LogManager.Use<NServiceBus.Logging.DefaultFactory>();

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Program.cs
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.ExtensionsLogging";
+        Console.Title = "ExtensionsLogging";
 
         #region NLogConfiguration
         var config = new LoggingConfiguration();

--- a/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Program.cs
+++ b/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.ExtensionsLogging";
+        Console.Title = "ExtensionsLogging";
 
         #region NLogConfiguration
         var config = new LoggingConfiguration();

--- a/samples/logging/extensions-logging/Extensions.Logging_3/Sample/Program.cs
+++ b/samples/logging/extensions-logging/Extensions.Logging_3/Sample/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.ExtensionsLogging";
+        Console.Title = "ExtensionsLogging";
 
         #region NLogConfiguration
         var config = new LoggingConfiguration();

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Program.cs
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Program.cs
@@ -12,7 +12,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.Log4NetCustom";
+        Console.Title = "Log4NetCustom";
         #region ConfigureLog4Net
         var layout = new PatternLayout
         {

--- a/samples/logging/metrics/Metrics_3/Endpoint/Program.cs
+++ b/samples/logging/metrics/Metrics_3/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Metrics.Tracing.Endpoint";
+        Console.Title = "TracingEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.Metrics.Tracing.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/logging/metrics/Metrics_4/Endpoint/Program.cs
+++ b/samples/logging/metrics/Metrics_4/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Metrics.Tracing.Endpoint";
+        Console.Title = "TracingEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.Metrics.Tracing.Endpoint");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/logging/metrics/Metrics_5/Endpoint/Program.cs
+++ b/samples/logging/metrics/Metrics_5/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Metrics.Tracing.Endpoint";
+        Console.Title = "TracingEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.Metrics.Tracing.Endpoint");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/logging/new-relic/Metrics_3/Endpoint/Program.cs
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Metrics.Tracing.Endpoint";
+        Console.Title = "TracingEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.Metrics.Tracing.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Program.cs
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.Metrics.Tracing.Endpoint");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "TracingEndpoint");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/logging/new-relic/Metrics_5/Endpoint/Program.cs
+++ b/samples/logging/new-relic/Metrics_5/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.Metrics.Tracing.Endpoint");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "TracingEndpoint");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/logging/nlog-custom/NLog_3/Sample/Program.cs
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Logging.NLogCustom";
+        Console.Title = "NLogCustom";
 
         #region ConfigureNLog
 

--- a/samples/logging/notifications/Core_7/Sample/Program.cs
+++ b/samples/logging/notifications/Core_7/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Notifications";
+        Console.Title = "Notifications";
 
         #region logging
 

--- a/samples/logging/notifications/Core_8/Sample/Program.cs
+++ b/samples/logging/notifications/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Notifications";
+        Console.Title = "Notifications";
 
         #region logging
 

--- a/samples/logging/notifications/Core_9/Sample/Program.cs
+++ b/samples/logging/notifications/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Notifications";
+        Console.Title = "Notifications";
 
         #region logging
 

--- a/samples/messagemutators/Core_7/Sample/Program.cs
+++ b/samples/messagemutators/Core_7/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageMutators";
+        Console.Title = "MessageMutators";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageMutators");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/messagemutators/Core_8/Sample/Program.cs
+++ b/samples/messagemutators/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageMutators";
+        Console.Title = "MessageMutators";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageMutators");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/messagemutators/Core_9/Sample/Program.cs
+++ b/samples/messagemutators/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MessageMutators";
+        Console.Title = "MessageMutators";
         var endpointConfiguration = new EndpointConfiguration("Samples.MessageMutators");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/mongodb/simple/MongoDB_2/Client/Program.cs
+++ b/samples/mongodb/simple/MongoDB_2/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.MongoDB.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/mongodb/simple/MongoDB_2/Server/Program.cs
+++ b/samples/mongodb/simple/MongoDB_2/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Server";
+        Console.Title = "Server";
 
         #region mongoDbConfig
 

--- a/samples/mongodb/simple/MongoDB_3/Client/Program.cs
+++ b/samples/mongodb/simple/MongoDB_3/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.MongoDB.Client");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/mongodb/simple/MongoDB_3/Server/Program.cs
+++ b/samples/mongodb/simple/MongoDB_3/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Server";
+        Console.Title = "Server";
 
         #region mongoDbConfig
 

--- a/samples/mongodb/simple/MongoDB_4/Client/Program.cs
+++ b/samples/mongodb/simple/MongoDB_4/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.MongoDB.Client");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/mongodb/simple/MongoDB_4/Server/Program.cs
+++ b/samples/mongodb/simple/MongoDB_4/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MongoDB.Server";
+        Console.Title = "Server";
 
         #region mongoDbConfig
 

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/MsmqPublisher/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.MsmqPublisher";
+        Console.Title = "MsmqPublisher";
         #region publisher-config
 
         var endpointConfiguration = new EndpointConfiguration("MsmqPublisher");

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/NativeMsmqToSql/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/NativeMsmqToSql/Program.cs
@@ -15,7 +15,7 @@ class Program
 {
     static void Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.NativeMsmqToSql";
+        Console.Title = "NativeMsmqToSql";
 
         #region receive-from-msmq-using-native-messaging
 

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_1/SqlRelay/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.SqlRelay";
+        Console.Title = "SqlRelay";
         #region sqlrelay-config
         var endpointConfiguration = new EndpointConfiguration("SqlRelay");
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/MsmqPublisher/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/MsmqPublisher/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.MsmqPublisher";
+        Console.Title = "MsmqPublisher";
         #region publisher-config
 
         var endpointConfiguration = new EndpointConfiguration("MsmqPublisher");

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/NativeMsmqToSql/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/NativeMsmqToSql/Program.cs
@@ -15,7 +15,7 @@ class Program
 {
     static void Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.NativeMsmqToSql";
+        Console.Title = "NativeMsmqToSql";
 
         #region receive-from-msmq-using-native-messaging
 

--- a/samples/msmq/msmqtosqlrelay/MsmqTransport_2/SqlRelay/Program.cs
+++ b/samples/msmq/msmqtosqlrelay/MsmqTransport_2/SqlRelay/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MsmqToSqlRelay.SqlRelay";
+        Console.Title = "SqlRelay";
         #region sqlrelay-config
         var endpointConfiguration = new EndpointConfiguration("SqlRelay");
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/msmq/simple/MsmqTransport_1/Sample/Program.cs
+++ b/samples/msmq/simple/MsmqTransport_1/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Msmq.Simple";
+        Console.Title = "MsmqSimple";
         #region ConfigureMsmqEndpoint
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Msmq.Simple");

--- a/samples/msmq/simple/MsmqTransport_2/Sample/Program.cs
+++ b/samples/msmq/simple/MsmqTransport_2/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Msmq.Simple";
+        Console.Title = "MsmqSimple";
         #region ConfigureMsmqEndpoint
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Msmq.Simple");

--- a/samples/multi-tenant/di/Core_7/Endpoint/Program.cs
+++ b/samples/multi-tenant/di/Core_7/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/multi-tenant/di/Core_8/Endpoint/Program.cs
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/multi-tenant/di/Core_9/Endpoint/Program.cs
+++ b/samples/multi-tenant/di/Core_9/Endpoint/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/multi-tenant/nhibernate/NHibernate_10/Receiver/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_10/Receiver/Program.cs
@@ -12,7 +12,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         #region NHibernateConfiguration
 

--- a/samples/multi-tenant/nhibernate/NHibernate_10/Sender/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_10/Sender/Program.cs
@@ -11,7 +11,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
 
         var random = new Random();
 

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Program.cs
@@ -13,7 +13,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         #region NHibernateConfiguration
 

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Program.cs
@@ -12,7 +12,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         #region NHibernateConfiguration
 

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Program.cs
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Program.cs
@@ -11,7 +11,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
 
         var random = new Random();
 

--- a/samples/multi-tenant/ravendb/Core_7/Receiver/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_7/Receiver/Program.cs
@@ -14,7 +14,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
 

--- a/samples/multi-tenant/ravendb/Core_7/Sender/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_7/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/ravendb/Core_8/Receiver/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_8/Receiver/Program.cs
@@ -14,7 +14,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
 

--- a/samples/multi-tenant/ravendb/Core_8/Sender/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/ravendb/Core_9/Receiver/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_9/Receiver/Program.cs
@@ -14,7 +14,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
 

--- a/samples/multi-tenant/ravendb/Core_9/Sender/Program.cs
+++ b/samples/multi-tenant/ravendb/Core_9/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Program.cs
@@ -11,7 +11,7 @@ class Program
     {
         const string tablePrefix = "";
 
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
         endpointConfiguration.LimitMessageProcessingConcurrencyTo(1);

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Program.cs
@@ -12,7 +12,7 @@ class Program
     {
         const string tablePrefix = "";
 
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
         endpointConfiguration.LimitMessageProcessingConcurrencyTo(1);

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/multi-tenant/sqlp/SqlPersistence_8/Receiver/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_8/Receiver/Program.cs
@@ -12,7 +12,7 @@ class Program
     {
         const string tablePrefix = "";
 
-        Console.Title = "Samples.MultiTenant.Receiver";
+        Console.Title = "Receiver";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Receiver");
         endpointConfiguration.LimitMessageProcessingConcurrencyTo(1);

--- a/samples/multi-tenant/sqlp/SqlPersistence_8/Sender/Program.cs
+++ b/samples/multi-tenant/sqlp/SqlPersistence_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultiTenant.Sender";
+        Console.Title = "Sender";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.MultiTenant.Sender");

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Attributes/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Attributes/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Attributes";
+        Console.Title = "Attributes";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Attributes");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Default/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Default/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Default";
+        Console.Title = "Default";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Default");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Fluent/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Fluent/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Fluent";
+        Console.Title = "Fluent";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Fluent");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Loquacious/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Loquacious/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Loquacious";
+        Console.Title = "Loquacious";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Loquacious");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.XmlMapping/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.XmlMapping/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.XmlMapping";
+        Console.Title = "XmlMapping";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.XmlMapping");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Attributes";
+        Console.Title = "Attributes";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Attributes");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Default";
+        Console.Title = "Default";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Default");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Fluent";
+        Console.Title = "Fluent";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Fluent");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Loquacious";
+        Console.Title = "Loquacious";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Loquacious");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.XmlMapping";
+        Console.Title = "XmlMapping";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.XmlMapping");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Attributes";
+        Console.Title = "Attributes";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Attributes");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Default";
+        Console.Title = "Default";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Default");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Fluent";
+        Console.Title = "Fluent";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Fluent");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.Loquacious";
+        Console.Title = "Loquacious";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.Loquacious");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Program.cs
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomNhMappings.XmlMapping";
+        Console.Title = "XmlMapping";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomNhMappings.XmlMapping");
         endpointConfiguration.EnableInstallers();

--- a/samples/nhibernate/simple/NHibernate_10/Client/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_10/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.NHibernate.Client");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/nhibernate/simple/NHibernate_10/Server/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_10/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Server";
+        Console.Title = "Server";
 
         #region Config
 

--- a/samples/nhibernate/simple/NHibernate_8/Client/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.NHibernate.Client");
         endpointConfiguration.EnableInstallers();
         //endpointConfiguration.UsePersistence<NHibernatePersistence>();

--- a/samples/nhibernate/simple/NHibernate_8/Server/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Server";
+        Console.Title = "Server";
 
         #region Config
 

--- a/samples/nhibernate/simple/NHibernate_9/Client/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_9/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.NHibernate.Client");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/nhibernate/simple/NHibernate_9/Server/Program.cs
+++ b/samples/nhibernate/simple/NHibernate_9/Server/Program.cs
@@ -11,7 +11,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.NHibernate.Server";
+        Console.Title = "Server";
 
         #region Config
 

--- a/samples/outbox/rabbit/Core_7/Sample/Program.cs
+++ b/samples/outbox/rabbit/Core_7/Sample/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.Outbox";
+        Console.Title = "RabbitMQOutbox";
 
         #region ConfigureTransport
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.Outbox");

--- a/samples/outbox/rabbit/Core_8/Sample/Program.cs
+++ b/samples/outbox/rabbit/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.Outbox";
+        Console.Title = "RabbitMQOutbox";
 
         #region ConfigureTransport
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.Outbox");

--- a/samples/outbox/rabbit/Core_9/Sample/Program.cs
+++ b/samples/outbox/rabbit/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.Outbox";
+        Console.Title = "RabbitMQOutbox";
 
         #region ConfigureTransport
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.Outbox");

--- a/samples/outbox/sql/Core_7/Receiver/Program.cs
+++ b/samples/outbox/sql/Core_7/Receiver/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SQLOutboxEF.Receiver";
+        Console.Title = "Receiver";
 
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlOutbox;Integrated Security=True;Max Pool Size=100;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlOutbox;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/outbox/sql/Core_7/Sender/Program.cs
+++ b/samples/outbox/sql/Core_7/Sender/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlOutbox.Sender";
+        Console.Title = "Sender";
         var random = new Random();
 
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlOutbox.Sender");

--- a/samples/outbox/sql/Core_8/Receiver/Program.cs
+++ b/samples/outbox/sql/Core_8/Receiver/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SQLOutboxEF.Receiver";
+        Console.Title = "Receiver";
 
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlOutbox;Integrated Security=True;Max Pool Size=100;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlOutbox;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/outbox/sql/Core_8/Sender/Program.cs
+++ b/samples/outbox/sql/Core_8/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlOutbox.Sender";
+        Console.Title = "Sender";
         var random = new Random();
 
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlOutbox.Sender");

--- a/samples/outbox/sql/Core_9/Receiver/Program.cs
+++ b/samples/outbox/sql/Core_9/Receiver/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SQLOutboxEF.Receiver";
+        Console.Title = "Receiver";
 
         // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlOutbox;Integrated Security=True;Max Pool Size=100;Encrypt=false
         var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlOutbox;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/outbox/sql/Core_9/Sender/Program.cs
+++ b/samples/outbox/sql/Core_9/Sender/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlOutbox.Sender";
+        Console.Title = "Sender";
         var random = new Random();
 
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlOutbox.Sender");

--- a/samples/performance-counters/PerfCounters_4/Sample/Program.cs
+++ b/samples/performance-counters/PerfCounters_4/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PerfCounters";
+        Console.Title = "PerfCounters";
         var endpointConfiguration = new EndpointConfiguration("Samples.PerfCounters");
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/performance-counters/PerfCounters_5/Sample/Program.cs
+++ b/samples/performance-counters/PerfCounters_5/Sample/Program.cs
@@ -1,5 +1,5 @@
 
-Console.Title = "Samples.PerfCounters";
+Console.Title = "PerfCounters";
 var endpointConfiguration = new EndpointConfiguration("Samples.PerfCounters");
 endpointConfiguration.EnableInstallers();
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/performance-counters/PerfCounters_6/Sample/Program.cs
+++ b/samples/performance-counters/PerfCounters_6/Sample/Program.cs
@@ -1,5 +1,5 @@
 
-Console.Title = "Samples.PerfCounters";
+Console.Title = "PerfCounters";
 var endpointConfiguration = new EndpointConfiguration("Samples.PerfCounters");
 endpointConfiguration.EnableInstallers();
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/Program.cs
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AuditFilter";
+        Console.Title = "AuditFilter";
         var endpointConfiguration = new EndpointConfiguration("Samples.AuditFilter");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/Program.cs
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AuditFilter";
+        Console.Title = "AuditFilter";
         var endpointConfiguration = new EndpointConfiguration("Samples.AuditFilter");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/audit-filtering/Core_9/AuditFilter/Program.cs
+++ b/samples/pipeline/audit-filtering/Core_9/AuditFilter/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.AuditFilter";
+        Console.Title = "AuditFilter";
         var endpointConfiguration = new EndpointConfiguration("Samples.AuditFilter");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/dispatch-notifications/Core_7/SampleApp/Program.cs
+++ b/samples/pipeline/dispatch-notifications/Core_7/SampleApp/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DispatchNotification";
+        Console.Title = "DispatchNotification";
 
         #region endpoint-configuration
         var endpointConfiguration = new EndpointConfiguration("Samples.DispatchNotification");

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/Program.cs
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DispatchNotification";
+        Console.Title = "DispatchNotification";
 
         #region endpoint-configuration
         var endpointConfiguration = new EndpointConfiguration("Samples.DispatchNotification");

--- a/samples/pipeline/dispatch-notifications/Core_9/SampleApp/Program.cs
+++ b/samples/pipeline/dispatch-notifications/Core_9/SampleApp/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.DispatchNotification";
+        Console.Title = "DispatchNotification";
 
         #region endpoint-configuration
         var endpointConfiguration = new EndpointConfiguration("Samples.DispatchNotification");

--- a/samples/pipeline/feature-toggle/Core_7/Sample/Program.cs
+++ b/samples/pipeline/feature-toggle/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineFeatureToggle";
+        Console.Title = "PipelineFeatureToggle";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineFeatureToggle");
 
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Program.cs
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineFeatureToggle";
+        Console.Title = "PipelineFeatureToggle";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineFeatureToggle");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pipeline/feature-toggle/Core_9/Sample/Program.cs
+++ b/samples/pipeline/feature-toggle/Core_9/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineFeatureToggle";
+        Console.Title = "PipelineFeatureToggle";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineFeatureToggle");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pipeline/handler-timer/Core_7/Sample/Program.cs
+++ b/samples/pipeline/handler-timer/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineHandlerTimer";
+        Console.Title = "PipelineHandlerTimer";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineHandlerTimer");
 
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/pipeline/handler-timer/Core_8/Sample/Program.cs
+++ b/samples/pipeline/handler-timer/Core_8/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineHandlerTimer";
+        Console.Title = "PipelineHandlerTimer";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineHandlerTimer");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pipeline/handler-timer/Core_9/Sample/Program.cs
+++ b/samples/pipeline/handler-timer/Core_9/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PipelineHandlerTimer";
+        Console.Title = "PipelineHandlerTimer";
         var endpointConfiguration = new EndpointConfiguration("Samples.PipelineHandlerTimer");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/Program.cs
+++ b/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_7/SignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_7/SignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.SignedSender";
+        Console.Title = "SignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.SignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_7/UnsignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_7/UnsignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.UnsignedSender";
+        Console.Title = "UnsignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.UnsignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/Program.cs
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_8/SignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.SignedSender";
+        Console.Title = "SignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.SignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.UnsignedSender";
+        Console.Title = "UnsignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.UnsignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_9/ReceivingEndpoint/Program.cs
+++ b/samples/pipeline/message-signing/Core_9/ReceivingEndpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_9/SignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_9/SignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.SignedSender";
+        Console.Title = "SignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.SignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/Core_9/UnsignedSender/Program.cs
+++ b/samples/pipeline/message-signing/Core_9/UnsignedSender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.SigningAndEncryption.UnsignedSender";
+        Console.Title = "UnsignedSender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.SigningAndEncryption.UnsignedSender");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/message-signing/sample.md
+++ b/samples/pipeline/message-signing/sample.md
@@ -16,9 +16,9 @@ downloadbutton
 
 Running the sample will result in three different NServiceBus message endpoints, each running within their own console window:
 
-1. **Samples.Pipeline.SigningAndEncryption.ReceivingEndpoint**: Receives messages from the other two endpoints, but only successfully processing messages with a valid signature.
-1. **Samples.Pipeline.SigningAndEncryption.SignedSender**: Sends messages to the ReceivingEndpoint with a proper signature.
-1. **Samples.Pipeline.SigningAndEncryption.UnsignedSender**: Sends messages to the ReceivingEndpoint with a fake, invalid signature.
+1. **ReceivingEndpoint**: Receives messages from the other two endpoints, but only successfully processing messages with a valid signature.
+1. **SignedSender**: Sends messages to the ReceivingEndpoint with a proper signature.
+1. **UnsignedSender**: Sends messages to the ReceivingEndpoint with a fake, invalid signature.
 
 Pressing any key from the **SignedSender** window will result in a message sent to the **ReceivingEndpoint** that is successfully processed:
 

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Program.cs
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Receiver");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/session-filtering/Core_7/Sender/Program.cs
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Sender");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Program.cs
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Receiver");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/session-filtering/Core_8/Sender/Program.cs
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Sender");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/session-filtering/Core_9/Receiver/Program.cs
+++ b/samples/pipeline/session-filtering/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Receiver");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/session-filtering/Core_9/Sender/Program.cs
+++ b/samples/pipeline/session-filtering/Core_9/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Console.Title = "Samples.SessionFilter.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.SessionFilter.Sender");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/unit-of-work/Core_7/Endpoint/Program.cs
+++ b/samples/pipeline/unit-of-work/Core_7/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Program.cs
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/pipeline/unit-of-work/Core_9/Endpoint/Program.cs
+++ b/samples/pipeline/unit-of-work/Core_9/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Pipeline.UnitOfWork.Endpoint";
+        Console.Title = "UnitOfWorkEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Pipeline.UnitOfWork.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.CustomExtensionEndpoint";
+        Console.Title = "CustomExtensionEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomExtensionEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/plugin-based-config/Core_7/MefExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_7/MefExtensionEndpoint/Program.cs
@@ -12,7 +12,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.MefExtensionEndpoint";
+        Console.Title = "MefExtensionEndpoint";
 
         var containerConfiguration = new ContainerConfiguration();
 

--- a/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.CustomExtensionEndpoint";
+        Console.Title = "CustomExtensionEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomExtensionEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/plugin-based-config/Core_8/MefExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_8/MefExtensionEndpoint/Program.cs
@@ -12,7 +12,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.MefExtensionEndpoint";
+        Console.Title = "MefExtensionEndpoint";
 
         var containerConfiguration = new ContainerConfiguration();
 

--- a/samples/plugin-based-config/Core_9/CustomExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_9/CustomExtensionEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.CustomExtensionEndpoint";
+        Console.Title = "CustomExtensionEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomExtensionEndpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/plugin-based-config/Core_9/MefExtensionEndpoint/Program.cs
+++ b/samples/plugin-based-config/Core_9/MefExtensionEndpoint/Program.cs
@@ -12,7 +12,7 @@ static class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.MefExtensionEndpoint";
+        Console.Title = "MefExtensionEndpoint";
 
         var containerConfiguration = new ContainerConfiguration();
 

--- a/samples/pubsub/message-driven/Core_7/Publisher/Program.cs
+++ b/samples/pubsub/message-driven/Core_7/Publisher/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.MessageDrivenPublisher";
+        Console.Title = "MessageDrivenPublisher";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.MessageDrivenPublisher");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.UseTransport<MsmqTransport>();

--- a/samples/pubsub/message-driven/Core_7/Subscriber/Program.cs
+++ b/samples/pubsub/message-driven/Core_7/Subscriber/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.MessageDrivenSubscriber";
+        Console.Title = "MessageDrivenSubscriber";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.MessageDrivenSubscriber");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
 

--- a/samples/pubsub/message-driven/Core_8/Publisher/Program.cs
+++ b/samples/pubsub/message-driven/Core_8/Publisher/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.MessageDrivenPublisher";
+        Console.Title = "MessageDrivenPublisher";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.MessageDrivenPublisher");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pubsub/message-driven/Core_8/Subscriber/Program.cs
+++ b/samples/pubsub/message-driven/Core_8/Subscriber/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.MessageDrivenSubscriber";
+        Console.Title = "MessageDrivenSubscriber";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.MessageDrivenSubscriber");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pubsub/native/Core_7/Publisher/Program.cs
+++ b/samples/pubsub/native/Core_7/Publisher/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Publisher";
+        Console.Title = "Publisher";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Publisher");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/pubsub/native/Core_7/Subscriber/Program.cs
+++ b/samples/pubsub/native/Core_7/Subscriber/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Subscriber";
+        Console.Title = "Subscriber";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Subscriber");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/pubsub/native/Core_8/Publisher/Program.cs
+++ b/samples/pubsub/native/Core_8/Publisher/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Publisher";
+        Console.Title = "Publisher";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Publisher");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/pubsub/native/Core_8/Subscriber/Program.cs
+++ b/samples/pubsub/native/Core_8/Subscriber/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Subscriber";
+        Console.Title = "Subscriber";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Subscriber");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/pubsub/native/Core_9/Publisher/Program.cs
+++ b/samples/pubsub/native/Core_9/Publisher/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Publisher";
+        Console.Title = "Publisher";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Publisher");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/pubsub/native/Core_9/Subscriber/Program.cs
+++ b/samples/pubsub/native/Core_9/Subscriber/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.PubSub.Subscriber";
+        Console.Title = "Subscriber";
         var endpointConfiguration = new EndpointConfiguration("Samples.PubSub.Subscriber");
 
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.NativeIntegration.Receiver";
+        Console.Title = "Receiver";
 
         #region ConfigureRabbitQueueName
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.NativeIntegration");

--- a/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.NativeIntegration.Receiver";
+        Console.Title = "Receiver";
 
         #region ConfigureRabbitQueueName
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.NativeIntegration");

--- a/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.NativeIntegration.Receiver";
+        Console.Title = "Receiver";
 
         #region ConfigureRabbitQueueName
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.NativeIntegration");

--- a/samples/rabbitmq/native-integration/Rabbit_9/Receiver/Program.cs
+++ b/samples/rabbitmq/native-integration/Rabbit_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.NativeIntegration.Receiver";
+        Console.Title = "Receiver";
 
         #region ConfigureRabbitQueueName
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.NativeIntegration");

--- a/samples/rabbitmq/simple/Rabbit_6/Receiver/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_6/Receiver/Program.cs
@@ -9,7 +9,7 @@ namespace Receiver
     {
         static async Task Main()
         {
-            Console.Title = "Samples.RabbitMQ.SimpleReceiver";
+            Console.Title = "SimpleReceiver";
             var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleReceiver");
             var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
             transport.UseConventionalRoutingTopology();

--- a/samples/rabbitmq/simple/Rabbit_6/Sender/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_6/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.SimpleSender";
+        Console.Title = "SimpleSender";
         #region ConfigureRabbit
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleSender");
         var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();

--- a/samples/rabbitmq/simple/Rabbit_7/Receiver/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_7/Receiver/Program.cs
@@ -9,7 +9,7 @@ namespace Receiver
     {
         static async Task Main()
         {
-            Console.Title = "Samples.RabbitMQ.SimpleReceiver";
+            Console.Title = "SimpleReceiver";
             var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleReceiver");
             var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
             transport.UseConventionalRoutingTopology(QueueType.Quorum);

--- a/samples/rabbitmq/simple/Rabbit_7/Sender/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_7/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.SimpleSender";
+        Console.Title = "SimpleSender";
         #region ConfigureRabbit
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleSender");
         var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();

--- a/samples/rabbitmq/simple/Rabbit_8/Receiver/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_8/Receiver/Program.cs
@@ -9,7 +9,7 @@ namespace Receiver
     {
         static async Task Main()
         {
-            Console.Title = "Samples.RabbitMQ.SimpleReceiver";
+            Console.Title = "SimpleReceiver";
             var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleReceiver");
             var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
             transport.UseConventionalRoutingTopology(QueueType.Quorum);

--- a/samples/rabbitmq/simple/Rabbit_8/Sender/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_8/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.SimpleSender";
+        Console.Title = "SimpleSender";
 
         #region ConfigureRabbit
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleSender");

--- a/samples/rabbitmq/simple/Rabbit_9/Receiver/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_9/Receiver/Program.cs
@@ -9,7 +9,7 @@ namespace Receiver
     {
         static async Task Main()
         {
-            Console.Title = "Samples.RabbitMQ.SimpleReceiver";
+            Console.Title = "SimpleReceiver";
             var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleReceiver");
             var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
             transport.UseConventionalRoutingTopology(QueueType.Quorum);

--- a/samples/rabbitmq/simple/Rabbit_9/Sender/Program.cs
+++ b/samples/rabbitmq/simple/Rabbit_9/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RabbitMQ.SimpleSender";
+        Console.Title = "SimpleSender";
 
         #region ConfigureRabbit
         var endpointConfiguration = new EndpointConfiguration("Samples.RabbitMQ.SimpleSender");

--- a/samples/ravendb/simple/Raven_7/Client/Program.cs
+++ b/samples/ravendb/simple/Raven_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RavenDB.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.RavenDB.Client");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/ravendb/simple/Raven_7/Server/Program.cs
+++ b/samples/ravendb/simple/Raven_7/Server/Program.cs
@@ -10,7 +10,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RavenDB.Server";
+        Console.Title = "Server";
 
         #region Config
 

--- a/samples/ravendb/simple/Raven_8/Client/Program.cs
+++ b/samples/ravendb/simple/Raven_8/Client/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.RavenDB.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.RavenDB.Client");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/ravendb/simple/Raven_8/Server/Program.cs
+++ b/samples/ravendb/simple/Raven_8/Server/Program.cs
@@ -7,7 +7,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 
-Console.Title = "Samples.RavenDB.Server";
+Console.Title = "Server";
 
 #region Config
 

--- a/samples/ravendb/simple/Raven_9/Client/Program.cs
+++ b/samples/ravendb/simple/Raven_9/Client/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.RavenDB.Client";
+Console.Title = "Client";
 var endpointConfiguration = new EndpointConfiguration("Samples.RavenDB.Client");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/ravendb/simple/Raven_9/Server/Program.cs
+++ b/samples/ravendb/simple/Raven_9/Server/Program.cs
@@ -6,7 +6,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 
-Console.Title = "Samples.RavenDB.Server";
+Console.Title = "Server";
 
 #region Config
 

--- a/samples/router/backplane/Router_3/Blue.Client/Program.cs
+++ b/samples/router/backplane/Router_3/Blue.Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Blue.Client";
+        Console.Title = "BlueClient";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/router/backplane/Router_3/Blue.Router/Program.cs
+++ b/samples/router/backplane/Router_3/Blue.Router/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Blue.Router";
+        Console.Title = "BlueRouter";
 
         var routerConfig = await RouterConfigurator.Prepare(ConnectionStrings.Blue, "Blue");
 

--- a/samples/router/backplane/Router_3/Green.Billing/Program.cs
+++ b/samples/router/backplane/Router_3/Green.Billing/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Green.Billing";
+        Console.Title = "GreenBilling";
         var endpointConfiguration = new EndpointConfiguration("Green.Billing");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/router/backplane/Router_3/Green.Router/Program.cs
+++ b/samples/router/backplane/Router_3/Green.Router/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Green.Router";
+        Console.Title = "GreenRouter";
 
         var routerConfig = await RouterConfigurator.Prepare(ConnectionStrings.Green, "Green");
 

--- a/samples/router/backplane/Router_3/Red.Router/Program.cs
+++ b/samples/router/backplane/Router_3/Red.Router/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Red.Router";
+        Console.Title = "RedRouter";
 
         var routerConfig = await RouterConfigurator.Prepare(ConnectionStrings.Red, "Red");
 

--- a/samples/router/backplane/Router_3/Red.Sales/Program.cs
+++ b/samples/router/backplane/Router_3/Red.Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Red.Sales";
+        Console.Title = "RedSales";
         var endpointConfiguration = new EndpointConfiguration("Red.Sales");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/router/backplane/Router_3/Red.Shipping/Program.cs
+++ b/samples/router/backplane/Router_3/Red.Shipping/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Red.Shipping";
+        Console.Title = "RedShipping";
         var endpointConfiguration = new EndpointConfiguration("Red.Shipping");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/router/mixed-transports/Router_3/Client/Program.cs
+++ b/samples/router/mixed-transports/Router_3/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.MixedTransports.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.Router.MixedTransports.Client");

--- a/samples/router/mixed-transports/Router_3/Router/Program.cs
+++ b/samples/router/mixed-transports/Router_3/Router/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.MixedTransports.Router";
+        Console.Title = "Router";
 
         #region RouterConfig
 

--- a/samples/router/mixed-transports/Router_3/Server/Program.cs
+++ b/samples/router/mixed-transports/Router_3/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.MixedTransports.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration(
             "Samples.Router.MixedTransports.Server");
 

--- a/samples/router/sites/Router_3/Client/Program.cs
+++ b/samples/router/sites/Router_3/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.Sites.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
         var endpointConfiguration = new EndpointConfiguration("Samples.Router.Sites.Client");

--- a/samples/router/sites/Router_3/RouterA/Program.cs
+++ b/samples/router/sites/Router_3/RouterA/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.Sites.RouterA";
+        Console.Title = "RouterA";
 
         var routerConfig = new RouterConfiguration("SiteA");
         routerConfig.AddInterface<LearningTransport>("Local", t => { });

--- a/samples/router/sites/Router_3/RouterB/Program.cs
+++ b/samples/router/sites/Router_3/RouterB/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.Sites.RouterB";
+        Console.Title = "RouterB";
 
         var routerConfig = new RouterConfiguration("SiteB");
         routerConfig.AddInterface<LearningTransport>("Local", t => { });

--- a/samples/router/sites/Router_3/Server/Program.cs
+++ b/samples/router/sites/Router_3/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Router.Sites.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration(
             "Samples.Router.Sites.Server");
 

--- a/samples/router/sql-switch/Router_3/Billing/Program.cs
+++ b/samples/router/sql-switch/Router_3/Billing/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Green.Billing";
+        Console.Title = "GreenBilling";
         var endpointConfiguration = new EndpointConfiguration("Green.Billing");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/router/sql-switch/Router_3/Client/Program.cs
+++ b/samples/router/sql-switch/Router_3/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Blue.Client";
+        Console.Title = "BlueClient";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/router/sql-switch/Router_3/Sales/Program.cs
+++ b/samples/router/sql-switch/Router_3/Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Red.Sales";
+        Console.Title = "RedSales";
         var endpointConfiguration = new EndpointConfiguration("Red.Sales");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/router/sql-switch/Router_3/Shipping/Program.cs
+++ b/samples/router/sql-switch/Router_3/Shipping/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Red.Shipping";
+        Console.Title = "RedShipping";
         var endpointConfiguration = new EndpointConfiguration("Red.Shipping");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/routing-slips/MessageRouting_4/ResultHost/Program.cs
+++ b/samples/routing-slips/MessageRouting_4/ResultHost/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RoutingSlips.ResultHost";
+        Console.Title = "ResultHost";
         var endpointConfiguration = new EndpointConfiguration("Samples.RoutingSlips.ResultHost");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/routing-slips/MessageRouting_4/Sender/Program.cs
+++ b/samples/routing-slips/MessageRouting_4/Sender/Program.cs
@@ -10,7 +10,7 @@ class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.RoutingSlips.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.RoutingSlips.Sender");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/routing-slips/MessageRouting_4/StepA/Program.cs
+++ b/samples/routing-slips/MessageRouting_4/StepA/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RoutingSlips.StepA";
+        Console.Title = "StepA";
         var endpointConfiguration = new EndpointConfiguration("Samples.RoutingSlips.StepA");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/routing-slips/MessageRouting_4/StepB/Program.cs
+++ b/samples/routing-slips/MessageRouting_4/StepB/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RoutingSlips.StepB";
+        Console.Title = "StepB";
         var endpointConfiguration = new EndpointConfiguration("Samples.RoutingSlips.StepB");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/routing-slips/MessageRouting_4/StepC/Program.cs
+++ b/samples/routing-slips/MessageRouting_4/StepC/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.RoutingSlips.StepC";
+        Console.Title = "StepC";
         var endpointConfiguration = new EndpointConfiguration("Samples.RoutingSlips.StepC");
 
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/routing/command-routing/Core_7/Receiver/Program.cs
+++ b/samples/routing/command-routing/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CommandRouting.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Receiver");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/routing/command-routing/Core_7/Sender/Program.cs
+++ b/samples/routing/command-routing/Core_7/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CommandRouting.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Sender");
 
         #region configure-command-route

--- a/samples/routing/command-routing/Core_8/Receiver/Program.cs
+++ b/samples/routing/command-routing/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CommandRouting.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Receiver");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/routing/command-routing/Core_8/Sender/Program.cs
+++ b/samples/routing/command-routing/Core_8/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CommandRouting.Sender";
+        Console.Title = "Sender";
         var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Sender");
 
         #region configure-command-route

--- a/samples/routing/command-routing/Core_9/Receiver/Program.cs
+++ b/samples/routing/command-routing/Core_9/Receiver/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.CommandRouting.Receiver";
+Console.Title = "Receiver";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Receiver");
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/routing/command-routing/Core_9/Sender/Program.cs
+++ b/samples/routing/command-routing/Core_9/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.CommandRouting.Sender";
+Console.Title = "Sender";
 var endpointConfiguration = new EndpointConfiguration("Samples.CommandRouting.Sender");
 
 #region configure-command-route

--- a/samples/routing/fair-distribution/Core_7/Client/Program.cs
+++ b/samples/routing/fair-distribution/Core_7/Client/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/routing/fair-distribution/Core_7/Server/Program.cs
+++ b/samples/routing/fair-distribution/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Server.1";
+        Console.Title = "Server1";
         var endpointConfiguration = new EndpointConfiguration("Samples.FairDistribution.Server");
         endpointConfiguration.OverrideLocalAddress("Samples.FairDistribution.Server-1");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();

--- a/samples/routing/fair-distribution/Core_7/Server2/Program.cs
+++ b/samples/routing/fair-distribution/Core_7/Server2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Server.2";
+        Console.Title = "Server2";
         var endpointConfiguration = new EndpointConfiguration("Samples.FairDistribution.Server");
         endpointConfiguration.OverrideLocalAddress("Samples.FairDistribution.Server-2");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();

--- a/samples/routing/fair-distribution/Core_8/Client/Program.cs
+++ b/samples/routing/fair-distribution/Core_8/Client/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/routing/fair-distribution/Core_8/Server/Program.cs
+++ b/samples/routing/fair-distribution/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Server.1";
+        Console.Title = "Server1";
         var endpointConfiguration = new EndpointConfiguration("Samples.FairDistribution.Server");
         endpointConfiguration.OverrideLocalAddress("Samples.FairDistribution.Server-1");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/routing/fair-distribution/Core_8/Server2/Program.cs
+++ b/samples/routing/fair-distribution/Core_8/Server2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FairDistribution.Server.2";
+        Console.Title = "Server2";
         var endpointConfiguration = new EndpointConfiguration("Samples.FairDistribution.Server");
         endpointConfiguration.OverrideLocalAddress("Samples.FairDistribution.Server-2");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/routing/instance-mapping-file/Core_7/Billing/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_7/Billing/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Billing";
+        Console.Title = "Billing";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Billing");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();

--- a/samples/routing/instance-mapping-file/Core_7/Client/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_7/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/routing/instance-mapping-file/Core_7/Sales/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_7/Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Sales.1";
+        Console.Title = "Sales1";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Sales");
         endpointConfiguration.OverrideLocalAddress("Samples.InstanceMappingFile.Sales-1");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();

--- a/samples/routing/instance-mapping-file/Core_7/Sales2/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_7/Sales2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Sales.2";
+        Console.Title = "Sales2";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Sales");
         endpointConfiguration.OverrideLocalAddress("Samples.InstanceMappingFile.Sales-2");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();

--- a/samples/routing/instance-mapping-file/Core_7/Shipping/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_7/Shipping/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Shipping";
+        Console.Title = "Shipping";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Shipping");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();

--- a/samples/routing/instance-mapping-file/Core_8/Billing/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_8/Billing/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Billing";
+        Console.Title = "Billing";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Billing");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();
         endpointConfiguration.EnableInstallers();

--- a/samples/routing/instance-mapping-file/Core_8/Client/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_8/Client/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Client";
+        Console.Title = "Client";
         const string letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ";
         var random = new Random();
 

--- a/samples/routing/instance-mapping-file/Core_8/Sales/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_8/Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Sales.1";
+        Console.Title = "Sales1";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Sales");
         endpointConfiguration.OverrideLocalAddress("Samples.InstanceMappingFile.Sales-1");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/routing/instance-mapping-file/Core_8/Sales2/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_8/Sales2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Sales.2";
+        Console.Title = "Sales2";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Sales");
         endpointConfiguration.OverrideLocalAddress("Samples.InstanceMappingFile.Sales-2");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();

--- a/samples/routing/instance-mapping-file/Core_8/Shipping/Program.cs
+++ b/samples/routing/instance-mapping-file/Core_8/Shipping/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.InstanceMappingFile.Shipping";
+        Console.Title = "Shipping";
         var endpointConfiguration = new EndpointConfiguration("Samples.InstanceMappingFile.Shipping");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();
         endpointConfiguration.EnableInstallers();

--- a/samples/saga/simple/Core_7/Sample/Program.cs
+++ b/samples/saga/simple/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SimpleSaga";
+        Console.Title = "SimpleSaga";
         var endpointConfiguration = new EndpointConfiguration("Samples.SimpleSaga");
 
         #region config

--- a/samples/saga/simple/Core_8/Sample/Program.cs
+++ b/samples/saga/simple/Core_8/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SimpleSaga";
+        Console.Title = "SimpleSaga";
         var endpointConfiguration = new EndpointConfiguration("Samples.SimpleSaga");
 
         #region config

--- a/samples/saga/simple/Core_9/Sample/Program.cs
+++ b/samples/saga/simple/Core_9/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SimpleSaga";
+        Console.Title = "SimpleSaga";
         var endpointConfiguration = new EndpointConfiguration("Samples.SimpleSaga");
 
         #region config

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.MySql";
+        Console.Title = "MySql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.MySql");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.PostgreSql";
+        Console.Title = "PostgreSql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.PostgreSql");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.SqlServer";
+        Console.Title = "SqlServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.SqlServer");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.EnableInstallers();

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.MySql";
+        Console.Title = "MySql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.MySql");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.PostgreSql";
+        Console.Title = "PostgreSql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.PostgreSql");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.SqlServer";
+        Console.Title = "SqlServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.SqlServer");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.EnableInstallers();

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointMySql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointMySql/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.MySql";
+        Console.Title = "MySql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.MySql");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointPostgreSql/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointPostgreSql/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.PostgreSql";
+        Console.Title = "PostgreSql";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.PostgreSql");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointSqlServer/Program.cs
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointSqlServer/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlSagaFinder.SqlServer";
+        Console.Title = "SqlServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlSagaFinder.SqlServer");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/scaleout/senderside/Core_7/Client/Program.cs
+++ b/samples/scaleout/senderside/Core_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Client");
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/scaleout/senderside/Core_7/Server1/Program.cs
+++ b/samples/scaleout/senderside/Core_7/Server1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Server1";
+        Console.Title = "Server1";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Server");
 
         #region Server-Set-InstanceId

--- a/samples/scaleout/senderside/Core_7/Server2/Program.cs
+++ b/samples/scaleout/senderside/Core_7/Server2/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Server2";
+        Console.Title = "Server2";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Server");
         var discriminator = ConfigurationManager.AppSettings["InstanceId"];
         endpointConfiguration.MakeInstanceUniquelyAddressable(discriminator);

--- a/samples/scaleout/senderside/Core_8/Client/Program.cs
+++ b/samples/scaleout/senderside/Core_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Client");
         endpointConfiguration.UsePersistence<NonDurablePersistence>();
         endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/scaleout/senderside/Core_8/Server1/Program.cs
+++ b/samples/scaleout/senderside/Core_8/Server1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Server1";
+        Console.Title = "Server1";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Server");
 
         #region Server-Set-InstanceId

--- a/samples/scaleout/senderside/Core_8/Server2/Program.cs
+++ b/samples/scaleout/senderside/Core_8/Server2/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SenderSideScaleOut.Server2";
+        Console.Title = "Server2";
         var endpointConfiguration = new EndpointConfiguration("Samples.SenderSideScaleOut.Server");
         var discriminator = ConfigurationManager.AppSettings["InstanceId"];
         endpointConfiguration.MakeInstanceUniquelyAddressable(discriminator);

--- a/samples/scheduling/fluentscheduler/Core_7/Receiver/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Receiver");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/fluentscheduler/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_7/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Scheduler");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/fluentscheduler/Core_8/Receiver/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/fluentscheduler/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_8/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/fluentscheduler/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/fluentscheduler/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/fluentscheduler/Core_9/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.FluentScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.FluentScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/hangfire/Core_7/Receiver/Program.cs
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Receiver");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/hangfire/Core_8/Receiver/Program.cs
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/hangfire/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.HangfireScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.HangfireScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/quartz/Core_7/Receiver/Program.cs
+++ b/samples/scheduling/quartz/Core_7/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Receiver");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/scheduling/quartz/Core_8/Receiver/Program.cs
+++ b/samples/scheduling/quartz/Core_8/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/scheduling/quartz/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/quartz/Core_9/Receiver/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Receiver";
+        Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Receiver");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Program.cs
@@ -9,7 +9,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.QuartzScheduler.Scheduler";
+        Console.Title = "Scheduler";
         var endpointConfiguration = new EndpointConfiguration("Samples.QuartzScheduler.Scheduler");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/scheduler/Core_7/Sample/Program.cs
+++ b/samples/scheduling/scheduler/Core_7/Sample/Program.cs
@@ -10,7 +10,7 @@ class Program
     [Obsolete]
     static async Task Main()
     {
-        Console.Title = "Samples.Scheduling";
+        Console.Title = "Scheduling";
         var endpointConfiguration = new EndpointConfiguration("Samples.Scheduling");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/scheduling/scheduler/Core_8/Sample/Program.cs
+++ b/samples/scheduling/scheduler/Core_8/Sample/Program.cs
@@ -10,7 +10,7 @@ class Program
     [Obsolete]
     static async Task Main()
     {
-        Console.Title = "Samples.Scheduling";
+        Console.Title = "Scheduling";
         var endpointConfiguration = new EndpointConfiguration("Samples.Scheduling");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/timer/Core_8/Sample/Program.cs
+++ b/samples/scheduling/timer/Core_8/Sample/Program.cs
@@ -10,7 +10,7 @@ partial class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.Scheduling.Timer";
+        Console.Title = "SchedulingTimer";
         var endpointConfiguration = new EndpointConfiguration("Samples.Scheduling.Timer");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/scheduling/timer/Core_9/Sample/Program.cs
+++ b/samples/scheduling/timer/Core_9/Sample/Program.cs
@@ -10,7 +10,7 @@ partial class Program
 
     static async Task Main()
     {
-        Console.Title = "Samples.Scheduling.Timer";
+        Console.Title = "SchedulingTimer";
         var endpointConfiguration = new EndpointConfiguration("Samples.Scheduling.Timer");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/serializers/change-message-type/Core_7/SamplePhase1/Program.cs
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase1/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase1";
+        Console.Title = "Phase1";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase1");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/serializers/change-message-type/Core_7/SamplePhase2/Program.cs
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase2/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase2";
+        Console.Title = "Phase2";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase2");
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/Program.cs
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase1";
+        Console.Title = "Phase1";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/Program.cs
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase2";
+        Console.Title = "Phase2";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/serializers/change-message-type/Core_9/SamplePhase1/Program.cs
+++ b/samples/serializers/change-message-type/Core_9/SamplePhase1/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase1";
+        Console.Title = "Phase1";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/serializers/change-message-type/Core_9/SamplePhase2/Program.cs
+++ b/samples/serializers/change-message-type/Core_9/SamplePhase2/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ChangeMessageIdentity.Phase2";
+        Console.Title = "Phase2";
 
         var endpointConfiguration = new EndpointConfiguration("ChangeMessageIdentity.Phase2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "NewtonsoftBsonEndpoint";
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "ExternalNewtonsoftBsonEndpoint";
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "NewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "ExternalNewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         #region configAll
 

--- a/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.XmlEndpoint";
+        Console.Title = "XmlEndpoint";
         #region configXml
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.XmlEndpoint");
         endpointConfiguration.UseSerialization<XmlSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "ExternalNewtonsoftBsonEndpoint";
 
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "NewtonsoftBsonEndpoint";
 
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "NewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "ExternalNewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         #region configAll
 

--- a/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "ExternalNewtonsoftJsonEndpoint";
 
         #region configSystemJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.SystemJsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "SystemJsonEndpoint";
 
         #region configSystemJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.SystemJsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.XmlEndpoint";
+        Console.Title = "XmlEndpoint";
 
         #region configXml
 

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "ExternalNewtonsoftBsonEndpoint";
 
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftBsonEndpoint";
+        Console.Title = "NewtonsoftBsonEndpoint";
 
         #region configExternalNewtonsoftBson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftBsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "NewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "ExternalNewtonsoftJsonEndpoint";
         #region configExternalNewtonsoftJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint");
         var serialization = endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();

--- a/samples/serializers/multiple-deserializers/Core_9/ReceivingEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/ReceivingEndpoint/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ReceivingEndpoint";
+        Console.Title = "ReceivingEndpoint";
 
         #region configAll
 

--- a/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "ExternalNewtonsoftJsonEndpoint";
 
         #region configSystemJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.SystemJsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "ExternalNewtonsoftJsonEndpoint";
+        Console.Title = "SystemJsonEndpoint";
 
         #region configSystemJson
         var endpointConfiguration = new EndpointConfiguration("Samples.MultipleDeserializers.SystemJsonEndpoint");

--- a/samples/serializers/multiple-deserializers/Core_9/XmlEndpoint/Program.cs
+++ b/samples/serializers/multiple-deserializers/Core_9/XmlEndpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.MultipleDeserializers.XmlEndpoint";
+        Console.Title = "XmlEndpoint";
 
         #region configXml
 

--- a/samples/serializers/multiple-deserializers/sample.md
+++ b/samples/serializers/multiple-deserializers/sample.md
@@ -15,13 +15,13 @@ This sample uses the AddDeserializer API to illustrate a receiving endpoint dese
 
 There are multiple sending endpoints, one per serializer.
 
-### ExternalNewtonsoftJsonEndpoint
+### NewtonsoftJsonEndpoint
 
 Sends messages using the external [Json.NET serializer](/nservicebus/serialization/newtonsoft.md) in JSON format.
 
 snippet: configExternalNewtonsoftJson
 
-### ExternalNewtonsoftBsonEndpoint
+### NewtonsoftBsonEndpoint
 
 Sends messages using the external [Json.NET serializer](/nservicebus/serialization/newtonsoft.md) in BSON format.
 

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Program.cs
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.ExternalBson";
+        Console.Title = "ExternalBson";
 
         #region config
 

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Program.cs
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Program.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Bson;
 using NServiceBus;
 using NServiceBus.MessageMutator;
 
-Console.Title = "Samples.Serialization.ExternalBson";
+Console.Title = "ExternalBson";
 
 #region config
 

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_4/Sample/Program.cs
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_4/Sample/Program.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Bson;
 using NServiceBus;
 using NServiceBus.MessageMutator;
 
-Console.Title = "Samples.Serialization.ExternalBson";
+Console.Title = "ExternalBson";
 
 #region config
 

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Program.cs
@@ -8,7 +8,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.ExternalJson";
+        Console.Title = "ExternalJson";
 
         #region config
 

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Program.cs
@@ -5,7 +5,7 @@ using NServiceBus;
 using NServiceBus.MessageMutator;
 
 
-Console.Title = "Samples.Serialization.ExternalJson";
+Console.Title = "ExternalJson";
 
 #region config
 

--- a/samples/serializers/newtonsoft/Newtonsoft_4/Sample/Program.cs
+++ b/samples/serializers/newtonsoft/Newtonsoft_4/Sample/Program.cs
@@ -5,7 +5,7 @@ using NServiceBus;
 using NServiceBus.MessageMutator;
 
 
-Console.Title = "Samples.Serialization.ExternalJson";
+Console.Title = "ExternalJson";
 
 #region config
 

--- a/samples/serializers/system-json/Core_8/Sample/Program.cs
+++ b/samples/serializers/system-json/Core_8/Sample/Program.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-Console.Title = "Samples.Serialization.SystemJson";
+Console.Title = "SystemJson";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.SystemJson");
 

--- a/samples/serializers/system-json/Core_9/Sample/Program.cs
+++ b/samples/serializers/system-json/Core_9/Sample/Program.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-Console.Title = "Samples.Serialization.SystemJson";
+Console.Title = "SystemJson";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.SystemJson");
 

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase1/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase1/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.TransitionPhase1";
+        Console.Title = "TransitionPhase1";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase1");
         endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase2/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase2/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.TransitionPhase2";
+        Console.Title = "TransitionPhase2";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase2");
         endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase3/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase3/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.TransitionPhase3";
+        Console.Title = "TransitionPhase3";
         var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase3");
         endpointConfiguration.SharedConfig();
 

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase4/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase4/Program.cs
@@ -7,7 +7,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.TransitionPhase4";
+        Console.Title = "TransitionPhase4";
         var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase4");
         endpointConfiguration.SharedConfig();
 

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase1";
+Console.Title = "TransitionPhase1";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase1");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase2";
+Console.Title = "TransitionPhase2";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase2");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase3";
+Console.Title = "TransitionPhase3";
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase3");
 endpointConfiguration.SharedConfig();
 

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase4";
+Console.Title = "TransitionPhase4";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase4");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase1/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase1/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase1";
+Console.Title = "TransitionPhase1";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase1");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase2/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase2/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase2";
+Console.Title = "TransitionPhase2";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase2");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase3/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase3/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase3";
+Console.Title = "TransitionPhase3";
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase3");
 endpointConfiguration.SharedConfig();
 

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase4/Program.cs
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase4/Program.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using NServiceBus;
 
-Console.Title = "Samples.Serialization.TransitionPhase4";
+Console.Title = "TransitionPhase4";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.TransitionPhase4");
 endpointConfiguration.SharedConfig();

--- a/samples/serializers/xml/Core_7/Sample/Program.cs
+++ b/samples/serializers/xml/Core_7/Sample/Program.cs
@@ -9,7 +9,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Serialization.Xml";
+        Console.Title = "Xml";
         #region config
         var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.Xml");
         // this is optional since Xml is the default serializer

--- a/samples/serializers/xml/Core_8/Sample/Program.cs
+++ b/samples/serializers/xml/Core_8/Sample/Program.cs
@@ -4,7 +4,7 @@ using NServiceBus;
 using NServiceBus.MessageMutator;
 
 
-Console.Title = "Samples.Serialization.Xml";
+Console.Title = "Xml";
 
 #region config
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.Xml");

--- a/samples/serializers/xml/Core_9/Sample/Program.cs
+++ b/samples/serializers/xml/Core_9/Sample/Program.cs
@@ -4,7 +4,7 @@ using NServiceBus;
 using NServiceBus.MessageMutator;
 
 
-Console.Title = "Samples.Serialization.Xml";
+Console.Title = "Xml";
 
 #region config
 var endpointConfiguration = new EndpointConfiguration("Samples.Serialization.Xml");

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/3rdPartySystem/Program.cs
@@ -9,7 +9,7 @@ class Program3rdParty
 
     static void Main()
     {
-        Console.Title = "Samples.CustomChecks.3rdPartySystem";
+        Console.Title = "3rdPartySystem";
         Console.WriteLine("Press enter to toggle the server and return an error or success");
         Console.WriteLine("Press any other key to exit");
 

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_3/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomChecks.Monitor3rdParty";
+        Console.Title = "Monitor3rdParty";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomChecks.Monitor3rdParty");
         endpointConfiguration.UseTransport<LearningTransport>();
 

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/3rdPartySystem/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/3rdPartySystem/Program.cs
@@ -9,7 +9,7 @@ class Program3rdParty
 
     static void Main()
     {
-        Console.Title = "Samples.CustomChecks.3rdPartySystem";
+        Console.Title = "3rdPartySystem";
         Console.WriteLine("Press enter to toggle the server and return an error or success");
         Console.WriteLine("Press any other key to exit");
 

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/Sample/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomChecks.Monitor3rdParty";
+        Console.Title = "Monitor3rdParty";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomChecks.Monitor3rdParty");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/3rdPartySystem/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/3rdPartySystem/Program.cs
@@ -9,7 +9,7 @@ class Program3rdParty
 
     static void Main()
     {
-        Console.Title = "Samples.CustomChecks.3rdPartySystem";
+        Console.Title = "3rdPartySystem";
         Console.WriteLine("Press enter to toggle the server and return an error or success");
         Console.WriteLine("Press any other key to exit");
 

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/Sample/Program.cs
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.CustomChecks.Monitor3rdParty";
+        Console.Title = "Monitor3rdParty";
         var endpointConfiguration = new EndpointConfiguration("Samples.CustomChecks.Monitor3rdParty");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/servicecontrol/monitoring3rdparty/sample.md
+++ b/samples/servicecontrol/monitoring3rdparty/sample.md
@@ -20,11 +20,11 @@ downloadbutton
 
 Running the project will result in 3 console windows:
 
-1. **Samples.CustomChecks.3rdPartySystem**: Represents the third-party system by simulating an HTTP service running on `http://localhost:57789`. At startup, the custom check is returning success, but the state can be toggled between success and failure by pressing <kbd>Enter</kbd>.
-1. **Samples.CustomChecks.Monitor3rdParty**: The endpoint containing the custom check. The success or failure of the third-party system is continuously written to the console.
+1. **3rdPartySystem**: Represents the third-party system by simulating an HTTP service running on `http://localhost:57789`. At startup, the custom check is returning success, but the state can be toggled between success and failure by pressing <kbd>Enter</kbd>.
+1. **Monitor3rdParty**: The endpoint containing the custom check. The success or failure of the third-party system is continuously written to the console.
 1. **PlatformLauncher**: Runs an in-process version of ServiceControl and ServicePulse. When the ServiceControl instance is ready, a browser window will be launched displaying the Custom Checks view in ServicePulse.
 
-Try toggling the status of the third-party system by pressing <kbd>Enter</kbd> in the **Samples.CustomChecks.3rdPartySystem** window, and watch the change in the output of the **Samples.CustomChecks.Monitor3rdParty** window.
+Try toggling the status of the third-party system by pressing <kbd>Enter</kbd> in the **3rdPartySystem** window, and watch the change in the output of the **Monitor3rdParty** window.
 
 The status of the custom check is also reported to ServiceControl, and can be viewed in ServicePulse. In the browser window, navigate to the ServicePulse **Custom Checks** page to see the status change from success to error. The ServicePulse **Dashboard** page provides the overall status of custom checks.
 

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ServiceInsightCustomViewer.Endpoint";
+        Console.Title = "ServiceInsightCustomViewerEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ServiceInsightCustomViewer.Endpoint");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.AuditProcessedMessagesTo("audit");

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "ServiceInsightCustomViewerEndpoint";
+        Console.Title = "CustomViewerEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ServiceInsightCustomViewer.Endpoint");
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.AuditProcessedMessagesTo("audit");

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ServiceInsightCustomViewer.Endpoint";
+        Console.Title = "ServiceInsightCustomViewerEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ServiceInsightCustomViewer.Endpoint");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "ServiceInsightCustomViewerEndpoint";
+        Console.Title = "CustomViewerEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ServiceInsightCustomViewer.Endpoint");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport<LearningTransport>();
@@ -20,18 +20,18 @@ class Program
         #endregion
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration);
-        
+
         var completeOrder = new CompleteOrder
         {
             CreditCard = "123-456-789"
         };
         await endpointInstance.SendLocal(completeOrder);
-        
+
         Console.WriteLine("Message sent");
-        
+
         Console.WriteLine("Launching platform...");
         await Particular.PlatformLauncher.Launch();
-        
+
         await endpointInstance.Stop();
     }
 }

--- a/samples/showcase/cinema/Core_8/Cinema.Headquarters/Program.cs
+++ b/samples/showcase/cinema/Core_8/Cinema.Headquarters/Program.cs
@@ -7,7 +7,7 @@ namespace Cinema.Headquarters
     {
         public static void Main(string[] args)
         {
-            Console.Title = "Cinema.Headquarters";
+            Console.Title = "Headquarters";
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/samples/showcase/on-premises/Core_7/Store.ContentManagement/Program.cs
+++ b/samples/showcase/on-premises/Core_7/Store.ContentManagement/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.ContentManagement";
+        Console.Title = "ContentManagement";
         var endpointConfiguration = new EndpointConfiguration("Store.ContentManagement");
         endpointConfiguration.ApplyCommonConfiguration(transport =>
         {

--- a/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Program.cs
+++ b/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.CustomerRelations";
+        Console.Title = "CustomerRelations";
         var endpointConfiguration = new EndpointConfiguration("Store.CustomerRelations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_7/Store.Operations/Program.cs
+++ b/samples/showcase/on-premises/Core_7/Store.Operations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Operations";
+        Console.Title = "Operations";
         var endpointConfiguration = new EndpointConfiguration("Store.Operations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_7/Store.Sales/Program.cs
+++ b/samples/showcase/on-premises/Core_7/Store.Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Sales";
+        Console.Title = "Sales";
         var endpointConfiguration = new EndpointConfiguration("Store.Sales");
         endpointConfiguration.ApplyCommonConfiguration();
 

--- a/samples/showcase/on-premises/Core_8/Store.ContentManagement/Program.cs
+++ b/samples/showcase/on-premises/Core_8/Store.ContentManagement/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.ContentManagement";
+        Console.Title = "ContentManagement";
         var endpointConfiguration = new EndpointConfiguration("Store.ContentManagement");
         endpointConfiguration.ApplyCommonConfiguration(routing =>
         {

--- a/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Program.cs
+++ b/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.CustomerRelations";
+        Console.Title = "CustomerRelations";
         var endpointConfiguration = new EndpointConfiguration("Store.CustomerRelations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_8/Store.Operations/Program.cs
+++ b/samples/showcase/on-premises/Core_8/Store.Operations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Operations";
+        Console.Title = "Operations";
         var endpointConfiguration = new EndpointConfiguration("Store.Operations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_8/Store.Sales/Program.cs
+++ b/samples/showcase/on-premises/Core_8/Store.Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Sales";
+        Console.Title = "Sales";
         var endpointConfiguration = new EndpointConfiguration("Store.Sales");
         endpointConfiguration.ApplyCommonConfiguration();
 

--- a/samples/showcase/on-premises/Core_9/Store.ContentManagement/Program.cs
+++ b/samples/showcase/on-premises/Core_9/Store.ContentManagement/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.ContentManagement";
+        Console.Title = "ContentManagement";
         var endpointConfiguration = new EndpointConfiguration("Store.ContentManagement");
         endpointConfiguration.ApplyCommonConfiguration(routing =>
         {

--- a/samples/showcase/on-premises/Core_9/Store.CustomerRelations/Program.cs
+++ b/samples/showcase/on-premises/Core_9/Store.CustomerRelations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.CustomerRelations";
+        Console.Title = "CustomerRelations";
         var endpointConfiguration = new EndpointConfiguration("Store.CustomerRelations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_9/Store.Operations/Program.cs
+++ b/samples/showcase/on-premises/Core_9/Store.Operations/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Operations";
+        Console.Title = "Operations";
         var endpointConfiguration = new EndpointConfiguration("Store.Operations");
         endpointConfiguration.ApplyCommonConfiguration();
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/showcase/on-premises/Core_9/Store.Sales/Program.cs
+++ b/samples/showcase/on-premises/Core_9/Store.Sales/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Store.Sales";
+        Console.Title = "Sales";
         var endpointConfiguration = new EndpointConfiguration("Store.Sales");
         endpointConfiguration.ApplyCommonConfiguration();
 

--- a/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Program.cs
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.InjectingServices";
+        Console.Title = "InjectingServices";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.InjectingServices");
         endpointConfiguration.EnableInstallers();

--- a/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Program.cs
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Program.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading.Tasks;
 
 
-Console.Title = "Samples.SqlPersistence.InjectingServices";
+Console.Title = "InjectingServices";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.InjectingServices");
 endpointConfiguration.EnableInstallers();

--- a/samples/sql-persistence/injecting-services/SqlPersistence_8/Endpoint/Program.cs
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_8/Endpoint/Program.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading.Tasks;
 
 
-Console.Title = "Samples.SqlPersistence.InjectingServices";
+Console.Title = "InjectingServices";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.InjectingServices");
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/Program.cs
@@ -10,7 +10,7 @@ class Program
         var defaultFactory = LogManager.Use<DefaultFactory>();
         defaultFactory.Level(LogLevel.Warn);
 
-        Console.Title = "Samples.RenameSaga.Version1";
+        Console.Title = "Version1";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.RenameSaga");
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/Program.cs
@@ -12,7 +12,7 @@ class Program
         var defaultFactory = LogManager.Use<DefaultFactory>();
         defaultFactory.Level(LogLevel.Warn);
 
-        Console.Title = "Samples.RenameSaga.Version2";
+        Console.Title = "Version2";
 
         Console.WriteLine("Renaming SQL tables:");
         Console.WriteLine("    from Samples_RenameSaga_MyReplySagaVersion1 to Samples_RenameSaga_MyReplySagaVersion2");

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/Program.cs
@@ -7,7 +7,7 @@ using NServiceBus.Logging;
 var defaultFactory = LogManager.Use<DefaultFactory>();
 defaultFactory.Level(LogLevel.Warn);
 
-Console.Title = "Samples.RenameSaga.Version1";
+Console.Title = "Version1";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.RenameSaga");
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/Program.cs
@@ -8,7 +8,7 @@ using NServiceBus.MessageMutator;
 var defaultFactory = LogManager.Use<DefaultFactory>();
 defaultFactory.Level(LogLevel.Warn);
 
-Console.Title = "Samples.RenameSaga.Version2";
+Console.Title = "Version2";
 
 Console.WriteLine("Renaming SQL tables:");
 Console.WriteLine("    from Samples_RenameSaga_MyReplySagaVersion1 to Samples_RenameSaga_MyReplySagaVersion2");

--- a/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion1/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion1/Program.cs
@@ -7,7 +7,7 @@ using NServiceBus.Logging;
 var defaultFactory = LogManager.Use<DefaultFactory>();
 defaultFactory.Level(LogLevel.Warn);
 
-Console.Title = "Samples.RenameSaga.Version1";
+Console.Title = "Version1";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.RenameSaga");
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion2/Program.cs
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion2/Program.cs
@@ -8,7 +8,7 @@ using NServiceBus.MessageMutator;
 var defaultFactory = LogManager.Use<DefaultFactory>();
 defaultFactory.Level(LogLevel.Warn);
 
-Console.Title = "Samples.RenameSaga.Version2";
+Console.Title = "Version2";
 
 Console.WriteLine("Renaming SQL tables:");
 Console.WriteLine("    from Samples_RenameSaga_MyReplySagaVersion1 to Samples_RenameSaga_MyReplySagaVersion2");

--- a/samples/sql-persistence/simple/SqlPersistence_6/Client/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_6/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.EndpointMySql";
+        Console.Title = "EndpointMySql";
 
         #region MySqlConfig
 

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.EndpointSqlServer";
+        Console.Title = "EndpointSqlServer";
 
         #region sqlServerConfig
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.Client");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/Program.cs
@@ -2,7 +2,7 @@
 using MySql.Data.MySqlClient;
 using NServiceBus;
 
-Console.Title = "Samples.SqlPersistence.EndpointMySql";
+Console.Title = "EndpointMySql";
 
 #region MySqlConfig
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/Program.cs
@@ -2,7 +2,7 @@
 using Microsoft.Data.SqlClient;
 using NServiceBus;
 
-Console.Title = "Samples.SqlPersistence.EndpointSqlServer";
+Console.Title = "EndpointSqlServer";
 
 #region sqlServerConfig
 

--- a/samples/sql-persistence/simple/SqlPersistence_8/Client/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.SqlPersistence.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.SqlPersistence.Client");
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointMySql/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointMySql/Program.cs
@@ -2,7 +2,7 @@
 using MySql.Data.MySqlClient;
 using NServiceBus;
 
-Console.Title = "Samples.SqlPersistence.EndpointMySql";
+Console.Title = "EndpointMySql";
 
 #region MySqlConfig
 

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointSqlServer/Program.cs
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointSqlServer/Program.cs
@@ -2,7 +2,7 @@
 using Microsoft.Data.SqlClient;
 using NServiceBus;
 
-Console.Title = "Samples.SqlPersistence.EndpointSqlServer";
+Console.Title = "EndpointSqlServer";
 
 #region sqlServerConfig
 

--- a/samples/sqltransport-nhpersistence/Core_7/Receiver/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_7/Receiver/Program.cs
@@ -7,7 +7,7 @@ using NHibernate.Tool.hbm2ddl;
 using NServiceBus;
 using NServiceBus.Persistence;
 
-Console.Title = "Samples.SqlNHibernate.Receiver";
+Console.Title = "Receiver";
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/sqltransport-nhpersistence/Core_7/Sender/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_7/Sender/Program.cs
@@ -5,7 +5,7 @@ using NHibernate.Driver;
 using NServiceBus;
 using NServiceBus.Persistence;
 
-Console.Title = "Samples.SqlNHibernate.Sender";
+Console.Title = "Sender";
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlNHibernate.Sender");

--- a/samples/sqltransport-nhpersistence/Core_8/Receiver/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_8/Receiver/Program.cs
@@ -8,7 +8,7 @@ using NServiceBus;
 using NServiceBus.Persistence;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.SqlNHibernate.Receiver";
+Console.Title = "Receiver";
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/sqltransport-nhpersistence/Core_8/Sender/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_8/Sender/Program.cs
@@ -6,7 +6,7 @@ using NServiceBus;
 using NServiceBus.Persistence;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.SqlNHibernate.Sender";
+Console.Title = "Sender";
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/sqltransport-nhpersistence/Core_9/Receiver/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_9/Receiver/Program.cs
@@ -8,7 +8,7 @@ using NServiceBus;
 using NServiceBus.Persistence;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.SqlNHibernate.Receiver";
+Console.Title = "Receiver";
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/sqltransport-nhpersistence/Core_9/Sender/Program.cs
+++ b/samples/sqltransport-nhpersistence/Core_9/Sender/Program.cs
@@ -6,7 +6,7 @@ using NServiceBus;
 using NServiceBus.Persistence;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.SqlNHibernate.Sender";
+Console.Title = "Sender";
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNHibernate;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNHibernate;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Program.cs
@@ -3,7 +3,7 @@ using System.IO;
 using Microsoft.Data.SqlClient;
 using NServiceBus;
 
-Console.Title = "Samples.Sql.Receiver";
+Console.Title = "Receiver";
 
 #region ReceiverConfiguration
 

--- a/samples/sqltransport-sqlpersistence/Core_7/Sender/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_7/Sender/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NServiceBus;
 
-Console.Title = "Samples.Sql.Sender";
+Console.Title = "Sender";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sql.Sender");
 endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 using NServiceBus;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.Sql.Receiver";
+Console.Title = "Receiver";
 
 #region ReceiverConfiguration
 

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using NServiceBus;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.Sql.Sender";
+Console.Title = "Sender";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sql.Sender");
 endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/sqltransport-sqlpersistence/Core_9/Receiver/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_9/Receiver/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 using NServiceBus;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.Sql.Receiver";
+Console.Title = "Receiver";
 
 #region ReceiverConfiguration
 

--- a/samples/sqltransport-sqlpersistence/Core_9/Sender/Program.cs
+++ b/samples/sqltransport-sqlpersistence/Core_9/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using NServiceBus;
 using NServiceBus.Transport.SqlServer;
 
-Console.Title = "Samples.Sql.Sender";
+Console.Title = "Sender";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.Sql.Sender");
 endpointConfiguration.SendFailedMessagesTo("error");

--- a/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Program.cs
+++ b/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Program.cs
@@ -11,7 +11,7 @@ using NServiceBus;
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNativeIntegration;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNativeIntegration;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";
 
-Console.Title = "Samples.SqlServer.NativeIntegration";
+Console.Title = "NativeIntegration";
 
 #region EndpointConfiguration
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.NativeIntegration");

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Program.cs
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Program.cs
@@ -11,7 +11,7 @@ using NServiceBus;
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNativeIntegration;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNativeIntegration;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";
 
-Console.Title = "Samples.SqlServer.NativeIntegration";
+Console.Title = "NativeIntegration";
 
 #region EndpointConfiguration
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.NativeIntegration");

--- a/samples/sqltransport/native-integration/SqlTransport_8/Receiver/Program.cs
+++ b/samples/sqltransport/native-integration/SqlTransport_8/Receiver/Program.cs
@@ -11,7 +11,7 @@ using NServiceBus;
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=NsbSamplesSqlNativeIntegration;Integrated Security=True;Max Pool Size=100;Encrypt=false
 var connectionString = @"Server=localhost,1433;Initial Catalog=NsbSamplesSqlNativeIntegration;User Id=SA;Password=yourStrong(!)Password;Max Pool Size=100;Encrypt=false";
 
-Console.Title = "Samples.SqlServer.NativeIntegration";
+Console.Title = "NativeIntegration";
 
 #region EndpointConfiguration
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.NativeIntegration");

--- a/samples/sqltransport/simple/SqlTransport_6/Receiver/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_6/Receiver/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using NServiceBus;
 
-Console.Title = "Samples.SqlServer.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleReceiver");
 var transport = endpointConfiguration.UseTransport<SqlServerTransport>();

--- a/samples/sqltransport/simple/SqlTransport_6/Sender/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_6/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.SqlServer.SimpleSender";
+Console.Title = "SimpleSender";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleSender");
 endpointConfiguration.EnableInstallers();
 

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Program.cs
@@ -2,7 +2,7 @@ using System;
 using NServiceBus;
 
 
-Console.Title = "Samples.SqlServer.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleReceiver");
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=SqlServerSimple;Integrated Security=True;Max Pool Size=100;Encrypt=false

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.SqlServer.SimpleSender";
+Console.Title = "SimpleSender";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleSender");
 endpointConfiguration.EnableInstallers();
 

--- a/samples/sqltransport/simple/SqlTransport_8/Receiver/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_8/Receiver/Program.cs
@@ -2,7 +2,7 @@ using System;
 using NServiceBus;
 
 
-Console.Title = "Samples.SqlServer.SimpleReceiver";
+Console.Title = "SimpleReceiver";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleReceiver");
 
 // for SqlExpress use Data Source=.\SqlExpress;Initial Catalog=SqlServerSimple;Integrated Security=True;Max Pool Size=100;Encrypt=false

--- a/samples/sqltransport/simple/SqlTransport_8/Sender/Program.cs
+++ b/samples/sqltransport/simple/SqlTransport_8/Sender/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using NServiceBus;
 
-Console.Title = "Samples.SqlServer.SimpleSender";
+Console.Title = "SimpleSender";
 var endpointConfiguration = new EndpointConfiguration("Samples.SqlServer.SimpleSender");
 endpointConfiguration.EnableInstallers();
 

--- a/samples/startup-shutdown-sequence/Core_7/Sample/Program.cs
+++ b/samples/startup-shutdown-sequence/Core_7/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.StartupShutdown";
+        Console.Title = "StartupShutdown";
         LogManager.Use<DefaultFactory>().Level(LogLevel.Error);
         #region Program
         Logger.WriteLine("Starting configuration");

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Program.cs
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.StartupShutdown";
+        Console.Title = "StartupShutdown";
         LogManager.Use<DefaultFactory>().Level(LogLevel.Error);
         #region Program
         Logger.WriteLine("Starting configuration");

--- a/samples/startup-shutdown-sequence/Core_9/Sample/Program.cs
+++ b/samples/startup-shutdown-sequence/Core_9/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.StartupShutdown";
+        Console.Title = "StartupShutdown";
         LogManager.Use<DefaultFactory>().Level(LogLevel.Error);
         #region Program
         Logger.WriteLine("Starting configuration");

--- a/samples/throttling/Core_7/Limited/Program.cs
+++ b/samples/throttling/Core_7/Limited/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Limited";
+        Console.Title = "Limited";
 
         #region LimitConcurrency
 

--- a/samples/throttling/Core_7/Sender/Program.cs
+++ b/samples/throttling/Core_7/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Sender";
+        Console.Title = "Sender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Throttling.Sender");
 

--- a/samples/throttling/Core_8/Limited/Program.cs
+++ b/samples/throttling/Core_8/Limited/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Limited";
+        Console.Title = "Limited";
 
         #region LimitConcurrency
 

--- a/samples/throttling/Core_8/Sender/Program.cs
+++ b/samples/throttling/Core_8/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Sender";
+        Console.Title = "Sender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Throttling.Sender");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/throttling/Core_9/Limited/Program.cs
+++ b/samples/throttling/Core_9/Limited/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Limited";
+        Console.Title = "Limited";
 
         #region LimitConcurrency
 

--- a/samples/throttling/Core_9/Sender/Program.cs
+++ b/samples/throttling/Core_9/Sender/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Throttling.Sender";
+        Console.Title = "Sender";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Throttling.Sender");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/unit-of-work/Core_7/Sample/Program.cs
+++ b/samples/unit-of-work/Core_7/Sample/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UnitOfWork";
+        Console.Title = "UnitOfWork";
         var endpointConfiguration = new EndpointConfiguration("Samples.UnitOfWork");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/unit-of-work/Core_8/Sample/Program.cs
+++ b/samples/unit-of-work/Core_8/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UnitOfWork";
+        Console.Title = "UnitOfWork";
         var endpointConfiguration = new EndpointConfiguration("Samples.UnitOfWork");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/unobtrusive/Core_7/Client/Program.cs
+++ b/samples/unobtrusive/Core_7/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Client");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/unobtrusive/Core_7/Server/Program.cs
+++ b/samples/unobtrusive/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Server");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/unobtrusive/Core_8/Client/Program.cs
+++ b/samples/unobtrusive/Core_8/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Client");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/unobtrusive/Core_8/Server/Program.cs
+++ b/samples/unobtrusive/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Server");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/unobtrusive/Core_9/Client/Program.cs
+++ b/samples/unobtrusive/Core_9/Client/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Client";
+        Console.Title = "Client";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Client");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/unobtrusive/Core_9/Server/Program.cs
+++ b/samples/unobtrusive/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Unobtrusive.Server";
+        Console.Title = "Server";
         var endpointConfiguration = new EndpointConfiguration("Samples.Unobtrusive.Server");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/username-header/Core_7/Endpoint1/Program.cs
+++ b/samples/username-header/Core_7/Endpoint1/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint1");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/username-header/Core_7/Endpoint2/Program.cs
+++ b/samples/username-header/Core_7/Endpoint2/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint2");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/username-header/Core_8/Endpoint1/Program.cs
+++ b/samples/username-header/Core_8/Endpoint1/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/username-header/Core_8/Endpoint2/Program.cs
+++ b/samples/username-header/Core_8/Endpoint2/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/username-header/Core_9/Endpoint1/Program.cs
+++ b/samples/username-header/Core_9/Endpoint1/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint1";
+        Console.Title = "Endpoint1";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint1");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/username-header/Core_9/Endpoint2/Program.cs
+++ b/samples/username-header/Core_9/Endpoint2/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.UsernameHeader.Endpoint2";
+        Console.Title = "Endpoint2";
         var endpointConfiguration = new EndpointConfiguration("Samples.UsernameHeader.Endpoint2");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/wcf/Wcf_2/Wcf/Program.cs
+++ b/samples/wcf/Wcf_2/Wcf/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Wcf.Endpoint";
+        Console.Title = "WcfEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Wcf.Endpoint");
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/wcf/Wcf_3/Wcf/Program.cs
+++ b/samples/wcf/Wcf_3/Wcf/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Wcf.Endpoint";
+        Console.Title = "WcfEndpoint";
 
         var endpointConfiguration = new EndpointConfiguration("Samples.Wcf.Endpoint");
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/web/asp-mvc-application/Core_7/Server/Program.cs
+++ b/samples/web/asp-mvc-application/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Mvc.Server";
+        Console.Title = "MvcServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.Server");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UsePersistence<LearningPersistence>();

--- a/samples/web/asp-mvc-application/Core_8/Server/Program.cs
+++ b/samples/web/asp-mvc-application/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Mvc.Server";
+        Console.Title = "MvcServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.Server");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/web/asp-mvc-application/Core_9/Server/Program.cs
+++ b/samples/web/asp-mvc-application/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.Mvc.Server";
+        Console.Title = "MvcServer";
         var endpointConfiguration = new EndpointConfiguration("Samples.Mvc.Server");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/web/asp-web-application/Core_7/Server/Program.cs
+++ b/samples/web/asp-web-application/Core_7/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     public static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.AsyncPages.Server");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "AsyncPagesServer");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/web/asp-web-application/Core_8/Server/Program.cs
+++ b/samples/web/asp-web-application/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     public static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.AsyncPages.Server");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "AsyncPagesServer");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseTransport(new LearningTransport());
 

--- a/samples/web/asp-web-application/Core_9/Server/Program.cs
+++ b/samples/web/asp-web-application/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     public static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.AsyncPages.Server");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "AsyncPagesServer");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();

--- a/samples/web/blazor-server-application/Core_8/Server/Program.cs
+++ b/samples/web/blazor-server-application/Core_8/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     public static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.Blazor.Server");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "BlazorServer");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/web/blazor-server-application/Core_9/Server/Program.cs
+++ b/samples/web/blazor-server-application/Core_9/Server/Program.cs
@@ -6,7 +6,7 @@ class Program
 {
     public static async Task Main()
     {
-        var endpointConfiguration = new EndpointConfiguration(Console.Title = "Samples.Blazor.Server");
+        var endpointConfiguration = new EndpointConfiguration(Console.Title = "BlazorServer");
         endpointConfiguration.EnableCallbacks(makesRequests: false);
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Program.cs
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASPNETCore.Endpoint";
+        Console.Title = "ASPNETCoreEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ASPNETCore.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport<LearningTransport>();

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Program.cs
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASPNETCore.Endpoint";
+        Console.Title = "ASPNETCoreEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ASPNETCore.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/Endpoint/Program.cs
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/Endpoint/Program.cs
@@ -6,7 +6,7 @@ static class Program
 {
     static async Task Main()
     {
-        Console.Title = "Samples.ASPNETCore.Endpoint";
+        Console.Title = "ASPNETCoreEndpoint";
         var endpointConfiguration = new EndpointConfiguration("Samples.ASPNETCore.Endpoint");
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseTransport(new LearningTransport());

--- a/tests/IntegrityTests/Samples.cs
+++ b/tests/IntegrityTests/Samples.cs
@@ -9,7 +9,7 @@ using NUnit.Framework.Internal;
 
 namespace IntegrityTests
 {
-    internal class Samples
+    internal partial class Samples
     {
         [Test]
         public void NoMinorSamples()
@@ -91,5 +91,37 @@ namespace IntegrityTests
 
             throw new Exception($"Couldn't figure out major version from target framework '{tfm}'");
         }
+
+        [Test]
+        public void ConstrainConsoleTitlesForWindowsTerminal()
+        {
+            var regex = ConsoleTitleRegex();
+
+            new TestRunner("Program.cs", "Console.Title values should be simple like 'Client' not 'Samples.SampleName.Client' and <= 26 characters to fit in Windows Terminal tabs")
+                .IgnoreSnippets()
+                .Run(path =>
+                {
+                    var text = File.ReadAllText(path);
+
+                    foreach (var match in regex.Matches(text).OfType<Match>())
+                    {
+                        var value = match.Groups[1].Value;
+
+                        if (value.Contains('.'))
+                        {
+                            return (false, $"'{value}' should not contain namespaced segments");
+                        }
+                        else if (value.Length > 26)
+                        {
+                            return (false, $"'{value}' is longer than 26 characters");
+                        }
+                    }
+
+                    return (true, null);
+                });
+        }
+
+        [GeneratedRegex(@"Console\.Title\s+=\s+""([^""]+)""", RegexOptions.Compiled)]
+        private static partial Regex ConsoleTitleRegex();
     }
 }

--- a/tutorials/quickstart/Solution/Platform/Program.cs
+++ b/tutorials/quickstart/Solution/Platform/Program.cs
@@ -9,7 +9,7 @@ namespace Platform
 
         static async Task Main()
         {
-            Console.Title = "Particular Service Platform Launcher";
+            Console.Title = "Platform Launcher";
             await Particular.PlatformLauncher.Launch();
         }
 


### PR DESCRIPTION
Now that Windows Terminal is commonplace, the long "namespaced" console title values like "Samples.SampleName.EndpointName" are now too long to be viewed within the Windows Terminal tab. All you see is 3 different windows all called "Samples.WhateverTheSampleNam…" and it gets cut off before the useful bit.

This PR adds a test to ensure that they do not contain periods (so not in that namespaced format) as as well as limits them to 26 characters.

And then it fixes everything.