### PR TITLE
Mention token credentials in ASQ

### DIFF
--- a/transports/azure-storage-queues/configuration.md
+++ b/transports/azure-storage-queues/configuration.md
@@ -71,6 +71,12 @@ Note that multiple connection string formats apply when working with Azure stora
 
 For more details refer to [Configuring Azure Connection Strings](https://docs.microsoft.com/en-us/azure/storage/storage-configure-connection-string) document.
 
+## Token-credentials
+
+Enables usage of Azure Active Directory (AAD) authentication such as [managed identities for Azure resources](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) instead of the shared secret in the connection string.
+
+Use the corresponding `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload when creating the clients passed to the transport.
+
 partial: aliases
 
 partial: sanitization

--- a/transports/azure-storage-queues/configuration.md
+++ b/transports/azure-storage-queues/configuration.md
@@ -77,7 +77,7 @@ partial: aliases
 
 Enables usage of Azure Active Directory (AAD) authentication such as [managed identities for Azure resources](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) instead of the shared secret in the connection string.
 
-Use the corresponding `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload when creating the clients passed to the transport.
+Use the corresponding [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload when creating the clients passed to the transport.
 
 partial: sanitization
 

--- a/transports/azure-storage-queues/configuration.md
+++ b/transports/azure-storage-queues/configuration.md
@@ -71,16 +71,15 @@ Note that multiple connection string formats apply when working with Azure stora
 
 For more details refer to [Configuring Azure Connection Strings](https://docs.microsoft.com/en-us/azure/storage/storage-configure-connection-string) document.
 
+partial: aliases
+
 ## Token-credentials
 
 Enables usage of Azure Active Directory (AAD) authentication such as [managed identities for Azure resources](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) instead of the shared secret in the connection string.
 
 Use the corresponding `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload when creating the clients passed to the transport.
 
-partial: aliases
-
 partial: sanitization
-
 
 ## Serialization
 

--- a/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
@@ -2,5 +2,3 @@
 Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
-
-Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
@@ -2,3 +2,5 @@
 Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
+
+Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asq_[7,8].partial.md
@@ -3,4 +3,4 @@ Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
 
-Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.
+Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asqn_[11,).partial.md
+++ b/transports/azure-storage-queues/configuration_config_asqn_[11,).partial.md
@@ -2,3 +2,5 @@
 Settings should be set when instantiating the transport:
 
 snippet: AzureStorageQueueConfigCodeOnly
+
+Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asqn_[11,).partial.md
+++ b/transports/azure-storage-queues/configuration_config_asqn_[11,).partial.md
@@ -3,4 +3,4 @@ Settings should be set when instantiating the transport:
 
 snippet: AzureStorageQueueConfigCodeOnly
 
-Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.
+Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
@@ -2,3 +2,5 @@
 Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
+
+Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
@@ -3,4 +3,4 @@ Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
 
-Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload that suits the authentication needs when creating the clients passed to the transport.
+Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`CloudTableClient`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.table.cloudtableclient?view=azure-dotnet#constructors) constructor overload that suits the authentication needs when creating the clients passed to the transport.

--- a/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
+++ b/transports/azure-storage-queues/configuration_config_asqn_[9,10].partial.md
@@ -3,4 +3,4 @@ Settings can be overridden only using configuration API:
 
 snippet: AzureStorageQueueConfigCodeOnly
 
-Use the `QueueServiceClient`, `BlobServiceClient` or `TableServiceClient` constructor overload that suits the authentication needs when creating the clients passed to the transport.
+Use the [`QueueServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.queues.queueserviceclient.-ctor?view=azure-dotnet), [`BlobServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobserviceclient.-ctor?view=azure-dotnet) or [`TableServiceClient`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tableserviceclient.-ctor?view=azure-dotnet) constructor overload that suits the authentication needs when creating the clients passed to the transport.


### PR DESCRIPTION
The ASQ transport has a code-only mode that is already documented. That snippets currently favors the connection string approach in the snippet. Since the clients have multiple constructors, showing all of them could be confusing. I have decided to mention that they should use whatever ctor overload that makes sense for their authentication scenarios. 