### PR TITLE
Updating hosting docker sample

### DIFF
--- a/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_7/Receiver/Receiver.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Build.Containers" Version="8.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/samples/hosting/docker/Core_7/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_7/Sender/Sender.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Build.Containers" Version="8.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />

--- a/samples/hosting/docker/Core_7/docker-compose.yml
+++ b/samples/hosting/docker/Core_7/docker-compose.yml
@@ -1,5 +1,4 @@
 # startcode compose
-version: "3.8"
 services:
     sender:
         image: sender

--- a/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Build.Containers" Version="8.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/hosting/docker/Core_8/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_8/Sender/Sender.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Build.Containers" Version="8.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="8.*" />
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/hosting/docker/Core_8/docker-compose.yml
+++ b/samples/hosting/docker/Core_8/docker-compose.yml
@@ -1,5 +1,4 @@
 # startcode compose
-version: "3.8"
 services:
     sender:
         image: sender

--- a/samples/hosting/docker/Core_9/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_9/Receiver/Receiver.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Build.Containers" Version="8.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.*" />
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/hosting/docker/Core_9/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_9/Sender/Sender.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/docker/Core_9/docker-compose.yml
+++ b/samples/hosting/docker/Core_9/docker-compose.yml
@@ -1,5 +1,4 @@
 # startcode compose
-version: "3.8"
 services:
     sender:
         image: sender

--- a/samples/hosting/docker/sample.md
+++ b/samples/hosting/docker/sample.md
@@ -18,7 +18,7 @@ The endpoints use the [.NET SDK Container Building Tools](https://github.com/dot
 
 To containerize a .NET app using `dotnet publish`:
 
-- **[.NET 8+ SDK](https://dotnet.microsoft.com/download/dotnet/8.0)**: Check your installed SDK version with `dotnet --info`.
+- **[.NET 8.0.200 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)** (or higher): Check your installed SDK version with `dotnet --info`.
 - **[Docker Community Edition](https://www.docker.com/products/docker-desktop)**: Ensure Docker is installed and running on your system.
 
 ## Running the sample

--- a/samples/hosting/docker/sample.md
+++ b/samples/hosting/docker/sample.md
@@ -12,6 +12,15 @@ redirects:
 
 This sample demonstrates how to use Docker Linux containers to host NServiceBus endpoints communicating over the [RabbitMQ transport](/transports/rabbitmq/). While this sample uses [Docker Compose](https://docs.docker.com/compose/) to demonstrate how to orchestrate a multi-container application, the containers are compatible withe other orchestration technologies, for example [Kubernetes](https://kubernetes.io/docs/home/).
 
+The endpoints use the [.NET SDK Container Building Tools](https://github.com/dotnet/sdk-container-builds) to enable the creation of containers via the `dotnet publish` command. See the [Microsoft tutorial](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?pivots=dotnet-8-0) and [customization documentation](https://github.com/dotnet/sdk-container-builds/blob/main/docs/ContainerCustomization.md) for more details.
+
+## Prerequisites
+
+To containerize a .NET app using `dotnet publish`, you'll need:
+
+- **[.NET 8+ SDK](https://dotnet.microsoft.com/download/dotnet/8.0)**: Check your installed SDK version with `dotnet --info`.
+- **[Docker Community Edition](https://www.docker.com/products/docker-desktop)**: Ensure Docker is installed and running on your system.
+
 ## Running the sample
 
 Running the sample involves building the container images and starting the multi-container application.
@@ -53,10 +62,6 @@ docker-compose down
 ## Code walk-through
 
 This sample consists of `Sender` and `Receiver` endpoints exchanging messages using the [RabbitMQ transport](/transports/rabbitmq/). Each of these three components runs in a separate Docker Linux container.
-
-### Endpoint containers
-
-The endpoints use the [.NET SDK Container Building Tools](https://github.com/dotnet/sdk-container-builds) to enable the creation of containers via the `dotnet publish` command. See the [Microsoft tutorial](https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?pivots=dotnet-8-0) and [customization documentation](https://github.com/dotnet/sdk-container-builds/blob/main/docs/ContainerCustomization.md) for more details.
 
 ### Orchestration
 

--- a/samples/hosting/docker/sample.md
+++ b/samples/hosting/docker/sample.md
@@ -16,7 +16,7 @@ The endpoints use the [.NET SDK Container Building Tools](https://github.com/dot
 
 ## Prerequisites
 
-To containerize a .NET app using `dotnet publish`, you'll need:
+To containerize a .NET app using `dotnet publish`:
 
 - **[.NET 8+ SDK](https://dotnet.microsoft.com/download/dotnet/8.0)**: Check your installed SDK version with `dotnet --info`.
 - **[Docker Community Edition](https://www.docker.com/products/docker-desktop)**: Ensure Docker is installed and running on your system.


### PR DESCRIPTION
Addressing feedback 
- https://github.com/Particular/docs.particular.net/issues/6848

Changes:
- removing version attribute from docker-compose files - no longer required
- adding prerequisites section 
- removing explicit package reference (Microsoft.Net.Build.Containers) since it is now included in the SDK
- adding required attribute to projects now that an explicit reference to the package is not required