### PR TITLE
Clarify that DataBus supports any serializable type, not just byte arrays

### DIFF
--- a/nservicebus/messaging/claimcheck/index.md
+++ b/nservicebus/messaging/claimcheck/index.md
@@ -65,10 +65,12 @@ There are two ways to specify the message properties to be sent using the `DataB
 
 > [!NOTE]
 > `DataBus` properties must be top-level properties on a message class.
+>
+> Apart from `byte[]`, any data type is supported as long as it is serializable. For example, you can use `string`, custom classes, or other serializable types as `DataBus` properties.
 
 ### Using `ClaimCheckProperty<T>`
 
-Set the type of the property to be sent over as `ClaimCheckProperty<byte[]>`:
+Set the type of the property to be sent over as `ClaimCheckProperty<byte[]>`, or any other serializable type:
 
 snippet: MessageWithLargePayload
 
@@ -80,7 +82,7 @@ In the configuration of the endpoint include:
 
 snippet: DefineMessageWithLargePayloadUsingConvention
 
-Set the type of the property as `byte[]`:
+Set the type of the property as `byte[]`, or any other serializable type:
 
 snippet: MessageWithLargePayloadUsingConvention
 


### PR DESCRIPTION
This update clarifies in the DataBus documentation that, in addition to byte[], any data type is supported as long as it is serializable. This addresses feedback from issue [Feedback: 'NServiceBus DataBus feature' #7233
](https://github.com/Particular/docs.particular.net/issues/7233) and helps users understand that they can use types such as string, custom classes, or other serializable types as DataBus properties.