### PR TITLE
Add amqp connection string info  to upgrade guide

### DIFF
--- a/servicecontrol/upgrades/6.4to6.5.md
+++ b/servicecontrol/upgrades/6.4to6.5.md
@@ -16,8 +16,12 @@ By default, ServiceControl will infer the required settings from the connection 
 
 If custom settings are required to successfully access the management API, they must be added to the instance connection string before upgrading to ensure that the upgrade is successful and the instance can start properly.
 
+Connection strings using the [amqp URI](https://www.rabbitmq.com/docs/uri-spec) format are not compatible with ServiceControl's connection string options, so the connection string must be manually converted to the format defined by the [transport](/transports/rabbitmq/connection-settings.md#connection-string-options) before adding the management API options.
+
 > [!NOTE]
 > If [usage reporting](/servicecontrol/servicecontrol-instances/configuration.md#usage-reporting-when-using-the-rabbitmq-transport) settings have previously been configured in an error instance's `ServiceControl.exe.config` file, these settings will be detected and migrated to the equivalent connection string options automatically as part of the upgrade process.
+>
+>This migration will not happen if the connection string is using the amqp URI format. The connection string must be manually converted first before upgrading to enable the settings migration.
 >
 >Since usage reporting settings are exclusive to error instances, audit and monitoring instances will never have settings that can be migrated automatically.
 

--- a/transports/rabbitmq/connection-settings.md
+++ b/transports/rabbitmq/connection-settings.md
@@ -8,7 +8,7 @@ redirects:
  - nservicebus/rabbitmq/connection-settings
 ---
 
-The RabbitMQ transport requires a connection string to connect to the RabbitMQ broker, and there are two different styles to choose from. It can accept the standard [AMQP URI](https://www.rabbitmq.com/uri-spec.html) connection strings, or a custom format documented below.
+The RabbitMQ transport requires a connection string to connect to the RabbitMQ broker, and there are two different styles to choose from. It can accept the standard [amqp URI](https://www.rabbitmq.com/uri-spec.html) connection strings, or a custom format documented below.
 
 
 ### Specifying the connection string via code


### PR DESCRIPTION
There are some edge cases around the use of amqp connection strings, so let's call that out in the upgrade guide.