### PR TITLE
Fix snippets & samples

### DIFF
--- a/Snippets/ABSDataBus/ABSDataBus_6/ABSDataBus_6.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_6/ABSDataBus_6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.*" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_5.1/ASBFunctionsWorker_5.1.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_5.1/ASBFunctionsWorker_5.1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_5/ASBFunctionsWorker_5.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_5/ASBFunctionsWorker_5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />

--- a/Snippets/ASBS/ASBS_4/ASBS_4.csproj
+++ b/Snippets/ASBS/ASBS_4/ASBS_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />

--- a/Snippets/ASBS/ASBS_5/ASBS_5.csproj
+++ b/Snippets/ASBS/ASBS_5/ASBS_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />

--- a/Snippets/ASP/ASTP_6/ASTP_6.csproj
+++ b/Snippets/ASP/ASTP_6/ASTP_6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="6.*" />

--- a/Snippets/ASQ/ASQN_13/ASQN_13.csproj
+++ b/Snippets/ASQ/ASQN_13/ASQN_13.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="13.*" />

--- a/Snippets/Bridge/Bridge_3.1/Bridge_3.1.csproj
+++ b/Snippets/Bridge/Bridge_3.1/Bridge_3.1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.MessagingBridge" Version="3.1.*" />

--- a/Snippets/Callbacks/Callbacks_5/Callbacks_5.csproj
+++ b/Snippets/Callbacks/Callbacks_5/Callbacks_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="5.*" />

--- a/Snippets/CallbacksTesting/CallbacksTesting_5/CallbacksTesting_5.csproj
+++ b/Snippets/CallbacksTesting/CallbacksTesting_5/CallbacksTesting_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks.Testing" Version="5.*" />

--- a/Snippets/Core/Core_9.1/Core_9.1.csproj
+++ b/Snippets/Core/Core_9.1/Core_9.1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Core9</RootNamespace>
   </PropertyGroup>
 

--- a/Snippets/Core/Core_9/Core_9.csproj
+++ b/Snippets/Core/Core_9/Core_9.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Core9</RootNamespace>
   </PropertyGroup>
 

--- a/Snippets/CosmosDB/CosmosDB_3/CosmosDB_3.csproj
+++ b/Snippets/CosmosDB/CosmosDB_3/CosmosDB_3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="3.*" />

--- a/Snippets/CustomChecks/CustomChecks_5/CustomChecks_5.csproj
+++ b/Snippets/CustomChecks/CustomChecks_5/CustomChecks_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="5.*" />

--- a/Snippets/DataBus/Core_9/Core_9.csproj
+++ b/Snippets/DataBus/Core_9/Core_9.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Core9</RootNamespace>
   </PropertyGroup>
 

--- a/Snippets/DataBus/DataBus_1/ClaimCheck_1.csproj
+++ b/Snippets/DataBus/DataBus_1/ClaimCheck_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>ClaimCheck_1</RootNamespace>
   </PropertyGroup>
 

--- a/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
+++ b/Snippets/DynamoDB/DynamoDB_1/DynamoDB_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Snippets/DynamoDB/DynamoDB_2/DynamoDB_2.csproj
+++ b/Snippets/DynamoDB/DynamoDB_2/DynamoDB_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_3/Extensions.Hosting_3.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_3/Extensions.Hosting_3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_3/Extensions.Logging_3.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_3/Extensions.Logging_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="3.*" />

--- a/Snippets/FileShareDataBus/Core_9/Core_9.csproj
+++ b/Snippets/FileShareDataBus/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/Snippets/FileShareDataBus/DataBus_1/DataBus_1.csproj
+++ b/Snippets/FileShareDataBus/DataBus_1/DataBus_1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/Snippets/Gateway/Gateway_5/Gateway_5.csproj
+++ b/Snippets/Gateway/Gateway_5/Gateway_5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway" Version="5.*" />

--- a/Snippets/GatewayRavenDB/GatewayRavenDB_4/GatewayRavenDB_4.csproj
+++ b/Snippets/GatewayRavenDB/GatewayRavenDB_4/GatewayRavenDB_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway.RavenDB" Version="4.*" />

--- a/Snippets/GatewaySql/GatewaySql_3/GatewaySql_3.csproj
+++ b/Snippets/GatewaySql/GatewaySql_3/GatewaySql_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway.Sql" Version="3.*" />

--- a/Snippets/Heartbeats/Heartbeats_5/Heartbeats_5.csproj
+++ b/Snippets/Heartbeats/Heartbeats_5/Heartbeats_5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />

--- a/Snippets/LearningPersistence/Core_9/Core_9.csproj
+++ b/Snippets/LearningPersistence/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/Snippets/LearningTransport/Core_9/Core_9.csproj
+++ b/Snippets/LearningTransport/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/Snippets/Metrics/Metrics_5/Metrics_5.csproj
+++ b/Snippets/Metrics/Metrics_5/Metrics_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics" Version="5.*" />

--- a/Snippets/MetricsServiceControl/MetricsServiceControl_5/MetricsServiceControl_5.csproj
+++ b/Snippets/MetricsServiceControl/MetricsServiceControl_5/MetricsServiceControl_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />

--- a/Snippets/NHibernate/NHibernate_10/NHibernate_10.csproj
+++ b/Snippets/NHibernate/NHibernate_10/NHibernate_10.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.NHibernate" Version="10.*" />

--- a/Snippets/Newtonsoft/Newtonsoft_4/Newtonsoft_4.csproj
+++ b/Snippets/Newtonsoft/Newtonsoft_4/Newtonsoft_4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />

--- a/Snippets/NonDurablePersistence/NonDurablePersistence_2/NonDurablePersistence_2.csproj
+++ b/Snippets/NonDurablePersistence/NonDurablePersistence_2/NonDurablePersistence_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>NonDurablePersistence_2</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/PlatformConnector/PlatformConnector_3/PlatformConnector_3.csproj
+++ b/Snippets/PlatformConnector/PlatformConnector_3/PlatformConnector_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ServicePlatform.Connector" Version="3.*" />

--- a/Snippets/PlatformSample/PlatformSample_3/PlatformSample_3.csproj
+++ b/Snippets/PlatformSample/PlatformSample_3/PlatformSample_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/PostgreSqlTransport_8.csproj
+++ b/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/PostgreSqlTransport_8.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/PropertyEncryption/PropertyEncryption_5/PropertyEncryption_5.csproj
+++ b/Snippets/PropertyEncryption/PropertyEncryption_5/PropertyEncryption_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="5.*" />

--- a/Snippets/Rabbit/Rabbit_9.1/Rabbit_9.1.csproj
+++ b/Snippets/Rabbit/Rabbit_9.1/Rabbit_9.1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.1.*" />

--- a/Snippets/Rabbit/Rabbit_9.2/Rabbit_9.2.csproj
+++ b/Snippets/Rabbit/Rabbit_9.2/Rabbit_9.2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.2.*" />

--- a/Snippets/Rabbit/Rabbit_9/Rabbit_9.csproj
+++ b/Snippets/Rabbit/Rabbit_9/Rabbit_9.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.0.*" />

--- a/Snippets/Rabbit/Rabbit_9/Usage.cs
+++ b/Snippets/Rabbit/Rabbit_9/Usage.cs
@@ -136,7 +136,7 @@ class Usage
         #region rabbitmq-client-certificate
 
         var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
-        transport.SetClientCertificate(X509CertificateLoader.LoadCertificateFromFile("/path/to/certificate"));
+        transport.SetClientCertificate(new X509Certificate2("/path/to/certificate"));
 
         #endregion
     }

--- a/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
+++ b/Snippets/Rabbit/Rabbit_All/Rabbit_All.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/Snippets/Raven/Raven_9/Raven_9.csproj
+++ b/Snippets/Raven/Raven_9/Raven_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RavenDB" Version="9.*" />

--- a/Snippets/RawMessaging/Core_9/Core_9.csproj
+++ b/Snippets/RawMessaging/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/Snippets/SQSLambda/SQSLambda_2/SQSLambda_2.csproj
+++ b/Snippets/SQSLambda/SQSLambda_2/SQSLambda_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/SagaAudit/SagaAudit_5/SagaAudit_5.csproj
+++ b/Snippets/SagaAudit/SagaAudit_5/SagaAudit_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="5.*" />

--- a/Snippets/SqlPersistence/SqlPersistence_8/SqlPersistence_8.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_8/SqlPersistence_8.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SqlPersistenceGenerateScripts>false</SqlPersistenceGenerateScripts>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
+++ b/Snippets/SqlPersistence/SqlPersistence_All/SqlPersistence_All.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/Snippets/SqlTransport/SqlTransport_8/SqlTransport_8.csproj
+++ b/Snippets/SqlTransport/SqlTransport_8/SqlTransport_8.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="8.*" />

--- a/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
+++ b/Snippets/SqlTransport/SqlTransport_All/SqlTransport_All.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Transactions" />

--- a/Snippets/Sqs/Sqs_7/Sqs_7.csproj
+++ b/Snippets/Sqs/Sqs_7/Sqs_7.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AmazonSQS" Version="7.*" />

--- a/Snippets/SystemJson/Core_9/Core_9.csproj
+++ b/Snippets/SystemJson/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/Snippets/Testing/Testing_9/Testing_9.csproj
+++ b/Snippets/Testing/Testing_9/Testing_9.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/Snippets/TransactionalSession.DynamoDB/DynamoTS_2/DynamoTS_2.csproj
+++ b/Snippets/TransactionalSession.DynamoDB/DynamoTS_2/DynamoTS_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/TransactionalSession/TransactionalSession_3/TransactionalSession_3.csproj
+++ b/Snippets/TransactionalSession/TransactionalSession_3/TransactionalSession_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.TransactionalSession" Version="3.*" />

--- a/Snippets/UniformSession/UniformSession_4/UniformSession_4.csproj
+++ b/Snippets/UniformSession/UniformSession_4/UniformSession_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession" Version="4.*" />

--- a/Snippets/UniformSessionTesting/UniformSessionTesting_4/UniformSessionTesting_4.csproj
+++ b/Snippets/UniformSessionTesting/UniformSessionTesting_4/UniformSessionTesting_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.UniformSession.Testing" Version="4.*" />

--- a/Snippets/Xml/Core_9/Core_9.csproj
+++ b/Snippets/Xml/Core_9/Core_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Core9</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Snippets/mongodb/MongoDB_4/MongoDB_4.csproj
+++ b/Snippets/mongodb/MongoDB_4/MongoDB_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Storage.MongoDB" Version="4.*" />

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Client/Client.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Server/Server.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.DynamoDB" Version="2.*" />

--- a/samples/aws/dynamodb-simple/DynamoDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Client/Client.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Server/Server.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/aws/lambda-sqs/SQSLambda_2/Messages/Messages.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_2/Messages/Messages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_2/RegularEndpoint/RegularEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_2/RegularEndpoint/RegularEndpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_2/ServerlessEndpoint/ServerlessEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_2/ServerlessEndpoint/ServerlessEndpoint.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/ClientUI.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/DeployDatabase/DeployDatabase.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/DeployDatabase/DeployDatabase.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Messages/Messages.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Messages/Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/Sales.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/Sales.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-native-integration/Sqs_7/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_7/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-native-integration/Sqs_7/Sender/Sender.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_7/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-simple/Sqs_7/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_7/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-simple/Sqs_7/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_7/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-simple/Sqs_7/Shared/Shared.csproj
+++ b/samples/aws/sqs-simple/Sqs_7/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/ConsoleEndpoint/ConsoleEndpoint.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_5/ConsoleEndpoint/ConsoleEndpoint.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_5/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_5/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_5/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_5/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeShared/NativeShared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Publisher/Publisher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeShared/NativeShared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/Publisher/Publisher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_4/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_4/NativeSender/NativeSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_5/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_5/NativeSender/NativeSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/options/ASBS_5/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/options/ASBS_5/Publisher/Publisher.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/options/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/options/ASBS_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />

--- a/samples/azure-service-bus-netstandard/options/ASBS_5/Subscriber/Subscriber.csproj
+++ b/samples/azure-service-bus-netstandard/options/ASBS_5/Subscriber/Subscriber.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj"/>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Receiver/Receiver.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/Sender.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Receiver/Receiver.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/Sender.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Publisher/Publisher.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Subscriber/Subscriber.csproj
+++ b/samples/azure-service-bus-netstandard/topology-migration/ASBS_5/Subscriber/Subscriber.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/simple/ASTP_6/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_6/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASTP_6/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_6/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/simple/ASTP_6/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/table/ASTP_6/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_6/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/table/ASTP_6/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_6/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/table/ASTP_6/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/transactions/ASTP_6/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_6/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/azure-table/transactions/ASTP_6/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_6/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/native-integration-asq/ASQN_13/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_13/NativeSender/NativeSender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_13/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_13/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_13/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_13/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/storage-queues/ASQN_13/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_13/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/storage-queues/ASQN_13/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_13/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/storage-queues/ASQN_13/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_13/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/azure/storage-queues/ASQN_13/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_13/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />

--- a/samples/azure/webjob-host/Core_9/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_9/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/AsbEndpoint/AsbEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0-windows;net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Bridge/Bridge.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFrameworks>net9.0-windows;net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/service-control/Bridge_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/bridge/service-control/Bridge_2/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/bridge/service-control/Bridge_3/Bridge/Bridge.csproj
+++ b/samples/bridge/service-control/Bridge_3/Bridge/Bridge.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/service-control/Bridge_3/Endpoint/Endpoint.csproj
+++ b/samples/bridge/service-control/Bridge_3/Endpoint/Endpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/service-control/Bridge_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/bridge/service-control/Bridge_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/bridge/service-control/Bridge_3/Shared/Shared.csproj
+++ b/samples/bridge/service-control/Bridge_3/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/bridge/service-control/TransportBridge_1/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/bridge/service-control/TransportBridge_1/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_3/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_3/Bridge/Bridge.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_3/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_3/LeftReceiver/LeftReceiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_3/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_3/LeftSender/LeftSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_3/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_3/RightReceiver/RightReceiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_3/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_3/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/bridge/sql-multi-instance/Bridge_3/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Bridge/Bridge.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_3/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Helpers/Helpers.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_3/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_3/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_3/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_3/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/callbacks/Callbacks_5/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_5/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_5/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_5/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_5/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/callbacks/Callbacks_5/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_5/WebSender/WebSender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/consumer-driven-contracts/Core_9/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_9/Consumer1/Consumer1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/consumer-driven-contracts/Core_9/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_9/Consumer2/Consumer2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/consumer-driven-contracts/Core_9/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_9/Producer/Producer.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Consumer1\Contracts\Consumer1Contract.cs" />

--- a/samples/cooperative-cancellation/Core_9/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/cosmosdb/container/CosmosDB_3/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_3/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/container/CosmosDB_3/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_3/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="3.*" />

--- a/samples/cosmosdb/container/CosmosDB_3/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/cosmosdb/simple/CosmosDB_3/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_3/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/simple/CosmosDB_3/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_3/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="3.*" />

--- a/samples/cosmosdb/simple/CosmosDB_3/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_3/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_3/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/transactions/CosmosDB_3/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_3/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="3.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_3/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/custom-recoverability/Core_9/Client/Client.csproj
+++ b/samples/custom-recoverability/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/custom-recoverability/Core_9/Server/Server.csproj
+++ b/samples/custom-recoverability/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/custom-recoverability/Core_9/Shared/Shared.csproj
+++ b/samples/custom-recoverability/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_6/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_6/Receiver/Receiver.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_6/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/blob-storage-databus/ABSDataBus_6/Sender/Sender.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_6/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="6.*" />

--- a/samples/databus/blob-storage-databus/ABSDataBus_6/Shared/Shared.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/custom-serializer/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_9/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_9/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/databus/custom-serializer/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/file-share-databus/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.1.*" />

--- a/samples/databus/file-share-databus/Core_9/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.1.*" />

--- a/samples/databus/file-share-databus/Core_9/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.1.*" />

--- a/samples/databus/file-share-databus/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/file-share-databus/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/file-share-databus/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />

--- a/samples/databus/redis/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_9/Receiver/Receiver.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/databus/redis/Core_9/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_9/Sender/Sender.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/databus/redis/Core_9/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/delayed-delivery/Core_9/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_9/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_9/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/dependency-injection/aspnetcore/Core_9/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />

--- a/samples/dependency-injection/aspnetcore/Core_9/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_9/SampleAutofac/SampleAutofac.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.*" />

--- a/samples/dependency-injection/externally-managed-mode/Core_9/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_5/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_5/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_5/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_5/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/encryption/message-body-encryption/Core_9/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_9/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_9/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_9/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_9/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/entity-framework-core/SqlPersistence_8/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_8/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework-core/SqlPersistence_8/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_9/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_9/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="2.*" />

--- a/samples/errorhandling/Core_9/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/errorhandling/Core_9/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_9/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/errorhandling/Core_9/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_9/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_9/Client/Client.csproj
+++ b/samples/faulttolerance/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_9/Server/Server.csproj
+++ b/samples/faulttolerance/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_9/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/feature/Core_9/Sample/Sample.csproj
+++ b/samples/feature/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/fullduplex/Core_9/Client/Client.csproj
+++ b/samples/fullduplex/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_9/Server/Server.csproj
+++ b/samples/fullduplex/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_9/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/gateway/Gateway_5/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_5/Headquarters/Headquarters.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_5/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_5/RemoteSite/RemoteSite.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_5/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_5/Shared/Shared.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_5/WebClient/WebClient.csproj
+++ b/samples/gateway/Gateway_5/WebClient/WebClient.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/header-manipulation/Core_9/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -3,11 +3,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
+++ b/samples/hosting/aspire/Core_9/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_9/Billing/Billing.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_9/ClientUI/ClientUI.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_9/Messages/Messages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_9/Sales/Sales.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_8/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/docker/Core_8/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_8/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/hosting/docker/Core_8/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/hosting/docker/Core_9/Receiver/Receiver.csproj
+++ b/samples/hosting/docker/Core_9/Receiver/Receiver.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 

--- a/samples/hosting/docker/Core_9/Sender/Sender.csproj
+++ b/samples/hosting/docker/Core_9/Sender/Sender.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 

--- a/samples/hosting/docker/Core_9/Shared/Shared.csproj
+++ b/samples/hosting/docker/Core_9/Shared/Shared.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/generic-host/Core_9/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_9/GenericHost/GenericHost.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/immutable-messages/Core_9/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_9/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_9/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/logging/custom-factory/Core_9/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/logging/datadog/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_9/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" Version="8.*" />

--- a/samples/logging/default/Core_9/Sample/Sample.csproj
+++ b/samples/logging/default/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/logging/extensions-logging/Extensions.Logging_3/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_3/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/logging/metrics/Metrics_5/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_5/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/logging/new-relic/Metrics_5/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_5/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent.Api" Version="10.*" />

--- a/samples/logging/notifications/Core_9/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/message-assembly-sharing/Core_9/Receiver/Receiver.csproj
+++ b/samples/message-assembly-sharing/Core_9/Receiver/Receiver.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/message-assembly-sharing/Core_9/Sender/Sender.csproj
+++ b/samples/message-assembly-sharing/Core_9/Sender/Sender.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/message-assembly-sharing/Core_9/Shared/Shared.csproj
+++ b/samples/message-assembly-sharing/Core_9/Shared/Shared.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/messagemutators/Core_9/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/mongodb/simple/MongoDB_4/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_4/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_4/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_4/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_4/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/multi-tenant/di/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_9/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/multi-tenant/nhibernate/NHibernate_10/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_10/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_10/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_10/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/nhibernate/NHibernate_10/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/multi-tenant/propagation/Core_9/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_9/Billing/Billing.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/propagation/Core_9/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/propagation/Core_9/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_9/Sales/Sales.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/propagation/Core_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/multi-tenant/ravendb/Core_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_8/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_8/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/near-realtime-clients/Core_9/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_9/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_9/ClientHub/ClientHub.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_9/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_9/Publisher/Publisher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_9/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_9/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Attributes/Sample.Attributes.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Default/Sample.Default.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Fluent/Sample.Fluent.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/custom-mappings/NHibernate_10/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/nhibernate/simple/NHibernate_10/Client/Client.csproj
+++ b/samples/nhibernate/simple/NHibernate_10/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_10/Server/Server.csproj
+++ b/samples/nhibernate/simple/NHibernate_10/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/nhibernate/simple/NHibernate_10/Shared/Shared.csproj
+++ b/samples/nhibernate/simple/NHibernate_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/open-telemetry/application-insights/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/application-insights/Core_9/Endpoint/Endpoint.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/customizing/Core_9/Sample/Sample.csproj
+++ b/samples/open-telemetry/customizing/Core_9/Sample/Sample.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_9/Publisher/Publisher.csproj
+++ b/samples/open-telemetry/jaeger/Core_9/Publisher/Publisher.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_9/Shared/Shared.csproj
+++ b/samples/open-telemetry/jaeger/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_9/Subscriber/Subscriber.csproj
+++ b/samples/open-telemetry/jaeger/Core_9/Subscriber/Subscriber.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/logging/Core_9/GenericHost/GenericHost.csproj
+++ b/samples/open-telemetry/logging/Core_9/GenericHost/GenericHost.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/open-telemetry/metrics-shim/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/metrics-shim/Core_9/Endpoint/Endpoint.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/prometheus-grafana/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/prometheus-grafana/Core_9/Endpoint/Endpoint.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/outbox/cosmosdb/Core_9/Sample/Sample.csproj
+++ b/samples/outbox/cosmosdb/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/outbox/rabbit/Core_9/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/outbox/sql/Core_9/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_9/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_9/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/performance-counters/PerfCounters_6/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_6/Sample/Sample.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFrameworks>net9.0-windows;net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/audit-filtering/Core_9/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_9/AuditFilter/AuditFilter.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/dispatch-notifications/Core_9/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_9/SampleApp/SampleApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/feature-toggle/Core_9/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_9/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_9/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_9/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_9/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_9/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/header-propagation/Core_9/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_9/Messages/Messages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/header-propagation/Core_9/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_9/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/header-propagation/Core_9/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_9/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/masstransit-messages/Core_9/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_9/MTEndpoint/MTEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MassTransit.AspNetCore" Version="7.*" />

--- a/samples/pipeline/masstransit-messages/Core_9/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_9/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_9/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_9/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/message-signing/Core_9/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_9/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/message-signing/Core_9/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/message-signing/Core_9/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_9/SignedSender/SignedSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/message-signing/Core_9/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_9/UnsignedSender/UnsignedSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_9/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SessionFilter\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_9/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SessionFilter\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_9/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_9/SessionFilter/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pipeline/unit-of-work/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_9/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/code-first/PlatformConnector_3/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_3/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/code-first/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/json/PlatformConnector_3/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_3/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/json/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/json/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/ms-config/PlatformConnector_3/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_3/Endpoint/Endpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/ms-config/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Receiver/Receiver.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Sender/Sender.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Shared/Shared.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="8.*" />

--- a/samples/pubsub/native/Core_9/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_9/Publisher/Publisher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_9/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/pubsub/native/Core_9/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_9/Subscriber/Subscriber.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/rabbitmq/native-integration/Rabbit_9/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_9/NativeSender/NativeSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />

--- a/samples/rabbitmq/native-integration/Rabbit_9/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/rabbitmq/simple/Rabbit_9/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.*" />

--- a/samples/rabbitmq/simple/Rabbit_9/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="9.*" />

--- a/samples/rabbitmq/simple/Rabbit_9/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/ravendb/simple/Raven_9/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_9/Client/Client.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_9/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_9/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/recoverabilitypolicytesting/Core_9/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_9/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/samples/routing/command-routing/Core_9/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_9/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_9/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/routing/message-forwarding/Core_9/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_9/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/routing/message-forwarding/Core_9/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_9/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/routing/message-forwarding/Core_9/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_9/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_9/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_9/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_9/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_9/UpgradedDestination/UpgradedDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/saga/batching/Core_9/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_9/SharedMessages/SharedMessages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/batching/Core_9/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_9/WorkGenerator/WorkGenerator.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/batching/Core_9/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_9/WorkProcessor/WorkProcessor.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/nh-custom-sagafinder/NHibernate_10/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_10/Sample/Sample.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/simple/Core_9/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointMySql/EndpointMySql.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_8/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_9/Scheduler/Scheduler.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/scheduling/periodictimer/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Receiver/Receiver.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/scheduling/periodictimer/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Scheduler/Scheduler.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/scheduling/periodictimer/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/periodictimer/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/scheduling/quartz/Core_9/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_9/Scheduler/Scheduler.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_9/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/scheduling/timer/Core_9/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/serializers/change-message-type/Core_9/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_9/SamplePhase1/SamplePhase1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/serializers/change-message-type/Core_9/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_9/SamplePhase2/SamplePhase2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_9/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_9/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/SystemJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/SystemJsonEndpoint/SystemJsonEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_9/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_9/XmlEndpoint/XmlEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_4/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_4/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />

--- a/samples/serializers/newtonsoft/Newtonsoft_4/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_4/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/serializers/system-json/Core_9/Sample/Sample.csproj
+++ b/samples/serializers/system-json/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase1/SamplePhase1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase2/SamplePhase2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase3/SamplePhase3.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_9/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_9/SamplePhase4/SamplePhase4.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_9/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/serializers/xml/Core_9/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_5/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_5/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/EndpointsMonitor/EndpointsMonitor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_5/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_5/EndpointsMonitor/EndpointsMonitor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_5/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_5/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_5/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_5/PlatformLauncher/PlatformLauncher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/servicecontrol/fix-messages/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/fix-messages/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/fix-messages/Core_9/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
+++ b/samples/servicecontrol/fix-messages/Core_9/MessageRepairingEndpoint/MessageRepairingEndpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_9/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/fix-messages/Core_9/PlatformLauncher/PlatformLauncher.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_9/Receiver/Receiver.csproj
+++ b/samples/servicecontrol/fix-messages/Core_9/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_9/Sender/Sender.csproj
+++ b/samples/servicecontrol/fix-messages/Core_9/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/fix-messages/Core_9/Shared/Shared.csproj
+++ b/samples/servicecontrol/fix-messages/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_4/PlatformLauncher/PlatformLauncher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/3rdPartySystem/3rdPartySystem.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/3rdPartySystem/3rdPartySystem.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/PlatformLauncher/PlatformLauncher.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/Sample/Sample.csproj
+++ b/samples/servicecontrol/monitoring3rdparty/CustomChecks_5/Sample/Sample.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/retry-messages/Core_9/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/retry-messages/Core_9/PlatformLauncher/PlatformLauncher.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/retry-messages/Core_9/Receiver/Receiver.csproj
+++ b/samples/servicecontrol/retry-messages/Core_9/Receiver/Receiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/retry-messages/Core_9/Sender/Sender.csproj
+++ b/samples/servicecontrol/retry-messages/Core_9/Sender/Sender.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/retry-messages/Core_9/Shared/Shared.csproj
+++ b/samples/servicecontrol/retry-messages/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Endpoint.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Endpoint/Endpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <UseWpf>true</UseWpf>
     <RootNamespace>ServiceInsight.CustomViewer.Plugin</RootNamespace>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_2/Shared/Shared.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Endpoint.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />
-    <PackageReference Include="Particular.PlatformSample" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Endpoint/Program.cs
@@ -29,8 +29,8 @@ class Program
 
         Console.WriteLine("Message sent");
 
-        Console.WriteLine("Launching platform...");
-        await Particular.PlatformLauncher.Launch();
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
 
         await endpointInstance.Stop();
     }

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/PlatformLauncher/PlatformLauncher.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Particular.PlatformSample" Version="3.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/PlatformLauncher/Program.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/PlatformLauncher/Program.cs
@@ -1,0 +1,14 @@
+﻿namespace PlatformLauncher
+{
+    using System;
+    using System.Threading.Tasks;
+
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            Console.Title = "PlatformLauncher";
+            await Particular.PlatformLauncher.Launch();
+        }
+    }
+}

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsightCustomViewer.sln
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsightCustomViewer.sln
@@ -1,13 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35828.75
 MinimumVisualStudioVersion = 15.0.26730.12
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Endpoint", "Endpoint\Endpoint.csproj", "{E94B7783-5A00-4C72-9C9B-B126D8E59314}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{7B8DA931-9045-4A0C-A143-6F36F3175BBF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceInsight.Plugin", "ServiceInsight.Plugin\ServiceInsight.Plugin.csproj", "{DA3597F6-5B1E-4E07-9818-DD7EAD8FBF49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlatformLauncher", "PlatformLauncher\PlatformLauncher.csproj", "{834B1B50-D5BA-4BC3-FACD-8D87B2358630}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +21,8 @@ Global
 		{7B8DA931-9045-4A0C-A143-6F36F3175BBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA3597F6-5B1E-4E07-9818-DD7EAD8FBF49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DA3597F6-5B1E-4E07-9818-DD7EAD8FBF49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{834B1B50-D5BA-4BC3-FACD-8D87B2358630}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{834B1B50-D5BA-4BC3-FACD-8D87B2358630}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/Shared.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>

--- a/samples/showcase/cinema/Core_9/Cinema.Headquarters/Cinema.Headquarters.csproj
+++ b/samples/showcase/cinema/Core_9/Cinema.Headquarters/Cinema.Headquarters.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_9/Cinema.Messages/Cinema.Messages.csproj
+++ b/samples/showcase/cinema/Core_9/Cinema.Messages/Cinema.Messages.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_9/Cinema.TicketSales/Cinema.TicketSales.csproj
+++ b/samples/showcase/cinema/Core_9/Cinema.TicketSales/Cinema.TicketSales.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_9/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.ContentManagement/Store.ContentManagement.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_9/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_9/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.ECommerce/Store.ECommerce.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />

--- a/samples/showcase/on-premises/Core_9/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.Messages/Store.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/showcase/on-premises/Core_9/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.Operations/Store.Operations.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_9/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.Sales/Store.Sales.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_9/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_9/Store.Shared/Store.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/sql-persistence/injecting-services/SqlPersistence_8/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_8/Endpoint/Endpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion1/EndpointVersion1.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_8/EndpointVersion2/EndpointVersion2.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_8/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_8/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/Client/Client.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointMySql/EndpointMySql.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointOracle/EndpointOracle.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/ServerShared/ServerShared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_8/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_8/SharedMessages/SharedMessages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase1/Shared/SharedPhase1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase2/Shared/SharedPhase2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_8/Phase3/Shared/SharedPhase3.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_9/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_9/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport-nhpersistence/Core_9/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/sqltransport-sqlpersistence/Core_9/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_9/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.*" />

--- a/samples/sqltransport-sqlpersistence/Core_9/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="8.*" />

--- a/samples/sqltransport-sqlpersistence/Core_9/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.*" />

--- a/samples/sqltransport/native-integration/SqlTransport_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_8/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.*" />

--- a/samples/sqltransport/simple/SqlTransport_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_8/Receiver/Receiver.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_8/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_8/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_8/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/startup-shutdown-sequence/Core_9/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_9/Sample/Sample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/throttling/Core_9/Limited/Limited.csproj
+++ b/samples/throttling/Core_9/Limited/Limited.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_9/Sender/Sender.csproj
+++ b/samples/throttling/Core_9/Sender/Sender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_9/Shared/Shared.csproj
+++ b/samples/throttling/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_8/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_8/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_3/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_3/Backend/Backend.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_3/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_3/Frontend/Frontend.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_3/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_3/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unit-testing/Testing_9/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_9/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/samples/unobtrusive/Core_9/Client/Client.csproj
+++ b/samples/unobtrusive/Core_9/Client/Client.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unobtrusive/Core_9/Server/Server.csproj
+++ b/samples/unobtrusive/Core_9/Server/Server.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unobtrusive/Core_9/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_9/Shared/Shared.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/username-header/Core_9/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_9/Endpoint1/Endpoint1.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_9/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_9/Endpoint2/Endpoint2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_9/Shared/Shared.csproj
+++ b/samples/username-header/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/versioning/Core_9/Publisher/Publisher.csproj
+++ b/samples/versioning/Core_9/Publisher/Publisher.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />

--- a/samples/versioning/Core_9/V1.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_9/V1.Contracts/Contracts.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_9/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_9/V1.Subscriber/V1.Subscriber.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V1.Contracts\Contracts.csproj" />

--- a/samples/versioning/Core_9/V2.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_9/V2.Contracts/Contracts.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_9/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_9/V2.Subscriber/V2.Subscriber.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />

--- a/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_9/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />

--- a/samples/web/asp-mvc-application/Core_9/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="5.*" />

--- a/samples/web/asp-mvc-application/Core_9/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/web/asp-web-application/Core_9/Server/Server.csproj
+++ b/samples/web/asp-web-application/Core_9/Server/Server.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/asp-web-application/Core_9/Shared/Shared.csproj
+++ b/samples/web/asp-web-application/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/web/asp-web-application/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/asp-web-application/Core_9/WebApp/WebApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/blazor-server-application/Core_9/Server/Server.csproj
+++ b/samples/web/blazor-server-application/Core_9/Server/Server.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/blazor-server-application/Core_9/Shared/Shared.csproj
+++ b/samples/web/blazor-server-application/Core_9/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/blazor-server-application/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/blazor-server-application/Core_9/WebApp/WebApp.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_9/WebApp/WebApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />


### PR DESCRIPTION
This PR makes the following changes:

- Snippets projects should be single targeted and target the latest LTS release, so they have been changed to target `net8.0`.
- Samples need to be multi-targeted to offer versions of samples for all supported frameworks for a given NServiceBus release (unless a sample has additional constraints that limit which frameworks it can support), so all samples that were `net9.0` only have been changed to target `net8.0` as well.

> [!NOTE]
> The PlatformSample package currently requires a .NET 8 runtime be installed on the machine due to the embedded RavenDB that is used, so PlatformLauncher projects should target `net8.0` only to reflect that requirement.