### PR TITLE
Update extended support table to state NServiceBus7 is on extended support

### DIFF
--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -59,7 +59,7 @@ The following table describes the extended support status for all major versions
 | :------------------------: | :---------------------: | :-------------: | :-------------------------------------: | :-----------------------------------: |
 | <nobr>NServiceBus 9</nobr> | <nobr>2024-04-16</nobr> |   Mainstream    |             Current Version             |            Current Version            |
 | <nobr>NServiceBus 8</nobr> | <nobr>2022-11-17</nobr> |   Mainstream    |               2026-04-16                |              2028-04-16<sup>1</sup>   |
-| <nobr>NServiceBus 7</nobr> | <nobr>2018-03-30</nobr> |   Mainstream    |               2024-11-17                |              2026-11-17               |
+| <nobr>NServiceBus 7</nobr> | <nobr>2018-03-30</nobr> |   Extended      |               2024-11-17                |              2026-11-17               |
 | <nobr>NServiceBus 6</nobr> | <nobr>2016-10-11</nobr> |   Unsupported   |               2020-05-29                |              2022-05-29               |
 | <nobr>NServiceBus 5</nobr> | <nobr>2014-09-29</nobr> |   Unsupported   |               2018-10-11                |              2020-10-12               |
 | <nobr>NServiceBus 4</nobr> | <nobr>2013-07-11</nobr> |   Unsupported   |               2016-09-29                |              2018-09-29               |


### PR DESCRIPTION
This PR is part of https://github.com/Particular/CustomerSuccess/issues/4401 and deletes all NSB version 7 core samples and related components.