### PR TITLE
fix for running the script

### DIFF
--- a/Snippets/SqlPersistence/SqlPersistence_8/MySql_OutboxCreate.sql
+++ b/Snippets/SqlPersistence/SqlPersistence_8/MySql_OutboxCreate.sql
@@ -1,4 +1,5 @@
 startcode MySql_OutboxCreateSql
+SET @tablePrefix = IFNULL(@tablePrefix, '');
 set @tableNameQuoted = concat('`', @tablePrefix, 'OutboxData`');
 set @tableNameNonQuoted = concat(@tablePrefix, 'OutboxData');
 


### PR DESCRIPTION
Derek Comartin pointed out in an email that:

The MySQL Outbox Create Table SQL produces an error in MySQL8.

[](https://docs.particular.net/persistence/sql/mysql-scripts)

Running the code manually in MySQL produces the error when: prepare script from @createTable;
Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NULL' at line 1

However, in code, the MySqlException is

(0x80004005): Parameter '@tableNameQuoted' must be defined

Tried it locally, and this is the fix I came up with.
