### PR TITLE
Update compatibility information for RabbitMQ transport

### DIFF
--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[7,).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[7,).partial.md
@@ -5,4 +5,4 @@ The `stream_queue` and `quorum_queue` [feature flags](https://www.rabbitmq.com/f
 The broker requirements can be verified with the [`delays verify`](operations-scripting.md#delays-verify) command provided by the command line tool.
 
 > [!WARNING]
-> Running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) is not supported because [it does not support quorum queues or streams](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/best-practices-rabbitmq.html).
+> Running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) is not supported because [it does not support streams](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/best-practices-rabbitmq.html).


### PR DESCRIPTION
Amazon MQ now supports quorum queues. See https://aws.amazon.com/about-aws/whats-new/2024/07/amazon-mq-quorum-queues-rabbitmq-3-13/