### PR TITLE
Message Contract Guidance Improvements

### DIFF
--- a/nservicebus/messaging/messages-as-interfaces.md
+++ b/nservicebus/messaging/messages-as-interfaces.md
@@ -10,9 +10,7 @@ redirects:
 - nservicebus/messaging/interfaces-as-messages
 ---
 
-Events can be created on the fly from interfaces without first defining an explicit class implementing the interfaces. This technique can be used to support multiple inheritance for [polymorphic routing scenarios](./dynamic-dispatch-and-routing.md). In general, it is recommended to use [simple dedicated types](
-/nservicebus/messaging/messages-events-commands.md
-) as messages instead.
+Events can be created on the fly from interfaces without first defining an explicit class implementing the interfaces. This technique can be used to support multiple inheritance for [polymorphic routing scenarios](./dynamic-dispatch-and-routing.md). In general, it is recommended to use [dedicated, simple types](/nservicebus/messaging/messages-events-commands.md) as messages instead.
 
 ## Sending interface messages
 

--- a/nservicebus/messaging/messages-as-interfaces.md
+++ b/nservicebus/messaging/messages-as-interfaces.md
@@ -10,7 +10,9 @@ redirects:
 - nservicebus/messaging/interfaces-as-messages
 ---
 
-Events can be created on the fly from interfaces without first defining an explicit class implementing the interfaces. This is a useful technique to support multiple inheritance for [polymorphic routing scenarios](./dynamic-dispatch-and-routing.md) to make systems more resilient and maintainable over time.
+Events can be created on the fly from interfaces without first defining an explicit class implementing the interfaces. This technique can be used to support multiple inheritance for [polymorphic routing scenarios](./dynamic-dispatch-and-routing.md). In general, it is recommended to use [simple dedicated types](
+/nservicebus/messaging/messages-events-commands.md
+) as messages instead.
 
 ## Sending interface messages
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -60,7 +60,7 @@ Messages should:
 
 Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is recommended to use dedicated, simple types for each message.
 
-Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md). It may also be beneficial to [use them as interfaces](messages-as-interfaces.md).
+Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md).
 
 By following these guidelines message types are generally more compatible with [various serializers](nservicebus/serialization) and tend to be more evolvable over time.
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -62,7 +62,7 @@ Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is reco
 
 Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md).
 
-By following these guidelines message types are generally more compatible with [various serializers](nservicebus/serialization) and tend to be more evolvable over time.
+By following these guidelines message types are generally more compatible with [various serializers](/nservicebus/serialization) and tend to be more evolvable over time.
 
 ## Identifying messages
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -53,8 +53,7 @@ Messages should:
 * Be as small as possible
 * Satisfy the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle)
 * Favour simplicity and if necessary redundancy over object oriented practices like inheritance
-
-Types used for other purposes (e.g., domain objects, data access objects, or UI binding objects) should not be used as messages.
+* Avoid using types used for other purposes (e.g., domain objects, data access objects, or UI binding objects)
 
 > [!NOTE]
 > Prior to NServiceBus version 7.2, messages had to be defined as a `class`. Defining them as a `struct` would result in a runtime exception.

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -52,6 +52,7 @@ Messages should:
 * Be simple [POCO](https://en.wikipedia.org/wiki/Plain_old_CLR_object) types
 * Be as small as possible
 * Satisfy the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle)
+* Favour simplicity and if necessary redundancy over object oriented practices like inheritance
 
 Types used for other purposes (e.g., domain objects, data access objects, or UI binding objects) should not be used as messages.
 
@@ -59,6 +60,8 @@ Types used for other purposes (e.g., domain objects, data access objects, or UI 
 > Prior to NServiceBus version 7.2, messages had to be defined as a `class`. Defining them as a `struct` would result in a runtime exception.
 
 Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is recommended to use dedicated, simple types for each message.
+
+By following these guidelines message types are generally more compatible with [various serializers](nservicebus/serialization) and tend to be more evolvable over time.
 
 Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md). It may also be beneficial to [use them as interfaces](messages-as-interfaces.md).
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -58,7 +58,7 @@ Types used for other purposes (e.g., domain objects, data access objects, or UI 
 > [!NOTE]
 > Prior to NServiceBus version 7.2, messages had to be defined as a `class`. Defining them as a `struct` would result in a runtime exception.
 
-Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is recommended to use dedicated, simple types for each message or to use inheritance to reuse shared message characteristics.
+Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is recommended to use dedicated, simple types for each message.
 
 Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md). It may also be beneficial to [use them as interfaces](messages-as-interfaces.md).
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -60,9 +60,9 @@ Messages should:
 
 Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is recommended to use dedicated, simple types for each message.
 
-By following these guidelines message types are generally more compatible with [various serializers](nservicebus/serialization) and tend to be more evolvable over time.
-
 Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md). It may also be beneficial to [use them as interfaces](messages-as-interfaces.md).
+
+By following these guidelines message types are generally more compatible with [various serializers](nservicebus/serialization) and tend to be more evolvable over time.
 
 ## Identifying messages
 

--- a/nservicebus/messaging/messages-events-commands.md
+++ b/nservicebus/messaging/messages-events-commands.md
@@ -52,8 +52,8 @@ Messages should:
 * Be simple [POCO](https://en.wikipedia.org/wiki/Plain_old_CLR_object) types
 * Be as small as possible
 * Satisfy the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle)
-* Favour simplicity and if necessary redundancy over object oriented practices like inheritance
-* Avoid using types used for other purposes (e.g., domain objects, data access objects, or UI binding objects)
+* Favor simplicity and redundancy over object-oriented practices like inheritance
+* Not be re-used for other purposes (e.g., domain objects, data access objects, or UI binding objects)
 
 > [!NOTE]
 > Prior to NServiceBus version 7.2, messages had to be defined as a `class`. Defining them as a `struct` would result in a runtime exception.
@@ -62,7 +62,7 @@ Generic message definitions (e.g., `MyMessage<T>`) are not supported. It is reco
 
 Messages define the data contracts between endpoints. More details are available in the [sharing message contracts documentation](sharing-contracts.md).
 
-By following these guidelines message types are generally more compatible with [various serializers](/nservicebus/serialization) and tend to be more evolvable over time.
+By following these guidelines, message types are generally more compatible with [serializers](/nservicebus/serialization) and tend to be more evolvable over time.
 
 ## Identifying messages
 


### PR DESCRIPTION
This PR improves the message contract guidance by:

- De-emphasizing the importance of interface as messages since they require complicated runtime type generation and are rarely ever beneficial
- Remove the hint to apply "inheritance" and hints at messages should rather be straightforward "flat" types, and it is perfectly fine to relax a bit the object-oriented thinking there because then you get contracts that are way easier to evolve.