### PR TITLE
Update docs to remove Registry license location for NSB 8+

### DIFF
--- a/nservicebus/licensing/index_license-management_core_[7,8).partial.md
+++ b/nservicebus/licensing/index_license-management_core_[7,8).partial.md
@@ -10,7 +10,7 @@ A license can be configured via code-first configuration API:
 snippet: License
 
 > [!NOTE]
-> Licenses configured via code-first API take precendence over every other license source.
+> Licenses configured via code-first API take precedence over every other license source.
 
 ### Application-specific license location
 
@@ -62,7 +62,6 @@ license id=&quot;1222e1d1-2222-4a46-b1c6-943c442ca710&quot; expiration=&quot;201
 &lt;/license&gt;" />
 </appSettings>
 ```
-
 
 ### Windows Registry
 

--- a/nservicebus/licensing/index_license-management_core_[8,].partial.md
+++ b/nservicebus/licensing/index_license-management_core_[8,].partial.md
@@ -10,7 +10,7 @@ A license can be configured via code-first configuration API:
 snippet: License
 
 > [!NOTE]
-> Licenses configured via code-first API take precendence over every other license source.
+> Licenses configured via code-first API take precedence over every other license source.
 
 ### Application-specific license location
 
@@ -33,29 +33,6 @@ To install a license for all endpoints and Particular Service Platform applicati
 
 * Windows: `%PROGRAMDATA%\ParticularSoftware\license.xml`
 * Linux/macOS: `/usr/share/ParticularSoftware/license.xml`
-
-### Windows Registry
-
-> [!WARNING]
-> This option not available when targeting .NET Core.
-
-Licenses stored in a registry key named `License` in the following registry locations are automatically detected:
-* `HKEY_LOCAL_MACHINE\Software\ParticularSoftware`
-* `HKEY_CURRENT_USER\Software\ParticularSoftware`
-
-To install a license as a registry key, use the following steps:
-* Start the [Registry Editor](https://technet.microsoft.com/en-us/library/cc755256.aspx).
-* Go to `HKEY_LOCAL_MACHINE\Software\ParticularSoftware` or `HKEY_CURRENT_USER\Software\ParticularSoftware`.
-* Create a new Multi-String Value (`REG_MULTI_SZ`) named `License`.
-* Paste the contents of the license file.
-
-> [!NOTE]
-> If `HKEY_LOCAL_MACHINE` is the chosen license location, and the operating system is 64-bit, then repeat the import process for the `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\ParticularSoftware` key to support 32-bit clients.
-
-> [!NOTE]
-> If the license is stored in `HKEY_CURRENT_USER`, NServiceBus processes must run as the user account used to add the license file to the registry in order to access the license.
-
-It is safe to ignore any warnings regarding empty strings.
 
 ### Environment variable
 

--- a/nservicebus/upgrades/7to8/index.md
+++ b/nservicebus/upgrades/7to8/index.md
@@ -116,9 +116,11 @@ snippet: 7to8-DisablePublishing-UpgradeGuide
 
 ## Change to license file locations
 
- NServiceBus version 8 will no longer attempt to load the license file from the `appSettings` section of an app.config or web.config file, in order to create better alignment between .NET Framework 4.x and .NET Core.
+In order to create better alignment between .NET Framework 4.x and .NET Core, NServiceBus version 8 will no longer load license file information from the following locations:
 
-In NServiceBus version 7 and below, the license path can be loaded from the `NServiceBus/LicensePath` app setting, or the license text itself can be loaded from the `NServiceBus/License` app setting.
+- The `NServiceBus/LicensePath` setting in the `appSettings` section of an app.config or web.config file
+- The `NServiceBus/License` setting in the `appSettings` section of an app.config or web.config file
+- The Windows Registry
 
 Starting in NServiceBus version 8, one of the [other methods of providing a license](/nservicebus/licensing/?version=core_8) must be used instead.
 


### PR DESCRIPTION
NServiceBus 8 removed the Registry as a license source location, but the docs weren't updated to reflect that.

This PR fixes that and also updates the upgrade guide to make it clear that it was removed.