### PR TITLE
Refactor logger calls in samples to use structured logging

### DIFF
--- a/samples/throttling/Core_9/Limited/GitHubSearchHandler.cs
+++ b/samples/throttling/Core_9/Limited/GitHubSearchHandler.cs
@@ -13,10 +13,10 @@ public class GitHubSearchHandler(ILogger<GitHubSearchHandler> logger) :
 
     public async Task Handle(SearchGitHub message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received search request for branch '{message.Branch}' on '{message.Owner}/{message.Repository}'");
+        logger.LogInformation("Received search request for branch '{Branch}' on '{Owner}/{Repository}'", message.Branch, message.Owner, message.Repository);
 
         var result = await GitHubClient.Repository.Branch.Get(message.Owner, message.Repository, "master");
-        logger.LogInformation($"Found commit '{result.Commit.Sha}' for branch '{message.Branch}'. Replying.");
+        logger.LogInformation("Found commit '{CommitSha}' for branch '{Branch}'. Replying.", result.Commit.Sha, message.Branch);
         var response = new SearchResponse
         {
             Branch = message.Branch,

--- a/samples/throttling/Core_9/Limited/ThrottlingBehavior.cs
+++ b/samples/throttling/Core_9/Limited/ThrottlingBehavior.cs
@@ -17,7 +17,7 @@ public class ThrottlingBehavior(ILogger<ThrottlingBehavior> logger) :
         if (rateLimitReset.HasValue && rateLimitReset >= DateTime.UtcNow)
         {
             var localTime = rateLimitReset?.ToLocalTime();
-            logger.LogInformation($"Rate limit exceeded. Retry after {rateLimitReset} UTC ({localTime} local).");
+            logger.LogInformation("Rate limit exceeded. Retry after {RateLimitReset} UTC ({LocalTime} local).", rateLimitReset, localTime);
             await DelayMessage(context, rateLimitReset.Value);
             return;
         }
@@ -30,7 +30,7 @@ public class ThrottlingBehavior(ILogger<ThrottlingBehavior> logger) :
         {
             var nextReset = nextRateLimitReset = exception.Reset.UtcDateTime;
             var localTime = nextReset?.ToLocalTime();
-            logger.LogInformation($"Rate limit exceeded. Limit resets at {nextReset} UTC ({localTime} local).");
+            logger.LogInformation("Rate limit exceeded. Limit resets at {NextReset} UTC ({LocalTime} local).", nextReset, localTime);
             await DelayMessage(context, nextReset.Value);
         }
     }

--- a/samples/throttling/Core_9/Sender/GitHubSearchResponseHandler.cs
+++ b/samples/throttling/Core_9/Sender/GitHubSearchResponseHandler.cs
@@ -7,7 +7,7 @@ public class GitHubSearchResponseHandler(ILogger<GitHubSearchResponseHandler> lo
 {
     public Task Handle(SearchResponse message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Found commit '{message.CommitSha}' for branch '{message.Branch}'.");
+        logger.LogInformation("Found commit '{CommitSha}' for branch '{Branch}.'", message.CommitSha, message.Branch);
         return Task.CompletedTask;
     }
 }

--- a/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/OrderReceivedHandler.cs
+++ b/samples/transactional-session/cosmosdb/CosmosTS_1/Backend/OrderReceivedHandler.cs
@@ -14,7 +14,7 @@ class OrderReceivedHandler : IHandleMessages<OrderReceived>
 
     public async Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(OrderReceived)} event for order #{message.OrderId}");
+        logger.LogInformation("Received {Event} event for order #{OrderId}", nameof(OrderReceived), message.OrderId);
 
         var session = context.SynchronizedStorageSession.CosmosPersistenceSession();
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/OrderReceivedHandler.cs
+++ b/samples/transactional-session/cosmosdb/CosmosTS_2/Backend/OrderReceivedHandler.cs
@@ -13,7 +13,7 @@ class OrderReceivedHandler : IHandleMessages<OrderReceived>
 
     public async Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(OrderReceived)} event for order #{message.OrderId}");
+        logger.LogInformation("Received {Event} event for order #{OrderId}", nameof(OrderReceived), message.OrderId);
 
         var session = context.SynchronizedStorageSession.CosmosPersistenceSession();
 

--- a/samples/transactional-session/cosmosdb/CosmosTS_3/Backend/OrderReceivedHandler.cs
+++ b/samples/transactional-session/cosmosdb/CosmosTS_3/Backend/OrderReceivedHandler.cs
@@ -13,7 +13,7 @@ class OrderReceivedHandler : IHandleMessages<OrderReceived>
 
     public async Task Handle(OrderReceived message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Received {nameof(OrderReceived)} event for order #{message.OrderId}");
+        logger.LogInformation("Received {Event} event for order #{OrderId}", nameof(OrderReceived), message.OrderId);
 
         var session = context.SynchronizedStorageSession.CosmosPersistenceSession();
 

--- a/samples/unobtrusive/Core_9/Client/MyEventHandler.cs
+++ b/samples/unobtrusive/Core_9/Client/MyEventHandler.cs
@@ -5,7 +5,7 @@ public class MyEventHandler(ILogger<MyEventHandler> logger) : IHandleMessages<My
 {
     public Task Handle(MyEvent message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"MyEvent received from server with id:{message.EventId}");
+        logger.LogInformation("MyEvent received from server with id:{EventId}", message.EventId);
         return Task.CompletedTask;
     }
 }

--- a/samples/unobtrusive/Core_9/Client/ResponseHandler.cs
+++ b/samples/unobtrusive/Core_9/Client/ResponseHandler.cs
@@ -5,7 +5,7 @@ public class ResponseHandler(ILogger<ResponseHandler> logger) : IHandleMessages<
 {
     public Task Handle(Response message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Response received from server for request with id:{message.ResponseId}");
+        logger.LogInformation("Response received from server for request with id:{ResponseId}", message.ResponseId);
         return Task.CompletedTask;
     }
 }

--- a/samples/unobtrusive/Core_9/Server/LargeMessageHandler.cs
+++ b/samples/unobtrusive/Core_9/Server/LargeMessageHandler.cs
@@ -7,11 +7,11 @@ public class LargeMessageHandler(ILogger<LargeMessageHandler> logger) : IHandleM
     {
         if (message.LargeDataBus == null)
         {
-            logger.LogInformation($"Message [{message.GetType()}] received, id:{message.RequestId}");
+            logger.LogInformation("Message [{MessageType}] received, id:{RequestId}", message.GetType(), message.RequestId);
         }
         else
         {
-            logger.LogInformation($"Message [{message.GetType()}] received, id:{message.RequestId} and payload {message.LargeDataBus.Length} bytes");
+            logger.LogInformation("Message [{MessageType}] received, id:{RequestId} and payload {PayloadLength} bytes", message.GetType(), message.RequestId, message.LargeDataBus.Length);
         }
         return Task.CompletedTask;
     }

--- a/samples/unobtrusive/Core_9/Server/MessageThatExpiresHandler.cs
+++ b/samples/unobtrusive/Core_9/Server/MessageThatExpiresHandler.cs
@@ -6,7 +6,7 @@ public class MessageThatExpiresHandler(ILogger<MessageThatExpiresHandler> logger
 
     public Task Handle(MessageThatExpires message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Message [{message.GetType()}] received, id: [{message.RequestId}]");
+        logger.LogInformation("Message [{MessageType}] received, id: [{RequestId}]", message.GetType(), message.RequestId);
         return Task.CompletedTask;
     }
 }

--- a/samples/unobtrusive/Core_9/Server/MyCommandHandler.cs
+++ b/samples/unobtrusive/Core_9/Server/MyCommandHandler.cs
@@ -5,7 +5,7 @@ public class MyCommandHandler(ILogger<MyCommandHandler> logger) : IHandleMessage
 {
     public Task Handle(MyCommand message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Command received, id:{message.CommandId}");
+        logger.LogInformation("Command received, id:{CommandId}", message.CommandId);
         return Task.CompletedTask;
     }
 }

--- a/samples/unobtrusive/Core_9/Server/RequestMessageHandler.cs
+++ b/samples/unobtrusive/Core_9/Server/RequestMessageHandler.cs
@@ -4,7 +4,7 @@ public class RequestMessageHandler(ILogger<RequestMessageHandler> logger) : IHan
 {
     public Task Handle(Request message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Request received with id:{message.RequestId}");
+        logger.LogInformation("Request received with id:{RequestId}", message.RequestId);
 
         var response = new Response
         {

--- a/samples/username-header/Core_9/Endpoint2/HandlerUsingAccessor.cs
+++ b/samples/username-header/Core_9/Endpoint2/HandlerUsingAccessor.cs
@@ -21,8 +21,8 @@ public class HandlerUsingAccessor :
         var headers = context.MessageHeaders;
         var usernameFromHeader = headers["UserName"];
         var usernameFromAccessor = principalAccessor?.CurrentPrincipal?.Identity?.Name ?? "null";
-        logger.LogInformation($"Username extracted from header: {usernameFromHeader}");
-        logger.LogInformation($"Username extracted from accessor: {usernameFromAccessor}");
+        logger.LogInformation("Username extracted from header: {UsernameFromHeader}", usernameFromHeader);
+        logger.LogInformation("Username extracted from accessor: {UsernameFromAccessor}", usernameFromAccessor);
         return Task.CompletedTask;
     }
 }

--- a/samples/versioning/Core_9/V1.Subscriber/SomethingHappenedHandler.cs
+++ b/samples/versioning/Core_9/V1.Subscriber/SomethingHappenedHandler.cs
@@ -6,7 +6,7 @@ public class SomethingHappenedHandler(ILogger<SomethingHappenedHandler> logger) 
 {
     public Task Handle(ISomethingHappened message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Something happened with some data '{message.SomeData}'");
+        logger.LogInformation("Something happened with some data '{SomeData}'", message.SomeData);
         return Task.CompletedTask;
     }
 }

--- a/samples/versioning/Core_9/V2.Subscriber/SomethingMoreHappenedHandler.cs
+++ b/samples/versioning/Core_9/V2.Subscriber/SomethingMoreHappenedHandler.cs
@@ -7,7 +7,7 @@ public class SomethingMoreHappenedHandler(ILogger<SomethingMoreHappenedHandler> 
 {
     public Task Handle(ISomethingMoreHappened message, IMessageHandlerContext context)
     {
-        logger.LogInformation($"Something happened with some data '{message.SomeData}' and more information '{message.MoreInfo}'");
+        logger.LogInformation("Something happened with some data '{SomeData}' and more information '{MoreInfo}'", message.SomeData, message.MoreInfo);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Part of

https://github.com/Particular/GeneralPlatformExperience/issues/3482

Updated all logger.LogInformation and similar calls in the samples to use structured logging message templates and named parameters.

No functional changes