### PR TITLE
Improvements to the Step by step tutorial

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -13,15 +13,15 @@
     - Url: tutorials/nservicebus-step-by-step
       Title: Introduction
     - Url: tutorials/nservicebus-step-by-step/1-getting-started
-      Title: "Lesson 1: Getting Started"
+      Title: "Part 1: Getting Started"
     - Url: tutorials/nservicebus-step-by-step/2-sending-a-command
-      Title: "Lesson 2: Sending a command"
+      Title: "Part 2: Sending a command"
     - Url: tutorials/nservicebus-step-by-step/3-multiple-endpoints
-      Title: "Lesson 3: Multiple endpoints"
+      Title: "Part 3: Multiple endpoints"
     - Url: tutorials/nservicebus-step-by-step/4-publishing-events
-      Title: "Lesson 4: Publishing events"
+      Title: "Part 4: Publishing events"
     - Url: tutorials/nservicebus-step-by-step/5-retrying-errors
-      Title: "Lesson 5: Retrying errors"
+      Title: "Part 5: Retrying errors"
   - Title: NServiceBus Sagas
     Articles:
     - Url: tutorials/nservicebus-sagas

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -8,7 +8,7 @@
       Title: "Part 2: Recovering from failure"
     - Url: tutorials/quickstart/tutorial-extending-the-system
       Title: "Part 3: Extending the system"
-  - Title: Introduction to NServiceBus
+  - Title: NServiceBus Step-by-step
     Articles:
     - Url: tutorials/nservicebus-step-by-step
       Title: Introduction

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -86,7 +86,7 @@ Capturing the `transport` settings in a variable as shown will make things easie
 
 ### Starting up
 
-At the end of the `Main` method, after the configuration code, add the following lines which will: start the endpoint, keep it running until you press the <kbd>Enter</kbd> key, that will shut it down.
+At the end of the `Main` method, after the configuration code, add the following lines which will start the endpoint and keep it running until you press the <kbd>Enter</kbd> key to shut it down.
 
 snippet: Startup
 

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -51,11 +51,13 @@ In the **Program.cs** file, modify the code to look like the following:
 snippet: EmptyProgram
 
 > [!NOTE]
-> For the sake of brevity, code snippets in this tutorial do not contain the `using` statements needed to import namespaces. If you're using Visual Studio, unknown references such as `Task` or NServiceBus types will generate a "red squiggly" > underline effect. If you hover or click on the red squiggly, you can click on the "light bulb" icon or press <span style="white-space: nowrap"><kbd>Ctrl</kbd> + <kbd>.</kbd></span> to see the available fixes and insert the appropriate `using` > statements for the missing namespaces.
+> For the sake of brevity, code snippets in this tutorial do not contain the `using` statements needed to import namespaces. 
+> If you're using Visual Studio, unknown references such as `Task` or NServiceBus types will generate a "red squiggly" underline effect. 
+> If you hover or click on the red squiggly, you can click on the "light bulb" icon or press <span style="white-space: nowrap"><kbd>Ctrl</kbd> + <kbd>.</kbd></span> to see the available fixes and insert the appropriate `using` statements for the missing namespaces.
 >
 > Alternatively, in the code snippet's **Copy/Edit** menu you will find a **Copy usings** item that will copy the namespaces used by the snippet to your clipboard.
 
-Now that we have a `Main` method, let's take a look at the code we're going to add to it, then analyze the importance of each line. First, add the following code to the `Main` method:
+Now that we have a `Main` method, let's take a look at the code we're going to add, analyzing the importance of each line. First, add the following code to the `Main` method:
 
 snippet: Main
 
@@ -65,37 +67,38 @@ Now, let's go line-by-line and find out exactly what each step is doing.
 
 snippet: ConsoleTitle
 
-When running multiple console apps in the same solution, giving each a name makes them easier to identify. This console app's title is `ClientUI`. In later lessons, we'll expand this solution to host several more.
+When running multiple console apps in the same solution, giving each one a name makes them easier to identify. This console app's title is `ClientUI`. In later lessons, we'll expand this solution to host multiple applications.
 
 #### EndpointConfiguration
 
 snippet: EndpointName
 
-The `EndpointConfiguration` class is where we define all the settings that determine how our endpoint will operate. The single string parameter `ClientUI` is the [**endpoint name**](/nservicebus/endpoints/specify-endpoint-name.md), which serves as the logical identity for our endpoint, and forms a naming convention by which other things will derive their names, such as the **input queue** where the endpoint will listen for messages to process.
+The `EndpointConfiguration` class is where we define all the settings that determine how our endpoint will operate. The single string parameter `ClientUI` is the [**endpoint name**](/nservicebus/endpoints/specify-endpoint-name.md), which serves as the logical identifier for our endpoint, and forms a naming convention by which other components will derive their names, such as the **input queue** where the endpoint will listen for messages to process.
 When setting up the endpoint configuration you can choose how you want to serialize your messages. For this tutorial, we will be configuring the endpoint to use `SystemJsonSerializer` which uses the .NET `System.Text.Json` serializer.
 
 #### Transport
 
 snippet: LearningTransport
 
-This setting defines the [**transport**](/transports/) that NServiceBus will use to send and receive messages. We are using the [Learning transport](/transports/learning/), which is bundled in the NServiceBus core library as a starter transport for learning how to use NServiceBus without additional dependencies. All other transports are provided using different NuGet packages.
+This setting defines the [**transport**](/transports/) that NServiceBus will use to send and receive messages. We are using the [Learning transport](/transports/learning/), which is bundled in the NServiceBus.Core library as a starter transport for learning how to use NServiceBus without additional dependencies. All other transports are provided using different NuGet packages.
 
 Capturing the `transport` settings in a variable as shown will make things easier in [a later lesson](../3-multiple-endpoints/) when we start defining message routing rules.
 
 ### Starting up
 
-At the end of the `Main` method, after the configuration code, add the following code which will: start the endpoint, keep it running until we press the <kbd>Enter</kbd> key, then shut it down.
+At the end of the `Main` method, after the configuration code, add the following lines which will: start the endpoint, keep it running until you press the <kbd>Enter</kbd> key, that will shut it down.
 
 snippet: Startup
 
-The endpoint is initialized according to the settings defined by the `EndpointConfiguration` class. Once the endpoint starts, changes to the configuration information are no longer applied.
+The endpoint is initialized according to the settings defined by the `EndpointConfiguration` class. Once the endpoint starts, any changes made to the configuration information won't be applied.
+In order to apply configuration changes, you will need to restart the endpoint.
 
 When you run the endpoint for the first time, the endpoint will:
 
  * Display its logging information, which is [written to a file, Trace, and the Console](/nservicebus/logging/#default-logging). NServiceBus also logs to multiple levels, so you can [change the log level](/nservicebus/logging/#default-logging-changing-the-defaults-changing-the-logging-level) from `INFO` to `DEBUG` in order to get more information.
  * Display the [status of your license](/nservicebus/licensing/).
  * Attempt to add the current user to the "Performance Monitor Users" group so that it can write [performance counters](/monitoring/metrics/performance-counters.md) to track its health and progress.
- * Create fake, file-based "queues" in a `.learningtransport` directory inside your solution directory. It is recommended to add `.learningtransport` to your source control system's ignore file.
+ * Create file-based "queues" in the `.learningtransport` directory inside your solution directory. This is why we recommend to add `.learningtransport` to your source control system's ignore file.
 
 ## Summary
 

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -97,7 +97,7 @@ When you run the endpoint for the first time, the endpoint will:
  * Display its logging information, which is [written to a file, Trace, and the Console](/nservicebus/logging/#default-logging). NServiceBus also logs to multiple levels, so you can [change the log level](/nservicebus/logging/#default-logging-changing-the-defaults-changing-the-logging-level) from `INFO` to `DEBUG` in order to get more information.
  * Display the [status of your license](/nservicebus/licensing/).
  * Attempt to add the current user to the "Performance Monitor Users" group so that it can write [performance counters](/monitoring/metrics/performance-counters.md) to track its health and progress.
- * Create file-based "queues" in the `.learningtransport` directory inside your solution directory. This is why we recommend to add `.learningtransport` to your source control system's ignore file.
+ * Create file-based "queues" in the `.learningtransport` directory inside your solution directory. We recommend adding `.learningtransport` to your source control system's ignore file.
 
 ## Summary
 

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: "NServiceBus Step-by-step: Getting started"
-reviewed: 2023-07-15
+reviewed: 2024-05-13
 summary: In this 10-15 minute tutorial, you will learn how to set up a development machine for NServiceBus and create your very first messaging endpoint.
 redirects:
 - tutorials/intro-to-nservicebus/1-getting-started
@@ -8,7 +8,7 @@ redirects:
 - tutorials/intro-to-nservicebus/using-sql-transport
 extensions:
 - !!tutorial
-  nextText: "Next Lesson: Sending a command"
+  nextText: "Next: Sending a command"
   nextUrl: tutorials/nservicebus-step-by-step/2-sending-a-command
 ---
 

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -57,7 +57,7 @@ snippet: EmptyProgram
 >
 > Alternatively, in the code snippet's **Copy/Edit** menu you will find a **Copy usings** item that will copy the namespaces used by the snippet to your clipboard.
 
-Now that we have a `Main` method, let's take a look at the code we're going to add, analyzing the importance of each line. First, add the following code to the `Main` method:
+Now that we have a `Main` method, let's discuss the importance of each line we're going to add to it. First, add the following code to the `Main` method:
 
 snippet: Main
 

--- a/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/tutorial.md
@@ -90,8 +90,7 @@ At the end of the `Main` method, after the configuration code, add the following
 
 snippet: Startup
 
-The endpoint is initialized according to the settings defined by the `EndpointConfiguration` class. Once the endpoint starts, any changes made to the configuration information won't be applied.
-In order to apply configuration changes, you will need to restart the endpoint.
+The endpoint is initialized according to the settings defined by the `EndpointConfiguration` class. Once the endpoint starts, any changes made to the configuration won't be applied until you restart the endpoint.
 
 When you run the endpoint for the first time, the endpoint will:
 

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
@@ -1,13 +1,13 @@
 ---
 title: "NServiceBus Step-by-step: Sending a command"
-reviewed: 2023-03-12
+reviewed: 2024-05-13
 summary: In this 15-20 minute tutorial, you'll learn how to define NServiceBus messages and handlers, and send and receive a message.
 redirects:
 - tutorials/intro-to-nservicebus/2-sending-a-command
 - tutorials/nservicebus-101/lesson-2
 extensions:
 - !!tutorial
-  nextText: "Next Lesson: Multiple endpoints"
+  nextText: "Next: Multiple endpoints"
   nextUrl: tutorials/nservicebus-step-by-step/3-multiple-endpoints
 ---
 
@@ -20,19 +20,20 @@ In the next 15-20 minutes, you will learn how to define messages and message han
 
 A [**message**](/nservicebus/messaging/messages-events-commands.md) is a collection of data sent via one-way communication between two endpoints. In NServiceBus, we define messages via simple classes.
 
-In this lesson, we'll focus on one type of message: [commands](/nservicebus/messaging/messages-events-commands.md). In [Lesson 4: Publishing events](../4-publishing-events/) we'll expand to look at another type of message, events, as well.
+In this lesson, we'll focus on a specific type of message: [commands](/nservicebus/messaging/messages-events-commands.md). Later on, in [Part 4: Publishing events](../4-publishing-events/) we'll expand to look at another type of message, events.
 
 To define a command, create a class and mark it with the `ICommand` interface.
 
 snippet: Command
 
-By implementing this interface we let NServiceBus know that the class is a command so that it can build up some metadata about the message type when the endpoint starts up. Any properties you create within the message constitute the message data.
+By implementing this interface we let NServiceBus know that the class is a command so that it can build up some metadata about the message type when the endpoint starts up. Any properties you create within the message will constitute the message data.
 
-The name of the command class is also important. A command is an order to do something, so it should be named in the [imperative tense](https://en.wikipedia.org/wiki/Imperative_mood). `PlaceOrder` and `ChargeCreditCard` are good names for commands, because they are phrased as a command and are very specific. `PlaceOrder` will place an order and `ChargeCreditCard` will charge money on a credit card. `CustomerMessage`, on the other hand, is not a good example. It is not in the imperative, and it's vague. Another developer should know exactly what a command's purpose is just by reading the name.
+The name of your command classes it is important, as they allow to infer the intent of the class without looking at its content. A command is an order to do something, so it should be named in the [imperative tense](https://en.wikipedia.org/wiki/Imperative_mood). 
+`PlaceOrder` and `ChargeCreditCard` are good names for commands, because they are phrased as a command and are very specific. We could expect that `PlaceOrder` will place an order and `ChargeCreditCard` will charge money on a credit card. `CustomerMessage`, on the other hand, is not a good example. It is not in the imperative, and it's vague. Ideally another person should know exactly what a command's purpose is just by reading its name.
 
-Command names should also convey business intent. `UpdateCustomerPropertyXYZ`, while more specific than `CustomerMessage` isn't a good name for an command because it's focused only on the data manipulation rather than the business meaning behind it. `MarkCustomerAsGold`, or something else that is more business-oriented, is a better choice.
+Command names should also convey business intent. `UpdateCustomerPropertyXYZ`, while more specific than `CustomerMessage` isn't a good name for an command because it's focused only on the data manipulation rather than the business meaning behind it. `MarkCustomerAsGold`, or something else that is domain oriented, is a better choice.
 
-When sending a message, the endpoint's [serializer](/nservicebus/serialization/) will serialize an instance of the `DoSomething` class and add that to the contents of the outgoing message that goes to the queue. On the other end, the receiving endpoint will deserialize the message back to an instance of the message class so that it can be used in code.
+When sending a message, the endpoint's [serializer](/nservicebus/serialization/) will serialize the instance of the `DoSomething` class and add it to the contents of the outgoing message that goes to the queue. On the other end, the receiving endpoint will deserialize the message back to an instance of the message class so that it can be used by that endpoint.
 
 Messages can even contain child objects or collections. The supported range of structures is dictated by the [choice of serializer](/nservicebus/serialization/#supported-serializers).
 
@@ -40,7 +41,7 @@ snippet: ComplexCommand
 
 Messages are a contract between two endpoints. Any change to the message will likely involve a change on both the sender and receiver side. The more properties you have on a message, the more reasons it has to change, so keep your messages [as slim as possible](https://particular.net/blog/putting-your-events-on-a-diet).
 
-Also, do not embed logic within your message classes. Each message should contain only automatic properties and not computed properties or methods. It is a good practice to initialize collection properties as shown above, so that you never have to deal with a null collection.
+Also, do not embed logic within your message classes. Each message should contain only automatic properties and not computed properties or methods. It is a good practice to initialize collection properties as shown above, so that you never have to deal with serializing a null collection.
 
 In essence, messages should be carriers for data only. By keeping your messages small and giving them clear purpose, your code will be easy to understand and evolve.
 
@@ -73,7 +74,7 @@ snippet: EmptyHandlerAsync
 
 If you want to learn more about working with async methods, see [Asynchronous Handlers](/nservicebus/handlers/async-handlers.md).
 
-It makes no difference whether handlers are implemented inside one or multiple classes. A single class can implement multiple `IHandleMessages<T>` for multiple message types so you can group logically related message handlers together in the same class in order to make your code easier to understand. Just remember that each time a message is processed, a new instance of that class is instantiated by the framework. Thus, you can't set a private member variable in one message handler and then expect to have that value around when the next message (regardless of type) is processed.
+It makes no difference whether handlers are implemented inside one or multiple classes. A single class can implement multiple `IHandleMessages<T>` for multiple message types, so you can group logically related message handlers together in the same class in order to make your code easier to understand. Just remember that each time a message is processed, a new instance of that class is instantiated by the framework. Thus, you can't set a private member variable in one message handler and then expect to have that value around when the next message (regardless of type) is processed.
 
 snippet: MultiHandler
 
@@ -119,7 +120,7 @@ Now that we've defined a message, we can create a corresponding message handler.
 
  1. In the **ClientUI** project, create a new class named `PlaceOrderHandler`.
  1. Mark the handler class as public and implement the `IHandleMessages<PlaceOrder>` interface.
- 1. Add a logger instance, which will allow you to take advantage of the same logging system used by NServiceBus. This has an important advantage over `Console.WriteLine()`: the entries written with the logger will appear in the log file in addition to the console. Use this code to add the logger instance to your handler class:
+ 1. Add a logger instance, which will allow you to take advantage of the same logging system used by NServiceBus. This has an important advantage over `Console.WriteLine()`: the entries written with the logger will appear in the log file in addition to the console. Use this line to add the logger instance to your handler class:
     ```cs
     static ILog log = LogManager.GetLogger<PlaceOrderHandler>();
     ```
@@ -149,7 +150,7 @@ snippet: RunLoop
 
 Let's take a closer look at the case when we want to place an order. In order to create the `PlaceOrder` command, create an instance of the `PlaceOrder` class and supply a unique value for the `OrderId`. Then, after logging the details, we can send it with the `SendLocal` method.
 
-`SendLocal(object message)` is a method that is available on the `IEndpointInstance` interface, as we are using here, and also on the `IMessageHandlerContext` interface, which we saw when we were defining our message handler. The *Local* part means that we are not sending to an external endpoint (in a different process) so we intend to handle the message in the same endpoint that sent it. Using `SendLocal()`, we don't have to do anything special to tell the message where to go.
+`SendLocal(object message)` is a method that is available on the `IEndpointInstance` interface, as we are using here, and also on the `IMessageHandlerContext` interface, which we saw when we were defining our message handler. The *Local* part means that we are not sending to an external endpoint (in a different process) so we intend to handle the message in the same endpoint that sent it. By using `SendLocal()`, we don't have to do anything special to tell the message where to go.
 
 > [!NOTE]
 > In this lesson, we're using `SendLocal` (rather than the more commonly used `Send` method) so that we can explore how to define, send, and process messages without needing a second endpoint to process them. With `SendLocal`, we also don't need to define routing rules to control where the sent messages go. We'll learn about these concepts [in the next lesson](../3-multiple-endpoints/).
@@ -163,8 +164,8 @@ snippet: AddRunLoopToMain
 
 ### Running the solution
 
-Now we can run the solution. Whenever we press <kbd>P</kbd> on the console, a command message is sent and then processed by a handler class in the same project.
-
+Now we are ready to run the solution. Whenever we press <kbd>P</kbd> on the terminal, a command message is sent and then processed by a handler class in the same project.
+You should see something similar to this on your console:
 ```
 INFO  ClientUI.Program Press 'P' to place an order, or 'Q' to quit.
 p

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
@@ -20,7 +20,7 @@ In the next 15-20 minutes, you will learn how to define messages and message han
 
 A [**message**](/nservicebus/messaging/messages-events-commands.md) is a collection of data sent via one-way communication between two endpoints. In NServiceBus, we define messages via simple classes.
 
-In this lesson, we'll focus on a specific type of message: [commands](/nservicebus/messaging/messages-events-commands.md). Later on, in [Part 4: Publishing events](../4-publishing-events/) we'll expand to look at another type of message, events.
+In this lesson, we'll focus on a specific type of message: [commands](/nservicebus/messaging/messages-events-commands.md). Later on, in [Part 4: Publishing events](../4-publishing-events/) we'll expand to look at another type of message, `events`.
 
 To define a command, create a class and mark it with the `ICommand` interface.
 

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/tutorial.md
@@ -26,7 +26,7 @@ To define a command, create a class and mark it with the `ICommand` interface.
 
 snippet: Command
 
-By implementing this interface we let NServiceBus know that the class is a command so that it can build up some metadata about the message type when the endpoint starts up. Any properties you create within the message will constitute the message data.
+By implementing this interface, we let NServiceBus know that the class is a command so that it can build up some metadata about the message type when the endpoint starts up. Any properties you create within the message constitutes the message data.
 
 The name of your command classes it is important, as they allow to infer the intent of the class without looking at its content. A command is an order to do something, so it should be named in the [imperative tense](https://en.wikipedia.org/wiki/Imperative_mood). 
 `PlaceOrder` and `ChargeCreditCard` are good names for commands, because they are phrased as a command and are very specific. We could expect that `PlaceOrder` will place an order and `ChargeCreditCard` will charge money on a credit card. `CustomerMessage`, on the other hand, is not a good example. It is not in the imperative, and it's vague. Ideally another person should know exactly what a command's purpose is just by reading its name.

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/tutorial.md
@@ -1,13 +1,13 @@
 ---
 title: "NServiceBus Step-by-step: Multiple Endpoints"
-reviewed: 2023-11-17
+reviewed: 2024-05-21
 summary: In this 15-20-minute tutorial, you'll learn how to send messages between multiple endpoints and control the logical routing of messages between endpoints.
 redirects:
 - tutorials/intro-to-nservicebus/3-multiple-endpoints
 - tutorials/nservicebus-101/lesson-3
 extensions:
 - !!tutorial
-  nextText: "Next Lesson: Publishing events"
+  nextText: "Next: Publishing events"
   nextUrl: tutorials/nservicebus-step-by-step/4-publishing-events
 ---
 
@@ -19,7 +19,7 @@ In the next 15-20 minutes, you will learn how to send messages between multiple 
 
 ## Sending messages
 
-We've already shown how an endpoint can "send a message to itself" using the `SendLocal()` method, which is available on the `IEndpointInstance` that we use in the endpoint startup code to create a UI, and also on the `IMessageHandlerContext` that we can access while handling a message.
+We've already shown how an endpoint can "send a message to itself" using the `SendLocal()` method, which is available via the `IEndpointInstance` that we used in the endpoint to create a UI, and also via the `IMessageHandlerContext` that can be access while handling a message.
 
 snippet: SendLocal
 
@@ -35,22 +35,22 @@ We could specify where we want the message to go directly in code. There is actu
 
 snippet: SendDestination
 
-However, in most cases, this isn't a good idea. It requires each developer to remember where each message is supposed to go and type it in every time that message is sent.
+However, in most cases, this isn't a good idea. It requires that we remember where each message is supposed to go and type it in every time we send that message.
 
 Instead, NServiceBus should be made aware of the routing configuration, so that whenever a message is sent, the framework will know exactly where it should be delivered.
 
-This is **logical routing**, the mapping of specific message types to logical endpoints that can process those messages. Each command message should have one logical endpoint that owns that message and can process it.
+This concept is called **logical routing**, the mapping of specific message types to logical endpoints that can process those messages. Each command message should have one logical endpoint that owns that message and can process it.
 
 We say *logical routing* because this is at a logical layer only, which isn't necessarily the same as *physical routing*. Within one *logical* endpoint, there may be many *physical* endpoint instances deployed to multiple servers.
 
 > [!NOTE]
-> An [**endpoint**](/nservicebus/concepts/glossary.md#endpoint) is a logical concept, defined by an endpoint name and associated code, that defines an owner responsible for processing messages.
+> An [**endpoint**](/nservicebus/concepts/glossary.md#endpoint) is a logical concept, defined by an endpoint name and associated implementation, that defines an owner responsible for processing messages.
 >
 > An [**endpoint instance**](/nservicebus/concepts/glossary.md#endpoint-instance) is a physical instance of the endpoint deployed to a single server. Many endpoint instances may be deployed to many servers in order to scale out the processing of a high-volume message to multiple servers.
 
 For now, we'll only concern ourselves with logical routing, and leave the rest of it (physical routing, scale-out, etc.) for a later time.
 
-Because logical routing does not cover physical concerns, but only defines logical ownership, this is something that developers should control, and is not an operations concern. While operations may want to be able to move an endpoint to a different server using only configuration files, changing the owner for messages would require code changes and a recompile/redeploy anyway.
+Because logical routing does not cover physical concerns, but only defines logical ownership, this is something that we (as the implementators) should control, and is not an Operations (as in the part of our organization that handles the underlaying hardware infrastructure) concern. While Operations may want to be able to move an endpoint to a different server using only configuration files, changing the owner for messages would require code changes and a recompile/redeploy anyway.
 
 Therefore, it makes sense that logical routing is defined in code.
 
@@ -91,60 +91,58 @@ First, let's create a project for our new endpoint.
 
 ### Configuring an endpoint
 
-Now that we have a project for our Sales endpoint, we need to add similar code to configure and start an NServiceBus endpoint:
+Now that we have a project for our **Sales** endpoint, we need to add similar code to configure and start an NServiceBus endpoint:
 
 snippet: SalesProgram
 
-Most of this configuration looks exactly the same as our ClientUI endpoint. It's critical for the configuration between endpoints to match (especially message transport and serializer); otherwise, the endpoints would not be able to understand each other.
+Most of this configuration looks exactly the same as our **ClientUI** endpoint. It's critical for the configuration between endpoints to match (especially message transport and serializer); otherwise, the endpoints would not be able to understand each other.
 
-For example, if the ClientUI endpoint used `.UseSerialization<XmlSerializer>()` while the Sales endpoint used `.UseSerialization<JsonSerializer>()`, the Sales endpoint would not be able to understand the XML-serialized messages it received from ClientUI since it would be expecting JSON.
+For example, if the **ClientUI** endpoint used `.UseSerialization<XmlSerializer>()` while the **Sales** endpoint used `.UseSerialization<JsonSerializer>()`, the **Sales** endpoint would not be able to understand the XML-serialized messages it received from **ClientUI** since it would be expecting JSON.
 
-> [!NOTE]
-> **ProTip:** It's also possible to specify [multiple deserializers](/nservicebus/serialization/#specifying-additional-deserializers) to enable receiving messages serialized in different formats, for instance, to enable integration between teams, or to enable the use of a high-performance serializer in a performance-critical subsystem.
-
-To allow sending and receiving messages between endpoints using different serializers, additional deserialization capability may be specified. See [Serialization](/nservicebus/serialization)
+> [!TIP]
+> It's also possible to specify [multiple deserializers](/nservicebus/serialization/#specifying-additional-deserializers) to enable receiving messages serialized in different formats, for instance, to enable integration between teams, or to enable the use of a high-performance serializer in a performance-critical subsystem.
 
 While most of the configuration is the same, notice two specific lines that are different:
 
 snippet: EndpointDifferences
 
-The difference, of course, is the name "Sales" in the console title and `EndpointConfiguration` constructor, which defines the endpoint name for the Sales endpoint and gives it its own identity.
+The difference, of course, is the name "Sales" in the console title and `EndpointConfiguration` constructor, which defines the endpoint name for the **Sales** endpoint and gives it its own identity.
 
-This means that the Sales endpoint will create its own queue named `Sales` where it will listen for messages. We now have two processes that each have their own queues, so now we can send messages between them.
+This means that the **Sales** endpoint will create its own queue named `Sales` where it will listen for messages. We now have two processes that each have their own queues, so now we can send messages between them.
 
 > [!NOTE]
 > This is quite repetitive, but remember that this is still an introductory exercise. There are various methods, such as the [INeedInitialization interface](/nservicebus/lifecycle/ineedinitialization.md) which allow for centralizing the repetitive endpoint configuration code.
 
 ### Debugging multiple projects
 
-At this point, we could run the Sales endpoint, although we wouldn't expect Sales to do anything except start up, create its queues, and then wait for messages that would never arrive. This is a good exercise to do, although you can skip it if you're in a hurry.
+At this point, we could run the **Sales** endpoint, although we wouldn't expect **Sales** to do anything except start up, create its queues, and then wait for messages that would never arrive. This is a good exercise to do, although you can skip it if you're in a hurry.
 
 However, it's common in NServiceBus solutions to run multiple projects (i.e. endpoints) at once. To make this easier, configure both endpoints (**ClientUI** and **Sales**) to run at startup using Visual Studio's [multiple startup projects](https://msdn.microsoft.com/en-us/library/ms165413.aspx) feature.
 
-If you run the project now, ClientUI will work just as it did before, and Sales will start up and wait for messages that will never arrive.
+If you run the project now, **ClientUI** will work just as it did before, and **Sales** will start up and wait for messages that will never arrive.
 
 ### Moving the handler
 
-Now let's move the handler from ClientUI over to Sales where it belongs.
+Now let's move the handler from **ClientUI** over to **Sales** where it belongs.
 
  1. In the Solution Explorer, find **PlaceOrderHandler.cs** in the **ClientUI** project, and drag it to the **Sales** project.
  1. Open the new **PlaceOrderHandler.cs** in **Sales** and change the namespace from `ClientUI` to `Sales` to match its new home.
  1. Visual Studio's default action when you drag files between projects is to copy them, so you must delete the old **PlaceOrderHandler.cs** from the **ClientUI** endpoint.
 
-Now that the handler is in the correct endpoint, what would happen if we started the solution? Sales now have a message handler, but recall that ClientUI is still calling `endpointInstance.SendLocal(command)` which effectively sends the message to itself. But it doesn't have a handler for this message anymore.
+Now that the handler is in the correct endpoint, what would happen if we started the solution? **Sales** now has a message handler, but recall that ClientUI is still calling `endpointInstance.SendLocal(command)` which effectively sends the message to itself. But it doesn't have a handler for this message anymore.
 
-If you attempt to place an order in the ClientUI, an exception will be thrown because ClientUI no longer has a handler for it:
+If you attempt to place an order in **ClientUI**, an exception will be thrown because **ClientUI** no longer has a handler for it:
 
 > [!WARNING]
 > System.InvalidOperationException: No handlers could be found for message type: Messages.Commands.PlaceOrder
 
-In fact, you will probably get a giant wall of exception text, because the message is tried and retried, and then retried some more after successively longer delays, until finally failing for good sometime later. We'll cover this behavior in more detail in [Lesson 5: Retrying errors](../5-retrying-errors/).
+In fact, you will probably get a giant wall of exception text, because the message is tried and retried, and then retried some more after successively longer delays, until finally failing for good sometime later. We'll cover this behavior in detail in [Part 5: Retrying errors](../5-retrying-errors/).
 
-The important part is, if a message is accidentally sent to an endpoint we didn't intend, it won't just fail silently, and the message will not be lost.
+The important takeaway is, if a message is accidentally sent to an endpoint we didn't intend, it won't just fail silently, and the message will not be lost.
 
 ### Sending to another endpoint
 
-Now we need to change the ClientUI so that it is sending `PlaceOrder` to the Sales endpoint.
+Now we need to change **ClientUI** so that it is sending `PlaceOrder` to the **Sales** endpoint.
 
  1. In the **ClientUI** endpoint, modify the **Program.cs** file so that `endpointInstance.SendLocal(command)` is replaced by `endpointInstance.Send(command)`.
  1. In the `Main` method of the same file, use the `transport` variable to access the routing configuration and specify the logical routing for `PlaceOrder` by adding the following code after the line that configures the Learning Transport:
@@ -157,7 +155,7 @@ Reminder: As noted in [configuring an endpoint](#exercise-configuring-an-endpoin
 
 ### Running the solution
 
-Now when we run the solution, we get two console windows, one for ClientUI and one for Sales. After moving the windows around so that we can see both, we can try to place an order by pressing <kbd>P</kbd> in the **ClientUI** window.
+Now when we run the solution, we get two console windows, one for **ClientUI** and one for **Sales**. After moving the windows around so that we can see both, we can try to place an order by pressing <kbd>P</kbd> in the **ClientUI** window.
 
 > [!NOTE]
 > You can also keep console windows from showing up in random screen locations each time by right-clicking the console window's title bar, and in the **Layout** tab, unchecking the **Let system position window** checkbox.
@@ -186,12 +184,12 @@ INFO  Sales.PlaceOrderHandler Received PlaceOrder, OrderId = e19d6160-595a-4c30-
 
 At this point, we've managed to create two processes and achieve inter-process communication between them. Now let's try something different.
 
-1. In Visual Studio's **Debug** menu, select **Detach All** so that we can close one console window without Visual Studio closing all the other windows as well. Alternatively, you can run the solution using **Debug** > **Start Without Debugging** or Ctrl+F5.
-1. Close the Sales endpoint window so that only ClientUI is running.
-1. Press <kbd>P</kbd> several times to send several messages to the Sales endpoint. Note that it works just fine; messages are sent, and nothing fails because the Sales endpoint happens to be offline.
-1. Restart the Sales endpoint by right-clicking the **Sales** project and selecting **Debug** > **Start new instance**.
+1. In Visual Studio's **Debug** menu, select **Detach All** so that we can close one console window without Visual Studio closing all the other windows as well. Alternatively, you can run the solution using **Debug** > **Start Without Debugging** or <kbd>Ctrl</kbd> + <kbd>F5</kbd>.
+1. Close the **Sales** endpoint window so that only **ClientUI** is running.
+1. Press <kbd>P</kbd> several times to send several messages to the **Sales** endpoint. Note that it works just fine; messages are sent, and nothing fails because the **Sales** endpoint happens to be offline.
+1. Restart the **Sales** endpoint by right-clicking the **Sales** project and selecting **Debug** > **Start new instance**.
 
-After Sales starts up, it receives and processes all the messages that were waiting for it in the queue.
+After **Sales** starts up, it receives and processes all the messages that were waiting for it in the queue.
 
 The value in this approach is the ability to take a part of your system offline and have the rest of it proceed normally as though nothing is wrong, and then have everything return to normal when the offline piece comes back online.
 

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
@@ -69,7 +69,7 @@ Creating an event message is similar to creating a command. We create a class an
 
 snippet: Event
 
-All the other considerations for command messages apply to events as well. Properties can be simple types, complex types, or collections, it will depend on what the message serializer supports.
+All the other considerations for command messages apply to events as well. Properties can be simple types, complex types, or collections, depending on what the message serializer supports.
 
 With events, you should be even more careful about putting too much information in an event message. Sometimes this complexity can't be avoided for commands, as the command receiver needs the information to do its job. That's manageable for commands because the sender and receiver are highly coupled already. For events, it's a different story. Since a publisher of an event does not know (or care) how many subscribers it has, it may not be possible to modify all of them if a change is required to the event.
 

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
@@ -1,33 +1,32 @@
 ---
 title: "NServiceBus Step-by-step: Publishing Events"
-reviewed: 2023-11-24
+reviewed: 2024-05-21
 summary: In this 25-30 minute tutorial, you'll learn how to use the Publish/Subscribe pattern in NServiceBus to define, publish, and subscribe to an event.
 redirects:
 - tutorials/intro-to-nservicebus/4-publishing-events
 - tutorials/nservicebus-101/lesson-4
 extensions:
 - !!tutorial
-  nextText: "Next Lesson: Retrying errors"
+  nextText: "Next: Retrying errors"
   nextUrl: tutorials/nservicebus-step-by-step/5-retrying-errors
 ---
 
-So far in this tutorial, we have only sent **commands** – one-way messages from a sender to a specific receiver. There's another type of message we have yet to cover called an **event**. In many ways events are just like commands. They're simple classes and you deal with them in much the same way. But from an architectural standpoint, commands and events are *polar opposites*. This creates a useful dichotomy. We can take advantage of the properties of events to open up new possibilities in how we design software.
+So far in this tutorial, we have only sent **commands**, meaning one-way messages from a sender to a specific receiver. There's another type of message we have yet to cover called an **event**. In many ways events are just like commands. They're simple classes and you deal with them in much the same way. But from an architectural standpoint, commands and events are *polar opposites*. This creates a useful dichotomy. We can take advantage of the properties of events to open up new possibilities in how we design software.
 
 In the next 25-30 minutes, you will learn how the publish/subscribe pattern can help you create more maintainable code. Together, we'll learn to define, publish, and subscribe to an event.
 
 
 ## Events
 
-An **event** is another type of message that is published to multiple receivers, unlike a command which is sent to one receiver. Let's take a look at the formal definitions for commands and events:
+An **event** is another type of message that is published to multiple receivers, unlike a command which is sent to only one receiver. Let's take a look at the formal definitions for commands and events:
 
-> [!NOTE]
-> A **command** is a message that can be sent from one or more senders and is processed by a single receiver.
->
-> An **event** is a message that is published from a single sender, and is processed by (potentially) many receivers.
+A **command** is a message that can be sent from one or more senders and is processed by a single receiver.
+
+An **event** is a message that is published from a single sender, and is processed by (potentially) many receivers.
 
 You can see that in many ways, commands and events are exact opposites, and the differences in their definition leads us to different uses for each.
 
-A command can be sent from anywhere, but is processed by one receiver. This is very similar to a web service, or any other [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call)-style service. The big difference is that a one-way message does not have any return value like a web service would have. This means that the handler for the command is doing work for whomever is calling it, and that the sender has a very good idea about what it expects to happen as a result of sending the command. It is the sender saying "Will you please do something for me?" and so commands should be named in the [imperative tense](https://en.wikipedia.org/wiki/Imperative_mood), like `PlaceOrder` and `ChargeCreditCard`. This creates tight coupling between the sender and receiver, because while it is possible to reject a command, you can't have true autonomy if someone else can tell you what to do.
+A command can be sent from anywhere, but is processed by one receiver. This is very similar to a web service, or any other [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call)-style service. The big difference is that a command does not have any return value like a web service would have. This means that the handler for the command is doing work for whomever is calling it, and that the sender has a very good idea about what it expects to happen as a result of sending the command. It is the sender saying "Will you please do something for me?" and so commands should be named in the [imperative tense](https://en.wikipedia.org/wiki/Imperative_mood), like `PlaceOrder` and `ChargeCreditCard`. This creates tight coupling between the sender and receiver, because while it is possible to reject a command, you can't have true autonomy if someone else can tell you what to do.
 
 An event, on the other hand, is sent by one logical sender, and received by many receivers, or maybe one receiver, or even zero receivers.  This makes it an announcement that something has already happened. A subscriber can't reject or cancel an event any more than you could stop the New York Times from delivering newspapers to all of their subscribers. The publisher has no idea (and doesn't care) what receivers choose to do with the event; it's just making an announcement. So events should be named in the [past tense](https://en.wikipedia.org/wiki/Past_tense), commonly ending with the **-ed** suffix, like `OrderPlaced` and `CreditCardCharged`. This creates loose coupling, because while the contract (the content of the message) must be agreed upon, there is no requirement that subscribers of an event do anything.
 
@@ -53,9 +52,9 @@ The loose coupling provided by publishing events gives us quite a bit of flexibi
 
 ## Better code through decoupling
 
-Imagine you are implementing the SubmitOrder method for an e-commerce website. To complete the sale, you need to retrieve the shopping cart, insert an Order and OrderLines into the database, authorize a credit card transaction and capture the authorization, and email the user a receipt. You also may need to notify a fulfillment agency via a web service, update a wish list or gift registry, or store "frequently bought together" information, all depending upon your specific business requirements.
+Imagine you are implementing a `SubmitOrder` method for an e-commerce website. To complete the sale, you need to retrieve the shopping cart, insert an Order and OrderLines into the database, authorize a credit card transaction and capture the authorization, and email the user their receipt. You also may need to notify a fulfillment agency via a web service, update a wish list or gift registry, or store "frequently bought together" information, all depending upon your specific business requirements.
 
-You could do all this work in one monolithic method with hundreds of lines of code. You could further organize it by making each task a separate method, and have the SubmitOrder method call into each one of them in turn; but while this makes each method more manageable, it doesn't reduce the risk of running all those processes in a chain.
+You could do all this work in one monolithic method with hundreds of lines of code. You could further organize it by making each task a separate method, and have the `SubmitOrder` method call into each one of them in turn; but while this makes each method more manageable, it doesn't reduce the risk of running all those processes in a chain.
 
 When one of the steps in that long chain fails, you're left with a partially completed process that requires manual intervention to fix, either by mucking around manually in the database, manually reconciling with a credit card processor, or manually sending confirmation emails.
 
@@ -70,7 +69,7 @@ Creating an event message is similar to creating a command. We create a class an
 
 snippet: Event
 
-All the other considerations for command messages apply to events as well. Properties can be simple types, complex types, or collections - whatever the message serializer supports.
+All the other considerations for command messages apply to events as well. Properties can be simple types, complex types, or collections, it will depend on what the message serializer supports.
 
 With events, you should be even more careful about putting too much information in an event message. Sometimes this complexity can't be avoided for commands, as the command receiver needs the information to do its job. That's manageable for commands because the sender and receiver are highly coupled already. For events, it's a different story. Since a publisher of an event does not know (or care) how many subscribers it has, it may not be possible to modify all of them if a change is required to the event.
 
@@ -87,13 +86,13 @@ snippet: EventHandler
 
 ## Exercise
 
-Now that we've learned about events and the publish/subscribe pattern, let's make use of it in our ordering system. When a user places an order, we're going to publish an OrderPlaced event, then subscribe to it from two brand new endpoints: Billing and Shipping.
+Now that we've learned about events and the publish/subscribe pattern, let's make use of it in our ordering system. When a user places an order, we're going to publish an `OrderPlaced` event, then subscribe to it from two brand new endpoints: **Billing** and **Shipping**.
 
-We'll also create a new OrderBilled event that will be published by the Billing endpoint once the credit card transaction is complete.
+We'll also create a new OrderBilled event that will be published by the **Billing** endpoint once the credit card transaction is complete.
 
 ![Lesson 4 Diagram](diagram.svg)
 
-When the Shipping endpoint receives both the OrderPlaced and OrderBilled events, it will know that it is time to ship the product to the customer. Because this requires stored state, we can't accomplish that with message handlers alone. To implement that functionality, we would need a [Saga](/nservicebus/sagas/), but that will not be covered in this lesson.
+When the **Shipping** endpoint receives both the `OrderPlaced` and `OrderBilled` events, it will know that it is time to ship the product to the customer. Because this requires stored state, we can't accomplish that with message handlers alone. To implement that functionality, we would need a [Saga](/nservicebus/sagas/), but that will not be covered in this lesson.
 
 
 ### Create an event
@@ -181,6 +180,6 @@ You'll note that in the sample solution, the message for each handler says "Shou
 
 ## Summary
 
-In this lesson we learned all about events, how they differ from commands, and how that enables us to create systems that are more decoupled and that adhere to the Single Responsibility Principle. We published an `OrderPlaced` event from the Sales endpoint, and created the Billing and Shipping endpoints to subscribe to that event. We also published the `OrderBilled` event from the Billing endpoint, and subscribed to it in Shipping.
+In this lesson we learned all about events, how they differ from commands, and how that enables us to create systems that are more decoupled and that adhere to the Single Responsibility Principle. We published an `OrderPlaced` event from the **Sales** endpoint, and created the **Billing** and **Shipping** endpoints to subscribe to that event. We also published the `OrderBilled` event from the **Billing** endpoint, and subscribed to it in **Shipping**.
 
 In the final lesson for this tutorial, we'll see what happens when we introduce errors into our system, and see how we can automatically retry those messages to make a truly resilient system.

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
@@ -18,7 +18,7 @@ In the next 25-30 minutes, you will learn how the publish/subscribe pattern can 
 
 ## Events
 
-An **event** is another type of message that is published to multiple receivers, unlike a command which is sent to only one receiver. Let's take a look at the formal definitions for commands and events:
+Unlike a **command** which is sent to only one receiver, an **event** is another type of message that is published to multiple receivers. Let's take a look at the formal definitions for commands and events:
 
 A **command** is a message that can be sent from one or more senders and is processed by a single receiver.
 

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/tutorial.md
@@ -88,7 +88,7 @@ snippet: EventHandler
 
 Now that we've learned about events and the publish/subscribe pattern, let's make use of it in our ordering system. When a user places an order, we're going to publish an `OrderPlaced` event, then subscribe to it from two brand new endpoints: **Billing** and **Shipping**.
 
-We'll also create a new OrderBilled event that will be published by the **Billing** endpoint once the credit card transaction is complete.
+We'll also create a new `OrderBilled` event that will be published by the **Billing** endpoint once the credit card transaction is complete.
 
 ![Lesson 4 Diagram](diagram.svg)
 

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
@@ -79,7 +79,7 @@ Once a message is sent to the error queue, this indicates that a systemic failur
 
 NServiceBus embeds the exception details and stack trace into the message that it forwards to the error queue, so you don't need to search through a log file to find the details. Once the underlying issue is fixed, the message can be replayed. **Replaying a message** sends it back to its original queue in order to retry message processing after an issue has been fixed.
 
-> [!Note]
+> [!NOTE]
 > The [Particular Service Platform](/platform/), of which NServiceBus is a part, includes tools to make this kind of operational monitoring easy. If you'd like to learn more, check out the [message replay tutorial](/tutorials/message-replay/), which demonstrates how to use the platform tools to replay a failed message.
 
 Sometimes, a new release will contain a bug in handler logic that isn't found until the code is deployed. When this happens, many errors can flood into the error queue at once. At these times, it's incredibly useful to be able to roll back to the old version of the endpoint, and then replay the messages through proven code. Then you can take the time to properly troubleshoot and fix the issue before attempting a new deployment.

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
@@ -136,7 +136,7 @@ You can also [configure delayed retries](/nservicebus/recoverability/configure-d
 
 ### Transient exceptions
 
-Throwing a big exception is an example of a systemic error. Let's see how NServiceBus reacts when we throw more transient exception. To do this, let's introduce a random number generator so that we only throw an exception 20% of the time.
+Throwing a big exception is an example of a systemic error. Let's see how NServiceBus reacts when we throw a transient exception. To do this, let's introduce a random number generator so that we only throw an exception 20% of the time.
 
 1. In the **Sales** endpoint, locate the **PlaceOrderHandler**.
 1. Add a static **Random** instance to the class:

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/tutorial.md
@@ -70,7 +70,7 @@ Between immediate and delayed retries, there can be [many attempts to process a 
 
 The last step, moving the message to an error queue, is how NServiceBus deals with **systemic exceptions**. In a messaging system, systemic exceptions are the cause of **poison messages**, messages that cannot be processed successfully under any circumstances. Poison messages have to be moved aside, otherwise they will clog up the queue and prevent valid messages from being processed.
 
-We'll take a look at a few options for configuring retries in the exercise, but for more the details check out the [recoverability documentation](/nservicebus/recoverability/).
+We'll take a look at a few options for configuring retries in the exercise, but for more details, check out the [recoverability documentation](/nservicebus/recoverability/).
 
 
 ## Replaying messages

--- a/tutorials/nservicebus-step-by-step/index.md
+++ b/tutorials/nservicebus-step-by-step/index.md
@@ -17,15 +17,15 @@ extensions:
 
 include: nsb101-intro-paragraph
 
-- **[Part 1: Getting started](1-getting-started/)** (10-15 minutes) - learn how to set up your development environment and create your very first messaging endpoint.
+- **[Part 1: Getting started](1-getting-started/)** (10-15 minutes) - Set up your development environment and create your very first messaging endpoint.
 
-- **[Part 2: Sending a command](2-sending-a-command/)** (15-20 minutes) - learn how to define messages and message handlers, and send your first message.
+- **[Part 2: Sending a command](2-sending-a-command/)** (15-20 minutes) - Define messages and message handlers, and send your first message.
 
-- **[Part 3: Multiple endpoints](3-multiple-endpoints/)** (15-20 minutes) - learn how to create multiple endpoints and send messages between them.
+- **[Part 3: Multiple endpoints](3-multiple-endpoints/)** (15-20 minutes) - Create multiple endpoints and send messages between them.
 
-- **[Part 4: Publishing events](4-publishing-events/)** (25-30 minutes) - learn about the publish/subscribe pattern, how to publish events to multiple subscribers, and about the benefits of using this pattern to decouple business processes.
+- **[Part 4: Publishing events](4-publishing-events/)** (25-30 minutes) - Learn about the publish/subscribe pattern, how to publish events to multiple subscribers, and about the benefits of using this pattern to decouple business processes.
 
-- **[Part 5: Retrying errors](5-retrying-errors/)** (25-30 minutes) - learn how to use the Particular Service Platform tools to gracefully recover from exceptions in your code, allowing you to build systems that are resistant to failure.
+- **[Part 5: Retrying errors](5-retrying-errors/)** (25-30 minutes) - Use the Particular Service Platform tools to gracefully recover from exceptions in your code, allowing you to build systems that are resistant to failure.
 
 When you've completed all the exercises, your solution will look like this:
 

--- a/tutorials/nservicebus-step-by-step/index.md
+++ b/tutorials/nservicebus-step-by-step/index.md
@@ -11,24 +11,22 @@ redirects:
 - nservicebus/nservicebus-step-by-step-publish-subscribe-communication-code-first
 extensions:
 - !!tutorial
-  nextText: "Next Lesson: Getting started"
+  nextText: "Next: Getting started"
   nextUrl: tutorials/nservicebus-step-by-step/1-getting-started/
 ---
 
 include: nsb101-intro-paragraph
 
-- **[Lesson 1: Getting started](1-getting-started/)** (10-15 minutes) - learn how to set up your development environment and create your very first messaging endpoint.
+- **[Part 1: Getting started](1-getting-started/)** (10-15 minutes) - learn how to set up your development environment and create your very first messaging endpoint.
 
-- **[Lesson 2: Sending a command](2-sending-a-command/)** (15-20 minutes) - learn how to define messages and message handlers, and send your first message.
+- **[Part 2: Sending a command](2-sending-a-command/)** (15-20 minutes) - learn how to define messages and message handlers, and send your first message.
 
-- **[Lesson 3: Multiple endpoints](3-multiple-endpoints/)** (15-20 minutes) - learn how to create multiple endpoints and send messages between them.
+- **[Part 3: Multiple endpoints](3-multiple-endpoints/)** (15-20 minutes) - learn how to create multiple endpoints and send messages between them.
 
-- **[Lesson 4: Publishing events](4-publishing-events/)** (25-30 minutes) - learn about the publish/subscribe pattern, how to publish events to multiple subscribers, and about the benefits of using this pattern to decouple business processes.
+- **[Part 4: Publishing events](4-publishing-events/)** (25-30 minutes) - learn about the publish/subscribe pattern, how to publish events to multiple subscribers, and about the benefits of using this pattern to decouple business processes.
 
-- **[Lesson 5: Retrying errors](5-retrying-errors/)** (25-30 minutes) - learn how to use the Particular Service Platform tools to gracefully recover from exceptions in your code, allowing you to build systems that are resistant to failure.
+- **[Part 5: Retrying errors](5-retrying-errors/)** (25-30 minutes) - learn how to use the Particular Service Platform tools to gracefully recover from exceptions in your code, allowing you to build systems that are resistant to failure.
 
 When you've completed all the exercises, your solution will look like this:
 
 ![Completed Solution Diagram](4-publishing-events/diagram.svg)
-
-**Go to [**Lesson 1: Getting started**](1-getting-started/) to begin.**

--- a/tutorials/nservicebus-step-by-step/index.md
+++ b/tutorials/nservicebus-step-by-step/index.md
@@ -9,6 +9,10 @@ redirects:
 - samples/step-by-step
 - nservicebus/nservicebus-step-by-step-guide
 - nservicebus/nservicebus-step-by-step-publish-subscribe-communication-code-first
+extensions:
+- !!tutorial
+  nextText: "Next Lesson: Getting started"
+  nextUrl: tutorials/nservicebus-step-by-step/1-getting-started/
 ---
 
 include: nsb101-intro-paragraph

--- a/tutorials/nservicebus-step-by-step/index.md
+++ b/tutorials/nservicebus-step-by-step/index.md
@@ -1,8 +1,7 @@
 ---
 title: "NServiceBus Step-by-step"
 suppressRelated: true
-reviewed: 2023-07-23
-isLearningPath: true
+reviewed: 2024-05-13
 summary: Learn how to use NServiceBus quickly with this step-by-step tutorial, including the architectural concepts behind it.
 redirects:
 - tutorials/intro-to-nservicebus


### PR DESCRIPTION
I'm reviewing the Getting started section as part of my onboarding.
This PR is for changes to the Introduction to ServiceBus tutorial. 
### Observations:
- What is the name of the tutorial? NServiceBus Step-by-step or Introduction to NServiceBus
- The parts were called Lessons, I decided to follow the other tutorials and renamed them Parts
- There is a partial for the introduction text that is repeated on the first part, I'm tempted to remove it
- This line on part 2 confused me: 'Since the handlers in the tutorials are very simple and mostly just log information, they don't need to have the `async` keyword in the method definition. However, it's possible to add it and modify the handler to not return a `Task`'
- Part 2 takes more time to read than 15-20 minutes
- On Part 3, we could remove the note about Async Main, as it from a blogpost from 2017
- What date should we put on the review date?