### PR TITLE
Document that persister must take logical endpoint name into account when storing outbox records

### DIFF
--- a/nservicebus/messaging/message-identity.md
+++ b/nservicebus/messaging/message-identity.md
@@ -10,7 +10,7 @@ Each message dispatched from an [Endpoint](/nservicebus/endpoints/) has a unique
 Many features take advantage of message identity. For example, the [Outbox](/nservicebus/outbox) uses message identity to deduplicate messages and [recoverability](/nservicebus/recoverability/) uses message identity to keep track of how many times the endpoint has tried to process a message.
 
 > [!NOTE]
-> Message identities are not guaranteed to be unique across endpoints from a processing perspective. For example, a published event’s message identity will always be the same for all subscribers. In cases where a globally unique identity for processed messages are required, the name of the processing endpoint should be combined with the message identity.
+> Message identities are not guaranteed to be unique across endpoints from a processing perspective. For example, a published event’s message identity will always be the same for all subscribers. In cases where a globally unique identity for processed messages are required, the name of the processing [logical endpoint](/nservicebus/endpoints/#logical-endpoints) should be combined with the message identity.
 
 ## Specifying message identity
 

--- a/nservicebus/outbox/index.md
+++ b/nservicebus/outbox/index.md
@@ -182,7 +182,9 @@ In order to gradually convert an entire system from the DTC to the outbox:
 
 ## Message identity
 
-The outbox only uses the incoming [message identifier](/nservicebus/messaging/message-identity.md) as a unique key for deduplicating messages. If the sender does not use the outbox when sending messages, it is responsible for ensuring that the message identifier value is consistent when that message is sent multiple times.
+The outbox uses the incoming [message identifier](/nservicebus/messaging/message-identity.md) as a unique key for deduplicating messages. If the sender [specifies a custom message id](/nservicebus/messaging/message-identity.md#specifying-message-identity) when sending messages, it is responsible for ensuring that the message identifier value is consistent if the message is sent multiple times.
+
+Since message identifier are [only unique with in the scope of a logical endpoint from a processing perspective](/nservicebus/messaging/message-identity.md) its the responsibility of the persister to ensure that message identities are scoped to the [logical endpoint](/nservicebus/endpoints/#logical-endpoints) that is processing the message.
 
 ## Outbox expiration duration
 


### PR DESCRIPTION
This tries to clarify at a high level that persisters need to take the endpoint name into account