### PR TITLE
Update bridge simple sample to NServiceBus 10

### DIFF
--- a/samples/bridge/simple/Bridge_4/Bridge.sln
+++ b/samples/bridge/simple/Bridge_4/Bridge.sln
@@ -1,0 +1,35 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{5686FE6C-A5E3-40D1-A6BD-25F94DA612F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeftSender", "LeftSender\LeftSender.csproj", "{7036A49B-359F-4BC7-AFBA-DE3C7AB41986}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeftReceiver", "LeftReceiver\LeftReceiver.csproj", "{6A699A4E-F2FD-4B71-AF73-199B499482BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RightReceiver", "RightReceiver\RightReceiver.csproj", "{96028F4C-6B27-4CBE-95EB-A39F1EDCE045}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bridge", "Bridge\Bridge.csproj", "{355C998A-AAC0-4BAB-87B3-C5D34DE9C0B1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5686FE6C-A5E3-40D1-A6BD-25F94DA612F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5686FE6C-A5E3-40D1-A6BD-25F94DA612F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7036A49B-359F-4BC7-AFBA-DE3C7AB41986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7036A49B-359F-4BC7-AFBA-DE3C7AB41986}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A699A4E-F2FD-4B71-AF73-199B499482BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A699A4E-F2FD-4B71-AF73-199B499482BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96028F4C-6B27-4CBE-95EB-A39F1EDCE045}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96028F4C-6B27-4CBE-95EB-A39F1EDCE045}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{355C998A-AAC0-4BAB-87B3-C5D34DE9C0B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{355C998A-AAC0-4BAB-87B3-C5D34DE9C0B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/bridge/simple/Bridge_4/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_4/Bridge/Bridge.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
-    <PackageReference Include="NServiceBus" Version="9.*" />
-    <PackageReference Include="NServiceBus.MessagingBridge" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.MessagingBridge" Version="4.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_4/Bridge/Bridge.csproj
+++ b/samples/bridge/simple/Bridge_4/Bridge/Bridge.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.MessagingBridge" Version="3.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/bridge/simple/Bridge_4/Bridge/Program.cs
+++ b/samples/bridge/simple/Bridge_4/Bridge/Program.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+static class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Bridge";
+
+        var builder = Host.CreateApplicationBuilder();
+        var bridgeConfiguration = new BridgeConfiguration();
+
+        #region endpoint-adding-simple
+
+        var learningLeft = new BridgeTransport(new LearningTransport());
+        learningLeft.HasEndpoint("Samples.Bridge.LeftSender");
+
+        #endregion
+
+        var learningTransport = new LearningTransport
+        {
+            // Set storage directory and add the character '2' to simulate a different transport.
+            StorageDirectory = $"{LearningTransportInfrastructure.FindStoragePath()}2"
+        };
+        var learningRight = new BridgeTransport(learningTransport)
+        {
+            // A different name is required if transports are used twice.
+            Name = "right-side"
+        };
+
+        #region endpoint-adding-register-publisher-by-string
+
+        var rightReceiver = new BridgeEndpoint("Samples.Bridge.RightReceiver");
+        rightReceiver.RegisterPublisher("OrderReceived", "Samples.Bridge.LeftSender");
+
+        #endregion
+        learningRight.HasEndpoint(rightReceiver);
+
+        #region add-transports-to-bridge
+
+        bridgeConfiguration.AddTransport(learningLeft);
+        bridgeConfiguration.AddTransport(learningRight);
+
+        #endregion
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddSimpleConsole(options =>
+        {
+            options.IncludeScopes = false;
+            options.SingleLine = true;
+            options.TimestampFormat = "hh:mm:ss ";
+        });
+
+        builder.UseNServiceBusBridge(bridgeConfiguration);
+
+        var host = builder.Build();
+        await host.RunAsync();
+    }
+}

--- a/samples/bridge/simple/Bridge_4/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_4/LeftReceiver/LeftReceiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="NServiceBus" Version="9.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_4/LeftReceiver/LeftReceiver.csproj
+++ b/samples/bridge/simple/Bridge_4/LeftReceiver/LeftReceiver.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/bridge/simple/Bridge_4/LeftReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/Bridge_4/LeftReceiver/OrderReceivedHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using Microsoft.Extensions.Logging;
+
+public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
+    IHandleMessages<OrderReceived>
+{
+    public Task Handle(OrderReceived message, IMessageHandlerContext context)
+    {
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
+        return Task.CompletedTask;
+    }
+}

--- a/samples/bridge/simple/Bridge_4/LeftReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_4/LeftReceiver/Program.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+Console.Title = "LeftReceiver";
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftReceiver");
+endpointConfiguration.UsePersistence<LearningPersistence>();
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UseTransport(new LearningTransport());
+
+endpointConfiguration.Conventions().DefiningMessagesAs(t => t.Name == "OrderResponse");
+endpointConfiguration.Conventions().DefiningEventsAs(t => t.Name == "OrderReceived");
+
+endpointConfiguration.SendFailedMessagesTo("error");
+endpointConfiguration.EnableInstallers();
+
+
+Console.WriteLine("Press any key, the application is starting");
+Console.ReadKey();
+Console.WriteLine("Starting...");
+
+builder.UseNServiceBus(endpointConfiguration);
+await builder.Build().RunAsync();

--- a/samples/bridge/simple/Bridge_4/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_4/LeftSender/LeftSender.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_4/LeftSender/LeftSender.csproj
+++ b/samples/bridge/simple/Bridge_4/LeftSender/LeftSender.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/bridge/simple/Bridge_4/LeftSender/OrderResponseHandler.cs
+++ b/samples/bridge/simple/Bridge_4/LeftSender/OrderResponseHandler.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+public class OrderResponseHandler : IHandleMessages<OrderResponse>
+{
+    public Task Handle(OrderResponse message, IMessageHandlerContext context)
+    {
+        Console.WriteLine($"OrderResponse Reply received with Id {message.OrderId}");
+
+        return Task.CompletedTask;
+    }
+}

--- a/samples/bridge/simple/Bridge_4/LeftSender/Program.cs
+++ b/samples/bridge/simple/Bridge_4/LeftSender/Program.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+static class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "LeftSender";
+        var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.LeftSender");
+        endpointConfiguration.UsePersistence<LearningPersistence>();
+
+        endpointConfiguration.Conventions().DefiningCommandsAs(t => t.Name == "PlaceOrder");
+        endpointConfiguration.Conventions().DefiningMessagesAs(t => t.Name == "OrderResponse");
+        endpointConfiguration.Conventions().DefiningEventsAs(t => t.Name == "OrderReceived");
+
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        var routing = endpointConfiguration.UseTransport(new LearningTransport());
+        routing.RouteToEndpoint(typeof(PlaceOrder), "Samples.Bridge.RightReceiver");
+
+        endpointConfiguration.SendFailedMessagesTo("error");
+        endpointConfiguration.EnableInstallers();
+
+        var endpointInstance = await Endpoint.Start(endpointConfiguration);
+        await Start(endpointInstance);
+        await endpointInstance.Stop();
+    }
+
+    static async Task Start(IEndpointInstance endpointInstance)
+    {
+        Console.WriteLine("Press '1' to send the PlaceOrder command");
+        Console.WriteLine("Press '2' to publish the OrderReceived event");
+        Console.WriteLine("Press 'esc' other key to exit");
+
+        while (true)
+        {
+            var key = Console.ReadKey();
+            Console.WriteLine();
+
+            var orderId = Guid.NewGuid();
+            switch (key.Key)
+            {
+                case ConsoleKey.D1:
+                case ConsoleKey.NumPad1:
+                    var placeOrder = new PlaceOrder
+                    {
+                        OrderId = orderId
+                    };
+                    await endpointInstance.Send(placeOrder);
+                    Console.WriteLine($"Send PlaceOrder Command with Id {orderId}");
+                    break;
+                case ConsoleKey.D2:
+                case ConsoleKey.NumPad2:
+                    var orderReceived = new OrderReceived
+                    {
+                        OrderId = orderId
+                    };
+                    await endpointInstance.Publish(orderReceived);
+                    Console.WriteLine($"Published OrderReceived Event with Id {orderId}.");
+                    break;
+                case ConsoleKey.Escape:
+                    return;
+            }
+        }
+    }
+}

--- a/samples/bridge/simple/Bridge_4/RightReceiver/OrderReceivedHandler.cs
+++ b/samples/bridge/simple/Bridge_4/RightReceiver/OrderReceivedHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using Microsoft.Extensions.Logging;
+
+public class OrderReceivedHandler(ILogger<OrderReceivedHandler> logger) :
+    IHandleMessages<OrderReceived>
+{
+    public Task Handle(OrderReceived message, IMessageHandlerContext context)
+    {
+        logger.LogInformation("Subscriber has received OrderReceived event with OrderId {OrderId}.", message.OrderId);
+        return Task.CompletedTask;
+    }
+}

--- a/samples/bridge/simple/Bridge_4/RightReceiver/PlaceOrderHandler.cs
+++ b/samples/bridge/simple/Bridge_4/RightReceiver/PlaceOrderHandler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+public class PlaceOrderHandler(ILogger<PlaceOrderHandler> logger) : IHandleMessages<PlaceOrder>
+{
+    public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
+    {
+       logger.LogInformation("Received PlaceOrder Command with Id {OrderId}", message.OrderId);
+
+        await context.Reply(new OrderResponse { OrderId = message.OrderId });
+    }
+}

--- a/samples/bridge/simple/Bridge_4/RightReceiver/Program.cs
+++ b/samples/bridge/simple/Bridge_4/RightReceiver/Program.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+Console.Title = "RightReceiver";
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var endpointConfiguration = new EndpointConfiguration("Samples.Bridge.RightReceiver");
+endpointConfiguration.UsePersistence<LearningPersistence>();
+
+endpointConfiguration.Conventions().DefiningCommandsAs(t => t.Name == "PlaceOrder");
+endpointConfiguration.Conventions().DefiningMessagesAs(t => t.Name == "OrderResponse");
+endpointConfiguration.Conventions().DefiningEventsAs(t => t.Name == "OrderReceived");
+
+#region alternative-learning-transport
+var learningTransportDefinition = new LearningTransport
+{
+    // Set storage directory and add the character '2' to simulate a different transport.
+    StorageDirectory = $"{LearningTransportInfrastructure.FindStoragePath()}2"
+};
+endpointConfiguration.UseTransport(learningTransportDefinition);
+#endregion
+
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+
+endpointConfiguration.SendFailedMessagesTo("error");
+endpointConfiguration.EnableInstallers();
+
+
+Console.WriteLine("Press any key, the application is starting");
+Console.ReadKey();
+Console.WriteLine("Starting...");
+
+builder.UseNServiceBus(endpointConfiguration);
+await builder.Build().RunAsync();

--- a/samples/bridge/simple/Bridge_4/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_4/RightReceiver/RightReceiver.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="NServiceBus" Version="9.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_4/RightReceiver/RightReceiver.csproj
+++ b/samples/bridge/simple/Bridge_4/RightReceiver/RightReceiver.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/bridge/simple/Bridge_4/Shared/LearningTransportInfrastructure.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/LearningTransportInfrastructure.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+public static class LearningTransportInfrastructure
+{
+    public static string FindStoragePath()
+    {
+        var directory = AppDomain.CurrentDomain.BaseDirectory;
+        var assemblyName = Assembly.GetCallingAssembly().GetName().Name.ToLowerInvariant();
+
+        while (true)
+        {
+
+
+            var learningTransportDirectory = Path.Combine(directory, DefaultLearningTransportDirectory);
+            if (Directory.Exists(learningTransportDirectory))
+            {
+                return learningTransportDirectory;
+            }
+
+            // This works for samples
+            if (directory.ToLowerInvariant().EndsWith(assemblyName))
+            {
+                var solutionFolder = Directory.GetParent(directory);
+                if (solutionFolder != null)
+                    return Path.Combine(solutionFolder.FullName, DefaultLearningTransportDirectory);
+            }
+
+            var parent = Directory.GetParent(directory);
+
+            if (parent == null)
+            {
+                throw new Exception($"Unable to determine the storage directory path for the learning transport. Either create a '{DefaultLearningTransportDirectory}2' directory in one of this project’s parent directories, or specify the path explicitly using the 'StorageDirectory' property in the API.");
+            }
+
+            directory = parent.FullName;
+        }
+    }
+
+    const string DefaultLearningTransportDirectory = ".learningtransport";
+}

--- a/samples/bridge/simple/Bridge_4/Shared/OrderReceived.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/OrderReceived.cs
@@ -1,0 +1,6 @@
+using System;
+
+public class OrderReceived
+{
+    public Guid OrderId { get; set; }
+}

--- a/samples/bridge/simple/Bridge_4/Shared/OrderReceived.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/OrderReceived.cs
@@ -2,5 +2,5 @@ using System;
 
 public class OrderReceived
 {
-    public Guid OrderId { get; set; }
+    public required Guid OrderId { get; set; }
 }

--- a/samples/bridge/simple/Bridge_4/Shared/OrderResponse.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/OrderResponse.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+public class OrderResponse
+{
+    public Guid OrderId { get; set; }
+}

--- a/samples/bridge/simple/Bridge_4/Shared/OrderResponse.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/OrderResponse.cs
@@ -2,5 +2,5 @@
 
 public class OrderResponse
 {
-    public Guid OrderId { get; set; }
+    public required Guid OrderId { get; set; }
 }

--- a/samples/bridge/simple/Bridge_4/Shared/PlaceOrder.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/PlaceOrder.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+public class PlaceOrder
+{
+    public Guid OrderId { get; set; }
+}

--- a/samples/bridge/simple/Bridge_4/Shared/PlaceOrder.cs
+++ b/samples/bridge/simple/Bridge_4/Shared/PlaceOrder.cs
@@ -2,5 +2,5 @@
 
 public class PlaceOrder
 {
-    public Guid OrderId { get; set; }
+    public required Guid OrderId { get; set; }
 }

--- a/samples/bridge/simple/Bridge_4/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_4/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/bridge/simple/Bridge_4/Shared/Shared.csproj
+++ b/samples/bridge/simple/Bridge_4/Shared/Shared.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
- Upgraded from .NET 9/8 multi-targeting to .NET 10 (net10.0)
- Updated LangVersion from 12.0 to preview to support latest C# features
- NServiceBus: 9.* → 10.0.0-alpha.1
- NServiceBus.MessagingBridge: 3.* → 4.0.0-alpha.1
- NServiceBus.Extensions.Hosting: 3.0.1 → 4.0.0-alpha.1
- Microsoft.Extensions.Hosting: 8.* → 10.0.0-preview.5.25277.114
- Microsoft.Extensions.Logging.Console: 9.0.2 → 10.0.0-preview.5.25277.114
- Added 'required' modifier to message properties for better null safety
- Added prerelease.txt file to mark this as a prerelease sample
- Updated all project files to use single target framework (net10.0)
- [x] test
- Fixes: #7278
