### PR TITLE
Remove net6.0 TFM

### DIFF
--- a/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.0/ASBFunctions_1.0.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.1/ASBFunctions_1.1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.2/ASBFunctions_1.2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_1.3/ASBFunctions_1.3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_2/ASBFunctions_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_3/ASBFunctions_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/Snippets/ASBFunctions/ASBFunctions_4.4/ASBFunctions_4.4.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_4.4/ASBFunctions_4.4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
+++ b/Snippets/ASBFunctions/ASBFunctions_4/ASBFunctions_4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>V3</AzureFunctionsVersion>
   </PropertyGroup>
 

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_1/ASBFunctionsWorker_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_2/ASBFunctionsWorker_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_3/ASBFunctionsWorker_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_4/ASBFunctionsWorker_4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
+++ b/Snippets/BinaryDataBusSerializer/BinaryDataBusSerializer_1/BinaryDataBusSerializer_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
+++ b/Snippets/CosmosDB/CosmosDB_1/CosmosDB_1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />

--- a/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
+++ b/Snippets/CosmosDB/CosmosDB_2/CosmosDB_2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
+++ b/Snippets/CustomChecks/CustomChecks_3/CustomChecks_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
+++ b/Snippets/CustomChecks/CustomChecks_4/CustomChecks_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.CustomChecks" Version="4.*" />

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Extensions.Hosting_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Extensions.Hosting_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
+++ b/Snippets/Extensions.Logging/Extensions.Logging_2/Extensions.Logging_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Logging" Version="2.*" />

--- a/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
+++ b/Snippets/Heartbeats/Heartbeats_3/Heartbeats_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
+++ b/Snippets/Heartbeats/Heartbeats_4/Heartbeats_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Heartbeat" Version="4.*" />

--- a/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
+++ b/Snippets/SQSLambda/SQSLambda_1/SQSLambda_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
+++ b/Snippets/SagaAudit/SagaAudit_3/SagaAudit_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
+++ b/Snippets/SagaAudit/SagaAudit_4/SagaAudit_4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SagaAudit" Version="4.*" />

--- a/Snippets/Templates/Templates_1/Templates_1.csproj
+++ b/Snippets/Templates/Templates_1/Templates_1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ParticularTemplates" Version="1.*" />

--- a/Snippets/Templates/Templates_2/Templates_2.csproj
+++ b/Snippets/Templates/Templates_2/Templates_2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Templates/Templates_3/Templates_3.csproj
+++ b/Snippets/Templates/Templates_3/Templates_3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Templates/Templates_4/Templates_4.csproj
+++ b/Snippets/Templates/Templates_4/Templates_4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/Templates/Templates_5/Templates_5.csproj
+++ b/Snippets/Templates/Templates_5/Templates_5.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ParticularTemplates" Version="5.*" />

--- a/Snippets/Templates/Templates_6/Templates_6.csproj
+++ b/Snippets/Templates/Templates_6/Templates_6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ParticularTemplates" Version="6.*" />

--- a/Snippets/TransactionalSession.AzureTable/AzureTableTS_3/AzureTableTS_3.csproj
+++ b/Snippets/TransactionalSession.AzureTable/AzureTableTS_3/AzureTableTS_3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.AzureTable/AzureTableTS_4/AzureTableTS_4.csproj
+++ b/Snippets/TransactionalSession.AzureTable/AzureTableTS_4/AzureTableTS_4.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
 	</ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />    
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="6.*" />
   </ItemGroup>
 

--- a/Snippets/TransactionalSession.CosmosDB/CosmosTS_1/CosmosTS_1.csproj
+++ b/Snippets/TransactionalSession.CosmosDB/CosmosTS_1/CosmosTS_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.CosmosDB/CosmosTS_2/CosmosTS_2.csproj
+++ b/Snippets/TransactionalSession.CosmosDB/CosmosTS_2/CosmosTS_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Persistence.CosmosDB.TransactionalSession" Version="2.*" />

--- a/Snippets/TransactionalSession.DynamoDB/DynamoTS_1/DynamoTS_1.csproj
+++ b/Snippets/TransactionalSession.DynamoDB/DynamoTS_1/DynamoTS_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_3/MongoTS_3.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_3/MongoTS_3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Storage.MongoDB.TransactionalSession" Version="3.*" />

--- a/Snippets/TransactionalSession.NHibernate/NHibernateTS_8/NHibernateTS_8.csproj
+++ b/Snippets/TransactionalSession.NHibernate/NHibernateTS_8/NHibernateTS_8.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.NHibernate/NHibernateTS_9/NHibernateTS_9.csproj
+++ b/Snippets/TransactionalSession.NHibernate/NHibernateTS_9/NHibernateTS_9.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.NHibernate.TransactionalSession" Version="9.*" />

--- a/Snippets/TransactionalSession.RavenDB/RavenTS_7/RavenTS_7.csproj
+++ b/Snippets/TransactionalSession.RavenDB/RavenTS_7/RavenTS_7.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.RavenDB/RavenTS_8/RavenTS_8.csproj
+++ b/Snippets/TransactionalSession.RavenDB/RavenTS_8/RavenTS_8.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.RavenDB.TransactionalSession" Version="8.*" />

--- a/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_6/SqlPersistenceTS_6.csproj
+++ b/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_6/SqlPersistenceTS_6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_7/SqlPersistenceTS_7.csproj
+++ b/Snippets/TransactionalSession.SqlPersistence/SqlPersistenceTS_7/SqlPersistenceTS_7.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="7.*" />

--- a/Snippets/TransactionalSession/TransactionalSession_1/TransactionalSession_1.csproj
+++ b/Snippets/TransactionalSession/TransactionalSession_1/TransactionalSession_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snippets/TransactionalSession/TransactionalSession_2/TransactionalSession_2.csproj
+++ b/Snippets/TransactionalSession/TransactionalSession_2/TransactionalSession_2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.TransactionalSession" Version="2.*" />

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.DynamoDB" Version="1.*" />

--- a/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_1/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_1/Messages/Messages.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_1/Messages/Messages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_1/RegularEndpoint/RegularEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_1/RegularEndpoint/RegularEndpoint.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/Properties/launchSettings.json
+++ b/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe"
     }
   }
 }

--- a/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/ServerlessEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/ServerlessEndpoint.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/aws-lambda-tools-defaults.json
+++ b/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "default",
   "region": "",
   "configuration": "Debug",
-  "framework": "net6.0",
+  "framework": "net8.0",
   "template": "serverless.template",
   "template-parameters": "",
   "stack-name": "nservicebus-aws-lambda-sample",

--- a/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/serverless.template
+++ b/samples/aws/lambda-sqs/SQSLambda_1/ServerlessEndpoint/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "Template that creates an SQS queue and a function that is invoked when a new message arrives. This template is partially managed by Amazon.Lambda.Annotations (v1.2.0.0).",
+  "Description": "Template that creates an SQS queue and a function that is invoked when a new message arrives. This template is partially managed by Amazon.Lambda.Annotations (v1.7.0.0).",
   "Resources": {
     "ErrorQueue": {
       "Properties": {
@@ -41,7 +41,7 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "ServerlessEndpoint::LambdaFunctions.SqsLambda::FunctionHandler",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Function handling sqs events produced by pushing messages to the ServerlessEndpoint queue",
         "MemorySize": 256,
@@ -73,10 +73,16 @@
         "Tool": "Amazon.Lambda.Annotations",
         "SyncedEvents": [
           "RootGet"
-        ]
+        ],
+        "SyncedEventProperties": {
+          "RootGet": [
+            "Path",
+            "Method"
+          ]
+        }
       },
       "Properties": {
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": ".",
         "MemorySize": 256,
         "Timeout": 30,

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/ClientUI/ClientUI.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/DeployDatabase/DeployDatabase.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/DeployDatabase/DeployDatabase.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/Messages/Messages.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/Messages/Messages.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/Properties/launchSettings.json
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe"
     }
   }
 }

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/Sales.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/Sales.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/aws-lambda-tools-defaults.json
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "default",
   "region": "",
   "configuration": "Release",
-  "framework": "net6.0",
+  "framework": "net8.0",
   "template": "serverless.template",
   "template-parameters": ""
 }

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/serverless.template
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_1/Sales/serverless.template
@@ -76,7 +76,7 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "Sales::OrderProcessor::ProcessOrder",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Process an order",
         "MemorySize": 256,

--- a/samples/aws/sagas/DynamoDB_1/ClientUI/ClientUI.csproj
+++ b/samples/aws/sagas/DynamoDB_1/ClientUI/ClientUI.csproj
@@ -1,19 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="6.*" />
-    <PackageReference Include="NServiceBus" Version="8.*" />
+    <ProjectReference Include="..\Messages\Messages.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Messages\Messages.csproj" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="6.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/aws/sagas/DynamoDB_1/Messages/Messages.csproj
+++ b/samples/aws/sagas/DynamoDB_1/Messages/Messages.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sagas/DynamoDB_1/Sales/Properties/launchSettings.json
+++ b/samples/aws/sagas/DynamoDB_1/Sales/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe"
     }
   }
 }

--- a/samples/aws/sagas/DynamoDB_1/Sales/Sales.csproj
+++ b/samples/aws/sagas/DynamoDB_1/Sales/Sales.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
@@ -8,16 +9,18 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Generate ready to run images during publishing to improve cold start time. -->
     <PublishReadyToRun>true</PublishReadyToRun>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Messages\Messages.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.*" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.*" />
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="1.*" />
     <PackageReference Include="NServiceBus.Persistence.DynamoDB" Version="1.*" />
-    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Messages\Messages.csproj" />
-  </ItemGroup>
+
 </Project>

--- a/samples/aws/sagas/DynamoDB_1/Sales/aws-lambda-tools-defaults.json
+++ b/samples/aws/sagas/DynamoDB_1/Sales/aws-lambda-tools-defaults.json
@@ -8,7 +8,7 @@
   "profile": "default",
   "region": "",
   "configuration": "Release",
-  "framework": "net6.0",
+  "framework": "net8.0",
   "template": "serverless.template",
   "template-parameters": ""
 }

--- a/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
+++ b/samples/aws/sagas/DynamoDB_1/Sales/serverless.template
@@ -103,7 +103,7 @@
       "Type": "AWS::Serverless::Function",
       "Properties": {
         "Handler": "Sales::OrderProcessor::ProcessOrder",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet8",
         "CodeUri": "",
         "Description": "Process an order",
         "MemorySize": 256,

--- a/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_6/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
+++ b/samples/aws/sqs-simple/Sqs_6/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.KafkaTrigger.FunctionsHostBuilder/AzureFunctions.KafkaTrigger.FunctionsHostBuilder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
+++ b/samples/azure-functions/service-bus-kafka/ASBFunctionsWorker_4/ConsoleEndpoint/ConsoleEndpoint.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.ASBTrigger.FunctionsHostBuilder/AzureFunctions.ASBTrigger.FunctionsHostBuilder.csproj
@@ -1,18 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AzureFunctions.Messages\AzureFunctions.Messages.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus.AzureFunctions.InProcess.ServiceBus" Version="4.*" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.*" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AzureFunctions.Messages\AzureFunctions.Messages.csproj" />
-  </ItemGroup>
+
   <ItemGroup>
     <Content Include="..\local.settings.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
 </Project>

--- a/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
+++ b/samples/azure-functions/service-bus/ASBFunctions_4/AzureFunctions.Messages/AzureFunctions.Messages.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/azure-functions/service-bus/ASBFunctions_4/local.settings.json
+++ b/samples/azure-functions/service-bus/ASBFunctions_4/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
     "AzureWebJobsServiceBus": "<set your ASB connection string here>",

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeShared/NativeShared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeShared/NativeShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberA/NativeSubscriberA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NativeShared\NativeShared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/NativeSubscriberB/NativeSubscriberB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration-pub-sub/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/NativeSender/NativeSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/saga-transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -23,7 +23,7 @@
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/simple/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -22,7 +22,7 @@
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/table/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,14 +9,14 @@
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="System.Private.Uri" Version="4.*" />    
+    <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup Label="Force a later version of a transitive dependency">

--- a/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_3/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_4/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.AzureTable" Version="5.*" />

--- a/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
+++ b/samples/azure/azure-table/transactions/ASTP_5/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -18,5 +18,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -12,5 +12,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_10/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.*" />
@@ -19,7 +19,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_11/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_12/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,10 +9,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.*" />    
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.*" />
-    <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="9.*" />    
+    <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -12,5 +12,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
+++ b/samples/azure/native-integration-asq/ASQN_9/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint1/Endpoint1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Endpoint2/Endpoint2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -12,5 +12,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_10/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_10/StorageReader/StorageReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint1/Endpoint1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Force a later version of a transitive dependency">
     <PackageReference Include="System.Net.NameResolution" Version="4.*" />
   </ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Endpoint2/Endpoint2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_11/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />    
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_11/StorageReader/StorageReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint1/Endpoint1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Endpoint2/Endpoint2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
+++ b/samples/azure/storage-queues/ASQN_12/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />    
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
+++ b/samples/azure/storage-queues/ASQN_12/StorageReader/StorageReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
   <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
+++ b/samples/azure/webjob-host/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+  <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/AsbEndpoint/AsbEndpoint.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-	<LangVersion>10.0</LangVersion>
+  <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
-	<PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
-	<PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
+  <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/MsmqEndpoint/MsmqEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/MsmqEndpoint/MsmqEndpoint.csproj
@@ -5,9 +5,9 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
-	<PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
-	<PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
+  <PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/Bridge_2/Shared/Shared.csproj
@@ -4,6 +4,6 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/AsbEndpoint/AsbEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/AsbEndpoint/AsbEndpoint.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
-	<LangVersion>10.0</LangVersion>
+  <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
-	<PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
-	<PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
+  <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/MsmqEndpoint/MsmqEndpoint.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/MsmqEndpoint/MsmqEndpoint.csproj
@@ -5,9 +5,9 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
-	<PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
-	<PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.*" />
+  <PackageReference Include="NServiceBus.Transport.Msmq" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/Shared/Shared.csproj
+++ b/samples/bridge/azure-service-bus-msmq-bridge/TransportBridge_1/Shared/Shared.csproj
@@ -4,6 +4,6 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NServiceBus" Version="8.*" />
+  <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/service-control/Bridge_2/Bridge/Bridge.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
+++ b/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
+++ b/samples/bridge/service-control/Bridge_2/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/service-control/Bridge_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/bridge/service-control/Bridge_2/PlatformLauncher/PlatformLauncher.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 
 </Project>

--- a/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/service-control/Bridge_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 

--- a/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_2/Bridge/Bridge.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftReceiver/LeftReceiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_2/LeftSender/LeftSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_2/RightReceiver/RightReceiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Bridge/Bridge.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.*" />

--- a/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Helpers/Helpers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Helpers\Helpers.csproj" />

--- a/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
+++ b/samples/bridge/sql-multi-instance/Bridge_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
+++ b/samples/callbacks/Callbacks_4/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_4/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/callbacks/Callbacks_4/Sender/Sender.csproj
+++ b/samples/callbacks/Callbacks_4/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/callbacks/Callbacks_4/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/callbacks/Callbacks_4/Shared/Shared.csproj
+++ b/samples/callbacks/Callbacks_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
+++ b/samples/callbacks/Callbacks_4/WebSender/WebSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer1/Consumer1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Consumer2/Consumer2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Consumer1\Contracts\Consumer1Contract.cs" />

--- a/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
+++ b/samples/consumer-driven-contracts/Core_8/Producer/Producer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cooperative-cancellation/Core_8/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cooperative-cancellation/Core_8/Server/Server.csproj
+++ b/samples/cooperative-cancellation/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/container/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/simple/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="2.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
+++ b/samples/cosmosdb/transactions/CosmosDB_2/SharedMessages/SharedMessages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/custom-recoverability/Core_8/Client/Client.csproj
+++ b/samples/custom-recoverability/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_8/Client/Client.csproj
+++ b/samples/custom-recoverability/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/custom-recoverability/Core_8/Server/Server.csproj
+++ b/samples/custom-recoverability/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/custom-recoverability/Core_8/Server/Server.csproj
+++ b/samples/custom-recoverability/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/custom-recoverability/Core_8/Shared/Shared.csproj
+++ b/samples/custom-recoverability/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+	<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/custom-recoverability/Core_8/Shared/Shared.csproj
+++ b/samples/custom-recoverability/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/DataBusBlobCleanupFunctions/DataBusBlobCleanupFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
+++ b/samples/databus/blob-storage-databus-cleanup-function/ABSDataBus_5/SenderAndReceiver/SenderAndReceiver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="5.*" />

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
+++ b/samples/databus/blob-storage-databus/ABSDataBus_5/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/delayed-delivery/Core_8/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Client/Client.csproj
+++ b/samples/delayed-delivery/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_8/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/delayed-delivery/Core_8/Server/Server.csproj
+++ b/samples/delayed-delivery/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/delayed-delivery/Core_8/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/delayed-delivery/Core_8/Shared/Shared.csproj
+++ b/samples/delayed-delivery/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_7/SampleAutofac/SampleAutofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.*" />

--- a/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
+++ b/samples/dependency-injection/aspnetcore/Core_8/SampleAutofac/SampleAutofac.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/autofac/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.*" />    
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.*" />
     <PackageReference Include="NServiceBus" Version="7.*" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.*" />    
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/castle/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/extensions-dependency-injection/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
+++ b/samples/dependency-injection/ninject/Ninject_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />
-    <PackageReference Include="NServiceBus.Ninject" Version="7.*" />    
+    <PackageReference Include="NServiceBus.Ninject" Version="7.*" />
   </ItemGroup>
 
   <ItemGroup Label="Resolves vulnerabilities">

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/structuremap/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
+++ b/samples/dependency-injection/unity/Extensions.DependencyInjection_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/basic-encryption/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
+++ b/samples/encryption/encryption-conventions/PropertyEncryption_4/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
+++ b/samples/encryption/message-body-encryption/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework-core/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Endpoint.SqlPersistence/Endpoint.SqlPersistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
+++ b/samples/entity-framework/SqlPersistence_7/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/errorhandling/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/errorhandling/Core_8/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/errorhandling/Core_8/Shared/Shared.csproj
+++ b/samples/errorhandling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithDelayedRetries/WithDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
+++ b/samples/errorhandling/Core_8/WithoutDelayedRetries/WithoutDelayedRetries.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_8/Client/Client.csproj
+++ b/samples/faulttolerance/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Client/Client.csproj
+++ b/samples/faulttolerance/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_8/Server/Server.csproj
+++ b/samples/faulttolerance/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/faulttolerance/Core_8/Server/Server.csproj
+++ b/samples/faulttolerance/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/faulttolerance/Core_8/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/faulttolerance/Core_8/Shared/Shared.csproj
+++ b/samples/faulttolerance/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/feature/Core_8/Sample/Sample.csproj
+++ b/samples/feature/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/feature/Core_8/Sample/Sample.csproj
+++ b/samples/feature/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Client/Client.csproj
+++ b/samples/fullduplex/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/fullduplex/Core_8/Server/Server.csproj
+++ b/samples/fullduplex/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/fullduplex/Core_8/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
+++ b/samples/gateway/Gateway_4/Headquarters/Headquarters.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
+++ b/samples/gateway/Gateway_4/RemoteSite/RemoteSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/gateway/Gateway_4/Shared/Shared.csproj
+++ b/samples/gateway/Gateway_4/Shared/Shared.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/gateway/Gateway_4/WebClient/WebClient.csproj
+++ b/samples/gateway/Gateway_4/WebClient/WebClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/gateway/Gateway_4/WebClient/WebClient.csproj
+++ b/samples/gateway/Gateway_4/WebClient/WebClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/header-manipulation/Core_8/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/header-manipulation/Core_8/Sample/Sample.csproj
+++ b/samples/header-manipulation/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
+++ b/samples/hosting/generic-host/Core_8/GenericHost/GenericHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_8/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/immutable-messages/Core_8/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/immutable-messages/Core_8/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/immutable-messages/Core_8/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
+++ b/samples/logging/commonlogging/CommonLogging_5/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
+++ b/samples/logging/custom-factory/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_7/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/logging/datadog/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" Version="8.*" />

--- a/samples/logging/default/Core_7/Sample/Sample.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/default/Core_7/Sample/Sample.csproj
+++ b/samples/logging/default/Core_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_8/Sample/Sample.csproj
+++ b/samples/logging/default/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/default/Core_8/Sample/Sample.csproj
+++ b/samples/logging/default/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_1/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
+++ b/samples/logging/extensions-logging/Extensions.Logging_2/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 

--- a/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
+++ b/samples/logging/log4net-custom/Log4Net_3/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <NoWarn>NU1605</NoWarn>

--- a/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/metrics/Metrics_4/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_3/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NewRelic.Agent.Api" Version="10.*" />

--- a/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
+++ b/samples/logging/new-relic/Metrics_4/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
+++ b/samples/logging/nlog-custom/NLog_3/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_7/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>

--- a/samples/logging/notifications/Core_7/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_7/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/logging/notifications/Core_8/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/logging/notifications/Core_8/Sample/Sample.csproj
+++ b/samples/logging/notifications/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/messagemutators/Core_8/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/messagemutators/Core_8/Sample/Sample.csproj
+++ b/samples/messagemutators/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
+++ b/samples/mongodb/simple/MongoDB_3/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/multi-tenant/di/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
+++ b/samples/multi-tenant/nhibernate/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Billing/Billing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Sales/Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/propagation/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
+++ b/samples/multi-tenant/ravendb/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/multi-tenant/sqlp/SqlPersistence_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/near-realtime-clients/Core_8/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/Client/Client.csproj
+++ b/samples/near-realtime-clients/Core_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
+++ b/samples/near-realtime-clients/Core_8/ClientHub/ClientHub.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
+++ b/samples/near-realtime-clients/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StockEvents\StockEvents.csproj" />

--- a/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
+++ b/samples/near-realtime-clients/Core_8/StockEvents/StockEvents.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Attributes/Sample.Attributes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Default/Sample.Default.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Fluent/Sample.Fluent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.Loquacious/Sample.Loquacious.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Sample.XmlMapping/Sample.XmlMapping.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
+++ b/samples/nhibernate/custom-mappings/NHibernate_9/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/application-insights/Core_8/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Publisher/Publisher.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/open-telemetry/jaeger/Core_8/Subscriber/Subscriber.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/metrics-shim/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/metrics-shim/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/metrics-shim/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/metrics-shim/Core_8/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/open-telemetry/prometheus-grafana/Core_8/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
+++ b/samples/outbox/rabbit/Core_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
+++ b/samples/outbox/sql/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_8/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/outbox/sql/Core_8/Sender/Sender.csproj
+++ b/samples/outbox/sql/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/outbox/sql/Core_8/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/outbox/sql/Core_8/Shared/Shared.csproj
+++ b/samples/outbox/sql/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
+++ b/samples/performance-counters/PerfCounters_5/Sample/Sample.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows;net6.0-windows;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus.Metrics.PerformanceCounters" Version="5.*" />
     <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
+++ b/samples/pipeline/audit-filtering/Core_8/AuditFilter/AuditFilter.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
+++ b/samples/pipeline/dispatch-notifications/Core_8/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
+++ b/samples/pipeline/feature-toggle/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/fix-messages-using-behavior/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Messages/Messages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/header-propagation/Core_8/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/MTEndpoint/MTEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-MTEndpoint-0796FBA1-1278-479A-94F8-C8918B42B338</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
+++ b/samples/pipeline/masstransit-messages/Core_8/NServiceBusSubscriber/NServiceBusSubscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <UserSecretsId>dotnet-NServiceBusSubscriber-573F9BD8-FB1A-4A4C-BC88-E4A997A00BE2</UserSecretsId>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/pipeline/message-signing/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
+++ b/samples/pipeline/message-signing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/SignedSender/SignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
+++ b/samples/pipeline/message-signing/Core_8/UnsignedSender/UnsignedSender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SessionFilter\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SessionFilter\Shared.csproj" />

--- a/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
+++ b/samples/pipeline/session-filtering/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
+++ b/samples/pipeline/session-filtering/Core_8/SessionFilter/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/pipeline/unit-of-work/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/code-first/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/json/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/platform-connector/ms-config/PlatformConnector_2/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
+++ b/samples/pubsub/native/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/pubsub/native/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/pubsub/native/Core_8/Shared/Shared.csproj
+++ b/samples/pubsub/native/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
+++ b/samples/pubsub/native/Core_8/Subscriber/Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/NativeSender/NativeSender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/native-integration/Rabbit_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>

--- a/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
+++ b/samples/rabbitmq/simple/Rabbit_8/Shared/Shared.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_8/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_8/Client/Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_8/Client/Client.csproj
+++ b/samples/ravendb/simple/Raven_8/Client/Client.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_8/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_8/Server/Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/ravendb/simple/Raven_8/Server/Server.csproj
+++ b/samples/ravendb/simple/Raven_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
+++ b/samples/ravendb/simple/Raven_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
+++ b/samples/routing-slips/MessageRouting_5/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
+++ b/samples/routing-slips/MessageRouting_5/ResultHost/ResultHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />

--- a/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
+++ b/samples/routing-slips/MessageRouting_5/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepA/StepA.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepB/StepB.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
+++ b/samples/routing-slips/MessageRouting_5/StepC/StepC.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
+++ b/samples/routing/command-routing/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_8/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/routing/command-routing/Core_8/Sender/Sender.csproj
+++ b/samples/routing/command-routing/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/routing/command-routing/Core_8/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/command-routing/Core_8/Shared/Shared.csproj
+++ b/samples/routing/command-routing/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
+++ b/samples/routing/message-forwarding/Core_8/Messages/Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
+++ b/samples/routing/message-forwarding/Core_8/NServiceBus.MessageForwarding/NServiceBus.MessageForwarding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/OriginalDestination/OriginalDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
+++ b/samples/routing/message-forwarding/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
+++ b/samples/routing/message-forwarding/Core_8/UpgradedDestination/UpgradedDestination.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
+++ b/samples/saga/batching/Core_8/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
+++ b/samples/saga/batching/Core_8/WorkGenerator/WorkGenerator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
+++ b/samples/saga/batching/Core_8/WorkProcessor/WorkProcessor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
+++ b/samples/saga/nh-custom-sagafinder/NHibernate_9/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/saga/simple/Core_8/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/simple/Core_8/Sample/Sample.csproj
+++ b/samples/saga/simple/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/saga/sql-sagafinder/SqlPersistence_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/hangfire/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/hangfire/Core_8/Scheduler/Scheduler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/hangfire/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
+++ b/samples/scheduling/quartz/Core_8/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
+++ b/samples/scheduling/quartz/Core_8/Scheduler/Scheduler.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
+++ b/samples/scheduling/quartz/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/scheduling/timer/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/scheduling/timer/Core_8/Sample/Sample.csproj
+++ b/samples/scheduling/timer/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/change-message-type/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftBsonEndpoint/ExternalNewtonsoftBsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ExternalNewtonsoftJsonEndpoint/ExternalNewtonsoftJsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/ReceivingEndpoint/ReceivingEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/SystemJsonEndpoint/SystemJsonEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
+++ b/samples/serializers/multiple-deserializers/Core_8/XmlEndpoint/XmlEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />

--- a/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft-bson/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
+++ b/samples/serializers/newtonsoft/Newtonsoft_3/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/system-json/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/system-json/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/system-json/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/system-json/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase1/SamplePhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase2/SamplePhase2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase3/SamplePhase3.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/SamplePhase4/SamplePhase4.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
+++ b/samples/serializers/transitioning-formats/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/serializers/xml/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/serializers/xml/Core_8/Sample/Sample.csproj
+++ b/samples/serializers/xml/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/EndpointsMonitor/AzureMonitorConnector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/azure-monitor-events/ServiceControlContracts_4/PlatformLauncher/PlatformLauncher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Particular.PlatformSample" Version="3.*" />

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -16,5 +16,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="8.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/EndpointsMonitor/EndpointsMonitor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/NServiceBusEndpoint/NServiceBusEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
+++ b/samples/servicecontrol/events-subscription/ServiceControlContracts_3/PlatformLauncher/PlatformLauncher.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Headquarters/Cinema.Headquarters.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.Messages/Cinema.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>

--- a/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
+++ b/samples/showcase/cinema/Core_8/Cinema.TicketSales/Cinema.TicketSales.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ContentManagement/Store.ContentManagement.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.CustomerRelations/Store.CustomerRelations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.ECommerce/Store.ECommerce.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Messages/Store.Messages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Operations/Store.Operations.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Sales/Store.Sales.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Store.Messages\Store.Messages.csproj" />

--- a/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />

--- a/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
+++ b/samples/showcase/on-premises/Core_8/Store.Shared/Store.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
+++ b/samples/sql-persistence/injecting-services/SqlPersistence_7/Endpoint/Endpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion1/EndpointVersion1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/EndpointVersion2/EndpointVersion2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
+++ b/samples/sql-persistence/saga-rename/SqlPersistence_7/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointMySql/EndpointMySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointOracle/EndpointOracle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointPostgreSql/EndpointPostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/EndpointSqlServer/EndpointSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -17,5 +17,5 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/ServerShared/ServerShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
+++ b/samples/sql-persistence/simple/SqlPersistence_7/SharedMessages/SharedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Drawing.Common" Version="8.*"  />
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MySql.Data" Version="8.*" />
   </ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointMySql/EndpointMySqlPhase1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointOracle/EndpointOraclePhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointPostgreSql/EndpointPostgreSqlPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/EndpointSqlServer/EndpointSqlServerPhase1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase1/Shared/SharedPhase1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointMySql/EndpointMySqlPhase2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointOracle/EndpointOraclePhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointPostgreSql/EndpointPostgreSqlPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/EndpointSqlServer/EndpointSqlServerPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -17,7 +17,7 @@
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\..\Phase1\EndpointSqlServer\Program.cs" />
     <Compile Include="..\..\Phase1\EndpointSqlServer\SqlHelper.cs" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase2/Shared/SharedPhase2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointMySql/EndpointMySqlPhase3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Drawing.Common" Version="8.*"  />
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\..\Phase1\EndpointMySql\Program.cs" />
     <Compile Include="..\..\Phase1\EndpointMySql\SqlHelper.cs" />

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointOracle/EndpointOraclePhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointPostgreSql/EndpointPostgreSqlPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/EndpointSqlServer/EndpointSqlServerPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
+++ b/samples/sql-persistence/transitioning-correlation-ids/SqlPersistence_7/Phase3/Shared/SharedPhase3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="NServiceBus.NHibernate" Version="9.*" />
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="7.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>

--- a/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-nhpersistence/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Receiver/Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="ServiceStack.OrmLite.SqlServer.Data.Core" Version="6.*" />
   </ItemGroup>
 
-  <ItemGroup Label="Resolves vulnerabilities">    
+  <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Text.RegularExpressions" Version="4.*" />
     <PackageReference Include="System.Private.Uri" Version="4.*" />
   </ItemGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="7.*" />

--- a/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.*" />

--- a/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
+++ b/samples/sqltransport-sqlpersistence/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.*" />

--- a/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/native-integration/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
+++ b/samples/sqltransport/simple/SqlTransport_7/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
+++ b/samples/startup-shutdown-sequence/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/throttling/Core_8/Limited/Limited.csproj
+++ b/samples/throttling/Core_8/Limited/Limited.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Limited/Limited.csproj
+++ b/samples/throttling/Core_8/Limited/Limited.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_8/Sender/Sender.csproj
+++ b/samples/throttling/Core_8/Sender/Sender.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/throttling/Core_8/Sender/Sender.csproj
+++ b/samples/throttling/Core_8/Sender/Sender.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/throttling/Core_8/Shared/Shared.csproj
+++ b/samples/throttling/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/throttling/Core_8/Shared/Shared.csproj
+++ b/samples/throttling/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_6/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
+++ b/samples/transactional-session/aspnetcore-webapi/SqlPersistenceTS_7/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.*" />
     <PackageReference Include="NServiceBus.Persistence.CosmosDB" Version="1.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/Backend.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.Persistence.CosmosDB.TransactionalSession" Version="1.*" />
     <PackageReference Include="NServiceBus.TransactionalSession" Version="1.*" />
   </ItemGroup>
-  
+
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
   </ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/Backend.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/unit-of-work/Core_8/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_8/Sample/Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/unit-of-work/Core_8/Sample/Sample.csproj
+++ b/samples/unit-of-work/Core_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/unit-testing/Testing_8/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_8/Sample/Sample.csproj
@@ -1,14 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NServiceBus" Version="8.*" />
     <PackageReference Include="NServiceBus.Testing" Version="8.*" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/unit-testing/Testing_8/Sample/Sample.csproj
+++ b/samples/unit-testing/Testing_8/Sample/Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unobtrusive/Core_8/Client/Client.csproj
+++ b/samples/unobtrusive/Core_8/Client/Client.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unobtrusive/Core_8/Client/Client.csproj
+++ b/samples/unobtrusive/Core_8/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/unobtrusive/Core_8/Server/Server.csproj
+++ b/samples/unobtrusive/Core_8/Server/Server.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/unobtrusive/Core_8/Server/Server.csproj
+++ b/samples/unobtrusive/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/unobtrusive/Core_8/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>

--- a/samples/unobtrusive/Core_8/Shared/Shared.csproj
+++ b/samples/unobtrusive/Core_8/Shared/Shared.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
+++ b/samples/username-header/Core_8/Endpoint1/Endpoint1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
+++ b/samples/username-header/Core_8/Endpoint2/Endpoint2.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/username-header/Core_8/Shared/Shared.csproj
+++ b/samples/username-header/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/username-header/Core_8/Shared/Shared.csproj
+++ b/samples/username-header/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_8/Publisher/Publisher.csproj
+++ b/samples/versioning/Core_8/Publisher/Publisher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />

--- a/samples/versioning/Core_8/Publisher/Publisher.csproj
+++ b/samples/versioning/Core_8/Publisher/Publisher.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V1.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>1.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V1.Contracts\Contracts.csproj" />

--- a/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
+++ b/samples/versioning/Core_8/V1.Subscriber/V1.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Version>2.0.0</Version>
   </PropertyGroup>

--- a/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
+++ b/samples/versioning/Core_8/V2.Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />

--- a/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
+++ b/samples/versioning/Core_8/V2.Subscriber/V2.Subscriber.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
+++ b/samples/web/asp-mvc-application/Core_8/AsyncPagesMVC/AsyncPagesMVC.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Callbacks" Version="4.*" />

--- a/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/asp-mvc-application/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/blazor-server-application/Core_8/Server/Server.csproj
+++ b/samples/web/blazor-server-application/Core_8/Server/Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/blazor-server-application/Core_8/Server/Server.csproj
+++ b/samples/web/blazor-server-application/Core_8/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
+++ b/samples/web/blazor-server-application/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/blazor-server-application/Core_8/WebApp/WebApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Endpoint/Endpoint.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.*" />

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/Shared/Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
+++ b/samples/web/send-from-aspnetcore-webapi/Core_8/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.*" />

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        public static readonly string[] sdkProjectAllowedTfmList = ["net9.0", "net9.0-windows","net8.0", "net8.0-windows", "net6.0", "net6.0-windows", "net48", "netstandard2.0"];
+        public static readonly string[] sdkProjectAllowedTfmList = ["net9.0", "net9.0-windows", "net8.0", "net8.0-windows", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -158,8 +158,6 @@ namespace IntegrityTests
             // null values here mean we don't want that tfm to be considered in the calculations
             {"net48", null },
             {"netstandard2.0", null },
-            { "net6.0", 10 },
-            { "net6.0-windows", 10 },
             { "net8.0", 12 },
             { "net8.0-windows", 12 },
             { "net9.0", 13 },


### PR DESCRIPTION
This PR removes `net6.0` from snippets and samples since it is no longer supported by Microsoft.

I've also removed it as a valid TFM from the integrity tests