### PR TITLE
editorial review of PostgreSQL transport docs

### DIFF
--- a/persistence/sql/postgresql-combining-persistence-with-transport.md
+++ b/persistence/sql/postgresql-combining-persistence-with-transport.md
@@ -7,28 +7,24 @@ related:
   - transports/postgresql
 ---
 
-## Connection behavior
+When [SQL persistence using the PostgreSQL dialect](/persistence/sql/dialect-postgresql.md) is used in combination with the [PostgreSQL transport](/transports/postgresql), the location of saga data depends on whether the [outbox](/nservicebus/outbox/) is enabled and the transaction mode.
 
-When combining [PostgreSQL](/transports/postgresql) and [SQL persistence using the PostgreSQL dialect](/persistence/sql/dialect-postgresql.md), the connection behaves differently based on whether the [Outbox](/nservicebus/outbox/) is enabled or disabled. This influences where the saga data is stored.
+## Outbox disabled
 
-### Without Outbox
-
-PostgreSQL Transport<br/>TransactionMode | Connection sharing | Saga location
+PostgreSQL Transport<br/>TransactionMode | Connection sharing | Saga data location
 :-:|:-:|:-:
 SendsAtomicWithReceive | PostgreSQL Transport uses isolated transaction for send and receive | Transport DB
 ReceiveOnly | PostgreSQL Transport uses isolated transaction for receive | Transport DB
 None | No transactions | Persistence DB
 
-#### Explicitly opting out of connection sharing when not using the Outbox
-
-When an endpoint uses PostgreSQL Persistence combined with the PostgreSQL Transport with [Outbox](/nservicebus/outbox/) disabled, the persistence uses the connection and transaction context established by the transport when accessing saga data. This behavior ensures *exactly-once* message processing behavior as the state change of the saga is committed atomically while consuming the message that triggered it.
+When the outbox is disabled, the persistence uses the connection and transaction context established by the transport when accessing saga data. This behavior ensures *exactly-once* message processing, as the state change of a saga is committed atomically with the consumption of the message that caused it.
 
 partial: Connection
 
-### With Outbox
+## Outbox enabled
 
-PostgreSQL Transport<br/>TransactionMode | Connection sharing | Saga location
+PostgreSQL Transport<br/>TransactionMode | Connection sharing | Saga data location
 :-:|:-:|:-:
 SendsAtomicWithReceive | Not supported | N/A
-ReceiveOnly | Connection sharing via PostgreSQL Transport storage context | Persistence DB
+ReceiveOnly | via PostgreSQL Transport storage context | Persistence DB
 None | Not supported | N/A

--- a/persistence/sql/postgresql-combining-persistence-with-transport_connection_sqlpersistence_[8,).partial.md
+++ b/persistence/sql/postgresql-combining-persistence-with-transport_connection_sqlpersistence_[8,).partial.md
@@ -1,4 +1,4 @@
-When using the [outbox](/nservicebus/outbox/), SQL Persistence always opens its own connection. In order to force using a separate connection even when the [outbox](/nservicebus/outbox/) is disabled, use the following API:
+This behaviour may be disabled, to force the persistance to create its own connection, as it does when the outbox is enabled:
 
 snippet: PostgreSqlDoNotShareConnection
 

--- a/samples/postgresqltransport/simple/sample.md
+++ b/samples/postgresqltransport/simple/sample.md
@@ -9,7 +9,7 @@ related:
 
 ## Prerequisites
 
-The uses a database `nservicebus`. Ensure it exists before running the sample.
+This sample uses a database named `nservicebus`. Ensure it exists before running the sample.
 
 ## Running the sample
 

--- a/transports/postgresql/addressing.md
+++ b/transports/postgresql/addressing.md
@@ -7,23 +7,25 @@ component: PostgreSqlTransport
 
 ## Format
 
-The PostgreSQL Transport address canonical form is a schema-qualified quoted identifier:
+The canonical form of a PostgreSQL transport address is a schema-qualified quoted identifier:
 
-```
+```text
 ""table"".""schema""
 ```
 
+Only the table name is mandatory. An address containing only a table name is a valid address, e.g. `MyTable`.
+
 ## Resolution
 
-The address is resolved into a fully-qualified table name that includes the table name and its schema. In the address, the table name is the only mandatory part. An address containing only a table name is a valid address, e.g. `MyTable`.
+The address is resolved into a fully-qualified table name that includes the table name and its schema.
 
 ### Schema
 
-The PostgreSQL transport needs to know what schema to use for a queue table when sending messages. The following API can be used to specify the schema for an endpoint when [routing](/nservicebus/messaging/routing.md) is used to find a destination queue table for a message:
+The transport needs to determine which schema to use for a queue table when sending messages. The following API is used to set the schema for an endpoint when [routing](/nservicebus/messaging/routing.md) is used to determine the destination queue for a message:
 
 snippet: postgresql-multischema-config-for-endpoint
 
-There are several cases when routing is not used and the transport needs specific configuration to find out the schema for a queue table:
+There are several cases when routing is not used and the transport requires specific configuration to determine the schema for a queue table:
 
 - [Error queue](/nservicebus/recoverability/configure-error-handling.md#configure-the-error-queue-address)
 - [Audit queue](/nservicebus/operations/auditing.md#configuring-auditing)
@@ -32,21 +34,20 @@ There are several cases when routing is not used and the transport needs specifi
   - [Custom Checks plugin](/monitoring/custom-checks/install-plugin.md)
 - [Overriding the default routing mechanism](/nservicebus/messaging/send-a-message.md#overriding-the-default-routing)
 
-Use the following API to configure the schema for a queue:
+The following API is used to set the schema for a queue:
 
 snippet: postgresql-multischema-config-for-queue
 
-The configuration above is applicable when sending to a queue or when a queue is passed in the configuration:
+The specified schema is used both when sending to a specific queue, and when a queue is set in endpoint configuration:
 
 snippet: postgresql-multischema-config-for-queue-send
 
 snippet: postgresql-multischema-config-for-queue-error
 
-The entire algorithm for calculating the schema is the following:
+The following algorithm is used to determine the schema:
 
-* If the schema is configured for a given queue via `UseSchemaForQueue`, the configured value is used.
-* If [logical routing](/nservicebus/messaging/routing.md#command-routing) is used and schema is configured for a given endpoint via `UseSchemaForEndpoint`, the configured schema is used.
-* If destination address contains a schema, the schema from address is used.
-* If default schema is configured via `DefaultSchema`, the configured value is used.
-* Otherwise, `public` is used as a default schema.
-
+- If the schema is set for a given queue using `UseSchemaForQueue`, that schema is used.
+- If [logical routing](/nservicebus/messaging/routing.md#command-routing) is used and the schema is set for a given endpoint using `UseSchemaForEndpoint`, that schema is used.
+- If the destination address contains a schema, that schema is used.
+- If a default schema is set using `DefaultSchema`, that schema is used.
+- Otherwise, the default schema `public` is used.


### PR DESCRIPTION
relates to https://github.com/Particular/docs.particular.net/pull/6595

I worked through the files in the order they are listed in https://github.com/Particular/docs.particular.net/pull/6595/files, and I managed to get half way through editing `transports/postgresql/addressing.md` before stopping and putting this aside for later.