### PR TITLE
Update the frequency when the whole site is built

### DIFF
--- a/.github/workflows/build-samples-and-snippets.yml
+++ b/.github/workflows/build-samples-and-snippets.yml
@@ -2,7 +2,7 @@ name: BuildSamplesAndSnippets
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */4 * * 1-5' # Every 4 hours, Monday-Friday
+    - cron: '0 2/4 * * 1-5' # Every 4 hours, Monday-Friday
 env:
   DOTNET_NOLOGO: true
   DOTNET_ROLL_FORWARD: Major


### PR DESCRIPTION
We have discovered that the time frame when we rebuild the doc site happens to coincide with the time that AWS updates their packages, which makes our pipeline fail because it is not able to find the right versions for those packages.
By updating the cron expression we will shift the time it gets trigger and ideally we will be able to prevent those transient errors.