### PR TITLE
docs review of hangfire sample

### DIFF
--- a/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Program.cs
@@ -20,7 +20,7 @@ class Program
         EndpointHelper.Instance = endpointInstance;
 
         // use in memory storage. Production should use more robust alternatives:
-        // SqlServer, Msmq, Redis etc
+        // SqlServer, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
 
         GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Program.cs
@@ -20,7 +20,7 @@ class Program
         EndpointHelper.Instance = endpointInstance;
 
         // use in memory storage. Production should use more robust alternatives:
-        // SqlServer, Msmq, Redis etc
+        // SqlServer, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
 
         GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Program.cs
@@ -21,7 +21,7 @@ class Program
         EndpointHelper.Instance = endpointInstance;
 
         // use in memory storage. Production should use more robust alternatives:
-        // SqlServer, Msmq, Redis etc
+        // SqlServer, Redis etc
         GlobalConfiguration.Configuration.UseMemoryStorage();
 
         GlobalConfiguration.Configuration.UseColouredConsoleLogProvider();

--- a/samples/scheduling/hangfire/sample.md
+++ b/samples/scheduling/hangfire/sample.md
@@ -1,10 +1,9 @@
 ---
 title: Hangfire Usage
 summary: Using Hangfire to send messages from within an NServiceBus endpoint.
-reviewed: 2021-07-28
+reviewed: 2024-07-05
 component: Core
 related:
-- nservicebus/messaging/timeout-manager
 - nservicebus/scheduling
 ---
 
@@ -38,7 +37,7 @@ Hangfire also supports Dependency Injection (DI) via the [JobActivator API](http
 
 The endpoint is started, and the `IEndpointInstance` is stored in the static endpoint helper.
 
-This sample uses in-memory storage for the jobs. Production scenarios should use more robust alternatives: SqlServer, MSMQ or Redis.
+This sample uses in-memory storage for the jobs. Production scenarios should use more robust alternatives: e.g. SqlServer or Redis.
 
 Hangfire calls their scheduler a [BackgroundJobServer](https://docs.hangfire.io/en/latest/background-processing/processing-background-jobs.html). It is started automatically when an instance of the `BackgroundJobServer` class is instantiated.
 

--- a/samples/scheduling/scheduler-drawbacks.include.md
+++ b/samples/scheduling/scheduler-drawbacks.include.md
@@ -1,3 +1,4 @@
-
+#if-version [,8)
 > [!NOTE]
 > The approach used in this sample can mitigate some of the architectural drawbacks of the [NServiceBus Scheduler](/nservicebus/scheduling/). The NServiceBus scheduler is built on top of the [Timeout Manager](/nservicebus/messaging/timeout-manager.md) which leverages the queuing system to trigger scheduled actions. Under heavy load there may be some disparity between the expected time of a scheduled action and execution time due to the delay between timeout messages being generated and processed.
+#end-if


### PR DESCRIPTION
remove references to timeout manager for versions where it is no longer supported and msmq