### PR TITLE
Docs Review

### DIFF
--- a/Snippets/Core/Core_7/HandlerOrdering.cs
+++ b/Snippets/Core/Core_7/HandlerOrdering.cs
@@ -6,14 +6,6 @@
     {
         void Simple(EndpointConfiguration endpointConfiguration)
         {
-            #region HandlerOrderingWithCode
-
-            endpointConfiguration.ExecuteTheseHandlersFirst(
-                typeof(HandlerB),
-                typeof(HandlerA),
-                typeof(HandlerC));
-
-            #endregion
         }
 
         void SpecifyingFirst(EndpointConfiguration endpointConfiguration)

--- a/Snippets/Core/Core_8/HandlerOrdering.cs
+++ b/Snippets/Core/Core_8/HandlerOrdering.cs
@@ -6,14 +6,6 @@
     {
         void Simple(EndpointConfiguration endpointConfiguration)
         {
-            #region HandlerOrderingWithCode
-
-            endpointConfiguration.ExecuteTheseHandlersFirst(
-                typeof(HandlerB),
-                typeof(HandlerA),
-                typeof(HandlerC));
-
-            #endregion
         }
 
         void SpecifyingFirst(EndpointConfiguration endpointConfiguration)

--- a/Snippets/Core/Core_9/HandlerOrdering.cs
+++ b/Snippets/Core/Core_9/HandlerOrdering.cs
@@ -6,14 +6,6 @@
     {
         void Simple(EndpointConfiguration endpointConfiguration)
         {
-            #region HandlerOrderingWithCode
-
-            endpointConfiguration.ExecuteTheseHandlersFirst(
-                typeof(HandlerB),
-                typeof(HandlerA),
-                typeof(HandlerC));
-
-            #endregion
         }
 
         void SpecifyingFirst(EndpointConfiguration endpointConfiguration)

--- a/nservicebus/handlers/handler-ordering.md
+++ b/nservicebus/handlers/handler-ordering.md
@@ -1,7 +1,7 @@
 ---
 title: Handler Ordering
 summary: Controlling the order in which handlers are executed
-reviewed: 2022-11-08
+reviewed: 2025-02-17
 component: Core
 redirects:
 - nservicebus/how-do-i-specify-the-order-in-which-handlers-are-invoked
@@ -26,16 +26,11 @@ If it is not possible to migrate this kind of functionality out of message handl
 
 The remaining handlers (i.e. ones not specified in the ordering) are executed in a non-deterministic order.
 
-
 ### With the configuration API
-
-snippet: HandlerOrderingWithCode
-
 
 #### Specifying one handler to run first
 
 snippet: HandlerOrderingWithFirst
-
 
 #### Specifying multiple handlers to run in order
 

--- a/persistence/sql/subscriptions.md
+++ b/persistence/sql/subscriptions.md
@@ -1,7 +1,7 @@
 ---
 title: Subscription Persister
 component: SqlPersistence
-reviewed: 2022-11-09
+reviewed: 2025-02-17
 redirects:
  - nservicebus/sql-persistence/subscriptions
 versions: '[2,)'
@@ -14,7 +14,7 @@ The storage of subscription information is required for [unicast transports](/tr
 
 Subscription information can be cached for a given period of time so that it does not have to be loaded every single time an event is being published. The longer the cache period is, the higher the chance that new subscribers miss some events. It happens when a subscription message arrives after the subscription information has been loaded into memory.
 
-Because of that, there is no good default value for the subscription caching period. It has to be specified by the user. In systems where subscriptions are static, the caching period can be relatively long. To configure it, use following API:
+Because of that, there is no good default value for the subscription caching period. It has to be specified by the user. In systems where subscriptions are static, the caching period can be relatively long. To configure it, use the following API:
 
 snippet: subscriptions_CacheFor
 

--- a/persistence/sql/subscriptions_connection_sqlpersistence_[4,).partial.md
+++ b/persistence/sql/subscriptions_connection_sqlpersistence_[4,).partial.md
@@ -2,4 +2,4 @@
 
 The subscription persister can be configured to use a dedicated connection builder. For example, it may be used for creating subscription tables in a separate database.
 
-snippet: SqlPersistenceSubscriptionConnection  
+snippet: SqlPersistenceSubscriptionConnection

--- a/samples/dependency-injection/extensions-dependency-injection/sample.md
+++ b/samples/dependency-injection/extensions-dependency-injection/sample.md
@@ -2,7 +2,7 @@
 title: NServiceBus.Extensions.DependencyInjection Usage
 summary: A sample that uses Microsoft's built-in dependency injection container
 component: Extensions.DependencyInjection
-reviewed: 2022-10-31
+reviewed: 2025-02-18
 related:
  - nservicebus/dependency-injection
  - nservicebus/dependency-injection/extensions-dependencyinjection


### PR DESCRIPTION
Part of https://github.com/Particular/GeneralPlatformExperience/issues/3443

Removed `HandlerOrderingWithCode` snippet as it is a duplicate of `HandlerOrderingWithMultiple` and two the same code snippets were being displayed on the page.