### PR TITLE
Add a note to recommend usage of microsoft.extensions.logging directly

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -679,17 +679,17 @@
     - Url: nservicebus/logging
       Title: About NServiceBus logging
     - Url: nservicebus/logging/extensions-logging
-      Title: Microsoft.Extensions.Logging
-    - Url: nservicebus/logging/message-contents
-      Title: Message contents
-    - Url: nservicebus/logging/usage
-      Title: Writing a log entry
+      Title: Extensions.Logging
     - Url: nservicebus/logging/log4net
       Title: Log4Net
     - Url: nservicebus/logging/nlog
       Title: NLog
     - Url: nservicebus/logging/common-logging
       Title: CommonLogging
+    - Url: nservicebus/logging/message-contents
+      Title: Message contents  
+    - Url: nservicebus/logging/usage
+      Title: Writing a log entry
     - Url: nservicebus/operations/auditing
       Title: Auditing Messages
   - Title: Security

--- a/nservicebus/logging/common-logging.md
+++ b/nservicebus/logging/common-logging.md
@@ -6,6 +6,8 @@ reviewed: 2022-11-24
 related:
 - samples/logging/commonlogging
 ---
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 The `NServiceBus.CommonLogging` package provides support for writing NServiceBus log entries to [Common.Logging](https://github.com/net-commons/common-logging). Common.Logging provides a simple logging abstraction to switch between different logging implementations, similar to [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging).
 

--- a/nservicebus/logging/common-logging.md
+++ b/nservicebus/logging/common-logging.md
@@ -6,7 +6,8 @@ reviewed: 2022-11-24
 related:
 - samples/logging/commonlogging
 ---
-> [!Note]
+
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 The `NServiceBus.CommonLogging` package provides support for writing NServiceBus log entries to [Common.Logging](https://github.com/net-commons/common-logging). Common.Logging provides a simple logging abstraction to switch between different logging implementations, similar to [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging).

--- a/nservicebus/logging/extensions-logging.md
+++ b/nservicebus/logging/extensions-logging.md
@@ -6,7 +6,8 @@ component: Extensions.Logging
 related:
 - samples/logging/extensions-logging
 ---
-> [!Note]
+
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 The `NServiceBus.Extensions.Logging` package provides support for writing NServiceBus log entries via the  [Microsoft.Extensions.Logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) abstractions. With this common logging abstraction, it is possible to log to different logging providers. Some third-party frameworks can perform semantic logging, also known as structured logging.

--- a/nservicebus/logging/extensions-logging.md
+++ b/nservicebus/logging/extensions-logging.md
@@ -6,17 +6,15 @@ component: Extensions.Logging
 related:
 - samples/logging/extensions-logging
 ---
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
-The `NServiceBus.Extensions.Logging` package provides support for writing NServiceBus log entries via the logging abstractions, [Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging), as explained in [Logging in .NET Core and ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/).
-
-With this common logging abstraction, it is possible to log to different logging providers. Some third-party frameworks can perform semantic logging, also known as structured logging.
+The `NServiceBus.Extensions.Logging` package provides support for writing NServiceBus log entries via the  [Microsoft.Extensions.Logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) abstractions. With this common logging abstraction, it is possible to log to different logging providers. Some third-party frameworks can perform semantic logging, also known as structured logging.
 
 > [!NOTE]
 > This package should only be used when configuring logging in a self-host model. If hosting with the [.NET Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) use [NServiceBus.Extensions.Hosting](/nservicebus/hosting/extensions-hosting.md) package instead.
 
 ## Compatibility
-
-It is recommended to use Microsoft.Extensions.Logging for logging.
 
 Microsoft.Extensions.Logging can be used to replace the following providers:
 

--- a/nservicebus/logging/index.md
+++ b/nservicebus/logging/index.md
@@ -10,6 +10,8 @@ related:
 - samples/logging
 ---
 
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 ## Default Logging
 

--- a/nservicebus/logging/index.md
+++ b/nservicebus/logging/index.md
@@ -10,7 +10,7 @@ related:
 - samples/logging
 ---
 
-> [!Note]
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 ## Default Logging

--- a/nservicebus/logging/log4net.md
+++ b/nservicebus/logging/log4net.md
@@ -6,6 +6,9 @@ component: Log4Net
 related:
 - samples/logging/log4net-custom
 ---
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
+
 
 Support for writing all NServiceBus log entries to [Log4Net](https://logging.apache.org/log4net/).
 

--- a/nservicebus/logging/log4net.md
+++ b/nservicebus/logging/log4net.md
@@ -6,7 +6,8 @@ component: Log4Net
 related:
 - samples/logging/log4net-custom
 ---
-> [!Note]
+
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 

--- a/nservicebus/logging/nlog.md
+++ b/nservicebus/logging/nlog.md
@@ -7,6 +7,9 @@ related:
 - samples/logging/nlog-custom
 ---
 
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
+
 Support for writing all NServiceBus log entries to [NLog](https://nlog-project.org/).
 
 

--- a/nservicebus/logging/nlog.md
+++ b/nservicebus/logging/nlog.md
@@ -7,7 +7,7 @@ related:
 - samples/logging/nlog-custom
 ---
 
-> [!Note]
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 Support for writing all NServiceBus log entries to [NLog](https://nlog-project.org/).

--- a/nservicebus/logging/usage.md
+++ b/nservicebus/logging/usage.md
@@ -1,14 +1,13 @@
 ---
-title: Logging from the user code
+title: Logging using the NServiceBus logging abstraction
 reviewed: 2024-05-14
 component: Core
 redirects:
 - nservicebus/logging-writing
 ---
 
-Logging is done via the [`Microsoft.Extensions.Logging` abstraction](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging) either by hosting using the [NServiceBus extension for the Microsoft Generic Host](/nservicebus/hosting/#microsoft-generic-host), or by using the [NServiceBus extensions for Microsoft logging](/nservicebus/logging/extensions-logging.md) when [self-hosting](/nservicebus/hosting/#self-hosting).
-
-## Using the NServiceBus logging abstraction
+> [!Note]
+> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 In legacy endpoints the NServiceBus logging abstraction is used for writing log messages from user code.
 

--- a/nservicebus/logging/usage.md
+++ b/nservicebus/logging/usage.md
@@ -6,7 +6,7 @@ redirects:
 - nservicebus/logging-writing
 ---
 
-> [!Note]
+> [!NOTE]
 > It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
 
 In legacy endpoints the NServiceBus logging abstraction is used for writing log messages from user code.


### PR DESCRIPTION
This PR adds in a note to all the logging docs by recommending the usage of Microsoft.Extension.Logging directly instead of using the following abstractions as these provide an abstraction over another abstraction

- [NServiceBus.Extensions.Logging](https://www.nuget.org/packages/NServiceBus.Extensions.Logging/) or
- [NServiceBus.Log4Net](https://www.nuget.org/packages/NServiceBus.Log4Net/) or 
- [NServiceBus.CommonLogging](https://www.nuget.org/packages/NServiceBus.CommonLogging/) 

Also, in this PR the left menu links for logging have been rearranged.