### PR TITLE
Update file-share-databus sample to NServiceBus 10

### DIFF
--- a/samples/databus/file-share-databus/Core_10/DataBus.sln
+++ b/samples/databus/file-share-databus/Core_10/DataBus.sln
@@ -1,0 +1,27 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sender", "Sender\Sender.csproj", "{D04CF1FC-C4C0-4959-A817-2BC68770CA9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{6987F415-B4D5-4380-ADED-EED5AF170608}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{E4A4B35E-AFD3-456C-A5AC-4A88AAD77156}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D04CF1FC-C4C0-4959-A817-2BC68770CA9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D04CF1FC-C4C0-4959-A817-2BC68770CA9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6987F415-B4D5-4380-ADED-EED5AF170608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6987F415-B4D5-4380-ADED-EED5AF170608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4A4B35E-AFD3-456C-A5AC-4A88AAD77156}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4A4B35E-AFD3-456C-A5AC-4A88AAD77156}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/databus/file-share-databus/Core_10/Receiver/MessageWithLargePayloadHandler.cs
+++ b/samples/databus/file-share-databus/Core_10/Receiver/MessageWithLargePayloadHandler.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+#region MessageWithLargePayloadHandler
+
+public class MessageWithLargePayloadHandler :
+    IHandleMessages<MessageWithLargePayload>
+{
+    static ILog log = LogManager.GetLogger<MessageWithLargePayloadHandler>();
+
+    public Task Handle(MessageWithLargePayload message, IMessageHandlerContext context)
+    {
+        log.Info($"Message received, size of blob property: {message.LargeBlob.Value.Length} Bytes");
+        return Task.CompletedTask;
+    }
+}
+
+#endregion

--- a/samples/databus/file-share-databus/Core_10/Receiver/MessageWithLargePayloadHandler.cs
+++ b/samples/databus/file-share-databus/Core_10/Receiver/MessageWithLargePayloadHandler.cs
@@ -11,7 +11,7 @@ public class MessageWithLargePayloadHandler :
 
     public Task Handle(MessageWithLargePayload message, IMessageHandlerContext context)
     {
-        log.Info($"Message received, size of blob property: {message.LargeBlob.Value.Length} Bytes");
+        log.Info($"Message received, size of blob property: {message.LargeBlob.Length} Bytes");
         return Task.CompletedTask;
     }
 }

--- a/samples/databus/file-share-databus/Core_10/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_10/Receiver/Program.cs
@@ -1,0 +1,20 @@
+using NServiceBus;
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Receiver";
+        var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
+        var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
+        dataBus.BasePath(@"..\..\..\..\storage");
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseTransport(new LearningTransport());
+        var endpointInstance = await Endpoint.Start(endpointConfiguration);
+        Console.WriteLine("Press any key to exit");
+        Console.ReadKey();
+        await endpointInstance.Stop();
+    }
+}

--- a/samples/databus/file-share-databus/Core_10/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/Core_10/Receiver/Program.cs
@@ -1,4 +1,5 @@
 using NServiceBus;
+using NServiceBus.ClaimCheck;
 using System;
 using System.Threading.Tasks;
 
@@ -8,8 +9,14 @@ class Program
     {
         Console.Title = "Receiver";
         var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Receiver");
-        var dataBus = endpointConfiguration.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>();
-        dataBus.BasePath(@"..\..\..\..\storage");
+        
+        var claimCheck = endpointConfiguration.UseClaimCheck<FileShareClaimCheck, SystemJsonClaimCheckSerializer>();
+        claimCheck.BasePath(@"..\..\..\..\storage");
+        
+        // Configure ClaimCheck properties using conventions
+        endpointConfiguration.Conventions()
+            .DefiningClaimCheckPropertiesAs(property => property.Name.EndsWith("Blob"));
+        
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/samples/databus/file-share-databus/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_10/Receiver/Receiver.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.1.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/databus/file-share-databus/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/Core_10/Receiver/Receiver.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.1.*" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/databus/file-share-databus/Core_10/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_10/Sender/Program.cs
@@ -1,0 +1,78 @@
+using NServiceBus;
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Sender";
+        var endpointConfiguration = new EndpointConfiguration("Samples.DataBus.Sender");
+
+        #region ConfigureDataBus
+
+        var claimCheck = endpointConfiguration.UseClaimCheck<FileShareClaimCheck, SystemJsonClaimCheckSerializer>();
+        claimCheck.BasePath(@"..\..\..\..\storage");
+        #endregion
+
+        endpointConfiguration.UsePersistence<LearningPersistence>();
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseTransport(new LearningTransport());
+        var endpointInstance = await Endpoint.Start(endpointConfiguration);
+        Console.WriteLine("Press 'D' to send a databus large message");
+        Console.WriteLine("Press 'N' to send a normal large message exceed the size limit and throw");
+        Console.WriteLine("Press any other key to exit");
+
+        while (true)
+        {
+            var key = Console.ReadKey();
+            Console.WriteLine();
+
+            if (key.Key == ConsoleKey.N)
+            {
+                await SendMessageTooLargePayload(endpointInstance);
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.D)
+            {
+                await SendMessageLargePayload(endpointInstance);
+                continue;
+            }
+            break;
+        }
+        await endpointInstance.Stop();
+    }
+
+
+    static async Task SendMessageLargePayload(IEndpointInstance endpointInstance)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        #region SendMessageLargePayload
+
+        var message = new MessageWithLargePayload
+        {
+            SomeProperty = "This message contains a large blob that will be sent on the data bus",
+            LargeBlob = new DataBusProperty<byte[]>(new byte[1024 * 1024 * 5]) //5MB
+        };
+        await endpointInstance.Send("Samples.DataBus.Receiver", message);
+
+        #endregion
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Console.WriteLine(@"Message sent, the payload is stored in: ..\..\..\storage");
+    }
+
+    static async Task SendMessageTooLargePayload(IEndpointInstance endpointInstance)
+    {
+        #region SendMessageTooLargePayload
+
+        var message = new AnotherMessageWithLargePayload
+        {
+            LargeBlob = new byte[1024 * 1024 * 5] //5MB
+        };
+        await endpointInstance.Send("Samples.DataBus.Receiver", message);
+
+        #endregion
+    }
+}

--- a/samples/databus/file-share-databus/Core_10/Sender/Program.cs
+++ b/samples/databus/file-share-databus/Core_10/Sender/Program.cs
@@ -1,4 +1,5 @@
 using NServiceBus;
+using NServiceBus.ClaimCheck;
 using System;
 using System.Threading.Tasks;
 
@@ -13,13 +14,18 @@ class Program
 
         var claimCheck = endpointConfiguration.UseClaimCheck<FileShareClaimCheck, SystemJsonClaimCheckSerializer>();
         claimCheck.BasePath(@"..\..\..\..\storage");
+        
+        // Configure ClaimCheck properties using conventions
+        endpointConfiguration.Conventions()
+            .DefiningClaimCheckPropertiesAs(property => property.Name.EndsWith("Blob"));
+
         #endregion
 
         endpointConfiguration.UsePersistence<LearningPersistence>();
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.UseTransport(new LearningTransport());
         var endpointInstance = await Endpoint.Start(endpointConfiguration);
-        Console.WriteLine("Press 'D' to send a databus large message");
+        Console.WriteLine("Press 'D' to send a claim check large message");
         Console.WriteLine("Press 'N' to send a normal large message exceed the size limit and throw");
         Console.WriteLine("Press any other key to exit");
 
@@ -47,18 +53,16 @@ class Program
 
     static async Task SendMessageLargePayload(IEndpointInstance endpointInstance)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         #region SendMessageLargePayload
 
         var message = new MessageWithLargePayload
         {
-            SomeProperty = "This message contains a large blob that will be sent on the data bus",
-            LargeBlob = new DataBusProperty<byte[]>(new byte[1024 * 1024 * 5]) //5MB
+            SomeProperty = "This message contains a large blob that will be sent via claim check",
+            LargeBlob = new byte[1024 * 1024 * 5] //5MB
         };
         await endpointInstance.Send("Samples.DataBus.Receiver", message);
 
         #endregion
-#pragma warning restore CS0618 // Type or member is obsolete
 
         Console.WriteLine(@"Message sent, the payload is stored in: ..\..\..\storage");
     }

--- a/samples/databus/file-share-databus/Core_10/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_10/Sender/Sender.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/databus/file-share-databus/Core_10/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/Core_10/Sender/Sender.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/databus/file-share-databus/Core_10/Shared/AnotherMessageWithLargePayload.cs
+++ b/samples/databus/file-share-databus/Core_10/Shared/AnotherMessageWithLargePayload.cs
@@ -1,0 +1,11 @@
+﻿using NServiceBus;
+
+#region AnotherMessageWithLargePayload
+
+public class AnotherMessageWithLargePayload :
+    ICommand
+{
+    public byte[] LargeBlob { get; set; }
+}
+
+#endregion

--- a/samples/databus/file-share-databus/Core_10/Shared/MessageWithLargePayload.cs
+++ b/samples/databus/file-share-databus/Core_10/Shared/MessageWithLargePayload.cs
@@ -1,0 +1,14 @@
+﻿using NServiceBus;
+
+#region MessageWithLargePayload
+
+//the data bus is allowed to clean up transmitted properties older than the TTBR
+[TimeToBeReceived("00:01:00")]
+public class MessageWithLargePayload :
+    ICommand
+{
+    public string SomeProperty { get; set; }
+    public DataBusProperty<byte[]> LargeBlob { get; set; }
+}
+
+#endregion

--- a/samples/databus/file-share-databus/Core_10/Shared/MessageWithLargePayload.cs
+++ b/samples/databus/file-share-databus/Core_10/Shared/MessageWithLargePayload.cs
@@ -2,13 +2,13 @@
 
 #region MessageWithLargePayload
 
-//the data bus is allowed to clean up transmitted properties older than the TTBR
+//the claim check is allowed to clean up transmitted properties older than the TTBR
 [TimeToBeReceived("00:01:00")]
 public class MessageWithLargePayload :
     ICommand
 {
     public string SomeProperty { get; set; }
-    public DataBusProperty<byte[]> LargeBlob { get; set; }
+    public byte[] LargeBlob { get; set; }
 }
 
 #endregion

--- a/samples/databus/file-share-databus/Core_10/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_10/Shared/Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.1.*" />
+  </ItemGroup>
+</Project>

--- a/samples/databus/file-share-databus/Core_10/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/Core_10/Shared/Shared.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.1.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Migrate from .NET 9 to .NET 10 preview
- Update NServiceBus packages to 10.0.0-alpha.1 versions
- Migrate from DataBus to ClaimCheck API
- Replace DataBusProperty<T> with regular byte[] properties
- Update ClaimCheck configuration and conventions
- Add prerelease.txt marker file

Fixes: #7291