### PR TITLE
Add missing permissions on AmazonSQS Transport

### DIFF
--- a/transports/sqs/index.md
+++ b/transports/sqs/index.md
@@ -2,7 +2,7 @@
 title: Amazon SQS Transport
 summary: A transport for Amazon Web Services Simple Queue Service.
 component: SQS
-reviewed: 2023-02-10
+reviewed: 2024-07-11
 related:
  - samples/aws/sqs-simple
 redirects:
@@ -30,7 +30,7 @@ partial: transport-at-a-glance
 
 An [AWS IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html) account with a pair of [Access Keys](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-getting-started.html) is required.
 
-The IAM account requires the following permissions:
+The IAM account requires the following permissions to provision infrastructure and run the transport:
 
 #### [SQS permissions](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html)
 

--- a/transports/sqs/index_sns-permissions_sqs_[5,).partial.md
+++ b/transports/sqs/index_sns-permissions_sqs_[5,).partial.md
@@ -2,9 +2,14 @@
 
  * CreateTopic
  * ListTopics
- * Unsubscribe
+ * GetTopicAttributes
+ * SetTopicAttributes
  * SetEndpointAttributes
+ * Publish
+ * Subscribe
+ * Unsubscribe
  * ListSubscriptions
+ * ListSubscriptionsByTopic
  * GetSubscriptionAttributes
  * SetSubscriptionAttributes
 


### PR DESCRIPTION
Improving documentation based on feedback given on our support case