### PR TITLE
Add documentation for MSMQ 2.0.4

### DIFF
--- a/transports/msmq/delayed-delivery_content_msmqtransport_[2.0,).partial.md
+++ b/transports/msmq/delayed-delivery_content_msmqtransport_[2.0,).partial.md
@@ -58,7 +58,7 @@ Defaults to `1` per sec.
 
 Create a class which implements the `IDelayedMessageStore` interface and pass an instance to the `DelayedDeliverySettings` constructor.
 
-If the custom store needs to set up some infrastructure (create tables, etc.) then it must implement `IDelayedMessageStoreWithInfrastructure`. This interface includes `IDelayedMessageStore` and adds a method for setting up the infrastructure. This method is called before `IDelayedMessageStore.Initialize()`.
+If the custom store needs to set up some infrastructure (create tables, etc.) then it must implement `IDelayedMessageStoreWithInfrastructure`. This interface extends `IDelayedMessageStore` adding a method for setting up the infrastructure. This new method is called before `IDelayedMessageStore.Initialize()`.
 
 ### Consistency
 

--- a/transports/msmq/delayed-delivery_content_msmqtransport_[2.0,).partial.md
+++ b/transports/msmq/delayed-delivery_content_msmqtransport_[2.0,).partial.md
@@ -58,6 +58,8 @@ Defaults to `1` per sec.
 
 Create a class which implements the `IDelayedMessageStore` interface and pass an instance to the `DelayedDeliverySettings` constructor.
 
+If the custom store needs to set up some infrastructure (create tables, etc.) then it must implement `IDelayedMessageStoreWithInfrastructure`. This interface includes `IDelayedMessageStore` and adds a method for setting up the infrastructure. This method is called before `IDelayedMessageStore.Initialize()`.
+
 ### Consistency
 
 In `TransactionScope` [transaction mode](/transports/transactions.md), the delayed message store is expected to enlist in the `TransactionScope` to ensure **exactly once** behavior. `FetchNextDueTimeout`, `Remove`, and sending messages to their destination queues are all executed in a single distributed transaction. The built-in SQL Server store supports this mode of operation.

--- a/transports/upgrades/msmq-2to2.0.4.md
+++ b/transports/upgrades/msmq-2to2.0.4.md
@@ -1,0 +1,36 @@
+---
+title: MSMQ Transport Upgrade Version 2 to 2.0.4
+summary: Migration instructions on how to upgrade the MSMQ transport from version 2 to 2.0.4
+reviewed: 2024-06-13
+component: MsmqTransport
+related:
+  - transports/msmq
+  - nservicebus/upgrades/7to8
+isUpgradeGuide: true
+upgradeGuideCoreVersions:
+  - 7
+  - 8
+---
+
+> [!NOTE]
+> If the endpoint being upgraded is not using delayed delivery or is using the `SqlServerDelayedMessageStore` that ships with the MSMQ transport package, no further action is needed. This class has already been updated as part of the release.
+
+Versions 2.0.0-2.0.3 of the transport include support for a custom delayed delivery message store by implementing `IDelayedMessageStore`. This interface contains a method to initialize the store when the endpoint starts. For this method to be called, two configuration options must be set:
+
+- the endpoint must be configured to run installers
+- the transport must be configured to create queues
+
+Version 2.0.4 preserves this behavior for backwards compatability. This can cause a problem in a minimal-access environment when either of the above conditions is not met, as `Initialize()` will not be called.
+
+To enable the endpoint to run in a minimal access environment, a new interface (`IDelayedMessageStoreWithInfrastructure`) has been added. This new interface extends the original `IDelayedMessageStore` interface.
+
+If a custom delayed delivery message store implements `IDelayedMessageStoreWithInfrastructure` then `Initialize()` is always called when the endpoint starts. The new `SetupInfrastructure()` method is only called if the above criteria are met.
+
+If the custom delayed delivery message store is used in an endpoint which meets both criteria above, no action is needed during an upgrade.
+
+If the custom delayed delivery message store is used in an endpoint where one or both of the criteria above are not met, follow this process to update it:
+
+1. Update the reference to the transport package to the latest version 2 release
+2. Update the class definition of the custom delayed delivery message store to use `IDelayedMessageStoreWithInfrastructure` (instead of `IDelayedMessageStore`)
+3. Move any code that creates infrastructure from the `Initialize()` method to the `SetupInfrastructure()` method.
+   - If there is information in the `Initialize()` method which is needed in `SetupInfrastructure()`, it can be stored in fields on the class. `Initialize()` is always called first.


### PR DESCRIPTION
Includes instructions for how to update custom delayed delivery message store implementations.

NOTES:
- The SQL Delayed Delivery Message store included in the package is already updated. If using it, no further action is needed.
- If a custom delayed delivery message store is being used in an endpoint with installers enabled, it is already being initialized. No further action is needed.