### PR TITLE
include SqlServer message store methods in documentation

### DIFF
--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
@@ -1,0 +1,222 @@
+namespace NServiceBus.Snippets
+{
+    using System;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Factory method for creating SQL Server connections.
+    /// </summary>
+    public delegate Task<SqlConnection> CreateSqlConnection(CancellationToken cancellationToken = default);
+
+    #region dms-without-infrastructure
+    public class DelayedMessageStore : IDelayedMessageStore
+    #endregion
+    {
+        public IDelayedMessageStore _instance;
+        public DelayedMessageStore(string connectionString)
+        {
+            _instance = new DelayedMessageStoreWithInfrastructure(connectionString);
+        }
+
+        public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
+        {
+            return _instance.FetchNextDueTimeout(at, cancellationToken);
+        }
+
+        public Task<bool> IncrementFailureCount(DelayedMessage entity, CancellationToken cancellationToken = default)
+        {
+            return _instance.IncrementFailureCount(entity, cancellationToken);
+        }
+
+        public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+        {
+            return _instance.Initialize(endpointName, transactionMode, cancellationToken);
+        }
+
+        public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+        {
+            return _instance.Next(cancellationToken);
+        }
+
+        public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default)
+        {
+            return _instance.Remove(entity, cancellationToken);
+        }
+
+        public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+        {
+            return _instance.Store(entity, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Implementation of the delayed message store based on the SQL Server.
+    /// </summary>
+    #region dms-with-infrastructure
+    public class DelayedMessageStoreWithInfrastructure : IDelayedMessageStoreWithInfrastructure
+    #endregion
+    {
+        string schema;
+        string tableName;
+        CreateSqlConnection createSqlConnection;
+
+        string quotedFullName;
+        string insertCommand;
+        string removeCommand;
+        string bumpFailureCountCommand;
+        string nextCommand;
+        string fetchCommand;
+
+        /// <summary>
+        /// Creates a new instance of the SQL Server delayed message store.
+        /// </summary>
+        /// <param name="connectionString">Connection string to the SQL Server database.</param>
+        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
+        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
+        public DelayedMessageStoreWithInfrastructure(string connectionString, string schema = null, string tableName = null)
+            : this(token => Task.FromResult(new SqlConnection(connectionString)), schema, tableName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the SQL Server delayed message store.
+        /// </summary>
+        /// <param name="connectionFactory">Factory for database connections.</param>
+        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
+        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
+        public DelayedMessageStoreWithInfrastructure(CreateSqlConnection connectionFactory, string schema = null, string tableName = null)
+        {
+            createSqlConnection = connectionFactory;
+            this.tableName = tableName;
+            this.schema = schema ?? "dbo";
+        }
+
+        /// <inheritdoc />
+        #region dms-store
+        public async Task Store(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken))
+            using (var cmd = new SqlCommand(insertCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                cmd.Parameters.AddWithValue("@destination", timeout.Destination);
+                cmd.Parameters.AddWithValue("@time", timeout.Time);
+                cmd.Parameters.AddWithValue("@headers", timeout.Headers);
+                cmd.Parameters.AddWithValue("@state", timeout.Body);
+                await cn.OpenAsync(cancellationToken);
+                _ = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+        #endregion
+
+
+        /// <inheritdoc />
+        #region dms-remove
+        public async Task<bool> Remove(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken))
+            using (var cmd = new SqlCommand(removeCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                await cn.OpenAsync(cancellationToken);
+                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
+                return affected == 1;
+            }
+        }
+        #endregion
+
+        /// <inheritdoc />
+        #region dms-increment-failure-count
+        public async Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken))
+            using (var cmd = new SqlCommand(bumpFailureCountCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+                await cn.OpenAsync(cancellationToken);
+                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
+                return affected == 1;
+            }
+        }
+        #endregion
+
+        /// <inheritdoc />
+        #region dms-initialise
+        public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+        {
+            if (tableName == null)
+            {
+                tableName = $"{endpointName}.timeouts";
+            }
+
+            quotedFullName = $"{SqlNameHelper.Quote(schema)}.{SqlNameHelper.Quote(tableName)}";
+
+            insertCommand = string.Format(SqlConstants.SqlInsert, quotedFullName);
+            removeCommand = string.Format(SqlConstants.SqlDelete, quotedFullName);
+            bumpFailureCountCommand = string.Format(SqlConstants.SqlUpdate, quotedFullName);
+            nextCommand = string.Format(SqlConstants.SqlGetNext, quotedFullName);
+            fetchCommand = string.Format(SqlConstants.SqlFetch, quotedFullName);
+
+            return Task.CompletedTask;
+        }
+        #endregion
+
+        /// <inheritdoc />
+        #region dms-setup-infrastructure
+        public async Task SetupInfrastructure(CancellationToken cancellationToken = default)
+        {
+            var creator = new TimeoutTableCreator(createSqlConnection, quotedFullName);
+            await creator.CreateIfNecessary(cancellationToken);
+        }
+        #endregion
+
+        /// <inheritdoc />
+        #region dms-next
+        public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+        {
+            using (var cn = await createSqlConnection(cancellationToken))
+            using (var cmd = new SqlCommand(nextCommand, cn))
+            {
+                await cn.OpenAsync(cancellationToken);
+                var result = (DateTime?)await cmd.ExecuteScalarAsync(cancellationToken);
+                return result.HasValue ? (DateTimeOffset?)new DateTimeOffset(result.Value, TimeSpan.Zero) : null;
+            }
+        }
+        #endregion
+
+        /// <inheritdoc />
+        #region dms-fetch-next-duetimeout
+        public async Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
+        {
+            DelayedMessage result = null;
+            using (var cn = await createSqlConnection(cancellationToken))
+            using (var cmd = new SqlCommand(fetchCommand, cn))
+            {
+                cmd.Parameters.AddWithValue("@time", at.UtcDateTime);
+
+                await cn.OpenAsync(cancellationToken);
+                using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow, cancellationToken))
+                {
+                    if (await reader.ReadAsync(cancellationToken))
+                    {
+                        result = new DelayedMessage
+                        {
+                            MessageId = (string)reader[0],
+                            Destination = (string)reader[1],
+                            Time = (DateTime)reader[2],
+                            Headers = (byte[])reader[3],
+                            Body = (byte[])reader[4],
+                            NumberOfRetries = (int)reader[5]
+                        };
+                    }
+                }
+            }
+
+            return result;
+        }
+        #endregion
+    }
+}

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
@@ -53,16 +53,17 @@ public class DelayedMessageStore : IDelayedMessageStore
 public class DelayedMessageStoreWithInfrastructure : IDelayedMessageStoreWithInfrastructure
 #endregion
 {
-    string schema;
-    string tableName;
-    CreateSqlConnection createSqlConnection;
+    private readonly string schema;
+    private readonly CreateSqlConnection createSqlConnection;
 
-    string quotedFullName;
-    string insertCommand;
-    string removeCommand;
-    string bumpFailureCountCommand;
-    string nextCommand;
-    string fetchCommand;
+    private string tableName;
+
+    private string quotedFullName;
+    private string insertCommand;
+    private string removeCommand;
+    private string bumpFailureCountCommand;
+    private string nextCommand;
+    private string fetchCommand;
 
     public DelayedMessageStoreWithInfrastructure(string connectionString, string schema = null, string tableName = null)
         : this(token => Task.FromResult(new SqlConnection(connectionString)), schema, tableName)
@@ -145,8 +146,7 @@ public class DelayedMessageStoreWithInfrastructure : IDelayedMessageStoreWithInf
     #region dms-setup-infrastructure
     public async Task SetupInfrastructure(CancellationToken cancellationToken = default)
     {
-        var creator = new TimeoutTableCreator(createSqlConnection, quotedFullName);
-        await creator.CreateIfNecessary(cancellationToken);
+        await TimeoutTableCreator.CreateIfNecessary(createSqlConnection, quotedFullName, cancellationToken);
     }
     #endregion
 

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/DelayedMessageStore.cs
@@ -1,222 +1,196 @@
-namespace NServiceBus.Snippets
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus;
+
+public delegate Task<SqlConnection> CreateSqlConnection(CancellationToken cancellationToken = default);
+
+#region dms-without-infrastructure
+public class DelayedMessageStore : IDelayedMessageStore
+#endregion
 {
-    using System;
-    using System.Data;
-    using System.Data.SqlClient;
-    using System.Threading;
-    using System.Threading.Tasks;
+    private readonly IDelayedMessageStore instance;
 
-    /// <summary>
-    /// Factory method for creating SQL Server connections.
-    /// </summary>
-    public delegate Task<SqlConnection> CreateSqlConnection(CancellationToken cancellationToken = default);
-
-    #region dms-without-infrastructure
-    public class DelayedMessageStore : IDelayedMessageStore
-    #endregion
+    public DelayedMessageStore(string connectionString)
     {
-        public IDelayedMessageStore _instance;
-        public DelayedMessageStore(string connectionString)
-        {
-            _instance = new DelayedMessageStoreWithInfrastructure(connectionString);
-        }
-
-        public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
-        {
-            return _instance.FetchNextDueTimeout(at, cancellationToken);
-        }
-
-        public Task<bool> IncrementFailureCount(DelayedMessage entity, CancellationToken cancellationToken = default)
-        {
-            return _instance.IncrementFailureCount(entity, cancellationToken);
-        }
-
-        public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
-        {
-            return _instance.Initialize(endpointName, transactionMode, cancellationToken);
-        }
-
-        public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
-        {
-            return _instance.Next(cancellationToken);
-        }
-
-        public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default)
-        {
-            return _instance.Remove(entity, cancellationToken);
-        }
-
-        public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
-        {
-            return _instance.Store(entity, cancellationToken);
-        }
+        instance = new DelayedMessageStoreWithInfrastructure(connectionString);
     }
 
-    /// <summary>
-    /// Implementation of the delayed message store based on the SQL Server.
-    /// </summary>
-    #region dms-with-infrastructure
-    public class DelayedMessageStoreWithInfrastructure : IDelayedMessageStoreWithInfrastructure
-    #endregion
+    public Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
     {
-        string schema;
-        string tableName;
-        CreateSqlConnection createSqlConnection;
+        return instance.FetchNextDueTimeout(at, cancellationToken);
+    }
 
-        string quotedFullName;
-        string insertCommand;
-        string removeCommand;
-        string bumpFailureCountCommand;
-        string nextCommand;
-        string fetchCommand;
+    public Task<bool> IncrementFailureCount(DelayedMessage entity, CancellationToken cancellationToken = default)
+    {
+        return instance.IncrementFailureCount(entity, cancellationToken);
+    }
 
-        /// <summary>
-        /// Creates a new instance of the SQL Server delayed message store.
-        /// </summary>
-        /// <param name="connectionString">Connection string to the SQL Server database.</param>
-        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
-        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
-        public DelayedMessageStoreWithInfrastructure(string connectionString, string schema = null, string tableName = null)
-            : this(token => Task.FromResult(new SqlConnection(connectionString)), schema, tableName)
+    public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+    {
+        return instance.Initialize(endpointName, transactionMode, cancellationToken);
+    }
+
+    public Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+    {
+        return instance.Next(cancellationToken);
+    }
+
+    public Task<bool> Remove(DelayedMessage entity, CancellationToken cancellationToken = default)
+    {
+        return instance.Remove(entity, cancellationToken);
+    }
+
+    public Task Store(DelayedMessage entity, CancellationToken cancellationToken = default)
+    {
+        return instance.Store(entity, cancellationToken);
+    }
+}
+
+#region dms-with-infrastructure
+public class DelayedMessageStoreWithInfrastructure : IDelayedMessageStoreWithInfrastructure
+#endregion
+{
+    string schema;
+    string tableName;
+    CreateSqlConnection createSqlConnection;
+
+    string quotedFullName;
+    string insertCommand;
+    string removeCommand;
+    string bumpFailureCountCommand;
+    string nextCommand;
+    string fetchCommand;
+
+    public DelayedMessageStoreWithInfrastructure(string connectionString, string schema = null, string tableName = null)
+        : this(token => Task.FromResult(new SqlConnection(connectionString)), schema, tableName)
+    {
+    }
+
+    public DelayedMessageStoreWithInfrastructure(CreateSqlConnection connectionFactory, string schema = null, string tableName = null)
+    {
+        createSqlConnection = connectionFactory;
+        this.tableName = tableName;
+        this.schema = schema ?? "dbo";
+    }
+
+    #region dms-store
+    public async Task Store(DelayedMessage timeout, CancellationToken cancellationToken = default)
+    {
+        using (var cn = await createSqlConnection(cancellationToken))
+        using (var cmd = new SqlCommand(insertCommand, cn))
         {
+            cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+            cmd.Parameters.AddWithValue("@destination", timeout.Destination);
+            cmd.Parameters.AddWithValue("@time", timeout.Time);
+            cmd.Parameters.AddWithValue("@headers", timeout.Headers);
+            cmd.Parameters.AddWithValue("@state", timeout.Body);
+            await cn.OpenAsync(cancellationToken);
+            _ = await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+    #endregion
+
+
+    #region dms-remove
+    public async Task<bool> Remove(DelayedMessage timeout, CancellationToken cancellationToken = default)
+    {
+        using (var cn = await createSqlConnection(cancellationToken))
+        using (var cmd = new SqlCommand(removeCommand, cn))
+        {
+            cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+            await cn.OpenAsync(cancellationToken);
+            var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return affected == 1;
+        }
+    }
+    #endregion
+
+    #region dms-increment-failure-count
+    public async Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default)
+    {
+        using (var cn = await createSqlConnection(cancellationToken))
+        using (var cmd = new SqlCommand(bumpFailureCountCommand, cn))
+        {
+            cmd.Parameters.AddWithValue("@id", timeout.MessageId);
+            await cn.OpenAsync(cancellationToken);
+            var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return affected == 1;
+        }
+    }
+    #endregion
+
+    #region dms-initialise
+    public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
+    {
+        if (tableName == null)
+        {
+            tableName = $"{endpointName}.timeouts";
         }
 
-        /// <summary>
-        /// Creates a new instance of the SQL Server delayed message store.
-        /// </summary>
-        /// <param name="connectionFactory">Factory for database connections.</param>
-        /// <param name="schema">(optional) schema to use. Defaults to dbo</param>
-        /// <param name="tableName">(optional) name of the table where delayed messages are stored. Defaults to name of the endpoint with .Delayed suffix.</param>
-        public DelayedMessageStoreWithInfrastructure(CreateSqlConnection connectionFactory, string schema = null, string tableName = null)
-        {
-            createSqlConnection = connectionFactory;
-            this.tableName = tableName;
-            this.schema = schema ?? "dbo";
-        }
+        quotedFullName = $"{SqlNameHelper.Quote(schema)}.{SqlNameHelper.Quote(tableName)}";
 
-        /// <inheritdoc />
-        #region dms-store
-        public async Task Store(DelayedMessage timeout, CancellationToken cancellationToken = default)
+        insertCommand = string.Format(SqlConstants.SqlInsert, quotedFullName);
+        removeCommand = string.Format(SqlConstants.SqlDelete, quotedFullName);
+        bumpFailureCountCommand = string.Format(SqlConstants.SqlUpdate, quotedFullName);
+        nextCommand = string.Format(SqlConstants.SqlGetNext, quotedFullName);
+        fetchCommand = string.Format(SqlConstants.SqlFetch, quotedFullName);
+
+        return Task.CompletedTask;
+    }
+    #endregion
+
+    #region dms-setup-infrastructure
+    public async Task SetupInfrastructure(CancellationToken cancellationToken = default)
+    {
+        var creator = new TimeoutTableCreator(createSqlConnection, quotedFullName);
+        await creator.CreateIfNecessary(cancellationToken);
+    }
+    #endregion
+
+    #region dms-next
+    public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
+    {
+        using (var cn = await createSqlConnection(cancellationToken))
+        using (var cmd = new SqlCommand(nextCommand, cn))
         {
-            using (var cn = await createSqlConnection(cancellationToken))
-            using (var cmd = new SqlCommand(insertCommand, cn))
+            await cn.OpenAsync(cancellationToken);
+            var result = (DateTime?)await cmd.ExecuteScalarAsync(cancellationToken);
+            return result.HasValue ? (DateTimeOffset?)new DateTimeOffset(result.Value, TimeSpan.Zero) : null;
+        }
+    }
+    #endregion
+
+    #region dms-fetch-next-duetimeout
+    public async Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
+    {
+        DelayedMessage result = null;
+        using (var cn = await createSqlConnection(cancellationToken))
+        using (var cmd = new SqlCommand(fetchCommand, cn))
+        {
+            cmd.Parameters.AddWithValue("@time", at.UtcDateTime);
+
+            await cn.OpenAsync(cancellationToken);
+            using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow, cancellationToken))
             {
-                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
-                cmd.Parameters.AddWithValue("@destination", timeout.Destination);
-                cmd.Parameters.AddWithValue("@time", timeout.Time);
-                cmd.Parameters.AddWithValue("@headers", timeout.Headers);
-                cmd.Parameters.AddWithValue("@state", timeout.Body);
-                await cn.OpenAsync(cancellationToken);
-                _ = await cmd.ExecuteNonQueryAsync(cancellationToken);
-            }
-        }
-        #endregion
-
-
-        /// <inheritdoc />
-        #region dms-remove
-        public async Task<bool> Remove(DelayedMessage timeout, CancellationToken cancellationToken = default)
-        {
-            using (var cn = await createSqlConnection(cancellationToken))
-            using (var cmd = new SqlCommand(removeCommand, cn))
-            {
-                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
-                await cn.OpenAsync(cancellationToken);
-                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
-                return affected == 1;
-            }
-        }
-        #endregion
-
-        /// <inheritdoc />
-        #region dms-increment-failure-count
-        public async Task<bool> IncrementFailureCount(DelayedMessage timeout, CancellationToken cancellationToken = default)
-        {
-            using (var cn = await createSqlConnection(cancellationToken))
-            using (var cmd = new SqlCommand(bumpFailureCountCommand, cn))
-            {
-                cmd.Parameters.AddWithValue("@id", timeout.MessageId);
-                await cn.OpenAsync(cancellationToken);
-                var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
-                return affected == 1;
-            }
-        }
-        #endregion
-
-        /// <inheritdoc />
-        #region dms-initialise
-        public Task Initialize(string endpointName, TransportTransactionMode transactionMode, CancellationToken cancellationToken = default)
-        {
-            if (tableName == null)
-            {
-                tableName = $"{endpointName}.timeouts";
-            }
-
-            quotedFullName = $"{SqlNameHelper.Quote(schema)}.{SqlNameHelper.Quote(tableName)}";
-
-            insertCommand = string.Format(SqlConstants.SqlInsert, quotedFullName);
-            removeCommand = string.Format(SqlConstants.SqlDelete, quotedFullName);
-            bumpFailureCountCommand = string.Format(SqlConstants.SqlUpdate, quotedFullName);
-            nextCommand = string.Format(SqlConstants.SqlGetNext, quotedFullName);
-            fetchCommand = string.Format(SqlConstants.SqlFetch, quotedFullName);
-
-            return Task.CompletedTask;
-        }
-        #endregion
-
-        /// <inheritdoc />
-        #region dms-setup-infrastructure
-        public async Task SetupInfrastructure(CancellationToken cancellationToken = default)
-        {
-            var creator = new TimeoutTableCreator(createSqlConnection, quotedFullName);
-            await creator.CreateIfNecessary(cancellationToken);
-        }
-        #endregion
-
-        /// <inheritdoc />
-        #region dms-next
-        public async Task<DateTimeOffset?> Next(CancellationToken cancellationToken = default)
-        {
-            using (var cn = await createSqlConnection(cancellationToken))
-            using (var cmd = new SqlCommand(nextCommand, cn))
-            {
-                await cn.OpenAsync(cancellationToken);
-                var result = (DateTime?)await cmd.ExecuteScalarAsync(cancellationToken);
-                return result.HasValue ? (DateTimeOffset?)new DateTimeOffset(result.Value, TimeSpan.Zero) : null;
-            }
-        }
-        #endregion
-
-        /// <inheritdoc />
-        #region dms-fetch-next-duetimeout
-        public async Task<DelayedMessage> FetchNextDueTimeout(DateTimeOffset at, CancellationToken cancellationToken = default)
-        {
-            DelayedMessage result = null;
-            using (var cn = await createSqlConnection(cancellationToken))
-            using (var cmd = new SqlCommand(fetchCommand, cn))
-            {
-                cmd.Parameters.AddWithValue("@time", at.UtcDateTime);
-
-                await cn.OpenAsync(cancellationToken);
-                using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow, cancellationToken))
+                if (await reader.ReadAsync(cancellationToken))
                 {
-                    if (await reader.ReadAsync(cancellationToken))
+                    result = new DelayedMessage
                     {
-                        result = new DelayedMessage
-                        {
-                            MessageId = (string)reader[0],
-                            Destination = (string)reader[1],
-                            Time = (DateTime)reader[2],
-                            Headers = (byte[])reader[3],
-                            Body = (byte[])reader[4],
-                            NumberOfRetries = (int)reader[5]
-                        };
-                    }
+                        MessageId = (string)reader[0],
+                        Destination = (string)reader[1],
+                        Time = (DateTime)reader[2],
+                        Headers = (byte[])reader[3],
+                        Body = (byte[])reader[4],
+                        NumberOfRetries = (int)reader[5]
+                    };
                 }
             }
-
-            return result;
         }
-        #endregion
+
+        return result;
     }
+    #endregion
 }

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlConstants.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlConstants.cs
@@ -1,16 +1,14 @@
-namespace NServiceBus.Snippets
+static class SqlConstants
 {
-    class SqlConstants
-    {
-        #region dms-sql-crud
-        public const string SqlInsert = "INSERT INTO {0} (Id, Destination, Time, Headers, State) VALUES (@id, @destination, @time, @headers, @state);";
-        public const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY Time";
-        public const string SqlDelete = "DELETE {0} WHERE Id = @id";
-        public const string SqlUpdate = "UPDATE {0} SET RetryCount = RetryCount + 1 WHERE Id = @id";
-        public const string SqlGetNext = "SELECT TOP 1 Time FROM {0} ORDER BY Time";
-        #endregion
-        #region dms-sql-create-table
-        public const string SqlCreateTable = @"
+    #region dms-sql-crud
+    public const string SqlInsert = "INSERT INTO {0} (Id, Destination, Time, Headers, State) VALUES (@id, @destination, @time, @headers, @state);";
+    public const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY Time";
+    public const string SqlDelete = "DELETE {0} WHERE Id = @id";
+    public const string SqlUpdate = "UPDATE {0} SET RetryCount = RetryCount + 1 WHERE Id = @id";
+    public const string SqlGetNext = "SELECT TOP 1 Time FROM {0} ORDER BY Time";
+    #endregion
+    #region dms-sql-create-table
+    public const string SqlCreateTable = @"
 if not exists (
     select * from sys.objects
     where
@@ -40,6 +38,5 @@ begin
     create index Index_Time on {0} (Time);
 end
 ";
-        #endregion
-    }
+    #endregion
 }

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlConstants.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlConstants.cs
@@ -1,0 +1,45 @@
+namespace NServiceBus.Snippets
+{
+    class SqlConstants
+    {
+        #region dms-sql-crud
+        public const string SqlInsert = "INSERT INTO {0} (Id, Destination, Time, Headers, State) VALUES (@id, @destination, @time, @headers, @state);";
+        public const string SqlFetch = "SELECT TOP 1 Id, Destination, Time, Headers, State, RetryCount FROM {0} WITH (READPAST, UPDLOCK, ROWLOCK) WHERE Time < @time ORDER BY Time";
+        public const string SqlDelete = "DELETE {0} WHERE Id = @id";
+        public const string SqlUpdate = "UPDATE {0} SET RetryCount = RetryCount + 1 WHERE Id = @id";
+        public const string SqlGetNext = "SELECT TOP 1 Time FROM {0} ORDER BY Time";
+        #endregion
+        #region dms-sql-create-table
+        public const string SqlCreateTable = @"
+if not exists (
+    select * from sys.objects
+    where
+        object_id = object_id('{0}')
+        and type in ('U')
+)
+begin
+    create table {0} (
+ 	    Id nvarchar(250) not null primary key,
+        Destination nvarchar(200),
+        State varbinary(max),
+        Time datetime,
+        Headers varbinary(max) not null,
+        RetryCount INT NOT NULL default(0)
+        )
+end
+
+if not exists
+(
+    select *
+    from sys.indexes
+    where
+        name = 'Index_Time' and
+        object_id = object_id('{0}')
+)
+begin
+    create index Index_Time on {0} (Time);
+end
+";
+        #endregion
+    }
+}

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlNameHelper.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlNameHelper.cs
@@ -1,33 +1,26 @@
-namespace NServiceBus.Snippets
+static class SqlNameHelper
 {
-    class SqlNameHelper
+    const string Prefix = "[";
+    const string Suffix = "]";
+
+    public static string Quote(string unquotedName)
     {
-        const string Prefix = "[";
-        const string Suffix = "]";
+        return unquotedName == null ? null : $"{Prefix}{unquotedName.Replace(Suffix, Suffix + Suffix)}{Suffix}";
+    }
 
-        public static string Quote(string unquotedName)
+    public static string Unquote(string quotedString)
+    {
+        if (quotedString == null)
         {
-            if (unquotedName == null)
-            {
-                return null;
-            }
-            return Prefix + unquotedName.Replace(Suffix, Suffix + Suffix) + Suffix;
+            return null;
         }
 
-        public static string Unquote(string quotedString)
+        if (!quotedString.StartsWith(Prefix) || !quotedString.EndsWith(Suffix))
         {
-            if (quotedString == null)
-            {
-                return null;
-            }
-
-            if (!quotedString.StartsWith(Prefix) || !quotedString.EndsWith(Suffix))
-            {
-                return quotedString;
-            }
-
-            return quotedString
-                .Substring(Prefix.Length, quotedString.Length - Prefix.Length - Suffix.Length).Replace(Suffix + Suffix, Suffix);
+            return quotedString;
         }
+
+        return quotedString
+            .Substring(Prefix.Length, quotedString.Length - Prefix.Length - Suffix.Length).Replace(Suffix + Suffix, Suffix);
     }
 }

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlNameHelper.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/SqlNameHelper.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus.Snippets
+{
+    class SqlNameHelper
+    {
+        const string Prefix = "[";
+        const string Suffix = "]";
+
+        public static string Quote(string unquotedName)
+        {
+            if (unquotedName == null)
+            {
+                return null;
+            }
+            return Prefix + unquotedName.Replace(Suffix, Suffix + Suffix) + Suffix;
+        }
+
+        public static string Unquote(string quotedString)
+        {
+            if (quotedString == null)
+            {
+                return null;
+            }
+
+            if (!quotedString.StartsWith(Prefix) || !quotedString.EndsWith(Suffix))
+            {
+                return quotedString;
+            }
+
+            return quotedString
+                .Substring(Prefix.Length, quotedString.Length - Prefix.Length - Suffix.Length).Replace(Suffix + Suffix, Suffix);
+        }
+    }
+}

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
@@ -2,18 +2,9 @@ using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 
-class TimeoutTableCreator
+static class TimeoutTableCreator
 {
-    private readonly CreateSqlConnection createSqlConnection;
-    private readonly string tableName;
-
-    public TimeoutTableCreator(CreateSqlConnection createSqlConnection, string tableName)
-    {
-        this.tableName = tableName;
-        this.createSqlConnection = createSqlConnection;
-    }
-
-    public async Task CreateIfNecessary(CancellationToken cancellationToken = default)
+    public static async Task CreateIfNecessary(CreateSqlConnection createSqlConnection, string tableName, CancellationToken cancellationToken = default)
     {
         var sql = string.Format(SqlConstants.SqlCreateTable, tableName);
         using (var connection = await createSqlConnection(cancellationToken))

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus.Snippets
+{
+    using System.Data.SqlClient;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class TimeoutTableCreator
+    {
+        public TimeoutTableCreator(CreateSqlConnection createSqlConnection, string tableName)
+        {
+            this.tableName = tableName;
+            this.createSqlConnection = createSqlConnection;
+        }
+
+        public async Task CreateIfNecessary(CancellationToken cancellationToken = default)
+        {
+            var sql = string.Format(SqlConstants.SqlCreateTable, tableName);
+            using (var connection = await createSqlConnection(cancellationToken))
+            {
+                await connection.OpenAsync(cancellationToken);
+                await Execute(sql, connection, cancellationToken);
+            }
+        }
+
+        static async Task Execute(string sql, SqlConnection connection, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using (var command = new SqlCommand(sql, connection, transaction))
+                    {
+                        await command.ExecuteNonQueryAsync(cancellationToken);
+                    }
+                    transaction.Commit();
+                }
+            }
+            catch (SqlException e) when (e.Number == 2714 || e.Number == 1913) //Object already exists
+            {
+                //Table creation scripts are based on sys.objects metadata views.
+                //It looks that these views are not fully transactional and might
+                //not return information on already created table under heavy load.
+                //This in turn can result in executing table create or index create queries
+                //for objects that already exists. These queries will fail with
+                // 2714 (table) and 1913 (index) error codes.
+            }
+        }
+
+        CreateSqlConnection createSqlConnection;
+        string tableName;
+    }
+}

--- a/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/SqlStore/TimeoutTableCreator.cs
@@ -1,52 +1,49 @@
-namespace NServiceBus.Snippets
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+
+class TimeoutTableCreator
 {
-    using System.Data.SqlClient;
-    using System.Threading;
-    using System.Threading.Tasks;
+    private readonly CreateSqlConnection createSqlConnection;
+    private readonly string tableName;
 
-    class TimeoutTableCreator
+    public TimeoutTableCreator(CreateSqlConnection createSqlConnection, string tableName)
     {
-        public TimeoutTableCreator(CreateSqlConnection createSqlConnection, string tableName)
-        {
-            this.tableName = tableName;
-            this.createSqlConnection = createSqlConnection;
-        }
+        this.tableName = tableName;
+        this.createSqlConnection = createSqlConnection;
+    }
 
-        public async Task CreateIfNecessary(CancellationToken cancellationToken = default)
+    public async Task CreateIfNecessary(CancellationToken cancellationToken = default)
+    {
+        var sql = string.Format(SqlConstants.SqlCreateTable, tableName);
+        using (var connection = await createSqlConnection(cancellationToken))
         {
-            var sql = string.Format(SqlConstants.SqlCreateTable, tableName);
-            using (var connection = await createSqlConnection(cancellationToken))
-            {
-                await connection.OpenAsync(cancellationToken);
-                await Execute(sql, connection, cancellationToken);
-            }
+            await connection.OpenAsync(cancellationToken);
+            await Execute(sql, connection, cancellationToken);
         }
+    }
 
-        static async Task Execute(string sql, SqlConnection connection, CancellationToken cancellationToken)
+    static async Task Execute(string sql, SqlConnection connection, CancellationToken cancellationToken)
+    {
+        try
         {
-            try
+            using (var transaction = connection.BeginTransaction())
             {
-                using (var transaction = connection.BeginTransaction())
+                using (var command = new SqlCommand(sql, connection, transaction))
                 {
-                    using (var command = new SqlCommand(sql, connection, transaction))
-                    {
-                        await command.ExecuteNonQueryAsync(cancellationToken);
-                    }
-                    transaction.Commit();
+                    await command.ExecuteNonQueryAsync(cancellationToken);
                 }
-            }
-            catch (SqlException e) when (e.Number == 2714 || e.Number == 1913) //Object already exists
-            {
-                //Table creation scripts are based on sys.objects metadata views.
-                //It looks that these views are not fully transactional and might
-                //not return information on already created table under heavy load.
-                //This in turn can result in executing table create or index create queries
-                //for objects that already exists. These queries will fail with
-                // 2714 (table) and 1913 (index) error codes.
+                transaction.Commit();
             }
         }
-
-        CreateSqlConnection createSqlConnection;
-        string tableName;
+        catch (SqlException e) when (e.Number == 2714 || e.Number == 1913) //Object already exists
+        {
+            //Table creation scripts are based on sys.objects metadata views.
+            //It looks that these views are not fully transactional and might
+            //not return information on already created table under heavy load.
+            //This in turn can result in executing table create or index create queries
+            //for objects that already exists. These queries will fail with
+            // 2714 (table) and 1913 (index) error codes.
+        }
     }
 }


### PR DESCRIPTION
Since `SqlServerDelayedMessageStore` only exists on the 2.0 release branch of the MSMQ transport, and not on master, it is not easily found by people trying to implement custom stores. This change adds the logic from `SqlServerDelayedMessageStore` to the delayed messages documentation for visibility