### PR TITLE
Fix for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/powershell:1": {}
+		"ghcr.io/devcontainers/features/powershell:1": {
+			"version": "7.4.2"
+		}
 	},
 	"forwardPorts": [
 		55666


### PR DESCRIPTION
Unfortunately, MS latest PS update broke the devcontainers for a lot of people!
This is a workaround for now.

See https://github.com/PowerShell/PowerShell/issues/23975
