### PR TITLE
Update docs on MSMQ bridge specifics

### DIFF
--- a/Snippets/Bridge/Bridge_2/Configuration.cs
+++ b/Snippets/Bridge/Bridge_2/Configuration.cs
@@ -196,9 +196,9 @@ public class Configuration
         #region custom-address
 
         var transport = new BridgeTransport(new MsmqTransport());
-        transport.HasEndpoint("Finance", "finance_queue_name");
+        transport.HasEndpoint("Finance", "finance@machinename");
 
-        var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
+        var endpoint = new BridgeEndpoint("Sales", "sales@machinename");
         transport.HasEndpoint(endpoint);
 
         #endregion

--- a/Snippets/Bridge/Bridge_2/Configuration.cs
+++ b/Snippets/Bridge/Bridge_2/Configuration.cs
@@ -196,9 +196,9 @@ public class Configuration
         #region custom-address
 
         var transport = new BridgeTransport(new MsmqTransport());
-        transport.HasEndpoint("Finance", "finance@machinename");
+        transport.HasEndpoint("Finance", "finance_queue_name");
 
-        var endpoint = new BridgeEndpoint("Sales", "sales@another-machine");
+        var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
         transport.HasEndpoint(endpoint);
 
         #endregion

--- a/Snippets/Bridge/Bridge_3/Configuration.cs
+++ b/Snippets/Bridge/Bridge_3/Configuration.cs
@@ -196,9 +196,9 @@ public class Configuration
         #region custom-address
 
         var transport = new BridgeTransport(new MsmqTransport());
-        transport.HasEndpoint("Finance", "finance_queue_name");
+        transport.HasEndpoint("Finance", "finance@machinename");
 
-        var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
+        var endpoint = new BridgeEndpoint("Sales", "sales@machinename");
         transport.HasEndpoint(endpoint);
 
         #endregion

--- a/Snippets/Bridge/Bridge_3/Configuration.cs
+++ b/Snippets/Bridge/Bridge_3/Configuration.cs
@@ -196,9 +196,9 @@ public class Configuration
         #region custom-address
 
         var transport = new BridgeTransport(new MsmqTransport());
-        transport.HasEndpoint("Finance", "finance@machinename");
+        transport.HasEndpoint("Finance", "finance_queue_name");
 
-        var endpoint = new BridgeEndpoint("Sales", "sales@another-machine");
+        var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
         transport.HasEndpoint(endpoint);
 
         #endregion

--- a/Snippets/Bridge/TransportBridge_1/Configuration.cs
+++ b/Snippets/Bridge/TransportBridge_1/Configuration.cs
@@ -197,9 +197,9 @@
             #region custom-address
 
             var transport = new BridgeTransport(new MsmqTransport());
-            transport.HasEndpoint("Finance", "finance@machinename");
+            transport.HasEndpoint("Finance", "finance_queue_name");
 
-            var endpoint = new BridgeEndpoint("Sales", "sales@another-machine");
+            var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
             transport.HasEndpoint(endpoint);
 
             #endregion

--- a/Snippets/Bridge/TransportBridge_1/Configuration.cs
+++ b/Snippets/Bridge/TransportBridge_1/Configuration.cs
@@ -197,9 +197,9 @@
             #region custom-address
 
             var transport = new BridgeTransport(new MsmqTransport());
-            transport.HasEndpoint("Finance", "finance_queue_name");
+            transport.HasEndpoint("Finance", "finance@machinename");
 
-            var endpoint = new BridgeEndpoint("Sales", "sales_queue_name");
+            var endpoint = new BridgeEndpoint("Sales", "sales@machinename");
             transport.HasEndpoint(endpoint);
 
             #endregion

--- a/nservicebus/bridge/configuration.md
+++ b/nservicebus/bridge/configuration.md
@@ -99,9 +99,6 @@ The "Sales" queue on the MSMQ transport and the "Billing" queue on the AzureServ
 
 The bridge provides the ability to change the address of the queue of incoming messages.
 
-> [!NOTE]
-> When forwarding messages to MSMQ endpoints that run on different servers than the bridge, the addresses of the queues that messages should be forwarded to _must_ be provided.
-
 snippet: custom-address
 
 ## Recoverability

--- a/nservicebus/bridge/configuration.md
+++ b/nservicebus/bridge/configuration.md
@@ -99,6 +99,9 @@ The "Sales" queue on the MSMQ transport and the "Billing" queue on the AzureServ
 
 The bridge provides the ability to change the address of the queue of incoming messages.
 
+> [!NOTE]
+> When forwarding messages to non-proxied MSMQ endpoints that run on different servers than the bridge, the addresses of the queues that messages should be forwarded to _must_ be provided.
+
 snippet: custom-address
 
 ## Recoverability

--- a/samples/bridge/azure-service-bus-msmq-bridge/sample.md
+++ b/samples/bridge/azure-service-bus-msmq-bridge/sample.md
@@ -61,7 +61,7 @@ snippet: asb-bridge-configuration
 The MSMQ bridge endpoint is configured by using the name of the actual MSMQ endpoint where the message needs to be routed to:
 
 > [!NOTE]
-> [Endpoints cannot read from remote MSMQ queues](/transports/msmq/#remote-queues), hence when forwarding messages to/from MSMQ endpoints, the bridge must be configured on each MSMQ server.
+> [Endpoints cannot read from remote MSMQ queues](/transports/msmq/#remote-queues), hence when reading messages from proxied MSMQ endpoints, the bridge must be configured on each MSMQ server that contains the proxy queues.
 
 snippet: create-msmq-endpoint-of-bridge
 

--- a/samples/bridge/azure-service-bus-msmq-bridge/sample.md
+++ b/samples/bridge/azure-service-bus-msmq-bridge/sample.md
@@ -61,7 +61,7 @@ snippet: asb-bridge-configuration
 The MSMQ bridge endpoint is configured by using the name of the actual MSMQ endpoint where the message needs to be routed to:
 
 > [!NOTE]
-> The `QueueAddress` parameter is needed to create an MSMQ bridge endpoint when the actual MSMQ endpoint and the bridge are running on separate servers
+> [Endpoints cannot read from remote MSMQ queues](/transports/msmq/#remote-queues), hence when forwarding messages to/from MSMQ endpoints, the bridge must be configured on each MSMQ server.
 
 snippet: create-msmq-endpoint-of-bridge
 


### PR DESCRIPTION
Update the documentation to:
- remove refence to `@machine` in the QueueAddress
- specify that the bridge needs to be installed on each MSMQ server