### PR TITLE
Use lower version of Microsoft.Azure.Functions.Worker.ApplicationInsights

### DIFF
--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -18,7 +18,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.*" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.*" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.*" />
+    <!--
+      Dependency on 1.2.* as 1.3.0 currently has a dependency on  Microsoft.Azure.Functions.Worker v1.19.0 which does
+      not yet exist in Nuget
+    -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.*" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.*" />
     <!--
-      Dependency on 1.2.* as 1.3.0 currently has a dependency on  Microsoft.Azure.Functions.Worker v1.19.0 which does
+      Dependency on 1.2.* as 1.3.0 currently has a dependency on  Microsoft.Azure.Functions.Worker.Core v1.19.0 which does
       not yet exist in Nuget
     -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.*" />


### PR DESCRIPTION
Prevents nuget error as a version 1.19.0 of Microsoft.Azure.Functions.Worker.Core does not exist on nuget yet