### PR TITLE
Update step by step tutorial to NServiceBus 9 and dotnet 8.0

### DIFF
--- a/tutorials/nservicebus-step-by-step/1-getting-started/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/1-getting-started/Solution/ClientUI/ClientUI.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/Messages/Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/2-sending-a-command/Solution/Messages/Messages.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/3-multiple-endpoints/Solution/Sales/Sales.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing.Messages/Billing.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing.Messages/Billing.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Billing/Billing.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Billing.Messages\Billing.Messages.csproj" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Sales/Sales.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-step-by-step/4-publishing-events/Solution/Shipping/Shipping.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Billing.Messages\Billing.Messages.csproj" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing.Messages/Billing.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing.Messages/Billing.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing/Billing.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Billing/Billing.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Billing.Messages\Billing.Messages.csproj" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/ClientUI/ClientUI.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales.Messages/Sales.Messages.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales.Messages/Sales.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Messages</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales/Sales.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Sales/Sales.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>
 </Project>

--- a/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Shipping/Shipping.csproj
+++ b/tutorials/nservicebus-step-by-step/5-retrying-errors/Solution/Shipping/Shipping.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <ProjectReference Include="..\Billing.Messages\Billing.Messages.csproj" />
     <ProjectReference Include="..\Sales.Messages\Sales.Messages.csproj" />
   </ItemGroup>


### PR DESCRIPTION
As a part of this [issue](https://github.com/Particular/DeveloperEducation/issues/4954)

All step-by-step tutorials have been upgraded to NServiceBus v9 and dotnet 8