### PR TITLE
Remove net7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Samples can be targeted to multiple [target frameworks](https://docs.microsoft.c
 When multi-targeting samples for NServiceBus 8 and earlier, The recommended set of frameworks is:
 
 ```xml
-<TargetFrameworks>net7.0;net6.0;net48</TargetFrameworks>
+<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 ```
 
 For NServiceBus 9, samples can't currently be multi-targeted, so they should be singled targeted:

--- a/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
+++ b/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Persistence.DynamoDB" Version="1.0.0" />
-    <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
+    <PackageReference Include="NServiceBus.Persistence.DynamoDB" Version="1.*" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.*" />
   </ItemGroup>
 
 </Project>

--- a/nservicebus/dotnet-templates/index_nsbendpoint_templates_[5,6).partial.md
+++ b/nservicebus/dotnet-templates/index_nsbendpoint_templates_[5,6).partial.md
@@ -31,10 +31,10 @@ Parameters allow the selection of message transport, data persistence, and hosti
 | Option | Description |
 |-|-|
 | `-n`,<br/>`--name` | The name of the endpoint to create. |
-| `-f`,<br/>`--framework` | The target framework for the project.<br/>One of: `net7.0` (default), `net6.0`, `net48`, `net472` |
+| `-f`,<br/>`--framework` | The target framework for the project.<br/>One of: `net8.0`, `net7.0` (default), `net6.0`, `net48`, `net472` |
 | `-t`,<br/>`--transport` | The message queue (transport) to use.<br/>One of `LearningTransport` (default), `AzureServiceBus`, `AzureStorageQueues`, `SQS`, `RabbitMQ`, `SQL`. |
 | `-p`,<br/>`--persistence` | Where to store data. This should be the same place business data is stored.<br/>One of `LearningPersistence` (default), `MSSQL`, `MySQL`, `PostgreSQL`, `Oracle`, `CosmosDB`, `AzureTable`, `RavenDB`, `MongoDB`, `DynamoDB` |
-| `-hm`,<br/>`--hosting` | The hosting model to use.<br/>One of: `ConsoleApp`, `WindowsService`, `Docker`|
+| `-hm`,<br/>`--hosting` | The hosting model to use.<br/>One of: `ConsoleApp` (default), `WindowsService`, `Docker`|
 
 For more details on available options and choices, use this command to get help:
 

--- a/nservicebus/dotnet-templates/index_nsbendpoint_templates_[6,).partial.md
+++ b/nservicebus/dotnet-templates/index_nsbendpoint_templates_[6,).partial.md
@@ -1,0 +1,41 @@
+## NServiceBus Endpoint
+
+The `nsbendpoint` template will create a C# project for an NServiceBus endpoint. By selecting options, the endpoint is preconfigured with choices of:
+
+*  Target framework
+*  [Message transport](/transports/)
+*  [Data persistence](/persistence/)
+*  [Hosting model](/nservicebus/hosting/), which can be one of:
+   * Console Application
+   * [Windows service hosting](/nservicebus/hosting/#self-hosting-windows-service-hosting)
+   * [Docker container hosing](/nservicebus/hosting/docker-host)
+
+Once the package is installed, the template can be found in the Visual Studio **New Project** dialog:
+
+![NServiceBus endpoint template in the Visual Studio New Project dialog](new-project.png)
+
+After naming the project and selecting a location for it on disk, the **Additional information** screen will allow customizing the template:
+
+![Customing endpoint properties in the additional information dialog](endpoint-additional-info.png)
+
+### Command-line usage
+
+The default usage will create a Console Application using Learning Transport, Learning Persistence:
+
+snippet: endpointdefault
+
+Parameters allow the selection of message transport, data persistence, and hosting model, including [Windows Service](/nservicebus/hosting/#self-hosting-windows-service-hosting) or [Docker container](/nservicebus/hosting/docker-host/) hosting.
+
+### Options
+
+| Option | Description |
+|-|-|
+| `-n`,<br/>`--name` | The name of the endpoint to create. |
+| `-f`,<br/>`--framework` | The target framework for the project.<br/>One of: `net8.0` (default) |
+| `-t`,<br/>`--transport` | The message queue (transport) to use.<br/>One of `LearningTransport` (default), `AzureServiceBus`, `AzureStorageQueues`, `SQS`, `RabbitMQ`, `SQL`. |
+| `-p`,<br/>`--persistence` | Where to store data. This should be the same place business data is stored.<br/>One of `LearningPersistence` (default), `MSSQL`, `MySQL`, `PostgreSQL`, `Oracle`, `CosmosDB`, `AzureTable`, `RavenDB`, `MongoDB`, `DynamoDB` |
+| `-hm`,<br/>`--hosting` | The hosting model to use.<br/>One of: `ConsoleApp` (default), `WindowsService`, `Docker`|
+
+For more details on available options and choices, use this command to get help:
+
+snippet: endpointhelp

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_5/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_5/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_5/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_5/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_3/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Migration/Migration.csproj
+++ b/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Migration/Migration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/hierarchy-migration/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+  <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+  <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
+++ b/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 </Project>

--- a/samples/bridge/service-control/TransportBridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/service-control/TransportBridge_1/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/bridge/service-control/TransportBridge_1/Endpoint/Endpoint.csproj
+++ b/samples/bridge/service-control/TransportBridge_1/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/bridge/service-control/TransportBridge_1/Shared/Shared.csproj
+++ b/samples/bridge/service-control/TransportBridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 </Project>

--- a/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/bridge/simple/TransportBridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/TransportBridge_1/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/TransportBridge_1/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/TransportBridge_1/LeftReceiver/LeftReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/TransportBridge_1/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/TransportBridge_1/LeftSender/LeftSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/TransportBridge_1/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/TransportBridge_1/RightReceiver/RightReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/TransportBridge_1/Shared/Shared.csproj
+++ b/samples/bridge/simple/TransportBridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Bridge/Bridge.csproj
@@ -1,7 +1,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Helpers/Helpers.csproj
@@ -1,7 +1,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_3/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_3/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_3/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_3/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_3/WebSender/WebSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 

--- a/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 

--- a/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer1/Consumer1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Consumer2/Consumer2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_7/Producer/Producer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cooperative-cancellation/Core_8/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/custom-recoverability/Core_7/Client/Client.csproj
+++ b/samples/custom-recoverability/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_7/Server/Server.csproj
+++ b/samples/custom-recoverability/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_7/Shared/Shared.csproj
+++ b/samples/custom-recoverability/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/custom-recoverability/Core_8/Client/Client.csproj
+++ b/samples/custom-recoverability/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_8/Server/Server.csproj
+++ b/samples/custom-recoverability/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_8/Shared/Shared.csproj
+++ b/samples/custom-recoverability/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
@@ -11,18 +11,17 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.*" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.*" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.*" />
-    <!--
-      Dependency on 1.2.* as 1.3.0 currently has a dependency on  Microsoft.Azure.Functions.Worker.Core v1.19.0 which does
-      not yet exist in Nuget
-    -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -11,19 +11,22 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.*" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="host.json" CopyToOutputDirectory="PreserveNewest"/>
-    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never"/>
+    <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/file-share-databus/Core_7/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_7/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_7/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/delayed-delivery/Core_7/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_7/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/delayed-delivery/Core_8/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_6/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_7/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_7/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Client/Client.csproj
+++ b/samples/faulttolerance/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Server/Server.csproj
+++ b/samples/faulttolerance/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_7/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/faulttolerance/Core_8/Client/Client.csproj
+++ b/samples/faulttolerance/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Server/Server.csproj
+++ b/samples/faulttolerance/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/feature/Core_7/Sample/Sample.csproj
+++ b/samples/feature/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/feature/Core_8/Sample/Sample.csproj
+++ b/samples/feature/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Client/Client.csproj
+++ b/samples/fullduplex/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Server/Server.csproj
+++ b/samples/fullduplex/Core_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_7/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_3/Headquarters/Headquarters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_3/RemoteSite/RemoteSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_3/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/header-manipulation/Core_7/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/header-manipulation/Core_8/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_7/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_7/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_8/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/hosting/docker/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/generic-host/Core_7/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_7/GenericHost/GenericHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_7/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_7/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_7/Sample/Sample.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_8/Sample/Sample.csproj
+++ b/samples/logging/default/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <NoWarn>NU1605</NoWarn>

--- a/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_7/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_8/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_7/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_8/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Billing/Billing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/ravendb/Core_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/near-realtime-clients/Core_7/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_7/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_7/ClientHub/ClientHub.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_7/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_7/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_7/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_7/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/near-realtime-clients/Core_8/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Attributes/Sample.Attributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Default/Sample.Default.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Fluent/Sample.Fluent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_8/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Server/Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/customizing/Core_8/Sample/Sample.csproj
+++ b/samples/open-telemetry/customizing/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/logging/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/open-telemetry/logging/Core_8/GenericHost/GenericHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_7/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_7/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_4/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net6.0-windows;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <LangVersion>10.0</LangVersion>

--- a/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net6.0-windows;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <LangVersion>10.0</LangVersion>

--- a/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_7/AuditFilter/AuditFilter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_7/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/handler-timer/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/header-propagation/Core_7/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/SignedSender/SignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_7/UnsignedSender/UnsignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_7/SessionFilter/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/platform-connector/code-first/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/json/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/ms-config/PlatformConnector_1/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_1/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/CustomExtensions/CustomExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_7/MefExtensions/MefExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_7/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensionEndpoint/CustomExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/CustomExtensions/CustomExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensionEndpoint/MefExtensionEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
+++ b/samples/plugin-based-config/Core_8/MefExtensions/MefExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/plugin-based-config/Core_8/Shared/Shared.csproj
+++ b/samples/plugin-based-config/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_7/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_7/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_7/Subscriber/Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_6/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_6/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_6/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_6/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_7/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_7/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_7/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_7/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_8/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_8/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/recoverabilitypolicytesting/Core_7/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_7/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_7/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_7/UpgradedDestination/UpgradedDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/saga/batching/Core_7/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_7/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_7/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_7/WorkGenerator/WorkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_7/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_7/WorkProcessor/WorkProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsing>enable</ImplicitUsing>
     <LangVersion>10.0</LangVersion>

--- a/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/saga/simple/Core_7/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/simple/Core_8/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_7/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_7/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
+++ b/samples/scheduling/scheduler/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/timer/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_7/XmlEndpoint/XmlEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/system-json/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/system-json/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase3/SamplePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/SamplePhase4/SamplePhase4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/xml/Core_7/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/xml/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ContentManagement/Store.ContentManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.ECommerce/Store.ECommerce.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Messages/Store.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Operations/Store.Operations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Sales/Store.Sales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_7/Store.Shared/Store.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_6/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion1/EndpointVersion1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/EndpointVersion2/EndpointVersion2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointMySql/EndpointMySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointOracle/EndpointOracle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_6/Phase3/Shared/SharedPhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-nhpersistence/Core_7/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_6/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Limited/Limited.csproj
+++ b/samples/throttling/Core_7/Limited/Limited.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Sender/Sender.csproj
+++ b/samples/throttling/Core_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_7/Shared/Shared.csproj
+++ b/samples/throttling/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/throttling/Core_8/Limited/Limited.csproj
+++ b/samples/throttling/Core_8/Limited/Limited.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Sender/Sender.csproj
+++ b/samples/throttling/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Shared/Shared.csproj
+++ b/samples/throttling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/unit-of-work/Core_7/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/unit-of-work/Core_8/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/unit-testing/Testing_7/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_7/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unit-testing/Testing_8/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/unobtrusive/Core_8/Client/Client.csproj
+++ b/samples/unobtrusive/Core_8/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/unobtrusive/Core_8/Server/Server.csproj
+++ b/samples/unobtrusive/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/unobtrusive/Core_8/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_7/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_7/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_7/Shared/Shared.csproj
+++ b/samples/username-header/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Shared/Shared.csproj
+++ b/samples/username-header/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_7/Publisher/Publisher.csproj
+++ b/samples/versioning/Core_7/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_7/V1.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_7/V1.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>1.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_7/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_7/V1.Subscriber/V1.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_7/V2.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_7/V2.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>2.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_7/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_7/V2.Subscriber/V2.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_8/Publisher/Publisher.csproj
+++ b/samples/versioning/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>1.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>2.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_7/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_7/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-web-application/Core_7/Server/Server.csproj
+++ b/samples/web/asp-web-application/Core_7/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-web-application/Core_7/Shared/Shared.csproj
+++ b/samples/web/asp-web-application/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-web-application/Core_7/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_7/WebApp/WebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-web-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-web-application/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/samples/web/asp-web-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-web-application/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/samples/web/asp-web-application/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_8/WebApp/WebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/samples/web/blazor-server-application/Core_8/Server/Server.csproj
+++ b/samples/web/blazor-server-application/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>exe</OutputType>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_7/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_7/WebApp/WebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        public static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net8.0-windows", "net7.0", "net7.0-windows", "net6.0", "net6.0-windows", "net48", "netstandard2.0"];
+        public static readonly string[] sdkProjectAllowedTfmList = ["net8.0", "net8.0-windows", "net6.0", "net6.0-windows", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -43,6 +43,12 @@ namespace IntegrityTests
 
                     foreach (var projectFile in projectFiles)
                     {
+                        //Don't analyze generated project files
+                        if (projectFile.Contains("obj"))
+                        {
+                            continue;
+                        }
+
                         var doc = XDocument.Load(projectFile);
 
                         if (doc.Root.Attribute("Sdk") == null)
@@ -82,6 +88,12 @@ namespace IntegrityTests
 
                     foreach (var projectFile in projectFiles)
                     {
+                        //Don't analyze generated project files
+                        if (projectFile.Contains("obj"))
+                        {
+                            continue;
+                        }
+
                         var doc = XDocument.Load(projectFile);
 
                         if (doc.Root.Attribute("Sdk") == null)
@@ -148,8 +160,6 @@ namespace IntegrityTests
             {"netstandard2.0", null },
             { "net6.0", 10 },
             { "net6.0-windows", 10 },
-            { "net7.0", 11 },
-            { "net7.0-windows", 11 },
             { "net8.0", 12 },
             { "net8.0-windows", 12 },
         };


### PR DESCRIPTION
This PR removes `net7.0` from all samples and snippets since .NET 7 went out of support in May 2024.

Integrity tests have been updated to remove `net7.0` as a valid option.

The ParticularTemplates documentation for the `framework` has been corrected as well.