### PR TITLE
Update tests to allow .NET 10.0

### DIFF
--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        public static readonly string[] sdkProjectAllowedTfmList = ["net10.0", "net10.0-windows","net9.0", "net9.0-windows", "net8.0", "net8.0-windows", "net48", "netstandard2.0"];
+        public static readonly string[] sdkProjectAllowedTfmList = ["net10.0", "net10.0-windows", "net9.0", "net9.0-windows", "net8.0", "net8.0-windows", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -83,7 +83,7 @@ namespace IntegrityTests
 
                     solutionLangVersion ??= fallbackLangVersion;
 
-                    var solutionLangVersionString = solutionLangVersion > latestStableLangVersion ? "preview" : solutionLangVersion.Value.ToString("N1");
+                    var solutionLangVersionString = solutionLangVersion > latestReleasedLangVersion ? "preview" : solutionLangVersion.Value.ToString("N1");
 
                     bool valid = true;
 
@@ -167,7 +167,7 @@ namespace IntegrityTests
             { "net10.0-windows", 14 }
         };
 
-        // This allows us to use the preview version of C# before is officially released
-        private const int latestStableLangVersion = 13;
+        // This needs to be kept up to date with the latest released version of C#
+        private const int latestReleasedLangVersion = 13;
     }
 }


### PR DESCRIPTION
This PR adds the .NET 10.0 framework to the integrity tests and attempts to future proof us for when C# 14 is not preview anymore.