### PR TITLE
remove all quickstart pages from learning path

### DIFF
--- a/tutorials/quickstart/tutorial-extending-the-system.md
+++ b/tutorials/quickstart/tutorial-extending-the-system.md
@@ -1,7 +1,6 @@
 ---
 title: "NServiceBus Quick Start: Extending the system"
-reviewed: 2022-06-29
-isLearningPath: true
+reviewed: 2024-01-31
 summary: "Part 3: Learn how easy it is to extend a distributed system by adding new functionality without affecting the other components of the system"
 extensions:
 - !!tutorial

--- a/tutorials/quickstart/tutorial-reliability.md
+++ b/tutorials/quickstart/tutorial-reliability.md
@@ -1,7 +1,6 @@
 ---
 title: "NServiceBus Quick Start: Recovering from failure"
-reviewed: 2022-06-29
-isLearningPath: true
+reviewed: 2024-01-31
 summary: "Part 2: Learn how to handle exceptions and automatically retry them so they don't bring the whole system down."
 extensions:
 - !!tutorial


### PR DESCRIPTION
Missed removing these 2 pages from the learning path in https://github.com/Particular/docs.particular.net/pull/6437