### PR TITLE
ServiceControl MaintenanceMode setting

### DIFF
--- a/servicecontrol/audit-instances/configuration.md
+++ b/servicecontrol/audit-instances/configuration.md
@@ -135,7 +135,7 @@ The maximum allowed time for the process to gracefully complete the shutdown aft
 
 ### ServiceControl.Audit/MaintenanceMode
 
-Run [ServiceControl audit instance in maintenance mode](https://docs.particular.net/servicecontrol/ravendb/accessing-database) in order to do database maintenance.
+Run [ServiceControl audit instance in maintenance mode](/servicecontrol/ravendb/accessing-database.md) in order to do database maintenance.
 
 | Context | Name |
 | --- | --- |

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -143,7 +143,7 @@ The maximum allowed time for the process to complete the shutdown.
 
 ### ServiceControl/MaintenanceMode
 
-Run [ServiceControl error instance in maintenance mode](https://docs.particular.net/servicecontrol/ravendb/accessing-database) in order to do database maintenance.
+Run [ServiceControl error instance in maintenance mode](/servicecontrol/ravendb/accessing-database.md) in order to do database maintenance.
 
 | Context | Name |
 | --- | --- |


### PR DESCRIPTION
Document the MaintenanceMode setting as this setting can come in handy when SC is misbehaving and the windows service is disabled. This allows to launch maintenance mode from the console.