### PR TITLE
Add a reference to AsyncInterfaces

### DIFF
--- a/samples/ravendb/simple/Raven_7/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_7/Server/Server.csproj
@@ -8,5 +8,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
     <PackageReference Include="NServiceBus.RavenDB" Version="7.*" />
     <PackageReference Include="RavenDB.Client" Version="5.*" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This reference is needed for the sample to run when using .NET (7, 8, 9).
The reference isn't needed for the full .NET Framework.