### PR TITLE
Refactor logger calls in aws samples to use structured logging

### DIFF
--- a/samples/aws/dynamodb-simple/DynamoDB_2/Client/OrderCompletedHandler.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Client/OrderCompletedHandler.cs
@@ -5,11 +5,11 @@ using NServiceBus;
 public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
     IHandleMessages<OrderCompleted>
 {
-   
+
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
 
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Server/OrderSaga.cs
@@ -27,7 +27,7 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
             OrderId = message.OrderId
         };
 
-        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
+      logger.LogInformation("Order will complete in 5 seconds");
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Server/OrderSaga.cs
@@ -20,14 +20,14 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", message.OrderId);
 
         var shipOrder = new ShipOrder
         {
             OrderId = message.OrderId
         };
 
-        logger.LogInformation("Order will complete in 5 seconds");
+        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,
@@ -41,7 +41,7 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/aws/dynamodb-simple/DynamoDB_2/Server/ShipOrderHandler.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_2/Server/ShipOrderHandler.cs
@@ -7,7 +7,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 
     public Task Handle(ShipOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-simple/DynamoDB_3/Client/OrderCompletedHandler.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_3/Client/OrderCompletedHandler.cs
@@ -5,11 +5,10 @@ using NServiceBus;
 public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
     IHandleMessages<OrderCompleted>
 {
-   
+
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-simple/DynamoDB_3/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_3/Server/OrderSaga.cs
@@ -27,7 +27,7 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
             OrderId = message.OrderId
         };
 
-        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
+       logger.LogInformation("Order will complete in 5 seconds");
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,

--- a/samples/aws/dynamodb-simple/DynamoDB_3/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_3/Server/OrderSaga.cs
@@ -20,14 +20,14 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
             OrderId = message.OrderId
         };
 
-        logger.LogInformation("Order will complete in 5 seconds");
+        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,
@@ -41,7 +41,7 @@ public class OrderSaga(ILogger<OrderSagaData> logger) :
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/aws/dynamodb-simple/DynamoDB_3/Server/ShipOrderHandler.cs
+++ b/samples/aws/dynamodb-simple/DynamoDB_3/Server/ShipOrderHandler.cs
@@ -7,7 +7,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 
     public Task Handle(ShipOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Client/OrderCompletedHandler.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Client/OrderCompletedHandler.cs
@@ -7,7 +7,7 @@ public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
 {
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Server/OrderSaga.cs
@@ -23,7 +23,7 @@ public class OrderSaga(ILogger<OrderSaga> logger):
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
@@ -45,13 +45,13 @@ public class OrderSaga(ILogger<OrderSaga> logger):
 
     public Task Handle(OrderShipped message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order with OrderId {Data.OrderId} shipped on {message.ShippingDate}");
+        logger.LogInformation("Order with OrderId {OrderId} shipped on {ShippingDate}", Data.OrderId, message.ShippingDate);
         return Task.CompletedTask;
     }
 
     public async Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/aws/dynamodb-transactions/DynamoDB_2/Server/ShipOrderHandler.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_2/Server/ShipOrderHandler.cs
@@ -31,7 +31,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 
         #endregion
 
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
 
         await context.Publish(new OrderShipped
         {

--- a/samples/aws/dynamodb-transactions/DynamoDB_3/Client/OrderCompletedHandler.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_3/Client/OrderCompletedHandler.cs
@@ -7,7 +7,7 @@ public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
 {
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/dynamodb-transactions/DynamoDB_3/Server/OrderSaga.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_3/Server/OrderSaga.cs
@@ -23,7 +23,7 @@ public class OrderSaga(ILogger<OrderSaga> logger):
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
@@ -45,13 +45,13 @@ public class OrderSaga(ILogger<OrderSaga> logger):
 
     public Task Handle(OrderShipped message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order with OrderId {Data.OrderId} shipped on {message.ShippingDate}");
+        logger.LogInformation("Order with OrderId {OrderId} shipped on {ShippingDate}", Data.OrderId, message.ShippingDate);
         return Task.CompletedTask;
     }
 
     public async Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/aws/dynamodb-transactions/DynamoDB_3/Server/ShipOrderHandler.cs
+++ b/samples/aws/dynamodb-transactions/DynamoDB_3/Server/ShipOrderHandler.cs
@@ -31,7 +31,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 
         #endregion
 
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
 
         await context.Publish(new OrderShipped
         {

--- a/samples/aws/lambda-sqs/SQSLambda_2/RegularEndpoint/ResponseMessageHandler.cs
+++ b/samples/aws/lambda-sqs/SQSLambda_2/RegularEndpoint/ResponseMessageHandler.cs
@@ -7,7 +7,7 @@ public class ResponseMessageHandler(ILogger<ResponseMessageHandler> logger) : IH
 
     public Task Handle(ResponseMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Handling {nameof(ResponseMessage)} in RegularEndpoint");
+        logger.LogInformation("Handling {MessageType} in RegularEndpoint", nameof(ResponseMessage));
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/lambda-sqs/SQSLambda_2/ServerlessEndpoint/TriggerMessageHandler.cs
+++ b/samples/aws/lambda-sqs/SQSLambda_2/ServerlessEndpoint/TriggerMessageHandler.cs
@@ -7,7 +7,7 @@ public class TriggerMessageHandler(ILogger<TriggerMessageHandler> logger) : IHan
 {
     public async Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Handling {nameof(TriggerMessage)} in ServerlessEndpoint.");
+        logger.LogInformation("Handling {MessageType} in ServerlessEndpoint.", nameof(TriggerMessage));
         await context.Send(new ResponseMessage());
     }
 }

--- a/samples/aws/lambda-sqs/SQSLambda_3/RegularEndpoint/ResponseMessageHandler.cs
+++ b/samples/aws/lambda-sqs/SQSLambda_3/RegularEndpoint/ResponseMessageHandler.cs
@@ -7,7 +7,7 @@ public class ResponseMessageHandler(ILogger<ResponseMessageHandler> logger) : IH
 
     public Task Handle(ResponseMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Handling {nameof(ResponseMessage)} in RegularEndpoint");
+        logger.LogInformation("Handling {MessageType} in RegularEndpoint", nameof(ResponseMessage));
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/lambda-sqs/SQSLambda_3/ServerlessEndpoint/TriggerMessageHandler.cs
+++ b/samples/aws/lambda-sqs/SQSLambda_3/ServerlessEndpoint/TriggerMessageHandler.cs
@@ -7,7 +7,7 @@ public class TriggerMessageHandler(ILogger<TriggerMessageHandler> logger) : IHan
 {
     public async Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Handling {nameof(TriggerMessage)} in ServerlessEndpoint.");
+        logger.LogInformation("Handling {MessageType} in ServerlessEndpoint.", nameof(TriggerMessage));
         await context.Send(new ResponseMessage());
     }
 }

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/OrderDelayedHandler.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/OrderDelayedHandler.cs
@@ -10,7 +10,7 @@ public class OrderDelayedHandler(ILogger<OrderDelayedHandler> logger) : IHandleM
                 .Select(s => s[Random.Shared.Next(s.Length)])
                 .ToArray());
 
-        logger.LogInformation($"Order {message.OrderId} is slightly delayed. We are sorry for the inconvenience. Use the coupon code '{coupon}' to get 10% off your next order.");
+        logger.LogInformation("Order {OrderId} is slightly delayed. We are sorry for the inconvenience. Use the coupon code '{Coupon}' to get 10% off your next order.", message.OrderId, coupon);
 
         return Task.CompletedTask;
     }

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/OrderShippedHandler.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/OrderShippedHandler.cs
@@ -3,7 +3,7 @@ public class OrderShippedHandler(ILogger<OrderShippedHandler> logger) : IHandleM
 {
     public Task Handle(OrderShipped message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order {message.OrderId} has shipped.");
+        logger.LogInformation("Order {OrderId} has shipped.", message.OrderId);
 
         return Task.CompletedTask;
     }

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/BillCustomerHandler.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/BillCustomerHandler.cs
@@ -5,7 +5,7 @@ public class BillCustomerHandler(ILogger<BillCustomerHandler> logger) : IHandleM
   public async Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
 
-        logger.LogInformation($"Billing customer for order {message.OrderId}.");
+        logger.LogInformation("Billing customer for order {OrderId}.", message.OrderId);
 
         await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(2, 5)), context.CancellationToken);
 

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/OrderSaga.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/OrderSaga.cs
@@ -19,7 +19,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) : Saga<OrderSagaData>,
 
     public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Placing order: {Data.OrderId}");
+        logger.LogInformation("Placing order: {OrderId}", Data.OrderId);
 
         await RequestTimeout(context, TimeSpan.FromSeconds(8), new OrderDelayed { OrderId = message.OrderId });
 
@@ -31,7 +31,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) : Saga<OrderSagaData>,
 
     public async Task Handle(CustomerBilled message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"The customer for order {Data.OrderId} has been billed.");
+        logger.LogInformation("The customer for order {OrderId} has been billed.", Data.OrderId);
         Data.CustomerBilled = true;
 
         await ShipItIfPossible(context);
@@ -39,7 +39,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) : Saga<OrderSagaData>,
 
     public async Task Handle(InventoryStaged message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"The inventory for order {Data.OrderId} has been staged.");
+        logger.LogInformation("The inventory for order {OrderId} has been staged.", Data.OrderId);
         Data.InventoryStaged = true;
 
         await ShipItIfPossible(context);
@@ -47,7 +47,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) : Saga<OrderSagaData>,
 
     public async Task Timeout(OrderDelayed state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order {Data.OrderId} is slightly delayed.");
+        logger.LogInformation("Order {OrderId} is slightly delayed.", Data.OrderId);
 
         await context.Publish(state);
     }
@@ -56,7 +56,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) : Saga<OrderSagaData>,
     {
         if (Data is { CustomerBilled: true, InventoryStaged: true })
         {
-            logger.LogInformation($"Order {Data.OrderId} has been shipped.");
+            logger.LogInformation("Order {OrderId} has been shipped.", Data.OrderId);
 
             // Send duplicate message for outbox test.
             await context.Publish(new OrderShipped { OrderId = Data.OrderId });

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/StageInventoryHandler.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/StageInventoryHandler.cs
@@ -4,7 +4,7 @@ public class StageInventoryHandler(ILogger<StageInventoryHandler> logger) : IHan
 {
     public async Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Staging inventory for order {message.OrderId}.");
+        logger.LogInformation("Staging inventory for order {OrderId}.", message.OrderId);
 
         await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(2, 5)), context.CancellationToken);
 

--- a/samples/aws/sqs-native-integration/Sqs_7/Receiver/AccessToAmazonSqsNativeMessageBehavior.cs
+++ b/samples/aws/sqs-native-integration/Sqs_7/Receiver/AccessToAmazonSqsNativeMessageBehavior.cs
@@ -7,7 +7,7 @@ using NServiceBus.Pipeline;
 #region BehaviorAccessingNativeMessage
 class AccessToAmazonSqsNativeMessageBehavior(ILogger<AccessToAmazonSqsNativeMessageBehavior> logger) : Behavior<IIncomingLogicalMessageContext>
 {
- 
+
     public override Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
     {
         // get the native Amazon SQS message
@@ -17,7 +17,7 @@ class AccessToAmazonSqsNativeMessageBehavior(ILogger<AccessToAmazonSqsNativeMess
         //do something useful with the native message
         if (nativeAttributeFound)
         {
-            logger.LogInformation($"Intercepted the native message and found attribute 'SomeKey' with value '{attributeValue.StringValue}'");
+            logger.LogInformation("Intercepted the native message and found attribute 'SomeKey' with value '{AttributeValue}'", attributeValue.StringValue);
         }
 
         return next();

--- a/samples/aws/sqs-native-integration/Sqs_7/Receiver/SomeNativeMessageHandler.cs
+++ b/samples/aws/sqs-native-integration/Sqs_7/Receiver/SomeNativeMessageHandler.cs
@@ -11,16 +11,16 @@ public class SomeNativeMessageHandler(ILogger<SomeNativeMessageHandler> logger) 
         var nativeMessage = context.Extensions.Get<Message>();
         var nativeAttributeFound = nativeMessage.MessageAttributes.TryGetValue("SomeKey", out var attributeValue);
 
-        logger.LogInformation($"Received {nameof(SomeNativeMessage)} with message {eventMessage.ThisIsTheMessage}.");
+        logger.LogInformation("Received {MessageType} with message {Message}", nameof(SomeNativeMessage), eventMessage.ThisIsTheMessage);
 
         if (nativeAttributeFound)
         {
-            logger.LogInformation($"Found attribute 'SomeKey' with value '{attributeValue.StringValue}'");
+            logger.LogInformation("Found attribute 'SomeKey' with value '{AttributeValue}'", attributeValue.StringValue);
         }
 
         if (context.ReplyToAddress != null)
         {
-            logger.LogInformation($"Sending reply to '{context.ReplyToAddress}'");
+            logger.LogInformation("Sending reply to '{ReplyToAddress}'", context.ReplyToAddress);
 
             await context.Reply(new SomeReply());
         }

--- a/samples/aws/sqs-native-integration/Sqs_8/Receiver/AccessToAmazonSqsNativeMessageBehavior.cs
+++ b/samples/aws/sqs-native-integration/Sqs_8/Receiver/AccessToAmazonSqsNativeMessageBehavior.cs
@@ -17,7 +17,7 @@ class AccessToAmazonSqsNativeMessageBehavior(ILogger<AccessToAmazonSqsNativeMess
         //do something useful with the native message
         if (nativeAttributeFound)
         {
-            logger.LogInformation($"Intercepted the native message and found attribute 'SomeKey' with value '{attributeValue.StringValue}'");
+            logger.LogInformation("Intercepted the native message and found attribute 'SomeKey' with value '{AttributeValue}'", attributeValue.StringValue);
         }
 
         return next();

--- a/samples/aws/sqs-native-integration/Sqs_8/Receiver/SomeNativeMessageHandler.cs
+++ b/samples/aws/sqs-native-integration/Sqs_8/Receiver/SomeNativeMessageHandler.cs
@@ -11,16 +11,16 @@ public class SomeNativeMessageHandler(ILogger<SomeNativeMessageHandler> logger) 
         var nativeMessage = context.Extensions.Get<Message>();
         var nativeAttributeFound = nativeMessage.MessageAttributes.TryGetValue("SomeKey", out var attributeValue);
 
-        logger.LogInformation($"Received {nameof(SomeNativeMessage)} with message {eventMessage.ThisIsTheMessage}.");
+        logger.LogInformation("Received {MessageType} with message {Message}", nameof(SomeNativeMessage), eventMessage.ThisIsTheMessage);
 
         if (nativeAttributeFound)
         {
-            logger.LogInformation($"Found attribute 'SomeKey' with value '{attributeValue.StringValue}'");
+            logger.LogInformation("Found attribute 'SomeKey' with value '{AttributeValue}'", attributeValue.StringValue);
         }
 
         if (context.ReplyToAddress != null)
         {
-            logger.LogInformation($"Sending reply to '{context.ReplyToAddress}'");
+            logger.LogInformation("Sending reply to '{ReplyToAddress}'", context.ReplyToAddress);
 
             await context.Reply(new SomeReply());
         }

--- a/samples/aws/sqs-simple/Sqs_7/Receiver/MyCommandHandler.cs
+++ b/samples/aws/sqs-simple/Sqs_7/Receiver/MyCommandHandler.cs
@@ -5,7 +5,7 @@ public class MyCommandHandler(ILogger<MyCommandHandler> logger) : IHandleMessage
 {
     public Task Handle(MyCommand commandMessage, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(MyCommand)} with a payload of {commandMessage.Data?.Length ?? 0} bytes.");
+        logger.LogInformation("Received {MessageType} with a payload of {PayloadLength} bytes.", nameof(MyCommand), commandMessage.Data?.Length ?? 0);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/sqs-simple/Sqs_7/Receiver/MyEventHandler.cs
+++ b/samples/aws/sqs-simple/Sqs_7/Receiver/MyEventHandler.cs
@@ -6,7 +6,7 @@ public class MyEventHandler(ILogger<MyEventHandler> logger) : IHandleMessages<My
 {
     public Task Handle(MyEvent eventMessage, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(MyEvent)} with a payload of {eventMessage.Data?.Length ?? 0} bytes.");
+        logger.LogInformation("Received {MessageType} with a payload of {PayloadLength} bytes.", nameof(MyEvent), eventMessage.Data?.Length ?? 0);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/sqs-simple/Sqs_8/Receiver/MyCommandHandler.cs
+++ b/samples/aws/sqs-simple/Sqs_8/Receiver/MyCommandHandler.cs
@@ -5,7 +5,7 @@ public class MyCommandHandler(ILogger<MyCommandHandler> logger) : IHandleMessage
 {
     public Task Handle(MyCommand commandMessage, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(MyCommand)} with a payload of {commandMessage.Data?.Length ?? 0} bytes.");
+        logger.LogInformation("Received {Command} with a payload of {Length} bytes.", nameof(MyCommand), commandMessage.Data?.Length ?? 0);
         return Task.CompletedTask;
     }
 }

--- a/samples/aws/sqs-simple/Sqs_8/Receiver/MyEventHandler.cs
+++ b/samples/aws/sqs-simple/Sqs_8/Receiver/MyEventHandler.cs
@@ -6,7 +6,7 @@ public class MyEventHandler(ILogger<MyEventHandler> logger) : IHandleMessages<My
 {
     public Task Handle(MyEvent eventMessage, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(MyEvent)} with a payload of {eventMessage.Data?.Length ?? 0} bytes.");
+        logger.LogInformation("Received {Event} with a payload of {Length} bytes.", nameof(MyEvent), eventMessage.Data?.Length ?? 0);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Part of

https://github.com/Particular/GeneralPlatformExperience/issues/3482

Updated all logger.LogInformation and similar calls in the AWS samples to use structured logging message templates and named parameters.

No functional changes