### PR TITLE
Editorial review of observability page

### DIFF
--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -5,61 +5,62 @@ reviewed: 2024-03-14
 callsToAction: ['solution-architect', 'poc-help']
 ---
 
-AWS offers several observability solutions which can be used with the Particular Service Platform. They provide native monitoring, logging, alarming, and dashboards with Amazon CloudWatch, tracing through AWS X-Ray, as well as other open-s&#111;urce based managed services, together providing [three pillars observability signals](https://opentelemetry.io/docs/concepts/signals/).
+AWS offers several observability solutions which can be used with the Particular Service Platform. They provide native monitoring, logging, alarming, and dashboards with Amazon CloudWatch, tracing through AWS X-Ray, as well as other open-source based managed services. Together these provide the three pillars of [observability signals](https://opentelemetry.io/docs/concepts/signals/).
 
-#### Amazon CloudWatch
+## Amazon CloudWatch
 
 [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) is a monitoring and observability service that allows one to collect and access performance and operational data in the form of logs and metrics on a single platform.
 
 :heavy_plus_sign: Pros:
 
-- A single tool to visualize metrics and logs emitted by the system
+- Single tool to visualize metrics and logs emitted by the system
 - Fully managed service
-- Tightly integrated with other AWS services, such as AWS Lambda and Amazon EC2
-- Supports querying data from multiple s&#111;urces, allowing one to monitor metrics on AWS, on premises or other clouds
-- Customizable dashboards and automated alarms and actions
+- Tightly integrated with other AWS services
+- Supports querying data from multiple sources
+- Customizable dashboards with automated alarms and actions
 - Real-time telemetry
 
 :heavy_minus_sign: Cons:
 
-- Amazon CloudWatch does not support traces
-- AWS CloudWatch offers a [free tier](https://aws.amazon.com/cloudwatch/pricing/), but costs may escalate with increases usage, requiring dedicated monitoring
+- Does not support traces
+- [Costs](https://aws.amazon.com/cloudwatch/pricing/) can escalate with increased usage
 
 The Particular Service Platform collects metrics in two forms:
 
-- OpenTelemetry-based metrics, which can be collected by enabling OpenTelemetry and exporting the metrics to Amazon CloudWatch
-- Custom metrics with NServiceBus.Metrics which can be exported to Amazon CloudWatch.
+1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](https://docs.particular.net/nservicebus/operations/opentelemetry) and exporting the metrics to Amazon CloudWatch.
+1. Custom metrics with `NServiceBus.Metrics` - can be exported to Amazon CloudWatch - TODO: Link this to TODO2 below.
 
-Try the Amazon CloudWatch sample for NServiceBus metrics and logs →
+Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 below.
 
 **TODO**:
 
-1. Create a sample that uses NSB metrics, which integrates with Cloudwatch
+1. Create a sample that uses Otel and integrates with CloudWatch
+1. Create a sample that uses NSB metrics, which integrates with CloudWatch
     1. Collect NSB metrics, send to cloudwatch
     2. Collect [NLog logs with extensions.logging](/samples/logging/extensions-logging/), [send to Cloudwatch](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/configure-logging-for-net-applications-in-amazon-cloudwatch-logs-by-using-nlog.html)
 
-#### Amazon X-Ray
+## Amazon X-Ray
 
-[Amazon X-Ray](https://aws.amazon.com/xray/) is a service that can collect trace data from the applications, providing insights that can help identify issues or bottlenecks that could benefit from optimization.
+[Amazon X-Ray](https://aws.amazon.com/xray/) is a service that can receive trace data from applications. The trace data can provide insights that can help identify performance bottlenecks, edge case errors, and other hard to detect issues.
 
 :heavy_plus_sign: Pros:
 
-- A single tool to visualize application-level traces and infrastructure-level traces
-- AWS X-Ray creates a service map using trace data
-- Integrates with other AWS services, such as AWS Lambda, Amazon EC2, Amazon ECS and AWS Elastic Beanstalk
+- Single tool to visualize application-level and infrastructure-level traces
+- Creates a service map using trace data
+- Tightly integrated with other AWS services
 - Fully managed service
 
 :heavy_minus_sign: Cons:
 
-- AWS X-Ray offers a [free tier](https://aws.amazon.com/xray/pricing/), but costs may escalate with increases usage, requiring dedicated monitoring
-- Pricing is based on the amount and the type of telemetry collected
-- AWS X-Ray is designed to work within the AWS ecosystem
-- AWS X-Ray’s `traceId` format differs from the [W3C format](https://www.w3.org/TR/trace-context/#trace-id), and requires mapping for compatibility reasons which should be considered when using [OpenTelemetry](/architecture/observability.md)
+- [Costs](https://aws.amazon.com/xray/pricing/) can escalate with increased usage
+- [OpenTelemetry](/architecture/observability.md) compatibility is not guaranteed due to `traceId` format differences from the [W3C specification](https://www.w3.org/TR/trace-context/#trace-id)
 
-The Particular Service Platform allows observability tools to capture spans emitted by NServiceBus, providing insights into message processing, retries, and more.
-
-&lt;link to presentation> [https:&#47;/particular.net/videos/message-processing-failed](https://particular.net/videos/message-processing-failed)
-
-In this presentation, Laila Bougria discusses the need for distributed tracing in distributed systems, as well as the [ADOT collector (AWS Distro for OpenTelemetry Collector)](https://aws-otel.github.io/docs/getting-started/collector), AWS’ OpenTelemetry Collector implementation that simplifies the export of distributed traces from applications to AWS X-Ray, amongst others.
+The Particular Service Platform allows observability tools to capture spans emitted by NServiceBus, providing insights into how messages are being processed.
 
 [Try the OpenTelemetry sample with export to Amazon X-Ray →](https://github.com/lailabougria/talks/tree/main/message-processing-failed-but-whats-the-root-cause/samples/aws)
+
+## Additional resources
+
+[Message processing failed... But what's the root cause?](https://particular.net/videos/message-processing-failed)
+
+In this presentation, Laila Bougria discusses the need for distributed tracing in distributed systems, as well as the [ADOT collector (AWS Distro for OpenTelemetry Collector)](https://aws-otel.github.io/docs/getting-started/collector), AWS’ OpenTelemetry Collector implementation that simplifies the export of distributed traces from applications to AWS X-Ray, amongst others.

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -27,7 +27,7 @@ AWS offers several observability solutions which can be used with the Particular
 
 The Particular Service Platform collects metrics in two forms:
 
-1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](https://docs.particular.net/nservicebus/operations/opentelemetry) and exporting the metrics to Amazon CloudWatch.
+1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](/nservicebus/operations/opentelemetry) and exporting the metrics to Amazon CloudWatch.
 1. Custom metrics with `NServiceBus.Metrics` - can be exported to Amazon CloudWatch - TODO: Link this to TODO2 below.
 
 Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 below.

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -27,7 +27,7 @@ AWS offers several observability solutions which can be used with the Particular
 
 The Particular Service Platform collects metrics in two forms:
 
-1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](/nservicebus/operations/opentelemetry) and exporting the metrics to Amazon CloudWatch.
+1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](/nservicebus/operations/opentelemetry.md) and exporting the metrics to Amazon CloudWatch.
 1. Custom metrics with `NServiceBus.Metrics` - can be exported to Amazon CloudWatch - TODO: Link this to TODO2 below.
 
 Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 below.

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -17,7 +17,7 @@ AWS offers several observability solutions which can be used with the Particular
 - Fully managed service
 - Tightly integrated with other AWS services
 - Supports querying data from multiple sources
-- Customizable dashboards with automated alarms and actions
+- Customizable dashboards with automated alarms and remediating actions
 - Real-time telemetry
 
 :heavy_minus_sign: Cons:

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -5,7 +5,7 @@ reviewed: 2024-03-14
 callsToAction: ['solution-architect', 'poc-help']
 ---
 
-AWS offers several observability solutions which can be used with the Particular Service Platform. They provide native monitoring, logging, alarming, and dashboards with Amazon CloudWatch, tracing through AWS X-Ray, as well as other open-source based managed services. Together these provide the three pillars of [observability signals](https://opentelemetry.io/docs/concepts/signals/).
+AWS offers several observability solutions that can be used with the Particular Service Platform. They provide native monitoring, logging, alarming, and dashboards with Amazon CloudWatch, tracing through AWS X-Ray, and other open-source-based managed services. Together, these provide the three pillars of [observability signals](https://opentelemetry.io/docs/concepts/signals/).
 
 ## Amazon CloudWatch
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -16,7 +16,7 @@ AWS offers several observability solutions that can be used with the Particular 
 - Single tool to visualize metrics and logs emitted by the system
 - Fully managed service
 - Tightly integrated with other AWS services
-- Supports querying data from multiple sources, allowing to monitor metrics on AWS, on-premises, or other cloud providers
+- Supports querying data from multiple sources, allowing you to monitor metrics from AWS, on-premises, or other cloud providers
 - Customizable dashboards with automated alarms and remediating actions
 - Real-time telemetry
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -1,7 +1,7 @@
 ---
 title: AWS observability services
 summary:
-reviewed: 2024-03-14
+reviewed: 2024-03-28
 callsToAction: ['solution-architect', 'poc-help']
 ---
 
@@ -28,16 +28,7 @@ AWS offers several observability solutions that can be used with the Particular 
 The Particular Service Platform collects metrics in two forms:
 
 1. OpenTelemetry-based metrics - can be collected by [enabling OpenTelemetry](/nservicebus/operations/opentelemetry.md) and exporting the metrics to Amazon CloudWatch.
-1. Custom metrics with `NServiceBus.Metrics` - can be exported to Amazon CloudWatch - TODO: Link this to TODO2 below.
-
-Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 below.
-
-**TODO**:
-
-1. Create a sample that uses Otel and integrates with CloudWatch
-1. Create a sample that uses NSB metrics, which integrates with CloudWatch
-    1. Collect NSB metrics, send to cloudwatch
-    2. Collect [NLog logs with extensions.logging](/samples/logging/extensions-logging/), [send to Cloudwatch](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/configure-logging-for-net-applications-in-amazon-cloudwatch-logs-by-using-nlog.html)
+1. Custom metrics with `NServiceBus.Metrics` - can be exported to Amazon CloudWatch.
 
 ## Amazon X-Ray
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -16,7 +16,7 @@ AWS offers several observability solutions that can be used with the Particular 
 - Single tool to visualize metrics and logs emitted by the system
 - Fully managed service
 - Tightly integrated with other AWS services
-- Supports querying data from multiple sources, allowing you to monitor metrics from AWS, on-premises, or other cloud providers
+- Supports querying data from multiple sources to monitor metrics from AWS, on-premises, or other cloud providers
 - Customizable dashboards with automated alarms and remediating actions
 - Real-time telemetry
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -53,7 +53,7 @@ Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 
 :heavy_minus_sign: Cons:
 
 - [Costs](https://aws.amazon.com/xray/pricing/) can escalate with increased usage
-- [OpenTelemetry](/architecture/observability.md) compatibility is not guaranteed due to `traceId` format differences from the [W3C specification](https://www.w3.org/TR/trace-context/#trace-id)
+- **TODO** Validate that this is still accurate [OpenTelemetry](/architecture/observability.md) compatibility is not guaranteed due to `traceId` format differences from the [W3C specification](https://www.w3.org/TR/trace-context/#trace-id)
 
 The Particular Service Platform allows observability tools to capture spans emitted by NServiceBus, providing insights into how messages are being processed.
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -16,7 +16,7 @@ AWS offers several observability solutions that can be used with the Particular 
 - Single tool to visualize metrics and logs emitted by the system
 - Fully managed service
 - Tightly integrated with other AWS services
-- Supports querying data from multiple sources hosted in AWS, on-premises, or other cloud providers
+- Supports querying data from multiple sources, allowing to monitor metrics on AWS, on-premises, or other cloud providers
 - Customizable dashboards with automated alarms and remediating actions
 - Real-time telemetry
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -53,7 +53,6 @@ Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 
 :heavy_minus_sign: Cons:
 
 - [Costs](https://aws.amazon.com/xray/pricing/) can escalate with increased usage
-- **TODO** Validate that this is still accurate [OpenTelemetry](/architecture/observability.md) compatibility is not guaranteed due to `traceId` format differences from the [W3C specification](https://www.w3.org/TR/trace-context/#trace-id)
 
 The Particular Service Platform allows observability tools to capture spans emitted by NServiceBus, providing insights into how messages are being processed.
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -16,7 +16,7 @@ AWS offers several observability solutions that can be used with the Particular 
 - Single tool to visualize metrics and logs emitted by the system
 - Fully managed service
 - Tightly integrated with other AWS services
-- Supports querying data from multiple sources
+- Supports querying data from multiple sources hosted in AWS, on-premises, or other cloud providers
 - Customizable dashboards with automated alarms and remediating actions
 - Real-time telemetry
 

--- a/architecture/aws/observability.md
+++ b/architecture/aws/observability.md
@@ -41,7 +41,7 @@ Try the Amazon CloudWatch sample for OpenTelemetry → TODO: Link this to TODO1 
 
 ## Amazon X-Ray
 
-[Amazon X-Ray](https://aws.amazon.com/xray/) is a service that can receive trace data from applications. The trace data can provide insights that can help identify performance bottlenecks, edge case errors, and other hard to detect issues.
+[Amazon X-Ray](https://aws.amazon.com/xray/) is a service that can receive trace data from applications. The trace data can provide insights to help identify the root cause of failures, hard-to-detect issues or side effects, and performance bottlenecks.
 
 :heavy_plus_sign: Pros:
 


### PR DESCRIPTION
This is our first editorial review of the `observability.md` page.
There are still samples missing in this document that need to be completed.

To do (do not merge until blocking items have been addressed) :
- [x] **[blocking]** Remove call to action to sample for NServiceBus.Metrics + CloudWatch - @WilliamBZA @NChaganlal 
- [x] [non-blocking] Create a [small task](https://github.com/Particular/docs.particular.net/issues/6536) to create a sample for NServiceBus.Metrics + CloudWatch - @WilliamBZA @NChaganlal add to main issue
- [x] [**blocking]** Doublecheck if the x-ray API overrides the traceId - @lailabougria - This is a none issue, removed