### PR TITLE
Update hosted broker options to include Amazon MQ

### DIFF
--- a/transports/rabbitmq/index.md
+++ b/transports/rabbitmq/index.md
@@ -17,6 +17,16 @@ Provides support for sending messages over [RabbitMQ](https://www.rabbitmq.com/)
 
 partial: broker-compatibility
 
+### Hosted broker options
+
+The transport has been confirmed to work with the following hosting providers:
+
+- [Amazon MQ](https://aws.amazon.com/amazon-mq/)
+- [CloudAMQP](https://www.cloudamqp.com/)
+
+> [!NOTE]
+> Other hosted options may work as long as they meet the requirements specified above.
+
 ## Transport at a glance
 
 |Feature                    |   |

--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[,7).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[,7).partial.md
@@ -1,4 +1,1 @@
-The transport is compatible with RabbitMQ broker version 3.4 or higher, either self-hosted or running on [CloudAMQP](https://www.cloudamqp.com/).
-
-> [!WARNING]
-> The transport is not compatible with RabbitMQ broker version 3.3.X and below.
+The transport is compatible with RabbitMQ broker version 3.4 or higher.

--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[10,).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[10,).partial.md
@@ -1,10 +1,7 @@
-The transport is compatible with RabbitMQ broker version 3.10.0 or higher, either self-hosted or running on [CloudAMQP](https://www.cloudamqp.com/).
+The transport is compatible with RabbitMQ broker version 3.10.0 or higher.
 
 The `stream_queue` and `quorum_queue` [feature flags](https://www.rabbitmq.com/feature-flags.html) must be enabled because the [delay infrastructure](delayed-delivery.md) requires [at-least-once dead lettering](https://blog.rabbitmq.com/posts/2022/03/at-least-once-dead-lettering/).
 
 The [RabbitMQ management plugin](https://www.rabbitmq.com/docs/management) must be enabled, and the plugin's [statistics and metrics collection must not be disabled](https://www.rabbitmq.com/docs/management#disable-stats). The port that the management API is using needs to be accessible by the transport. The default port is `15672` for HTTP and `15671` for HTTPS. See [Configuring RabbitMQ management API access](connection-settings.md#configuring-rabbitmq-management-api-access) for configuration options.
 
 The broker requirements can be verified with the [`delays verify`](operations-scripting.md#delays-verify) command provided by the command line tool.
-
-> [!WARNING]
-> Running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) is not supported because [it does not support streams](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/best-practices-rabbitmq.html).

--- a/transports/rabbitmq/index_broker-compatibility_rabbit_[7,10).partial.md
+++ b/transports/rabbitmq/index_broker-compatibility_rabbit_[7,10).partial.md
@@ -1,8 +1,5 @@
-The transport is compatible with RabbitMQ broker version 3.10.0 or higher, either self-hosted or running on [CloudAMQP](https://www.cloudamqp.com/).
+The transport is compatible with RabbitMQ broker version 3.10.0 or higher.
 
 The `stream_queue` and `quorum_queue` [feature flags](https://www.rabbitmq.com/feature-flags.html) must be enabled because the [delay infrastructure](delayed-delivery.md) requires [at-least-once dead lettering](https://blog.rabbitmq.com/posts/2022/03/at-least-once-dead-lettering/).
 
 The broker requirements can be verified with the [`delays verify`](operations-scripting.md#delays-verify) command provided by the command line tool.
-
-> [!WARNING]
-> Running on [Amazon MQ](https://aws.amazon.com/amazon-mq/) is not supported because [it does not support streams](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/best-practices-rabbitmq.html).


### PR DESCRIPTION
Amazon reached out to confirm that despite their documentation implying otherwise (which they've said they're going to work on clarifying), Amazon MQ does work with our transport, so I've updated the index page to reflect that.