### PR TITLE
Updating ServicePulse IIS install instructions for 1.38.3 release

### DIFF
--- a/Snippets/ServicePulse/ServicePulse_All/web.config
+++ b/Snippets/ServicePulse/ServicePulse_All/web.config
@@ -62,16 +62,7 @@
         </authorization>
       </security>
     </system.webServer>
-  </location>
-  <location path="api/messagestream">
-    <system.webServer>
-      <security>
-        <authorization>
-          <add accessType="Allow" users="?"/>
-        </authorization>
-      </security>
-    </system.webServer>
-  </location>
+  </location>  
   <location path="monitoring">
     <system.webServer>
       <security>

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -124,7 +124,7 @@ When using [monitoring capabilities](/monitoring) the following steps should be 
 
 Installation steps:
 
- 1. Install the IIS [Application Request Routing extension](https://www.iis.net/downloads/microsoft/application-request-routing).
+ 1. Install the IIS [URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite).
  1. Go to the root directory for the website created in the basic configuration.
  1. Edit `js\app.constants.js` and change the `monitoring_urls` value from `http://localhost:33633/` to `monitoring/`.
  1. Open the IIS management tool.

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -24,6 +24,9 @@ Steps
  1. Remove the `netsh` url restriction
  1. Create a website in IIS referring to the ServicePulse directory 
 
+> [!NOTE]
+> When performing an upgrade, it is recommended to delete your existing environment and start with a clean install. See [Upgrading ServicePulse hosted in IIS](#upgrading-servicepulse-hosted-in-iis) for more details.
+
 ### Detailed steps
 
 By default, ServicePulse is [installed](installation.md) as a Windows Service that will self-host the ServicePulse web application.
@@ -38,9 +41,6 @@ ServicePulse.Host.exe --extract --outPath="C:\inetpub\websites\ServicePulse"
 
 > [!NOTE]
 > `ServicePulse.Host.exe` can be found in the ServicePulse installation directory. The default location for this directory is `%programfiles(x86)%\Particular Software\ServicePulse`
-
-> [!NOTE]
-> When performing an upgrade, it is recommended to delete your existing environment and start with a clean install. See [Upgrading ServicePulse hosted in IIS](#upgrading-servicepulse-hosted-in-iis) for more details.
 
 2. Once the ServicePulse files are successfully extracted, configure a new IIS website whose physical path points to the location where the files have been extracted. Configure it to use port `9090`.
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -24,9 +24,6 @@ Steps
  1. Remove the `netsh` url restriction
  1. Create a website in IIS referring to the ServicePulse directory 
 
-> [!NOTE]
-> If you are upgrading from a previous version of Service Pulse, it is recommended to delete your existing environment and follow this document for a clean install. Follow this instructions [down below](#upgrading-servicepulse-hosted-in-iis).
-
 ### Detailed steps
 
 By default, ServicePulse is [installed](installation.md) as a Windows Service that will self-host the ServicePulse web application.
@@ -41,6 +38,9 @@ ServicePulse.Host.exe --extract --outPath="C:\inetpub\websites\ServicePulse"
 
 > [!NOTE]
 > `ServicePulse.Host.exe` can be found in the ServicePulse installation directory. The default location for this directory is `%programfiles(x86)%\Particular Software\ServicePulse`
+
+> [!NOTE]
+> When performing an upgrade, it is recommended to delete your existing environment and start with a clean install. See [Upgrading ServicePulse hosted in IIS](#upgrading-servicepulse-hosted-in-iis) for more details.
 
 2. Once the ServicePulse files are successfully extracted, configure a new IIS website whose physical path points to the location where the files have been extracted. Configure it to use port `9090`.
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -24,6 +24,9 @@ Steps
  1. Remove the `netsh` url restriction
  1. Create a website in IIS referring to the ServicePulse directory 
 
+> [!NOTE]
+> If you are upgrading from a previous version of Service Pulse, it is recommended to delete your existing environment and follow this document for a clean install. Follow this instructions [down below](#upgrading-servicepulse-hosted-in-iis).
+
 ### Detailed steps
 
 By default, ServicePulse is [installed](installation.md) as a Windows Service that will self-host the ServicePulse web application.

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -124,7 +124,7 @@ When using [monitoring capabilities](/monitoring) the following steps should be 
 
 Installation steps:
 
- 1. Install the IIS [URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite).
+ 1. Install the IIS [URL Rewrite extension](https://www.iis.net/downloads/microsoft/url-rewrite).
  1. Go to the root directory for the website created in the basic configuration.
  1. Edit `js\app.constants.js` and change the `monitoring_urls` value from `http://localhost:33633/` to `monitoring/`.
  1. Open the IIS management tool.

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -56,7 +56,7 @@ netsh http delete urlacl http://+:9090/
 > Make sure that the ServicePulse Windows Service is not running and that the URLACL has been removed or else IIS will not be able to use port 9090.
 
 > [!NOTE]
-> If TLS is to be applied to ServicePulse then ServiceControl also must be configured for TLS. This can be achieved by reverse proxying ServiceControl through IIS as outlined [below](#servicecontrol).
+> If TLS is to be applied to ServicePulse then ServiceControl also must be configured for TLS. This can be achieved by reverse proxying ServiceControl through IIS as outlined [below](#advanced-configuration-servicecontrol).
 
 ###  Hosting ServicePulse within a subfolder
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -1,7 +1,7 @@
 ---
 title: Install ServicePulse in IIS
 summary: Describes how to manually install ServicePulse in IIS
-reviewed: 2023-03-16
+reviewed: 2024-05-07
 component: ServicePulse
 ---
 
@@ -22,7 +22,6 @@ Steps
  1. Extract the ServicePulse files
  1. Disable/Remove ServicePulse
  1. Remove the `netsh` url restriction
- 1. Make sure that [WebSocket support is enabled for IIS](https://docs.microsoft.com/en-us/iis/get-started/whats-new-in-iis-8/iis-80-websocket-protocol-support)
  1. Create a website in IIS referring to the ServicePulse directory
  1. Configure URL Rewrites
 
@@ -162,35 +161,6 @@ Installation steps:
 > By exposing the REST API via the reverse proxy configuration, this protection is no longer in place. To address this, it is recommended that the IIS website be configured with one of the IIS authentication providers, such as Windows integration authentication.
 
 It is also recommended that the IIS website be configured to use TLS if an authorization provider is used.
-
-#### Configuring SignalR rewrite rules
-
-Due to a [bug in SignalR](https://github.com/SignalR/SignalR/issues/3649) in Microsoft.AspNet.SignalR.JS version 2.2.0, usage of IIS as a reverse proxy requires an additional URL Rewrite Rule. This rule should look as follows:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <system.webServer>
-        <rewrite>
-            <outboundRules>
-                <rule name="Update URL property" preCondition="JSON" enabled="true" stopProcessing="true">
-                    <match filterByTags="None" pattern="\&quot;Url\&quot;:\&quot;(.+?)\&quot;" />
-                    <conditions>
-                        <add input="{URL}" pattern="(.*)/api/" />
-                    </conditions>
-                    <action type="Rewrite" value="&quot;Url&quot;:&quot;{C:1}{R:1}&quot;" />
-                </rule>
-                <preConditions>
-                    <preCondition name="JSON">
-                        <add input="{URL}" pattern="/api/messagestream/negotiate" />
-                        <add input="{RESPONSE_CONTENT_TYPE}" pattern="application/json" />
-                    </preCondition>
-                </preConditions>
-            </outboundRules>
-        </rewrite>
-    </system.webServer>
-</configuration>
-```
 
 ### ServiceControl monitoring
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -56,7 +56,7 @@ netsh http delete urlacl http://+:9090/
 > Make sure that the ServicePulse Windows Service is not running and that the URLACL has been removed or else IIS will not be able to use port 9090.
 
 > [!NOTE]
-> If TLS is to be applied to ServicePulse then ServiceControl also must be configured for TLS. This can be achieved by reverse proxying ServiceControl through IIS as outlined below.
+> If TLS is to be applied to ServicePulse then ServiceControl also must be configured for TLS. This can be achieved by reverse proxying ServiceControl through IIS as outlined [below](#servicecontrol).
 
 ###  Hosting ServicePulse within a subfolder
 

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -22,8 +22,7 @@ Steps
  1. Extract the ServicePulse files
  1. Disable/Remove ServicePulse
  1. Remove the `netsh` url restriction
- 1. Create a website in IIS referring to the ServicePulse directory
- 1. Configure URL Rewrites
+ 1. Create a website in IIS referring to the ServicePulse directory 
 
 ### Detailed steps
 
@@ -56,45 +55,9 @@ netsh http delete urlacl http://+:9090/
 > [!NOTE]
 > If TLS is to be applied to ServicePulse then ServiceControl also must be configured for TLS. This can be achieved by reverse proxying ServiceControl through IIS as outlined below.
 
-5. Install the [URL Rewrite](https://www.iis.net/downloads/microsoft/url-rewrite) module, then in the root directory of the IIS website, create a `web.config` file with the following content:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-  <system.webServer>
-    <rewrite>
-      <rules>
-        <rule name="Handle app.constants.js requests from AngularJs" stopProcessing="true">
-          <match url="^a/js/app.constants.js(.*)" />
-          <action type="Rewrite" url="/js/app.constants.js{R:1}" />
-        </rule>
-      </rules>
-    </rewrite>
-  </system.webServer>
-</configuration>
-```
-
 ###  Hosting ServicePulse within a subfolder
 
-It is possible to host ServicePulse within a subfolder. The `web.config` containing the URL Rewrite rules must be placed in the subfolder containing the ServicePulse files. Secondly, the URL Rewrite configuration must be aware of the subfolder i.e the rewrite **must include the SubFolder name in the match part** of the rule.
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-  <system.webServer>
-    <rewrite>
-      <rules>
-        <rule name="Handle app.constants.js requests from AngularJs" stopProcessing="true">
-          <match url="^/a/js/app.constants.js(.*)" />
-          <action type="Rewrite" url="/SubFolder/js/app.constants.js{R:1}" />
-        </rule>
-      </rules>
-    </rewrite>
-  </system.webServer>
-</configuration>
-```
-
-The second required configuration change is to specify the name of the subfolder in the `base_url`. This is done by:
+It is possible to host ServicePulse within a subfolder. The name of the subfolder has to be specified in the `base_url` app constant. This is done by:
 
 1. Go to the root directory for the website created in the basic configuration.
 1. Edit `js\app.constants.js` file and set the `base_url` variable to be the name of the subfolder.
@@ -143,19 +106,12 @@ Installation steps:
                  <rule name="Rewrite main instance API URL" stopProcessing="true">
                     <match url="^api/(.*)" />
                     <action type="Rewrite" url="http://localhost:33333/api/{R:1}" />
-                </rule>
-                <rule name="Legacy rewrite main instance API URL" stopProcessing="true">
-                    <match url="^a/api(.*)" />
-                    <action type="Rewrite" url="http://localhost:33333/api/{R:1}" />
-                </rule>
+                </rule>                
             </rules>
         </rewrite>
     </system.webServer>
 </configuration>
 ```
-
-> [!WARNING]
-> When combining these rules with the ones specified above in [Detailed steps](#basic-setup-detailed-steps), ensure the rule named "Handle Vue.js routing paths" (i.e. `<match url="(.*)" />`) rule occurs _last_ in the list of rewrite rules. Otherwise, it will override the rules specified here.
 
 > [!WARNING]
 > By exposing the REST API via the reverse proxy configuration, this protection is no longer in place. To address this, it is recommended that the IIS website be configured with one of the IIS authentication providers, such as Windows integration authentication.
@@ -185,11 +141,7 @@ Installation steps:
                 <rule name="Rewrite monitoring API URL" stopProcessing="true">
                     <match url="^monitoring/(.*)" />
                     <action type="Rewrite" url="http://localhost:33633/{R:1}" />
-                </rule>
-                <rule name="Legacy rewrite monitoring API URL" stopProcessing="true">
-                    <match url="^a/monitoring/(.*)" />
-                    <action type="Rewrite" url="http://localhost:33633/{R:1}" />
-                </rule>
+                </rule>                
             </rules>
         </rewrite>
     </system.webServer>


### PR DESCRIPTION
With 1.38.3 release, SignalR(websockets) and AngularJS are no longer used. This PR removes everything related to these technologies.

- [x] ~create~ [reference](https://github.com/Particular/docs.particular.net/pull/6609/files#diff-d55e3cd8b26f1215c53ea89b830606efce84dcdabe75ce36ed9d28625d2cea37R28) upgrade guide and restate that a clean install is recommended when upgrading ~to ˜remove no longer required IIS configurations~ 