### PR TITLE
add  missing left menu link for azure

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -162,7 +162,8 @@
       Title: Scaling out
     - Url: nservicebus/biztalk
       Title: NServiceBus and Biztalk
-
+    - Url: nservicebus/azure
+      Title: NServiceBus and Azure
 
 
   - Title: Support Policy


### PR DESCRIPTION
This PR adds in the missing left menu link for [NServiceBus and Azure](https://docs.particular.net/nservicebus/azure/)