### PR TITLE
CosmosDB: Guidance on embedding partition keys in saga timeouts state

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1213,6 +1213,8 @@
       Url: persistence/cosmosdb
     - Title: Saga concurrency
       Url: persistence/cosmosdb/saga-concurrency
+    - Title: Saga timeouts
+      Url: persistence/cosmosdb/saga-timeouts
     - Title: Transactions
       Url: persistence/cosmosdb/transactions
     - Title: Migration from Azure Table Persistence

--- a/persistence/cosmosdb/saga-timeouts.md
+++ b/persistence/cosmosdb/saga-timeouts.md
@@ -5,6 +5,6 @@ component: CosmosDB
 reviewed: 2024-05-27
 ---
 
-When [sending saga timeouts](/nservicebus/sagas/timeouts) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed the partition to be used for the CosmosDB cannnot be extracted from the incoming saga timeout message.
+When [sending saga timeouts](/nservicebus/sagas/timeouts.md/) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed the partition to be used for the CosmosDB cannnot be extracted from the incoming saga timeout message.
 
 Ensure that the timeout data state that is passed to `RequestTimeout` contains the partition key information. The [Cosmos DB Persistence Usage with non-default container sample](/samples/cosmosdb/container/) demonstrates this.

--- a/persistence/cosmosdb/saga-timeouts.md
+++ b/persistence/cosmosdb/saga-timeouts.md
@@ -5,6 +5,6 @@ component: CosmosDB
 reviewed: 2024-05-27
 ---
 
-When [sending saga timeouts](https://docs.particular.net/nservicebus/sagas/timeouts) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed the partition to be used for the CosmosDB cannnot be extracted from the incoming saga timeout message.
+When [sending saga timeouts](/nservicebus/sagas/timeouts) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed the partition to be used for the CosmosDB cannnot be extracted from the incoming saga timeout message.
 
-Ensure that the timeout data state that is passed to `RequestTimeout` contains the partition key information. The [Cosmos DB Persistence Usage with non-default container sample](https://docs.particular.net/samples/cosmosdb/container/) demonstrates this.
+Ensure that the timeout data state that is passed to `RequestTimeout` contains the partition key information. The [Cosmos DB Persistence Usage with non-default container sample](/samples/cosmosdb/container/) demonstrates this.

--- a/persistence/cosmosdb/saga-timeouts.md
+++ b/persistence/cosmosdb/saga-timeouts.md
@@ -1,0 +1,10 @@
+---
+title: CosmosDB partition key and saga timeouts
+summary: How to resolve partition key with saga timeouts when using Azure Cosmos DB
+component: CosmosDB
+reviewed: 2024-05-27
+---
+
+When [sending saga timeouts](https://docs.particular.net/nservicebus/sagas/timeouts) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed the partition to be used for the CosmosDB cannnot be extracted from the incoming saga timeout message.
+
+Ensure that the timeout data state that is passed to `RequestTimeout` contains the partition key information. The [Cosmos DB Persistence Usage with non-default container sample](https://docs.particular.net/samples/cosmosdb/container/) demonstrates this.


### PR DESCRIPTION
This PR added some guidance on embedding partition keys in saga timeouts, as partition information is not automatically added to the timeout message and cannot be extracted from the incoming saga timeout message.