### PR TITLE
Fix Timestamp format block in headers based on version

### DIFF
--- a/nservicebus/messaging/headers.md
+++ b/nservicebus/messaging/headers.md
@@ -17,7 +17,13 @@ The headers of a message are similar to HTTP headers and contain metadata about 
 
 ## Timestamp format
 
+#if-version [8,)
 For all timestamp message headers, the format is `yyyy-MM-dd HH:mm:ss:ffffff Z`, where the time is UTC. The helper class `DateTimeOffsetHelper` supports converting from UTC to wire format and vice versa by using the `ToWireFormattedString(DateTimeOffset)` and `ToDateTimeOffset(string)` methods.
+#end-if
+
+#if-version [,8)
+For all timestamp message headers, the format is `yyyy-MM-dd HH:mm:ss:ffffff Z` where the time is UTC. The helper class `DateTimeExtensions` supports converting from UTC to wire format and vice versa by using the `ToWireFormattedString(DateTime)` and `ToUtcDateTime(string)` methods.
+#end-if
 
 ### ISO 8601 format
 
@@ -29,31 +35,12 @@ Differences:
 2. uses a `.` between seconds and milli/microseconds
 3. no space between the timestamp and the `Z`
 
-
 ```
 ISO 8601:    yyyy-MM-ddTHH:mm:ss.ffffffZ
 NServiceBus: yyyy-MM-dd HH:mm:ss:ffffff Z
 ```
 
 When doing native intergration and there is a need to parse the timestamp the `.` as second and milli/microsecond separator is where regular timestamp parsers often fail.
-
-Use the following code to generate or read the NServiceBus custom timestamp format.
-
-```cs
-const string Format = "yyyy-MM-dd HH:mm:ss:ffffff Z"; // Not ISO 8601
-
-public static string ToWireFormattedString(DateTime dateTime)
-{
-    return dateTime.ToUniversalTime()
-        .ToString(Format, CultureInfo.InvariantCulture);
-}
-
-public static DateTime ToUtcDateTime(string wireFormattedString)
-{
-    return DateTime.ParseExact(wireFormattedString, Format, CultureInfo.InvariantCulture)
-       .ToUniversalTime();
-}
-```
 
 ## Transport headers
 


### PR DESCRIPTION
- Issue - https://github.com/Particular/docs.particular.net/issues/7193

Added a partial class to support version-specific rendering of the Timestamp format block. This resolves incorrect references to the non-existent DateTimeExtensions helper.


Reference : https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/DateTimeOffsetHelper.cs