### PR TITLE
Moved the NServiceBus.NLog obsolete warning

### DIFF
--- a/nservicebus/logging/nlog.md
+++ b/nservicebus/logging/nlog.md
@@ -7,8 +7,7 @@ related:
 - samples/logging/nlog-custom
 ---
 
-> [!WARNING]
-> NServiceBus.NLog is obsolete. NServiceBus is now providing support for logging libraries through the Microsoft.Extensions.Logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
+partial: obsolete-warning
 
 partial: usage
 

--- a/nservicebus/logging/nlog_obsolete-warning_NLog_[3,).partial.md
+++ b/nservicebus/logging/nlog_obsolete-warning_NLog_[3,).partial.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> NServiceBus.NLog is obsolete. NServiceBus is now providing support for logging libraries through the Microsoft.Extensions.Logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.


### PR DESCRIPTION
<!-- Review the pull request guidelines:  https://github.com/Particular/StaffSuccess/blob/master/github/raising-pull-requests.md -->

<!--
This is the default pull request template.

If you're raising a PR that will be RFCed, please use the RFC template by adding &template=rfc.md to the URL or copy the template: https://github.com/Particular/StaffSuccess/blob/master/.github/PULL_REQUEST_TEMPLATE/rfc.md  
-->

PR Description…

## Change type

- [ ] Tiny mistakes or improvements that don't change the content or meaning
- [ ] A small decision according to the [decision-making guidelines](https://github.com/Particular/StaffSuccess/blob/master/guidelines/decision-making.md#process-for-small-decisions)
  - [ ] (Not required for decisions made by task forces) Decision type has been verified by someone not directly involved in the change being made in order to avoid bias.
  - [ ] (Not required for decisions made by task forces) The person verifying the decision type must **LEAVE A COMMENT** on this PR stating they approve the decision type. This does not imply agreement with the change, but only that the change type is correct. Sample comment: "Decision type has been verified as a small decision"
  - [ ] The PR has been approved by a reviewer who is not also the small decision verifier
  - [ ] Consider, is there some automation or other process that will make the necessary people aware of this at the appropriate time? If so, no announcement is needed. Otherwise, after the PR is merged, announce it in the relevant channel (e.g. in #staff-success or, if absolutely all staff should see it, in #announcements) and ping all the impacted parties.
- [ ] A [decision requiring an RFC but not a task force](https://github.com/Particular/StaffSuccess/blob/master/guidelines/decision-making.md#decisions-requiring-an-rfc-but-not-necessarily-a-task-force).
- [ ] An [RFC](https://github.com/Particular/StaffSuccess/blob/master/guidelines/RFC-process.md) created by a task force
- [x] Documentation update
- [ ] Other: