### PR TITLE
Update create-queues-powershell snippet to create nonclustered index

### DIFF
--- a/Snippets/SqlTransport/SqlTransport_All/Operations/QueueCreation/QueueCreation.ps1
+++ b/Snippets/SqlTransport/SqlTransport_All/Operations/QueueCreation/QueueCreation.ps1
@@ -107,7 +107,7 @@ function CreateQueue {
             [Body] [varbinary](max),
             [RowVersion] [bigint] identity(1,1) not null
         );
-        create clustered index [Index_RowVersion] on [{0}].[{1}]
+        create nonclustered index [Index_RowVersion] on [{0}].[{1}]
         (
             [RowVersion]
         )


### PR DESCRIPTION
Relates to https://github.com/Particular/docs.particular.net/issues/7186

Update the PowerShell scripts to create nonclustered indexes and align the script with the [C# code for queue creation](https://docs.particular.net/transports/sql/operations-scripting#create-queues-the-create-queue-helper-methods-in-c).