### PR TITLE
Document public unsupported APIs

### DIFF
--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -30,7 +30,7 @@ Given a version number `{major}.{minor}.{patch}`, increment the:
 
 * Text in log and exception messages is not considered part of the public API.
 * Specific instances where following SemVer could hide potential message loss between versions.
-* Public unsupported APIs: Undocumented APIs are unsupported; as such, they don't follow SemVer. Unsupported APIs are identified by the [`Experimental` attribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) to allow compilers to report the unsupported nature of the referenced member.
+* Experimental APIs: Public APIs marked with the [ExperimentalAttribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) are considered unsupported and do not adhere to SemVer. Using these APIs requires suppressing compiler warnings, explicitly opting into their unsupported nature. As such, they are subject to change without prior notice or guided obsoletion.
 
 ## Backporting important bug fixes
 

--- a/nservicebus/upgrades/release-policy.md
+++ b/nservicebus/upgrades/release-policy.md
@@ -30,6 +30,7 @@ Given a version number `{major}.{minor}.{patch}`, increment the:
 
 * Text in log and exception messages is not considered part of the public API.
 * Specific instances where following SemVer could hide potential message loss between versions.
+* Public unsupported APIs: Undocumented APIs are unsupported; as such, they don't follow SemVer. Unsupported APIs are identified by the [`Experimental` attribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) to allow compilers to report the unsupported nature of the referenced member.
 
 ## Backporting important bug fixes
 


### PR DESCRIPTION
This PR documents that undocumented APIs are unsupported and deviate from SemVer. Public unsupported APIs are also identified by the [`Experimental` attribute](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/experimental-attribute) to allow compilers to report the unsupported nature of the referenced member.