### PR TITLE
Remove reference to wire compatibility

### DIFF
--- a/nservicebus/upgrades/support-policy.md
+++ b/nservicebus/upgrades/support-policy.md
@@ -65,9 +65,7 @@ All new features are backward compatible by default. In rare cases when this is 
 
 ## Upgrading
 
-NServiceBus versions are wire-compatible; endpoints using different versions of NServiceBus can exchange messages with each other.
-
-However, some features might require data migration (e.g. converting from an old to a new format). The migration might be performed as a one-off automated action done through [installers](/nservicebus/operations/installers.md) or in the background by a running endpoint. If the conversion cannot be automated, the applicable upgrade guide will contain a description of the manual process (e.g. what script to run).
+When upgrading, some features might require data migration (e.g. converting from an old to a new format). The migration might be performed as a one-off automated action done through [installers](/nservicebus/operations/installers.md) or in the background by a running endpoint. If the conversion cannot be automated, the applicable upgrade guide will contain a description of the manual process (e.g. what script to run).
 
 Therefore the recommended approach is to upgrade *one* major version at a time, including a full regression test of the system and deployment to production after each major version upgrade. For example, if a system is using a 4.x.x version and the intention is to upgrade to the latest 6.x.x version, it is recommended to first upgrade to the latest 5.x.x version, following the relevant upgrade guides and deprecation messages. After the system is confirmed to work with the latest 5.x.x version, it may be upgraded to the latest 6.x.x version using the same process.
 


### PR DESCRIPTION
The existing statement about wire compatibility is too broad, so we should remove it for now.


It will be replaced with a more complete wire compatibility policy at a later date.