### PR TITLE
Masstransit messages sample doco review

### DIFF
--- a/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/MTEndpoint/MTEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_7/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/Program.cs
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/Program.cs
@@ -27,7 +27,7 @@ namespace NServiceBusSubscriber
                     #region Transport
                     var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
                     transport.ConnectionString("host=localhost;username=guest;password=guest");
-                    transport.UseConventionalRoutingTopology(QueueType.Quorum));
+                    transport.UseConventionalRoutingTopology(QueueType.Quorum);
                     #endregion
 
                     #region Serializer

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/Program.cs
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/Program.cs
@@ -27,7 +27,7 @@ namespace NServiceBusSubscriber
                     #region Transport
                     var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
                     transport.ConnectionString("host=localhost;username=guest;password=guest");
-                    transport.UseConventionalRoutingTopology(QueueType.Classic);
+                    transport.UseConventionalRoutingTopology(QueueType.Quorum));
                     #endregion
 
                     #region Serializer

--- a/samples/pipeline/masstransit-messages/Core_9/NServiceBusSubscriber/Program.cs
+++ b/samples/pipeline/masstransit-messages/Core_9/NServiceBusSubscriber/Program.cs
@@ -20,7 +20,7 @@ namespace NServiceBusSubscriber
             #region Transport
             var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
             transport.ConnectionString("host=localhost;username=guest;password=guest");
-            transport.UseConventionalRoutingTopology(QueueType.Classic);
+            transport.UseConventionalRoutingTopology(QueueType.Quorum);
             #endregion
 
             #region Serializer

--- a/samples/pipeline/masstransit-messages/sample.md
+++ b/samples/pipeline/masstransit-messages/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Consuming MassTransit messages with NServiceBus
 summary: Use the NServiceBus pipeline to consume messages sent by MassTransit.
-reviewed: 2021-11-04
+reviewed: 2024-09-22
 component: Core
 related:
  - nservicebus/pipeline
@@ -15,6 +15,12 @@ downloadbutton
 ## Prerequisites
 
 This sample requires a local instance of RabbitMQ.
+
+The easiest way to do this is to run MongoDB in Docker by running the following command
+
+```shell
+docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+```
 
 ## Message structure comparison
 

--- a/samples/pipeline/masstransit-messages/sample.md
+++ b/samples/pipeline/masstransit-messages/sample.md
@@ -16,7 +16,7 @@ downloadbutton
 
 This sample requires a local instance of RabbitMQ.
 
-The easiest way to do this is to run MongoDB in Docker by running the following command
+The easiest way to do this is to run RabbitMQ in Docker by running the following command
 
 ```shell
 docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management


### PR DESCRIPTION
- Add .NET Framework 4.8 sample to NSB 7 samples
- Use Quorum queues in NSB 8 and NSB 9 samples to prevent errors if using an instance of rabbitMQ with an error queue configured with type Quorum (ServiceControl will configure the error queue as Qurum). 
  - _'The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=406, text='PRECONDITION_FAILED - inequivalent arg 'x-queue-type' for queue 'error' in vhost '/': received none but current is the value 'quorum' of type 'longstr'', classId=50, methodId=10'_ 