### PR TITLE
Update sqlserver-combining-persistence-wth-transport.md

### DIFF
--- a/persistence/sql/sqlserver-combining-persistence-wth-transport.md
+++ b/persistence/sql/sqlserver-combining-persistence-wth-transport.md
@@ -20,6 +20,8 @@ AtomicSendsWithReceive | Not supported | N/A
 ReceiveOnly | Connection sharing via SQL Transport storage context | Persistence DB
 None | Not supported | N/A
 
+When using the [outbox](/nservicebus/outbox/), SQL Persistence always opens its own connection.
+
 ### Without Outbox
 
 SQL Transport<br/>TransactionMode | Connection sharing | Saga location
@@ -35,6 +37,11 @@ None | No transactions | Persistence DB
 
 When an endpoint uses SQL Persistence combined with the SQL Server Transport with [Outbox](/nservicebus/outbox/) disabled, the persistence uses the connection and transaction context established by the transport when accessing saga data. This behavior ensures *exactly-once* message processing behavior as the state change of the saga is committed atomically while consuming the message that triggered it.
 
-partial: Connection
+In order to force using a separate connection use the following API:
+
+snippet: MsSqlDoNotShareConnection
+
+> [!WARNING]
+> When opting out of connection sharing with Outbox disabled, NServiceBus does not guarantee *exactly-once* message processing behavior which means that saga message handling logic might be called multiple times for a single incoming message in case the previous processing attempts failed just before consuming the message.
 
 

--- a/persistence/sql/sqlserver-combining-persistence-wth-transport.md
+++ b/persistence/sql/sqlserver-combining-persistence-wth-transport.md
@@ -11,6 +11,15 @@ related:
 
 When combining [SQL Server transport](/transports/sql) and [SQL persistence using the Sql dialect](/persistence/sql), the connection behaves differently based on whether the [Outbox](/nservicebus/outbox/) is enabled or disabled. This influences where the saga data is stored.
 
+### With Outbox
+
+SQL Transport<br/>TransactionMode | Connection sharing | Saga location
+:-:|:-:|:-:
+TransactionScope | Not supported | N/A
+AtomicSendsWithReceive | Not supported | N/A
+ReceiveOnly | Connection sharing via SQL Transport storage context | Persistence DB
+None | Not supported | N/A
+
 ### Without Outbox
 
 SQL Transport<br/>TransactionMode | Connection sharing | Saga location
@@ -28,11 +37,4 @@ When an endpoint uses SQL Persistence combined with the SQL Server Transport wit
 
 partial: Connection
 
-### With Outbox
 
-SQL Transport<br/>TransactionMode | Connection sharing | Saga location
-:-:|:-:|:-:
-TransactionScope | Not supported | N/A
-AtomicSendsWithReceive | Not supported | N/A
-ReceiveOnly | Connection sharing via SQL Transport storage context | Persistence DB
-None | Not supported | N/A

--- a/persistence/sql/sqlserver-combining-persistence-wth-transport_connection_sqlpersistence_[3,).partial.md
+++ b/persistence/sql/sqlserver-combining-persistence-wth-transport_connection_sqlpersistence_[3,).partial.md
@@ -1,6 +1,0 @@
-When using the [outbox](/nservicebus/outbox/), SQL Persistence always opens its own connection. In order to force using a separate connection even when the [outbox](/nservicebus/outbox/) is disabled, use the following API:
-
-snippet: MsSqlDoNotShareConnection
-
-> [!WARNING]
-> In this mode NServiceBus does not guarantee *exactly-once* message processing behavior which means that saga message handling logic might be called multiple times for a single incoming message in case the previous processing attempts failed just before consuming the message.


### PR DESCRIPTION
Clarify how SQL connection sharing works when it comes to outbox.
Fixes #6842

Preview of the changes:
![image](https://github.com/user-attachments/assets/64f5428a-c612-46be-a8a5-d6342b8d9cd4)
