### PR TITLE
Review transactional session

### DIFF
--- a/Snippets/TransactionalSession/TransactionalSession_3/Api.cs
+++ b/Snippets/TransactionalSession/TransactionalSession_3/Api.cs
@@ -41,23 +41,23 @@ class Api
         #region configuring-timeout-transactional-session
 
         await session.Open(new MyPersistenceOpenSessionOptions
-        {
-            MaximumCommitDuration = TimeSpan.FromSeconds(15)
-        },
-                cancellationToken: cancellationToken);
+            {
+                MaximumCommitDuration = TimeSpan.FromSeconds(15)
+            },
+            cancellationToken: cancellationToken);
 
         #endregion
 
         #region configuring-metadata-transactional-session
 
         await session.Open(new MyPersistenceOpenSessionOptions
-        {
-            Metadata =
-                    {
-                        { "SomeKey", "SomeValue" }
-                    }
-        },
-                cancellationToken: cancellationToken);
+            {
+                Metadata =
+                {
+                    { "SomeKey", "SomeValue" }
+                }
+            },
+            cancellationToken: cancellationToken);
 
         #endregion
 

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -163,7 +163,8 @@ Internally, the transactional session doesn't use a single transaction that span
 The endpoint receives the control message and processes it as follows:
 
 * Find the outbox record.
-  * If it exists, and it hasn't been marked as dispatched, and there are pending operations they are dispatched, and the outbox record is set as dispatched.
+  * If it exists, and it hasn't been marked as dispatched, and there are pending operations:
+    * Dispatched the messages, and the outbox record is set as dispatched.
   * If it doesn't exist yet, delay the processing of the control message.
 
 ## Failure scenarios

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -142,17 +142,21 @@ Internally, the transactional session doesn't use a single transaction that span
 ### Phase 1
 
 1. The user opens a transactional session.
-2. A set of `PendingOperations` is initialized and collects the message operations.
+2. A set of `PendingTransportOperations` is initialized and collects the message operations.
 3. A transaction is started on the storage seam.
-4. The user can execute any required message operations using the transactional session.
-5. The user can store any data using the persistence-specific session, which is accessible through the transactional session.
-6. When all operations are registered, the user calls `Commit` on the transactional session.
-7. A control message to complete the transaction is dispatched to the local queue. The control message is independent of the message operations and is not stored in the outbox record.
-8. The message operations are converted and stored into an outbox record.
+4. The storage returns an open transaction.
+5. The user can execute any required message operations using the transactional session.
+6. Transport operations are captured by the `PendingTransportOperations`
+7. The user can store any data using the persistence-specific session, which is accessible through the transactional session.
+8. When all operations are registered, the user calls `Commit` on the transactional session.
+9. A control message to complete the transaction is dispatched to the local queue. The control message is independent of the message operations and is not stored in the outbox record.
+10. The message operations are converted into an outbox record.
+11. The outbox record is returned to the transactional session
+12. The outbox record is saved to the storage seam.
 9. The transaction is committed, and the outbox record and business data modifications are stored atomically.
 
 > [!NOTE]
-> Steps 7 and 8 are skipped, and as a consequence Phase 2, when no message operations are executed in the transactional session to avoid wasting queue and database resources.
+> When no message operations are executed in the transactional session, steps 9 through 12 are skipped (and as a consequence Phase 2 is also skipped) to avoid wasting queue and database resources.
 
 ### Phase 2
 

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -1,7 +1,7 @@
 ---
 title: Transactional session
 summary: Atomicity when modifying data and sending messages outside the context of a message handler
-reviewed: 2022-09-12
+reviewed: 2025-01-24
 component: TransactionalSession
 related:
 - samples/transactional-session/aspnetcore-webapi

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -77,13 +77,13 @@ The maximum commit duration does not represent the total transaction time, but r
 
 When the control message is consumed, but the outbox record is not yet available in storage, the following formula is applied to delay the message (see [Phase 2](#how-it-works-phase-2)):
 
-```text
+```csharp
 CommitDelayIncrement = 2 * CommitDelayIncrement;
-RemainingCommitDuration = RemainingCommitDuration -
-   (CommitDelayIncrement > RemainingCommitDuration ? RemainingCommitDuration : CommitDelayIncrement)
+RemainingCommitDuration = RemainingCommitDuration
+  - (CommitDelayIncrement > RemainingCommitDuration 
+      ? RemainingCommitDuration
+      : CommitDelayIncrement);
 ```
-
-The default commit delay increment is set to `Timespan.FromSeconds(2)`and cannot be overridden.
 
 partial: config
 

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -63,36 +63,6 @@ Disposing the transactional session without committing will roll back any change
 > [!NOTE]
 > The `Commit` operation may fail and throw an exception for reasons outlined in the [failure scenarios section](#failure-scenarios).
 
-### Advanced configuration
-
-#### Maximum commit duration
-
-The maximum commit duration limits the amount of time it can take for a transaction to commit the changes before the operation times out. The value can be configured when opening the session.
-
-The default value for the maximum commit duration is `TimeSpan.FromSeconds(15)`.
-
-snippet: configuring-timeout-transactional-session
-
-The maximum commit duration does not represent the total transaction time, but rather the time it takes to complete the commit operation (as observed from the perspective of the control message). In practice, the observed total commit time might be longer due to delays in the transport caused by latency, delayed delivery, load on the input queue, endpoint concurrency limits, and more.
-
-When the control message is consumed, but the outbox record is not yet available in storage, the following formula is applied to delay the message (see [Phase 2](#how-it-works-phase-2)):
-
-```csharp
-CommitDelayIncrement = 2 * CommitDelayIncrement;
-RemainingCommitDuration = RemainingCommitDuration
-  - (CommitDelayIncrement > RemainingCommitDuration 
-      ? RemainingCommitDuration
-      : CommitDelayIncrement);
-```
-
-partial: config
-
-#### Metadata
-
-It is possible to add metadata (e.g. tenant information) transactional session control message via custom headers. These headers can be accessed by a [custom behavior](/nservicebus/pipeline/manipulate-with-behaviors.md#add-a-new-step) when the control message is received in the `TransportReceive` part of the pipeline.
-
-snippet: configuring-metadata-transactional-session
-
 ## Requirements
 
 The transactional session feature requires a supported persistence package to store outgoing messages. This feature is currently supported for the following persistence packages:
@@ -207,3 +177,33 @@ If dispatching the control message fails, the transactional session changes will
 
 * The transactional session cannot be used in send-only endpoints. A full endpoint is required to send a control message to the local queue.
 * The transport must have the same or higher availability guarantees as the database.
+
+## Advanced configuration
+
+### Maximum commit duration
+
+The maximum commit duration limits the amount of time it can take for a transaction to commit the changes before the operation times out. The value can be configured when opening the session.
+
+The default value for the maximum commit duration is `TimeSpan.FromSeconds(15)`.
+
+snippet: configuring-timeout-transactional-session
+
+The maximum commit duration does not represent the total transaction time, but rather the time it takes to complete the commit operation (as observed from the perspective of the control message). In practice, the observed total commit time might be longer due to delays in the transport caused by latency, delayed delivery, load on the input queue, endpoint concurrency limits, and more.
+
+When the control message is consumed, but the outbox record is not yet available in storage, the following formula is applied to delay the message (see [Phase 2](#how-it-works-phase-2)):
+
+```csharp
+CommitDelayIncrement = 2 * CommitDelayIncrement;
+RemainingCommitDuration = RemainingCommitDuration
+  - (CommitDelayIncrement > RemainingCommitDuration 
+      ? RemainingCommitDuration
+      : CommitDelayIncrement);
+```
+
+partial: config
+
+### Metadata
+
+It is possible to add metadata (e.g. tenant information) transactional session control message via custom headers. These headers can be accessed by a [custom behavior](/nservicebus/pipeline/manipulate-with-behaviors.md#add-a-new-step) when the control message is received in the `TransportReceive` part of the pipeline.
+
+snippet: configuring-metadata-transactional-session

--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -174,7 +174,7 @@ The transactional session provides atomic store-and-send guarantees, similar to 
 * Transaction finishes with data being stored, and outgoing messages eventually sent - when the `Commit` path successfully stores the `OutboxRecord`
 * Transaction finishes with no visible side effects - when the control message stores the `OutboxRecord`
 
-Sending the control message first ensures that eventually, the transaction will have an atomic outcome. If the `Commit` of the `OutboxRecord` succeeds, the control message will ensure the outgoing operations are sent. If the `Commit` fails, the control message will (after the [maximum commit duration](#usage-advanced-configuration-maximum-commit-duration) elapses) eventually be consumed, leaving no side effects.
+Sending the control message first ensures that eventually, the transaction will have an atomic outcome. If the `Commit` of the `OutboxRecord` succeeds, the control message will ensure the outgoing operations are sent. If the `Commit` fails, the control message will (after the [maximum commit duration](#advanced-configuration-maximum-commit-duration) elapses) eventually be consumed, leaving no side effects.
 
 If dispatching the control message fails, the transactional session changes will roll back, and an error will be raised to the user committing the session.
 

--- a/nservicebus/transactional-session/index_config_transactionalsession_[,3.1).partial.md
+++ b/nservicebus/transactional-session/index_config_transactionalsession_[,3.1).partial.md
@@ -1,0 +1,1 @@
+The default commit delay increment is set to `Timespan.FromSeconds(2)`and cannot be overridden.


### PR DESCRIPTION
It looks like the auto-numbering behavior of Mermaid changed at some point which altered the table.

There is a lot of magic between markdown auto-numbers the ordered list and the diagram deciding number. I wonder if we should find a better way to correlate these two things.