### PR TITLE
Add PeriodicTimer sample

### DIFF
--- a/nservicebus/scheduling/index_content_core_[8,).partial.md
+++ b/nservicebus/scheduling/index_content_core_[8,).partial.md
@@ -1,9 +1,10 @@
 Executing code at various intervals is a common need when building enterprise systems. The following options are available for scheduling:
 
-* A [.NET Timer](https://msdn.microsoft.com/en-us/library/system.threading.timer.aspx).
-* [NServiceBus sagas](/nservicebus/sagas/)
-* [Quartz.NET](https://www.quartz-scheduler.net/). See the [Quartz.NET sample](/samples/scheduling/quartz/).
-* OS task scheduler, like the Windows task scheduler or Linux cron jobs.
-* [Timer trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)
-* [Hangfire](https://www.hangfire.io/). See the [Hangfire sample](/samples/scheduling/hangfire/).
-* [FluentScheduler](https://github.com/fluentscheduler/FluentScheduler). See the [FluentScheduler sample](/samples/scheduling/fluentscheduler/).
+- A [PeriodicTimer](https://learn.microsoft.com/en-us/dotnet/api/system.threading.periodictimer). See the [PeriodicTimer sample](/samples/scheduling/periodictimer/).
+- A [.NET Timer](https://msdn.microsoft.com/en-us/library/system.threading.timer.aspx).
+- [NServiceBus sagas](/nservicebus/sagas/)
+- [Quartz.NET](https://www.quartz-scheduler.net/). See the [Quartz.NET sample](/samples/scheduling/quartz/).
+- OS task scheduler, like the Windows task scheduler or Linux cron jobs.
+- [Timer trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)
+- [Hangfire](https://www.hangfire.io/). See the [Hangfire sample](/samples/scheduling/hangfire/).
+- [FluentScheduler](https://github.com/fluentscheduler/FluentScheduler). See the [FluentScheduler sample](/samples/scheduling/fluentscheduler/).

--- a/samples/scheduling/periodictimer/Core_9/PeriodicTimerScheduler.sln
+++ b/samples/scheduling/periodictimer/Core_9/PeriodicTimerScheduler.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "Scheduler\Scheduler.csproj", "{F1B97158-DCDD-436E-B705-8CE8DCD46087}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scheduler", "Scheduler\Scheduler.csproj", "{F1B97158-DCDD-436E-B705-8CE8DCD46087}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{F17E23FC-B707-450B-8DDB-206304A7C9D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{F17E23FC-B707-450B-8DDB-206304A7C9D4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{2C010FD6-F1DB-439E-8C93-FEFE5424BA30}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Receiver", "Receiver\Receiver.csproj", "{2C010FD6-F1DB-439E-8C93-FEFE5424BA30}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/scheduling/periodictimer/Core_9/PeriodicTimerScheduler.sln
+++ b/samples/scheduling/periodictimer/Core_9/PeriodicTimerScheduler.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scheduler", "Scheduler\Scheduler.csproj", "{F1B97158-DCDD-436E-B705-8CE8DCD46087}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{F17E23FC-B707-450B-8DDB-206304A7C9D4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{2C010FD6-F1DB-439E-8C93-FEFE5424BA30}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F1B97158-DCDD-436E-B705-8CE8DCD46087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1B97158-DCDD-436E-B705-8CE8DCD46087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F17E23FC-B707-450B-8DDB-206304A7C9D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F17E23FC-B707-450B-8DDB-206304A7C9D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C010FD6-F1DB-439E-8C93-FEFE5424BA30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C010FD6-F1DB-439E-8C93-FEFE5424BA30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4F3AC8D5-8221-4ADF-B6E7-CC8B007927A9}
+	EndGlobalSection
+EndGlobal

--- a/samples/scheduling/periodictimer/Core_9/Receiver/MyMessageHandler.cs
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/MyMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 

--- a/samples/scheduling/periodictimer/Core_9/Receiver/MyMessageHandler.cs
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/MyMessageHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+class MyMessageHandler(
+    ILogger<MyMessageHandler> log)
+    : IHandleMessages<MyMessage>
+{
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        log.LogInformation("Hello from MyHandler");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/scheduling/periodictimer/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
@@ -10,17 +9,15 @@ class Program
     {
         Console.Title = "Receiver";
 
-        var host = new HostBuilder()
-            .ConfigureLogging(logging => logging.AddConsole())
-            .UseNServiceBus(_ =>
-            {
-                var endpointConfig = new EndpointConfiguration("Receiver");
-                endpointConfig.UseTransport(new LearningTransport());
-                endpointConfig.UseSerialization<SystemJsonSerializer>();
-                return endpointConfig;
-            })
-            .Build();
+        var builder = Host.CreateApplicationBuilder();
 
+        var endpointConfig = new EndpointConfiguration("Receiver");
+        endpointConfig.UseTransport(new LearningTransport());
+        endpointConfig.UseSerialization<SystemJsonSerializer>();
+
+        builder.UseNServiceBus(endpointConfig);
+
+        var host = builder.Build();
         return host.RunAsync();
     }
 }

--- a/samples/scheduling/periodictimer/Core_9/Receiver/Program.cs
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+class Program
+{
+    static Task Main(string[] args)
+    {
+        Console.Title = "Receiver";
+
+        var host = new HostBuilder()
+            .ConfigureLogging(logging => logging.AddConsole())
+            .UseNServiceBus(_ =>
+            {
+                var endpointConfig = new EndpointConfiguration("Receiver");
+                endpointConfig.UseTransport(new LearningTransport());
+                endpointConfig.UseSerialization<SystemJsonSerializer>();
+                return endpointConfig;
+            })
+            .Build();
+
+        return host.RunAsync();
+    }
+}

--- a/samples/scheduling/periodictimer/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/Receiver.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/scheduling/periodictimer/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/periodictimer/Core_9/Scheduler/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+class Program
+{
+    static Task Main(string[] args)
+    {
+        Console.Title = "Scheduler";
+
+        #region ConfigureHost
+        var host = new HostBuilder()
+            .ConfigureLogging(logging => logging.AddConsole())
+            .UseNServiceBus(_ =>
+            {
+                var endpointConfig = new EndpointConfiguration("Scheduler");
+                endpointConfig.UseTransport(new LearningTransport());
+                endpointConfig.UseSerialization<SystemJsonSerializer>();
+
+                return endpointConfig;
+            })
+            .ConfigureServices(services => services.AddHostedService<SendMessageJob>())
+            .Build();
+        #endregion
+
+        return host.RunAsync();
+    }
+}

--- a/samples/scheduling/periodictimer/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/periodictimer/Core_9/Scheduler/Program.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using NServiceBus;
 
 class Program
@@ -12,20 +11,20 @@ class Program
         Console.Title = "Scheduler";
 
         #region ConfigureHost
-        var host = new HostBuilder()
-            .ConfigureLogging(logging => logging.AddConsole())
-            .UseNServiceBus(_ =>
-            {
-                var endpointConfig = new EndpointConfiguration("Scheduler");
-                endpointConfig.UseTransport(new LearningTransport());
-                endpointConfig.UseSerialization<SystemJsonSerializer>();
 
-                return endpointConfig;
-            })
-            .ConfigureServices(services => services.AddHostedService<SendMessageJob>())
-            .Build();
+        var builder = Host.CreateApplicationBuilder();
+
+        var endpointConfig = new EndpointConfiguration("Scheduler");
+        endpointConfig.UseTransport(new LearningTransport());
+        endpointConfig.UseSerialization<SystemJsonSerializer>();
+
+        builder.UseNServiceBus(endpointConfig);
+
+        builder.Services.AddHostedService<SendMessageJob>();
+
         #endregion
 
+        var host = builder.Build();
         return host.RunAsync();
     }
 }

--- a/samples/scheduling/periodictimer/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Scheduler/Scheduler.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/scheduling/periodictimer/Core_9/Scheduler/SendMessageJob.cs
+++ b/samples/scheduling/periodictimer/Core_9/Scheduler/SendMessageJob.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+#region SendMessageJob
+class SendMessageJob(IMessageSession messageSession) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(3));
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await messageSession.Send("Receiver", new MyMessage(), stoppingToken);
+        }
+    }
+}
+#endregion

--- a/samples/scheduling/periodictimer/Core_9/Shared/MyMessage.cs
+++ b/samples/scheduling/periodictimer/Core_9/Shared/MyMessage.cs
@@ -1,0 +1,7 @@
+﻿
+using NServiceBus;
+
+public class MyMessage
+    : IMessage
+{
+}

--- a/samples/scheduling/periodictimer/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Shared/Shared.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
+  </ItemGroup>
+</Project>

--- a/samples/scheduling/periodictimer/sample.md
+++ b/samples/scheduling/periodictimer/sample.md
@@ -1,0 +1,32 @@
+---
+title: PeriodTimer usage
+summary: Using PeriodicTimer in a BackgroundJob to send messages from within an NServiceBus endpoint.
+reviewed: 2024-06-26
+component: Core
+related:
+  - nservicebus/scheduling
+---
+
+This sample illustrates the use of [`PeriodicTimer`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.periodictimer) to send messages from within an NServiceBus endpoint.
+
+`PeriodicTimer` was introduced in .NET 6 and enables waiting asynchronously for timer ticks.
+
+## Running the project
+
+1.  Start both the Scheduler and Receiver projects.
+1.  At startup, Scheduler will schedule a message send to Receiver every 3 seconds.
+1.  Receiver will handle the message.
+
+## Code Walk-through
+
+### Define the background service
+
+The [`BackgroundService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.backgroundservice) defines the job to be run when the host starts. It sets up a `PeriodicTimer` which will tick every 3 seconds. Every time it ticks, a message using NServiceBus.
+
+snippet: SendMessageJob
+
+### Configure host
+
+The host is configured with NServiceBus and the background service created above. When the host starts, the background service is run and messages will be sent periodically.
+
+snippet: ConfigureHost

--- a/samples/scheduling/periodictimer/sample.md
+++ b/samples/scheduling/periodictimer/sample.md
@@ -21,7 +21,7 @@ This sample illustrates the use of [`PeriodicTimer`](https://learn.microsoft.com
 
 ### Define the background service
 
-The [`BackgroundService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.backgroundservice) defines the job to be run when the host starts. It sets up a `PeriodicTimer` which will tick every 3 seconds. Every time it ticks, a message using NServiceBus.
+The [`BackgroundService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.backgroundservice) defines the job to be run when the host starts. It sets up a `PeriodicTimer` which will tick every 3 seconds. Every time it ticks, a message is sent using NServiceBus.
 
 snippet: SendMessageJob
 


### PR DESCRIPTION
Adds a sample showing how to schedule messages with a [PeriodicTimer](https://learn.microsoft.com/en-us/dotnet/api/system.threading.periodictimer).

It has been deliberately added to the top of the list of options as this is probably the preferred in a modern system.