### PR TITLE
Include missing 'include major-upgrade' to major version bump guides

### DIFF
--- a/nservicebus/upgrades/7to8/index.md
+++ b/nservicebus/upgrades/7to8/index.md
@@ -9,6 +9,8 @@ upgradeGuideCoreVersions:
  - 8
 ---
 
+include: upgrade-major
+
 This document focuses on changes that are affecting general endpoint configuration and message handlers. For more upgrade guides, see the following additional guides:
 
 * [Changes for downstream implementations like custom/community transports, persistence, message serializers](implementations.md)

--- a/nservicebus/upgrades/8to9/index.md
+++ b/nservicebus/upgrades/8to9/index.md
@@ -9,6 +9,8 @@ upgradeGuideCoreVersions:
  - 9
 ---
 
+include: upgrade-major
+
 ## Removed support for .NET Framework
 
 NServiceBus 9 no longer supports any version of the .NET Framework. Instead, it targets .NET 8 only (read more about the [supported frameworks and platforms](/nservicebus/upgrades/supported-platforms.md)). Any component in NServiceBus 8 that is .NET Framework only (for example, the MSMQ transport) will not have a version that is compatible with NServiceBus 9. NServiceBus 8 will continue to be supported for use on the .NET Framework.


### PR DESCRIPTION
Include missing link to general 'major upgrade' guidance from major upgrade pages.