### PR TITLE
Remove ambiguous mapping rule

### DIFF
--- a/nservicebus/messaging/message-type-detection.md
+++ b/nservicebus/messaging/message-type-detection.md
@@ -18,7 +18,6 @@ The mapping rules are as follows:
 1. If the message contains the [`NServiceBus.EnclosedMessageTypes` header](/nservicebus/messaging/headers.md#serialization-headers-nservicebus-enclosedmessagetypes), the header value is used to find the message type. The header value may contain:
    - The [AssemblyQualifiedName](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname) of the message type (with or without the private key; both are supported). In cases when the assembly qualified type is not known by the endpoint, NServiceBus will fall back to any loaded type that matches the contained FullName, even when the type resides in a different assembly.
    - The [FullName](https://docs.microsoft.com/en-us/dotnet/api/system.type.fullname) of the message type. NServiceBus will map it to any loaded type that matches the specified FullName, even when the type resides in a different assembly.
-   - The Name of the type, without the assembly name.
 1. If the header is missing, some serializers can optionally [infer the message type](/nservicebus/serialization/#security-message-type-inference) based on the message payload. Serializers that support message type inference:
    - [XML](/nservicebus/serialization/xml.md#inferring-message-type-from-root-node-name) via the root node name
    - [JSON.NET](/nservicebus/serialization/newtonsoft.md#inferring-message-type-from-type) via a custom `$type` property


### PR DESCRIPTION
It was actually [discussed a while ago already](https://github.com/Particular/docs.particular.net/pull/6169#discussion_r1284302973) and there was no clear conclusion on how this option would differ from the `FullName`. I ran into this again today, as the wording could make one think that the "name" stands for just the type's name without the namespace (as the fullname option is already mentioned explicitly before), which is not the case (would be nice though...).