### PR TITLE
Refactor logger calls in samples to use structured logging

### DIFF
--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_6/AzureFunctions.ASBTrigger.Worker/FollowupMessageHandler.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_6/AzureFunctions.ASBTrigger.Worker/FollowupMessageHandler.cs
@@ -9,9 +9,7 @@ public class FollowupMessageHandler(ILogger<FollowupMessageHandler> logger) : IH
 
     public Task Handle(FollowupMessage message, IMessageHandlerContext context)
     {
-
-        logger.LogWarning($"Handling {nameof(FollowupMessage)} in {nameof(FollowupMessageHandler)}.");
-
+        logger.LogWarning("Handling {MessageType} in {HandlerType}.", nameof(FollowupMessage), nameof(FollowupMessageHandler));
         return Task.CompletedTask;
     }
 }

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_6/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_6/AzureFunctions.ASBTrigger.Worker/TriggerMessageHandler.cs
@@ -6,10 +6,10 @@ using NServiceBus;
 
 public class TriggerMessageHandler(ILogger<TriggerMessageHandler> logger) : IHandleMessages<TriggerMessage>
 {
-  
+
     public Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
-        logger.LogWarning($"Handling {nameof(TriggerMessage)} in {nameof(TriggerMessageHandler)}");
+        logger.LogWarning("Handling {MessageType} in {HandlerType}", nameof(TriggerMessage), nameof(TriggerMessageHandler));
 
         return context.SendLocal(new FollowupMessage());
     }

--- a/samples/azure-functions/service-bus/ASBFunctions_6/AzureFunctions.ASBTrigger.FunctionsHostBuilder/FollowupMessageHandler.cs
+++ b/samples/azure-functions/service-bus/ASBFunctions_6/AzureFunctions.ASBTrigger.FunctionsHostBuilder/FollowupMessageHandler.cs
@@ -6,11 +6,11 @@ using NServiceBus;
 
 public class FollowupMessageHandler(CustomComponent customComponent, ILogger<FollowupMessageHandler> logger) : IHandleMessages<FollowupMessage>
 {
-   
+
     public Task Handle(FollowupMessage message, IMessageHandlerContext context)
     {
-        logger.LogWarning($"Handling {nameof(FollowupMessage)} in {nameof(FollowupMessageHandler)}.");
-        logger.LogWarning($"Custom component returned: {customComponent.GetValue()}");
+        logger.LogWarning("Handling {MessageType} in {HandlerType}.", nameof(FollowupMessage), nameof(FollowupMessageHandler));
+        logger.LogWarning("Custom component returned: {Value}", customComponent.GetValue());
 
         return Task.CompletedTask;
     }

--- a/samples/azure-functions/service-bus/ASBFunctions_6/AzureFunctions.ASBTrigger.FunctionsHostBuilder/TriggerMessageHandler.cs
+++ b/samples/azure-functions/service-bus/ASBFunctions_6/AzureFunctions.ASBTrigger.FunctionsHostBuilder/TriggerMessageHandler.cs
@@ -6,11 +6,11 @@ using NServiceBus;
 
 public class TriggerMessageHandler(CustomComponent customComponent, ILogger<TriggerMessageHandler> logger) : IHandleMessages<TriggerMessage>
 {
-  
+
     public Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
-        logger.LogWarning($"Handling {nameof(TriggerMessage)} in {nameof(TriggerMessageHandler)}");
-        logger.LogWarning($"Custom component returned: {customComponent.GetValue()}");
+        logger.LogWarning("Handling {MessageType} in {HandlerType}", nameof(TriggerMessage), nameof(TriggerMessageHandler));
+        logger.LogWarning("Custom component returned: {Value}", customComponent.GetValue());
 
         return context.SendLocal(new FollowupMessage());
     }

--- a/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Receiver/NativeMessageHandler.cs
+++ b/samples/azure-service-bus-netstandard/native-integration/ASBS_5/Receiver/NativeMessageHandler.cs
@@ -7,11 +7,11 @@ using NServiceBus;
 public class NativeMessageHandler(ILogger<NativeMessageHandler> logger) :
     IHandleMessages<NativeMessage>
 {
-   
+
     public Task Handle(NativeMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Message content: {message.Content}");
-        logger.LogInformation($"Received native message sent on {message.SentOnUtc} UTC");
+        logger.LogInformation("Message content: {Content}", message.Content);
+        logger.LogInformation("Received native message sent on {SentOnUtc} UTC", message.SentOnUtc);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/PingHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Receiver/PingHandler.cs
@@ -17,12 +17,12 @@ namespace Receiver
 
         public async Task Handle(Ping message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Ping message #{message.Round}");
+            logger.LogInformation("Processing Ping message #{Round}", message.Round);
 
             var reply = new Pong { Acknowledgement = $"Ping #{message.Round} processed at {DateTimeOffset.UtcNow:s}" };
 
             await context.Reply(reply);
-            
+
             // throw new Exception("BOOM");
         }
     }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/PongHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/PongHandler.cs
@@ -16,7 +16,7 @@ namespace Sender
 
         public Task Handle(Pong message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Pong message: {message.Acknowledgement}");
+            logger.LogInformation("Processing Pong message: {Acknowledgement}", message.Acknowledgement);
 
             return Task.CompletedTask;
         }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/SenderWorker.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_3/Sender/SenderWorker.cs
@@ -28,7 +28,7 @@ namespace Sender
                 {
                     await messageSession.Send(new Ping { Round = round++ });
 
-                    logger.LogInformation($"Message #{round}");
+                    logger.LogInformation("Message #{Round}", round);
 
                     await Task.Delay(1_000, stoppingToken);
                 }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Receiver/PingHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Receiver/PingHandler.cs
@@ -17,12 +17,12 @@ namespace Receiver
 
         public async Task Handle(Ping message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Ping message #{message.Round}");
+            logger.LogInformation("Processing Ping message {@Round}", message.Round);
 
             var reply = new Pong { Acknowledgement = $"Ping #{message.Round} processed at {DateTimeOffset.UtcNow:s}" };
 
             await context.Reply(reply);
-            
+
             // throw new Exception("BOOM");
         }
     }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/PongHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/PongHandler.cs
@@ -16,7 +16,7 @@ namespace Sender
 
         public Task Handle(Pong message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Pong message: {message.Acknowledgement}");
+            logger.LogInformation("Processing Pong message: {Acknowledgement}", message.Acknowledgement);
 
             return Task.CompletedTask;
         }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/SenderWorker.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_4/Sender/SenderWorker.cs
@@ -28,7 +28,7 @@ namespace Sender
                 {
                     await messageSession.Send(new Ping { Round = round++ });
 
-                    logger.LogInformation($"Message #{round}");
+                    logger.LogInformation("Message #{Round}", round);
 
                     await Task.Delay(1_000, stoppingToken);
                 }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Receiver/PingHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Receiver/PingHandler.cs
@@ -17,12 +17,12 @@ namespace Receiver
 
         public async Task Handle(Ping message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Ping message #{message.Round}");
+            logger.LogInformation("Processing Ping message #{Round}", message.Round);
 
             var reply = new Pong { Acknowledgement = $"Ping #{message.Round} processed at {DateTimeOffset.UtcNow:s}" };
 
             await context.Reply(reply);
-            
+
             // throw new Exception("BOOM");
         }
     }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/PongHandler.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/PongHandler.cs
@@ -16,7 +16,7 @@ namespace Sender
 
         public Task Handle(Pong message, IMessageHandlerContext context)
         {
-            logger.LogInformation($"Processing Pong message: {message.Acknowledgement}");
+            logger.LogInformation("Processing Pong message: {Acknowledgement}", message.Acknowledgement);
 
             return Task.CompletedTask;
         }

--- a/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/SenderWorker.cs
+++ b/samples/azure-service-bus-netstandard/send-receive-with-nservicebus/ASBS_5/Sender/SenderWorker.cs
@@ -28,7 +28,7 @@ namespace Sender
                 {
                     await messageSession.Send(new Ping { Round = round++ });
 
-                    logger.LogInformation($"Message #{round}");
+                    logger.LogInformation("Message #{Round}", round);
 
                     await Task.Delay(1_000, stoppingToken);
                 }

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint1/Message2Handler.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint1/Message2Handler.cs
@@ -6,7 +6,7 @@ public class Message2Handler(ILogger<Message2Handler> logger) :
 {
     public Task Handle(Message2 message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received Message2: {message.Property}");
+        logger.LogInformation("Received Message2: {Property}", message.Property);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint2/Message1Handler.cs
+++ b/samples/azure-service-bus-netstandard/send-reply/ASBS_5/Endpoint2/Message1Handler.cs
@@ -5,10 +5,10 @@ using NServiceBus;
 public class Message1Handler (ILogger<Message1Handler> logger):
     IHandleMessages<Message1>
 {
- 
+
     public Task Handle(Message1 message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received Message1: {message.Property}");
+        logger.LogInformation("Received Message1: {Property}", message.Property);
 
         var message2 = new Message2
         {

--- a/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVoteCount.csproj
@@ -7,6 +7,7 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.*" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="6.*" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="6.*" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="9.*" />

--- a/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVotesSaga.cs
+++ b/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/CandidateVotesSaga.cs
@@ -1,14 +1,22 @@
-﻿using System.Threading.Tasks;
+﻿
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
 using NServiceBus.Persistence.ServiceFabric;
 
 [ServiceFabricSaga(CollectionName = "candidate-votes")]
 public class CandidateVotesSaga :
     Saga<CandidateVotesSaga.CandidateVoteData>,
-        IAmStartedByMessages<VotePlaced>,
-        IHandleMessages<CloseElection>,
-        IHandleMessages<TrackZipCodeReply>
+    IAmStartedByMessages<VotePlaced>,
+    IHandleMessages<CloseElection>,
+    IHandleMessages<TrackZipCodeReply>
 {
+    private readonly ILogger<CandidateVotesSaga> logger;
+
+    public CandidateVotesSaga(ILogger<CandidateVotesSaga> logger)
+    {
+        this.logger = logger;
+    }
 
     protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CandidateVoteData> mapper)
     {
@@ -47,7 +55,7 @@ public class CandidateVotesSaga :
 
     public Task Handle(TrackZipCodeReply message, IMessageHandlerContext context)
     {
-        Logger.Log($"##### CandidateVote saga for {Data.Candidate} got reply for zip code '{message.ZipCode}' tracking with current count of {message.CurrentCount}");
+        logger.LogInformation("##### CandidateVote saga for {Candidate} got reply for zip code '{ZipCode}' tracking with current count of {CurrentCount}", Data.Candidate, message.ZipCode, message.CurrentCount);
         return Task.CompletedTask;
     }
 

--- a/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/ReportVotesHandler.cs
+++ b/samples/azure/azure-service-fabric-routing/Core_8/CandidateVoteCount/ReportVotesHandler.cs
@@ -1,13 +1,19 @@
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
 
-public class ReportVotesHandler :
-    IHandleMessages<ReportVotes>
+public class ReportVotesHandler : IHandleMessages<ReportVotes>
 {
+    private readonly ILogger<ReportVotesHandler> logger;
+
+    public ReportVotesHandler(ILogger<ReportVotesHandler> logger)
+    {
+        this.logger = logger;
+    }
+
     public Task Handle(ReportVotes message, IMessageHandlerContext context)
     {
-        Logger.Log($"Closing voting, {message.Candidate} got {message.NumberOfVotes} votes ");
-
+        logger.LogInformation("Closing voting, {Candidate} got {NumberOfVotes} votes", message.Candidate, message.NumberOfVotes);
         return Task.FromResult(true);
     }
 }

--- a/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ReportZipCodeHandler.cs
+++ b/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ReportZipCodeHandler.cs
@@ -1,12 +1,20 @@
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NServiceBus;
 
 public class ReportZipCodeHandler :
     IHandleMessages<ReportZipCode>
 {
+    private readonly ILogger<ReportZipCodeHandler> logger;
+
+    public ReportZipCodeHandler(ILogger<ReportZipCodeHandler> logger)
+    {
+        this.logger = logger;
+    }
+
     public Task Handle(ReportZipCode message, IMessageHandlerContext context)
     {
-        Logger.Log($"Closing voting, {message.ZipCode} voted {message.NumberOfVotes} times ");
+        logger.LogInformation("Closing voting, {ZipCode} voted {NumberOfVotes} times", message.ZipCode, message.NumberOfVotes);
 
         return Task.FromResult(true);
     }

--- a/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ZipCodeVoteCount.csproj
+++ b/samples/azure/azure-service-fabric-routing/Core_8/ZipCodeVoteCount/ZipCodeVoteCount.csproj
@@ -7,6 +7,7 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="6.*" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="6.*" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="9.*" />

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Client/OrderCompletedHandler.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Client/OrderCompletedHandler.cs
@@ -8,7 +8,7 @@ public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
 
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Server/OrderIdAsPartitionKeyBehavior.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Server/OrderIdAsPartitionKeyBehavior.cs
@@ -31,17 +31,17 @@ class OrderIdAsPartitionKeyBehavior : Behavior<IIncomingLogicalMessageContext>
 
         if (context.Headers.TryGetValue(Headers.SagaId, out var sagaIdHeader))
         {
-            logger.LogInformation($"Saga Id Header: {sagaIdHeader}");
+            logger.LogInformation("Saga Id Header: {SagaIdHeader}", sagaIdHeader);
         }
 
         if (context.Extensions.TryGet<TableInformation>(out var tableInformation))
         {
 
-            logger.LogInformation($"Table Information: {tableInformation.TableName}");
+            logger.LogInformation("Table Information: {TableName}", tableInformation.TableName);
         }
 
 
-        logger.LogInformation($"Found partition key '{context.Extensions.Get<TableEntityPartitionKey>().PartitionKey}' from '{nameof(IProvideOrderId)}'");
+        logger.LogInformation("Found partition key '{PartitionKey}' from '{TypeName}'", context.Extensions.Get<TableEntityPartitionKey>().PartitionKey, nameof(IProvideOrderId));
 
         await next();
     }

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Server/OrderSaga.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Server/OrderSaga.cs
@@ -22,7 +22,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
@@ -44,13 +44,13 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
 
     public Task Handle(OrderShipped message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order with OrderId {Data.OrderId} shipped on {message.ShippingDate}");
+        logger.LogInformation("Order with OrderId {OrderId} shipped on {ShippingDate}", Data.OrderId, message.ShippingDate);
         return Task.CompletedTask;
     }
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/azure/azure-table/saga-transactions/ASTP_6/Server/ShipOrderHandler.cs
+++ b/samples/azure/azure-table/saga-transactions/ASTP_6/Server/ShipOrderHandler.cs
@@ -20,7 +20,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
         Store(orderShippingInformation, context);
 
 
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
 
         return context.Reply(new OrderShipped { OrderId = orderShippingInformation.OrderId, ShippingDate = orderShippingInformation.ShippedAt });
     }
@@ -33,5 +33,5 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 
         session.Batch.Add(new TableTransactionAction(TableTransactionActionType.Add, orderShippingInformation));
     }
- 
+
 }

--- a/samples/azure/azure-table/simple/ASTP_6/Client/OrderCompletedHandler.cs
+++ b/samples/azure/azure-table/simple/ASTP_6/Client/OrderCompletedHandler.cs
@@ -5,11 +5,10 @@ using NServiceBus;
 public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
     IHandleMessages<OrderCompleted>
 {
- 
+
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/azure-table/simple/ASTP_6/Server/OrderSaga.cs
+++ b/samples/azure/azure-table/simple/ASTP_6/Server/OrderSaga.cs
@@ -19,7 +19,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", message.OrderId);
 
         var shipOrder = new ShipOrder
         {
@@ -27,7 +27,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
         };
 
 
-        logger.LogInformation("Order will complete in 5 seconds");
+        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,
@@ -41,7 +41,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/azure/azure-table/simple/ASTP_6/Server/ShipOrderHandler.cs
+++ b/samples/azure/azure-table/simple/ASTP_6/Server/ShipOrderHandler.cs
@@ -7,8 +7,7 @@ public class ShipOrderHandler(ILogger<ShipOrderHandler> logger) :
 {
     public Task Handle(ShipOrder message, IMessageHandlerContext context)
     {
-
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/azure-table/table/ASTP_6/Client/OrderCompletedHandler.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Client/OrderCompletedHandler.cs
@@ -7,7 +7,7 @@ public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
 {
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/azure-table/table/ASTP_6/Server/BehaviorProvidingDynamicTable.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Server/BehaviorProvidingDynamicTable.cs
@@ -14,13 +14,13 @@ class BehaviorProvidingDynamicTable(ILogger<BehaviorProvidingDynamicTable> logge
             context.Headers.TryGetValue(Headers.SagaType, out var sagaTypeHeader) && sagaTypeHeader.Contains(nameof(ShipOrderSaga)))
         {
 
-            logger.LogInformation($"Message '{context.Message.MessageType.FullName}' destined to be handled by '{nameof(ShipOrderSaga)}' will use 'ShipOrderSagaData' table.");
+            logger.LogInformation("Message '{MessageType}' destined to be handled by '{SagaType}' will use '{TableName}' table.", context.Message.MessageType.FullName, nameof(ShipOrderSaga), "ShipOrderSagaData");
 
             context.Extensions.Set(new TableInformation("ShipOrderSagaData"));
         }
         else
         {
-            logger.LogInformation($"Message '{context.Message.MessageType.FullName}' destined to be handled by '{nameof(OrderSaga)}' will the default table.");
+            logger.LogInformation("Message '{MessageType}' destined to be handled by '{SagaType}' will use the default table.", context.Message.MessageType.FullName, nameof(OrderSaga));
         }
 
         return next();

--- a/samples/azure/azure-table/table/ASTP_6/Server/OrderSaga.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Server/OrderSaga.cs
@@ -23,7 +23,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
         Data.OrderDescription = $"The saga for order {message.OrderId}";
 
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
@@ -36,7 +36,7 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
     public Task Handle(CompleteOrder message, IMessageHandlerContext context)
     {
 
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/azure/azure-table/table/ASTP_6/Server/ShipOrderSaga.cs
+++ b/samples/azure/azure-table/table/ASTP_6/Server/ShipOrderSaga.cs
@@ -9,7 +9,7 @@ public class ShipOrderSaga(ILogger<ShipOrderSaga> logger) :
     IAmStartedByMessages<ShipOrder>,
     IHandleTimeouts<CompleteOrder>
 {
- 
+
     protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ShipOrderSagaData> mapper)
     {
         mapper.MapSaga(saga => saga.OrderId).ToMessage<ShipOrder>(msg => msg.OrderId);
@@ -17,17 +17,17 @@ public class ShipOrderSaga(ILogger<ShipOrderSaga> logger) :
 
     public Task Handle(ShipOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
         Data.OrderId = message.OrderId;
 
-        logger.LogInformation("Order will complete in 5 seconds");
+        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
         var timeoutData = new CompleteOrder();
         return RequestTimeout(context, TimeSpan.FromSeconds(5), timeoutData);
     }
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} about to complete");
+        logger.LogInformation("Saga with OrderId {OrderId} about to complete", Data.OrderId);
         MarkAsComplete();
 
         state.OrderId = Data.OrderId;

--- a/samples/azure/azure-table/transactions/ASTP_6/Client/OrderCompletedHandler.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Client/OrderCompletedHandler.cs
@@ -7,7 +7,7 @@ public class OrderCompletedHandler(ILogger<OrderCompletedHandler> logger) :
     public Task Handle(OrderCompleted message, IMessageHandlerContext context)
     {
 
-        logger.LogInformation($"Received OrderCompleted for OrderId {message.OrderId}");
+        logger.LogInformation("Received OrderCompleted for OrderId {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/OrderIdAsPartitionKeyBehavior.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/OrderIdAsPartitionKeyBehavior.cs
@@ -30,15 +30,15 @@ class OrderIdAsPartitionKeyBehavior : Behavior<IIncomingLogicalMessageContext>
 
         if (context.Headers.TryGetValue(Headers.SagaId, out var sagaIdHeader))
         {
-            logger.LogInformation($"Saga Id Header: {sagaIdHeader}");
+            logger.LogInformation("Saga Id Header: {SagaIdHeader}", sagaIdHeader);
         }
 
         if (context.Extensions.TryGet<TableInformation>(out var tableInformation))
         {
-            logger.LogInformation($"Table Information: {tableInformation.TableName}");
+            logger.LogInformation("Table Information: {TableName}", tableInformation.TableName);
         }
 
-        logger.LogInformation($"Found partition key '{context.Extensions.Get<TableEntityPartitionKey>().PartitionKey}' from '{nameof(IProvideOrderId)}'");
+        logger.LogInformation("Found partition key '{PartitionKey}' from '{Provider}'", context.Extensions.Get<TableEntityPartitionKey>().PartitionKey, nameof(IProvideOrderId));
 
         await next();
     }

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/OrderIdHeaderAsPartitionKeyBehavior.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/OrderIdHeaderAsPartitionKeyBehavior.cs
@@ -11,7 +11,7 @@ class OrderIdHeaderAsPartitionKeyBehavior(ILogger<OrderIdHeaderAsPartitionKeyBeh
     {
         if (context.Message.Headers.TryGetValue("Sample.AzureTable.Transaction.OrderId", out var orderId))
         {
-            logger.LogInformation($"Found partition key '{orderId}' from header 'Sample.AzureTable.Transaction'");
+            logger.LogInformation("Found partition key '{PartitionKey}' from header 'Sample.AzureTable.Transaction'", orderId);
 
             context.Extensions.Set(new TableEntityPartitionKey(orderId));
         }

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/OrderSaga.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/OrderSaga.cs
@@ -22,14 +22,14 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
         var orderDescription = $"The saga for order {message.OrderId}";
         Data.OrderDescription = orderDescription;
 
-        logger.LogInformation($"Received StartOrder message {Data.OrderId}. Starting Saga");
+        logger.LogInformation("Received StartOrder message {OrderId}. Starting Saga", Data.OrderId);
 
         var shipOrder = new ShipOrder
         {
             OrderId = message.OrderId
         };
 
-        logger.LogInformation("Order will complete in 5 seconds");
+        logger.LogInformation("Order will complete in {Seconds} seconds", 5);
         var timeoutData = new CompleteOrder
         {
             OrderDescription = orderDescription,
@@ -44,13 +44,13 @@ public class OrderSaga(ILogger<OrderSaga> logger) :
 
     public Task Handle(OrderShipped message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Order with OrderId {Data.OrderId} shipped on {message.ShippingDate}");
+        logger.LogInformation("Order with OrderId {OrderId} shipped on {ShippingDate}", Data.OrderId, message.ShippingDate);
         return Task.CompletedTask;
     }
 
     public Task Timeout(CompleteOrder state, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Saga with OrderId {Data.OrderId} completed");
+        logger.LogInformation("Saga with OrderId {OrderId} completed", Data.OrderId);
         MarkAsComplete();
         var orderCompleted = new OrderCompleted
         {

--- a/samples/azure/azure-table/transactions/ASTP_6/Server/ShipOrderHandler.cs
+++ b/samples/azure/azure-table/transactions/ASTP_6/Server/ShipOrderHandler.cs
@@ -21,7 +21,7 @@ public class ShipOrderHandler (ILogger<ShipOrderHandler> logger):
         Store(orderShippingInformation, context);
 
 
-        logger.LogInformation($"Order Shipped. OrderId {message.OrderId}");
+        logger.LogInformation("Order Shipped. OrderId {OrderId}", message.OrderId);
 
         var options = new PublishOptions();
         options.SetHeader("Sample.AzureTable.Transaction.OrderId", message.OrderId.ToString());

--- a/samples/azure/custom-audit-transport/Core_9/CustomAuditTransport/AuditThisMessageHandler.cs
+++ b/samples/azure/custom-audit-transport/Core_9/CustomAuditTransport/AuditThisMessageHandler.cs
@@ -9,7 +9,7 @@ public class AuditThisMessageHandler(ILogger<AuditThisMessageHandler> logger) :
     {
         if(message.Error) throw new System.Exception("Simulated error in message handler");
 
-        logger.LogInformation($"Handling {message.GetType().Name} with content: {message.Content}");
+        logger.LogInformation("Handling {MessageType} with content: {Content}", message.GetType().Name, message.Content);
         return Task.CompletedTask;
     }
 }

--- a/samples/azure/native-integration-asq/ASQN_13/Receiver/NativeMessageHandler.cs
+++ b/samples/azure/native-integration-asq/ASQN_13/Receiver/NativeMessageHandler.cs
@@ -6,7 +6,7 @@ public class NativeMessageHandler(ILogger<NativeMessageHandler> logger) : IHandl
 {
     public Task Handle(NativeMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Message content: {message.Content}");
+        logger.LogInformation("Message content: {Content}", message.Content);
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Part of

https://github.com/Particular/GeneralPlatformExperience/issues/3482

Updated all logger.LogInformation and similar calls in the Azure samples to use structured logging message templates and named parameters.

No functional changes