### PR TITLE
Reorder support policy left nav

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1365,6 +1365,10 @@
         Url: servicecontrol/powershell-cmdlets
     - Title: Licensing
       Url: servicecontrol/license
+    - Title: Support policy
+      Url: servicecontrol/upgrades/support-policy
+    - Title: Supported versions
+      Url: servicecontrol/upgrades/supported-versions
   - Title: Upgrade Guides
     Articles:
     - Title: Upgrade tips
@@ -1373,8 +1377,6 @@
       Url: servicecontrol/upgrades/new-persistence
     - Title: Zero downtime
       Url: servicecontrol/upgrades/zero-downtime
-    - Title: Support policy
-      Url: servicecontrol/upgrades/support-policy
     - Title: Version 4 to 5
       Url: servicecontrol/upgrades/4to5
     - Title: Version 3 to 4

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -150,21 +150,23 @@
     - Url: nservicebus/security-advisories/sqlserver-sqlinjection
       Title: 2016-07-05
 
+  - Title: Support Policy
+    Articles:
+    - Url: nservicebus/upgrades/support-policy
+      Title: About
+    - Url: nservicebus/upgrades/supported-versions
+      Title: Supported versions
+    - Url: nservicebus/upgrades/all-versions
+      Title: All versions
+    - Url: nservicebus/upgrades/supported-platforms
+      Title: Supported frameworks and platforms
+    - Url: nservicebus/upgrades/release-policy
+      Title: Release Policy
+
   - Title: Upgrade Guides
     Articles:
     - Url: nservicebus/upgrades
-      Title: About upgrading NServiceBus
-    - Url: nservicebus/upgrades/support-policy
-      Title: Support Policy
-      Articles:
-      - Url: nservicebus/upgrades/supported-versions
-        Title: Supported versions
-      - Url: nservicebus/upgrades/all-versions
-        Title: All versions
-      - Url: nservicebus/upgrades/supported-platforms
-        Title: Supported frameworks and platforms
-    - Url: nservicebus/upgrades/release-policy
-      Title: Release Policy
+      Title: About upgrading NServiceBus   
     - Url: nservicebus/upgrades/third-party-licenses
       Title: Third-party licenses
     - Url: nservicebus/upgrades/callbacks-1to2


### PR DESCRIPTION
- Related to  https://github.com/Particular/docs.particular.net/issues/4676

In this PR 
- the NSB support policy has been moved up to its own level and the support policy of ServiceControl has moved under the "Introduction" sub menu.
