### PR TITLE
Link to masstransit integration docs

### DIFF
--- a/samples/pipeline/masstransit-messages/sample.md
+++ b/samples/pipeline/masstransit-messages/sample.md
@@ -107,6 +107,9 @@ snippet: MassTransitConsumer
 
 Because the event is published in RabbitMQ, NServiceBus can also subscribe to it.
 
+> [!NOTE]
+> This sample shows how to use a NServiceBus behavior to ingest messages from a MassTransit system. To see how to alter the MassTransit messages to not need an NServiceBus behavior but instead use the [MassTransit.Interop.NServiceBus](https://nuget.org/packages/MassTransit.Interop.NServiceBus/) package, see [the MassTransit docs](https://masstransit.io/documentation/configuration/integrations/nsb).
+
 ## NServiceBus subscriber
 
 ### Basic setup


### PR DESCRIPTION
This links the integration docs to the corresponding MassTransit docs.

It is a corresponding PR to https://github.com/MassTransit/MassTransit/pull/5606 to make sure that both integration angles connect to each other.