### PR TITLE
Set  NuGetAuditMode to all by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>IDE0018</WarningsAsErrors>
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''">all</NuGetAuditMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This would allow us to detect transitive CVE issues in sample dependencies.