### PR TITLE
Using `namespace` without scope to remove indentation for quickstart snippets

### DIFF
--- a/tutorials/quickstart/Snippets/Core_9/Messages/OrderPlaces.cs
+++ b/tutorials/quickstart/Snippets/Core_9/Messages/OrderPlaces.cs
@@ -1,0 +1,10 @@
+using NServiceBus;
+
+namespace Messages
+{
+    public class OrderPlaced
+        : IEvent
+    {
+        public string OrderId { get; set; }
+    }
+}

--- a/tutorials/quickstart/Snippets/Core_9/OrderPlacedHandler.cs
+++ b/tutorials/quickstart/Snippets/Core_9/OrderPlacedHandler.cs
@@ -5,34 +5,24 @@ using NServiceBus;
 using Messages;
 using Microsoft.Extensions.Logging;
 
-namespace Shipping
+namespace Shipping;
+
+public class OrderPlacedHandler :
+    IHandleMessages<OrderPlaced>
 {
-    public class OrderPlacedHandler :
-        IHandleMessages<OrderPlaced>
+    private readonly ILogger<OrderPlacedHandler> logger;
+
+    public OrderPlacedHandler(ILogger<OrderPlacedHandler> logger)
     {
-        private readonly ILogger<OrderPlacedHandler> logger;
+        this.logger = logger;
+    }
 
-        public OrderPlacedHandler(ILogger<OrderPlacedHandler> logger)
-        {
-            this.logger = logger;
-        }
-
-        public Task Handle(OrderPlaced message, IMessageHandlerContext context)
-        {
-            logger.LogInformation(
-              $"Shipping has received OrderPlaced, OrderId = {message.OrderId}");
-            return Task.CompletedTask;
-        }
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+    {
+        logger.LogInformation(
+            $"Shipping has received OrderPlaced, OrderId = {message.OrderId}");
+        return Task.CompletedTask;
     }
 }
 
 #endregion
-
-namespace Messages
-{
-    public class OrderPlaced
-        : IEvent
-    {
-        public string OrderId { get; set; }
-    }
-}

--- a/tutorials/quickstart/Snippets/Core_9/ShippingProgram.cs
+++ b/tutorials/quickstart/Snippets/Core_9/ShippingProgram.cs
@@ -5,47 +5,48 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
-namespace Shipping
+namespace Shipping;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
-        {
-            Console.Title = "Shipping";
-            await CreateHostBuilder(args).RunConsoleAsync();
-        }
+        Console.Title = "Shipping";
+        await CreateHostBuilder(args).RunConsoleAsync();
+    }
 
-        public static IHostBuilder CreateHostBuilder(string[] args)
-        {
-            return Host.CreateDefaultBuilder(args)
-                       .UseNServiceBus(context =>
-                       {
-                           // Define the endpoint name
-                           var endpointConfig = new EndpointConfiguration("Shipping");
+    public static IHostBuilder CreateHostBuilder(string[] args)
+    {
+        return Host
+            .CreateDefaultBuilder(args)
+            .UseNServiceBus(context =>
+            {
+                // Define the endpoint name
+                var endpointConfig = new EndpointConfiguration("Shipping");
 
-                           // Choose JSON to serialize and deserialize messages
-                           endpointConfig.UseSerialization<SystemJsonSerializer>();
+                // Choose JSON to serialize and deserialize messages
+                endpointConfig.UseSerialization<SystemJsonSerializer>();
 
-                           // Select the learning (filesystem-based) transport to 
-                           // communicate with other endpoints
-                           endpointConfig.UseTransport<LearningTransport>();
+                // Select the learning (filesystem-based) transport to 
+                // communicate with other endpoints
+                endpointConfig.UseTransport<LearningTransport>();
 
-                           // Enable monitoring errors, auditing, and heartbeats
-                           // with the Particular Service Platform tools
-                           endpointConfig.SendFailedMessagesTo("error");
-                           endpointConfig.AuditProcessedMessagesTo("audit");
-                           endpointConfig.SendHeartbeatTo("Particular.ServiceControl");
+                // Enable monitoring errors, auditing, and heartbeats
+                // with the Particular Service Platform tools
+                endpointConfig.SendFailedMessagesTo("error");
+                endpointConfig.AuditProcessedMessagesTo("audit");
+                endpointConfig.SendHeartbeatTo("Particular.ServiceControl");
 
-                           // Enable monitoring endpoint performance
-                           var metrics = endpointConfig.EnableMetrics();
-                           metrics.SendMetricDataToServiceControl(
-                               "Particular.Monitoring",
-                               TimeSpan.FromMilliseconds(500));
+                // Enable monitoring endpoint performance
+                var metrics = endpointConfig.EnableMetrics();
+                metrics.SendMetricDataToServiceControl(
+                    "Particular.Monitoring",
+                    TimeSpan.FromMilliseconds(500)
+                );
 
-                           // Return the completed configuration
-                           return endpointConfig;
-                       });
-        }
+                // Return the completed configuration
+                return endpointConfig;
+            });
     }
 }
 


### PR DESCRIPTION
Slight improvement of https://github.com/Particular/docs.particular.net/pull/7075 further reducing indentation by not using namespace in a scope and wrap hostbuilder methods on a new line.