### PR TITLE
Update the "opening promise" of the quickstart

### DIFF
--- a/tutorials/quickstart/tutorial.md
+++ b/tutorials/quickstart/tutorial.md
@@ -8,11 +8,13 @@ extensions:
   nextUrl: tutorials/quickstart/tutorial-reliability
 ---
 
-Want to quickly learn what NServiceBus is all about? You're in the right place. In less than one hour, learn how to:
+Want to learn what NServiceBus is all about? You're in the right place. 
 
-* Connect different parts of a system using messages
-* Build a failure-resistant system using messages
-* Create a system that can be easily extended as new requirements are added
+In just 10 minutes, see how to:
+
+* Send and process command messages
+* Publish and subscribe to event messages
+* All fully abstracted from the underlying queuing system
 
 > [!NOTE]
 > * If you're new here, check out the [overview of NServiceBus](https://particular.net/nservicebus).


### PR DESCRIPTION
The current "promise" covers topics that are only dealt with in subsequent pages. As far as developers know when reading this text at the top of the page, the "one hour" promise is "monolithic" and covers the whole page - which might turn them away (as they might not have an hour to devote to it right then).

Making a smaller and more specific promise for just the first page is probably better.