### PR TITLE
Move suppression to outside of snippet region (keep docs clean)

### DIFF
--- a/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_9/BuyersRemorsePolicyMapping/BuyersRemorsePolicyMapping.cs
+++ b/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_9/BuyersRemorsePolicyMapping/BuyersRemorsePolicyMapping.cs
@@ -4,11 +4,11 @@ using NServiceBus;
 
 namespace Core_9.BuyersRemorsePolicyMapping;
 
+#pragma warning disable 9113
+
 #region BuyersRemorsePolicyMapping
 
-#pragma warning disable CS9113 // Parameter is unread.
 class BuyersRemorsePolicy(ILogger<BuyersRemorsePolicy> logger) : Saga<BuyersRemorseData>,
-#pragma warning restore CS9113 // Parameter is unread.
     IAmStartedByMessages<PlaceOrder>
 {
     protected override void ConfigureHowToFindSaga(SagaPropertyMapper<BuyersRemorseData> mapper)
@@ -25,6 +25,8 @@ class BuyersRemorsePolicy(ILogger<BuyersRemorsePolicy> logger) : Saga<BuyersRemo
 }
 
 #endregion
+
+#pragma warning restore 9113
 
 internal class PlaceOrder
 {

--- a/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_9/EmptyBuyersRemorsePolicy/EmptyBuyersRemorsePolicy.cs
+++ b/tutorials/nservicebus-sagas/2-timeouts/Snippets/Core_9/EmptyBuyersRemorsePolicy/EmptyBuyersRemorsePolicy.cs
@@ -3,12 +3,10 @@ using NServiceBus;
 
 namespace Core_9.EmptyBuyersRemorsePolicy;
 
-#pragma warning disable 1998
+#pragma warning disable 1998, 9113
 
 #region EmptyBuyersRemorsePolicy
-#pragma warning disable CS9113 // Parameter is unread.
 class BuyersRemorsePolicy(ILogger<BuyersRemorsePolicy> logger) : Saga<BuyersRemorseData>
-#pragma warning restore CS9113 // Parameter is unread.
 {
     protected override void ConfigureHowToFindSaga(SagaPropertyMapper<BuyersRemorseData> mapper)
     {
@@ -22,4 +20,4 @@ public class BuyersRemorseData : ContainSagaData
 }
 #endregion
 
-#pragma warning restore 1998
+#pragma warning restore 1998, 9113


### PR DESCRIPTION
If code suppressions appear within the snippet region, they will be included in the docs. In most cases, such as with saga timeouts, the doc reads better without suppressions in the snippets.

You can review the existing behaviour here; https://docs.particular.net/tutorials/nservicebus-sagas/2-timeouts/#exercise-buyersremorsepolicy-saga.