### PR TITLE
Moved design considerations section for Transactional Session into its own partial as it is only supported from v 3.3

### DIFF
--- a/nservicebus/transactional-session/index.md
+++ b/nservicebus/transactional-session/index.md
@@ -75,15 +75,7 @@ The transactional session feature requires a supported persistence package to st
 * [MongoDB](/persistence/mongodb)
 * [DynamoDB](/persistence/dynamodb/)
 
-## Design considerations
-
-It's recommended to not mix the processing of dispatch messages with business messages in order to get:
-
-- Predictable dispatch message dispatch: Processing of dispatch messages will be more reliable since there is no risk of getting delayed behind slow business messages
-- More accurate metrics: Metrics like critical time and queue length will accurately represent the performance of the dispatch message processing and not be skewed by business messages
-- Simplified management: Knowing that the endpoint only processes dispatch messages makes it possible to always retry all failed messages related to the endpoint via tools like ServicePulse
-
-When configuring endpoints for usage measurement in ServicePulse, mark dedicated transactional session processor endpoints with the appropriate [endpoint type indicator](/servicepulse/usage.md#setting-an-endpoint-type-endpoint-type-indicators).
+partial: design-considerations
 
 partial: remote-processor
 

--- a/nservicebus/transactional-session/index_design-considerations_transactionalsession_[3.3,).partial.md
+++ b/nservicebus/transactional-session/index_design-considerations_transactionalsession_[3.3,).partial.md
@@ -1,0 +1,9 @@
+## Design considerations
+
+It's recommended to not mix the processing of dispatch messages with business messages in order to get:
+
+- Predictable dispatch message dispatch: Processing of dispatch messages will be more reliable since there is no risk of getting delayed behind slow business messages
+- More accurate metrics: Metrics like critical time and queue length will accurately represent the performance of the dispatch message processing and not be skewed by business messages
+- Simplified management: Knowing that the endpoint only processes dispatch messages makes it possible to always retry all failed messages related to the endpoint via tools like ServicePulse
+
+When configuring endpoints for usage measurement in ServicePulse, mark dedicated transactional session processor endpoints with the appropriate [endpoint type indicator](/servicepulse/usage.md#setting-an-endpoint-type-endpoint-type-indicators).


### PR DESCRIPTION
Noticed that the design considerations section shows up for older versions of TransactionalSession when it is applicable only to v3.3.0 onwards