### PR TITLE
Fix incorrect property encryption configuration in the showcase sample

### DIFF
--- a/samples/showcase/on-premises/Core_7/Store.Shared/CommonConfiguration.cs
+++ b/samples/showcase/on-premises/Core_7/Store.Shared/CommonConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 using NServiceBus;
 using NServiceBus.Encryption.MessageProperty;
 using NServiceBus.MessageMutator;
@@ -13,10 +12,9 @@ public static class CommonConfiguration
         messageEndpointMappings?.Invoke(transport);
         endpointConfiguration.UsePersistence<LearningPersistence>();
         var defaultKey = "2015-10";
-        var ascii = Encoding.ASCII;
         var encryptionService = new RijndaelEncryptionService(
             encryptionKeyIdentifier: defaultKey,
-            key: ascii.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
+            key: Convert.FromBase64String("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
         endpointConfiguration.EnableMessagePropertyEncryption(encryptionService);
         endpointConfiguration.RegisterMessageMutator(new DebugFlagMutator());
     }

--- a/samples/showcase/on-premises/Core_8/Store.Shared/CommonConfiguration.cs
+++ b/samples/showcase/on-premises/Core_8/Store.Shared/CommonConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using NServiceBus;
 using NServiceBus.Encryption.MessageProperty;
 using NServiceBus.MessageMutator;
@@ -14,10 +13,9 @@ public static class CommonConfiguration
         messageEndpointMappings?.Invoke(transport);
         endpointConfiguration.UsePersistence<LearningPersistence>();
         var defaultKey = "2015-10";
-        var ascii = Encoding.ASCII;
         var encryptionService = new AesEncryptionService(
             encryptionKeyIdentifier: defaultKey,
-            key: ascii.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
+            key: Convert.FromBase64String("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
         endpointConfiguration.EnableMessagePropertyEncryption(encryptionService);
         endpointConfiguration.RegisterMessageMutator(new DebugFlagMutator());
     }

--- a/samples/showcase/on-premises/Core_9/Store.Shared/CommonConfiguration.cs
+++ b/samples/showcase/on-premises/Core_9/Store.Shared/CommonConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using NServiceBus;
 using NServiceBus.Encryption.MessageProperty;
 using NServiceBus.MessageMutator;
@@ -14,10 +13,9 @@ public static class CommonConfiguration
         messageEndpointMappings?.Invoke(transport);
         endpointConfiguration.UsePersistence<LearningPersistence>();
         var defaultKey = "2015-10";
-        var ascii = Encoding.ASCII;
         var encryptionService = new AesEncryptionService(
             encryptionKeyIdentifier: defaultKey,
-            key: ascii.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
+            key: Convert.FromBase64String("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"));
         endpointConfiguration.EnableMessagePropertyEncryption(encryptionService);
         endpointConfiguration.RegisterMessageMutator(new DebugFlagMutator());
     }


### PR DESCRIPTION
Fix incorrect property encryption configuration in the showcase sample

Ref: https://docs.particular.net/nservicebus/security/property-encryption