### PR TITLE
Update databus/redis sample to NServiceBus 10

### DIFF
--- a/samples/databus/redis/Core_10/BasicRedis.sln
+++ b/samples/databus/redis/Core_10/BasicRedis.sln
@@ -1,0 +1,35 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35201.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sender", "Sender\Sender.csproj", "{A2C85229-1A52-4D3B-90FF-EF9D93EE6216}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Receiver", "Receiver\Receiver.csproj", "{D295B34A-6424-4204-B007-971EE333D991}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{3282C6A4-9A1E-401D-BC87-71ECE1241A8E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DCDF2CA8-92D1-46E2-AFE2-4A39D6605557}"
+	ProjectSection(SolutionItems) = preProject
+		docker-compose.yml = docker-compose.yml
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A2C85229-1A52-4D3B-90FF-EF9D93EE6216}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2C85229-1A52-4D3B-90FF-EF9D93EE6216}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D295B34A-6424-4204-B007-971EE333D991}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D295B34A-6424-4204-B007-971EE333D991}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3282C6A4-9A1E-401D-BC87-71ECE1241A8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3282C6A4-9A1E-401D-BC87-71ECE1241A8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7B1C3D38-9A43-477C-8298-A9EAA9FB17CE}
+	EndGlobalSection
+EndGlobal

--- a/samples/databus/redis/Core_10/Receiver/ProcessTextHandler.cs
+++ b/samples/databus/redis/Core_10/Receiver/ProcessTextHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using Shared.Messages;
+
+class ProcessTextHandler(ILogger<ProcessTextHandler> log) : IHandleMessages<ProcessText>
+{
+    #region process-message
+    public Task Handle(ProcessText message, IMessageHandlerContext context)
+    {
+        log.LogInformation(
+            "Most common letter in sample: {mostCommonLetter}",
+            MostCommonLetter(message.LargeText)
+        );
+
+        return Task.CompletedTask;
+    }
+    #endregion
+
+    private static char MostCommonLetter(string text) => text.GroupBy(c => c).OrderByDescending(c => c.Count()).Select(c => c.Key).First();
+}

--- a/samples/databus/redis/Core_10/Receiver/Program.cs
+++ b/samples/databus/redis/Core_10/Receiver/Program.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using NServiceBus.ClaimCheck;
+using Shared;
+
+class Program
+{
+    static Task Main(string[] args)
+    {
+        Console.Title = "Receiver";
+
+        var builder = Host.CreateApplicationBuilder();
+
+        var endpointConfig = new EndpointConfiguration("Receiver");
+        endpointConfig.UseTransport(new LearningTransport());
+        endpointConfig.UseSerialization<SystemJsonSerializer>();
+        endpointConfig.UseClaimCheck(_ => new RedisClaimCheck("localhost"), new SystemJsonClaimCheckSerializer());
+        endpointConfig.Conventions().DefiningClaimCheckPropertiesAs(prop => prop.Name.StartsWith("Large"));
+
+        builder.UseNServiceBus(endpointConfig);
+
+        var host = builder.Build();
+
+        return host.RunAsync();
+    }
+}

--- a/samples/databus/redis/Core_10/Receiver/Program.cs
+++ b/samples/databus/redis/Core_10/Receiver/Program.cs
@@ -7,7 +7,7 @@ using Shared;
 
 class Program
 {
-    static Task Main(string[] args)
+    static async Task Main(string[] args)
     {
         Console.Title = "Receiver";
 
@@ -23,6 +23,6 @@ class Program
 
         var host = builder.Build();
 
-        return host.RunAsync();
+        await host.RunAsync();
     }
 }

--- a/samples/databus/redis/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_10/Receiver/Receiver.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/databus/redis/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_10/Receiver/Receiver.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/databus/redis/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_10/Receiver/Receiver.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>

--- a/samples/databus/redis/Core_10/Sender/Program.cs
+++ b/samples/databus/redis/Core_10/Sender/Program.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using NServiceBus.ClaimCheck;
+using Shared;
+using Shared.Messages;
+
+class Program
+{
+    static Task Main(string[] args)
+    {
+        Console.Title = "Sender";
+
+        var builder = Host.CreateApplicationBuilder();
+
+        var endpointConfig = new EndpointConfiguration("Sender");
+        var transport = endpointConfig.UseTransport(new LearningTransport());
+        transport.RouteToEndpoint(typeof(ProcessText), "Receiver");
+        endpointConfig.UseSerialization<SystemJsonSerializer>();
+
+        #region configure-claim-check
+        endpointConfig.UseClaimCheck(
+            _ => new RedisClaimCheck("localhost"),
+            new SystemJsonClaimCheckSerializer()
+        );
+        endpointConfig.Conventions()
+            .DefiningClaimCheckPropertiesAs(
+                prop => prop.Name.StartsWith("Large")
+            );
+        #endregion
+
+        builder.UseNServiceBus(endpointConfig);
+
+        builder.Services.AddHostedService<TextSenderHostedService>();
+
+        var host = builder.Build();
+
+        return host.RunAsync();
+    }
+}

--- a/samples/databus/redis/Core_10/Sender/Program.cs
+++ b/samples/databus/redis/Core_10/Sender/Program.cs
@@ -9,7 +9,7 @@ using Shared.Messages;
 
 class Program
 {
-    static Task Main(string[] args)
+    static async Task Main(string[] args)
     {
         Console.Title = "Sender";
 
@@ -37,6 +37,6 @@ class Program
 
         var host = builder.Build();
 
-        return host.RunAsync();
+        await host.RunAsync();
     }
 }

--- a/samples/databus/redis/Core_10/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_10/Sender/Sender.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/databus/redis/Core_10/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_10/Sender/Sender.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/databus/redis/Core_10/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_10/Sender/Sender.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>

--- a/samples/databus/redis/Core_10/Sender/TextSenderHostedService.cs
+++ b/samples/databus/redis/Core_10/Sender/TextSenderHostedService.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using Shared.Messages;
+
+class TextSenderHostedService(IMessageSession messageSession, ILogger<TextSenderHostedService> log) : BackgroundService
+{
+    const int Megabyte = 1024 * 1024;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        #region send-message
+        await messageSession.Send(new ProcessText
+        {
+            LargeText = GetRandomText(1 * Megabyte)
+        }, cancellationToken: stoppingToken);
+        #endregion
+
+        log.LogInformation("Sent message with 1MB of random text");
+    }
+
+    static string GetRandomText(int length)
+    {
+        return string.Create(length, length, (chars, state) =>
+        {
+            var random = new Random();
+            for(var i = 0; i < state; i++)
+            {
+                chars[i] = (char)random.Next('a', 'z');
+            }
+        });
+    }
+}

--- a/samples/databus/redis/Core_10/Shared/Messages/ProcessText.cs
+++ b/samples/databus/redis/Core_10/Shared/Messages/ProcessText.cs
@@ -1,0 +1,8 @@
+﻿using NServiceBus;
+
+namespace Shared.Messages;
+
+public class ProcessText : ICommand
+{
+    public string LargeText { get; set; }
+}

--- a/samples/databus/redis/Core_10/Shared/RedisClaimCheck.cs
+++ b/samples/databus/redis/Core_10/Shared/RedisClaimCheck.cs
@@ -1,0 +1,45 @@
+﻿namespace Shared;
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.ClaimCheck;
+using StackExchange.Redis;
+
+#region claim-check
+public class RedisClaimCheck(string configuration) : IClaimCheck
+{
+    private IConnectionMultiplexer redis;
+
+    public async Task<Stream> Get(
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        var db = redis.GetDatabase();
+        byte[] redisValue = await db.StringGetAsync(key);
+        return new MemoryStream(redisValue);
+    }
+
+    public async Task<string> Put(
+        Stream stream,
+        TimeSpan timeToBeReceived,
+        CancellationToken cancellationToken = default)
+    {
+        var db = redis.GetDatabase();
+        var key = $"particular:sample:claimcheck:{Guid.NewGuid()}";
+        var value = ((MemoryStream)stream).ToArray();
+        await db.StringSetAsync(
+            key,
+            value,
+            timeToBeReceived == TimeSpan.MaxValue ? null : timeToBeReceived
+        );
+        return key;
+    }
+
+    public async Task Start(CancellationToken cancellationToken = default)
+    {
+        redis = await ConnectionMultiplexer.ConnectAsync(configuration);
+    }
+}
+#endregion

--- a/samples/databus/redis/Core_10/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_10/Shared/Shared.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/databus/redis/Core_10/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_10/Shared/Shared.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>

--- a/samples/databus/redis/Core_10/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_10/Shared/Shared.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_10/docker-compose.yml
+++ b/samples/databus/redis/Core_10/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+name: "particular-sample-redis"
+services:
+  redis-local:
+    image: "redis/redis-stack:latest"
+    container_name: redis-stack
+    ports:
+      - "6379:6379"
+      - "8001:8001"


### PR DESCRIPTION
- Migrate from .NET 9 to .NET 10 preview
- Update to NServiceBus.Extensions.Hosting 4.0.0-alpha.1
- Update to NServiceBus.ClaimCheck 2.0.0-alpha.1
- Apply modern C# features (async Main methods)
- Add prerelease.txt marker for alpha package usage
- [x] test

Fixes #7292