### PR TITLE
Refactor logger calls in bridge samples to use structured logging

### DIFF
--- a/samples/bridge/service-control/TransportBridge_1/Endpoint/MyMessageHandler.cs
+++ b/samples/bridge/service-control/TransportBridge_1/Endpoint/MyMessageHandler.cs
@@ -7,7 +7,7 @@ class MyMessageHandler (ILogger<MyMessageHandler> logger):
 {
     public Task Handle(MyMessage message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Processing message {message.Id}");
+        logger.LogInformation("Processing message {Id}", message.Id);
         return FailureSimulator.Invoke();
     }
 }

--- a/samples/bridge/simple/Bridge_3/LeftReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/Bridge_3/LeftReceiver/OrderReceivedHandler.cs
@@ -7,7 +7,7 @@ public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
 {
     public Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Subscriber has received OrderReceived event with OrderId {message.OrderId}.");
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/simple/Bridge_3/RightReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/Bridge_3/RightReceiver/OrderReceivedHandler.cs
@@ -7,7 +7,7 @@ public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
 {
     public Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Subscriber has received OrderReceived event with OrderId {message.OrderId}.");
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/simple/Bridge_3/RightReceiver/PlaceOrderHandler.cs
+++ b/samples/bridge/simple/Bridge_3/RightReceiver/PlaceOrderHandler.cs
@@ -7,7 +7,7 @@ public class PlaceOrderHandler(ILogger<PlaceOrderHandler> logger) : IHandleMessa
 {
     public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
     {
-       logger.LogInformation($"Received PlaceOrder Command with Id {message.OrderId}");
+       logger.LogInformation("Received PlaceOrder Command with Id {OrderId}", message.OrderId);
 
         await context.Reply(new OrderResponse { OrderId = message.OrderId });
     }

--- a/samples/bridge/simple/TransportBridge_1/LeftReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/TransportBridge_1/LeftReceiver/OrderReceivedHandler.cs
@@ -7,7 +7,7 @@ public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
 {
     public Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Subscriber has received OrderReceived event with OrderId {message.OrderId}.");
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/simple/TransportBridge_1/LeftSender/OrderResponseHandler.cs
+++ b/samples/bridge/simple/TransportBridge_1/LeftSender/OrderResponseHandler.cs
@@ -7,7 +7,7 @@ public class OrderResponseHandler(ILogger<OrderResponseHandler> logger) : IHandl
 {
     public Task Handle(OrderResponse message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"OrderResponse Reply received with Id {message.OrderId}");
+        logger.LogInformation("OrderResponse Reply received with Id {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/simple/TransportBridge_1/RightReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/TransportBridge_1/RightReceiver/OrderReceivedHandler.cs
@@ -7,7 +7,7 @@ public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
 {
     public Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Subscriber has received OrderReceived event with OrderId {message.OrderId}.");
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/simple/TransportBridge_1/RightReceiver/PlaceOrderHandler.cs
+++ b/samples/bridge/simple/TransportBridge_1/RightReceiver/PlaceOrderHandler.cs
@@ -6,7 +6,7 @@ public class PlaceOrderHandler(ILogger<PlaceOrderHandler> logger) : IHandleMessa
 {
     public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received PlaceOrder Command with Id {message.OrderId}");
+        logger.LogInformation("Received PlaceOrder Command with Id {OrderId}", message.OrderId);
 
         await context.Reply(new OrderResponse { OrderId = message.OrderId });
     }

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/OrderHandler.cs
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Receiver/OrderHandler.cs
@@ -10,7 +10,7 @@ public class OrderHandler (ILogger<OrderHandler> logger):
 
     public Task Handle(ClientOrder message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Handling ClientOrder with ID {message.OrderId}");
+        logger.LogInformation("Handling ClientOrder with ID {OrderId}", message.OrderId);
         var clientOrderAccepted = new ClientOrderResponse
         {
             OrderId = message.OrderId

--- a/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/ClientOrderResponseHandler.cs
+++ b/samples/bridge/sql-multi-instance/TransportBridge_1/Sender/ClientOrderResponseHandler.cs
@@ -8,7 +8,7 @@ public class ClientOrderResponseHandler(ILogger<ClientOrderResponseHandler> logg
 {
     public Task Handle(ClientOrderResponse message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received ClientOrderResponse for ID {message.OrderId}");
+        logger.LogInformation("Received ClientOrderResponse for ID {OrderId}", message.OrderId);
         return Task.CompletedTask;
     }
 }

--- a/samples/bridge/sql-multi-instance/sample.md
+++ b/samples/bridge/sql-multi-instance/sample.md
@@ -57,7 +57,9 @@ The receiver mimics a back-end system. It is configured to use the SQL Server tr
 
 snippet: ReceiverConfiguration
 
-Note that the endpoint configuration contains no routing information, as the response message is a regular reply and NServiceBus, together with the bridge, will take care of all the routing with reply messages. The receiver replies with `ClientOrderResponse` back to the sender.
+> [!NOTE]
+
+> The endpoint configuration contains no routing information. The receiver responds to the sender with a `ClientOrderResponse` message using the [Reply method](/nservicebus/messaging/reply-to-a-message.md). Using this method, NServiceBus, together with the bridge, handles the routing of reply messages without any additional configuration.
 
 snippet: Reply
 

--- a/samples/bridge/sql-multi-instance/sample.md
+++ b/samples/bridge/sql-multi-instance/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Multi-Instance Mode
-summary: SQL Server Transport Running in Multi-Instance Mode using Bridge
-reviewed: 2025-06-30
+summary: SQL Server transport running in multi-instance mode using Bridge
+reviewed: 2023-07-04
 component: Bridge
 related:
 - nservicebus/bridge
@@ -9,7 +9,7 @@ related:
 - transports/sql/deployment-options
 ---
 
-This sample shows how to use the [NServiceBus Messaging Bridge](/nservicebus/bridge/) instead of the deprecated [SQL Server transport multi-instance mode](/transports/upgrades/sqlserver-31to4.md#multi-instance-mode).
+This is sample shows how to use the [NServiceBus Messaging Bridge](/nservicebus/bridge/) instead of the deprecated [SQL Server transport multi-instance mode](/transports/upgrades/sqlserver-31to4.md#multi-instance-mode).
 
 ## Prerequisites
 
@@ -57,8 +57,7 @@ The receiver mimics a back-end system. It is configured to use the SQL Server tr
 
 snippet: ReceiverConfiguration
 
-> [!NOTE]
-> The endpoint configuration contains no routing information. The receiver responds to the sender with a `ClientOrderResponse` message using the [Reply method](/nservicebus/messaging/reply-to-a-message.md). Using this method, NServiceBus, together with the bridge, handles the routing of reply messages without any additional configuration.
+Note that the endpoint configuration contains no routing information, as the response message is a regular reply and NServiceBus, together with the bridge, will take care of all the routing with reply messages. The receiver replies with `ClientOrderResponse` back to the sender.
 
 snippet: Reply
 
@@ -68,4 +67,4 @@ The bridge is configured with two transports. As both transports are of the same
 
 snippet: BridgeConfiguration
 
-Both transports have the endpoints defined on their side. As a result, the bridge will mimic those endpoints on the other side. This way, it becomes transparent to actual endpoints on either side that those endpoints are bridged.
+Both transports have the endpoints defined on their side and as a result, the bridge will mimic those endpoints on the other side. This way it becomes transparent to actual endpoints on either side that those endpoints are actually bridged.

--- a/samples/bridge/sql-multi-instance/sample.md
+++ b/samples/bridge/sql-multi-instance/sample.md
@@ -67,4 +67,4 @@ The bridge is configured with two transports. As both transports are of the same
 
 snippet: BridgeConfiguration
 
-Both transports have the endpoints defined on their side and as a result, the bridge will mimic those endpoints on the other side. This way it becomes transparent to actual endpoints on either side that those endpoints are actually bridged.
+Each transport configured in the bridge defines the endpoints it supports on its end. The bridge then creates corresponding shadow endpoints on the opposite side, effectively mirroring them. This setup allows messages to flow seamlessly across the transports without requiring the actual sender or receiver to be aware that bridging is occurring—their communication appears direct and uninterrupted.

--- a/samples/bridge/sql-multi-instance/sample.md
+++ b/samples/bridge/sql-multi-instance/sample.md
@@ -9,7 +9,7 @@ related:
 - transports/sql/deployment-options
 ---
 
-This is sample shows how to use the [NServiceBus Messaging Bridge](/nservicebus/bridge/) instead of the deprecated [SQL Server transport multi-instance mode](/transports/upgrades/sqlserver-31to4.md#multi-instance-mode).
+This sample shows how to use the [NServiceBus Messaging Bridge](/nservicebus/bridge/) instead of the deprecated [SQL Server transport multi-instance mode](/transports/upgrades/sqlserver-31to4.md#multi-instance-mode).
 
 ## Prerequisites
 


### PR DESCRIPTION
Part of

https://github.com/Particular/GeneralPlatformExperience/issues/3482

Updated all logger.LogInformation and similar calls in the bridge samples to use structured logging message templates and named parameters.

No functional changes