### PR TITLE
Add NServiceBus 10 dependency injection externally managed mode sample

### DIFF
--- a/samples/dependency-injection/externally-managed-mode/Core_10/ExternallyManagedContainer.sln
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/ExternallyManagedContainer.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "Sample\Sample.csproj", "{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E6C9C2A-8D9B-41AF-B5E5-1AF5310686E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3673C976-8AFC-4169-A103-E016521D0868}
+	EndGlobalSection
+EndGlobal

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Greeter.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Greeter.cs
@@ -1,0 +1,11 @@
+﻿using NServiceBus.Logging;
+
+public class Greeter
+{
+    private static readonly ILog log = LogManager.GetLogger<Greeter>();
+
+    public void SayHello()
+    {
+        log.Info("Hello from Greeter.");
+    }
+}

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MessageSender.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MessageSender.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+
+#region InjectingMessageSession
+public class MessageSender(IMessageSession messageSession)
+{
+    public Task SendMessage()
+    {
+        var myMessage = new MyMessage();
+        return messageSession.SendLocal(myMessage);
+    }
+}
+#endregion

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MyHandler.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MyHandler.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+#region InjectingDependency
+public class MyHandler(Greeter greeter) :
+    IHandleMessages<MyMessage>
+{
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        greeter.SayHello();
+        return Task.CompletedTask;
+    }
+}
+#endregion

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MyMessage.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/MyMessage.cs
@@ -1,0 +1,3 @@
+﻿using NServiceBus;
+
+public record MyMessage : IMessage;

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Program.cs
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Program.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+
+static class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "ExternallyManagedContainer";
+
+        var endpointConfiguration = new EndpointConfiguration("Sample");
+        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+        endpointConfiguration.UseTransport(new LearningTransport());
+
+        #region ContainerConfiguration
+
+        // ServiceCollection is provided by Microsoft.Extensions.DependencyInjection
+        var serviceCollection = new ServiceCollection();
+
+        // most dependencies may now be registered
+        serviceCollection.AddSingleton<Greeter>();
+        serviceCollection.AddSingleton<MessageSender>();
+
+        // EndpointWithExternallyManagedContainer.Create accepts an IServiceCollection,
+        // which is inherited by ServiceCollection
+        var endpointWithExternallyManagedContainer = EndpointWithExternallyManagedContainer
+            .Create(endpointConfiguration, serviceCollection);
+
+        // if IMessageSession is required as dependency, it may now be registered
+        serviceCollection.AddSingleton(p => endpointWithExternallyManagedContainer.MessageSession.Value);
+
+        #endregion
+
+        using (var serviceProvider = serviceCollection.BuildServiceProvider())
+        {
+            var endpoint = await endpointWithExternallyManagedContainer.Start(serviceProvider);
+
+            var sender = serviceProvider.GetRequiredService<MessageSender>();
+            await sender.SendMessage();
+
+            Console.WriteLine("Press any key to exit");
+            Console.ReadKey();
+            await endpoint.Stop();
+        }
+    }
+}

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Sample.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.4.25258.110" />
+  </ItemGroup>
+</Project>

--- a/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Sample.csproj
+++ b/samples/dependency-injection/externally-managed-mode/Core_10/Sample/Sample.csproj
@@ -6,6 +6,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.4.25258.110" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Implement 

- https://github.com/Particular/docs.particular.net/issues/7298

This adds a new Core_10 sample demonstrating external dependency injection container integration with NServiceBus 10 using modern C# features.

Key features:
- .NET 10 targeting with preview features enabled
- NServiceBus 10.0.0-alpha.1 integration
- Microsoft.Extensions.DependencyInjection container
- EndpointWithExternallyManagedContainer.Create API usage
- Modern C# 12+ language features:
  * Primary constructors for clean dependency injection
  * Record types for immutable messages
  * Top-level program structure
  * Target-typed new expressions

Components:
- MyMessage: Record type implementing IMessage
- Greeter: Service using NServiceBus.Logging for output
- MyHandler: Message handler with primary constructor for DI
- MessageSender: Service for sending messages with an injected IMessageSession
- Program: Main application using external DI container pattern

The sample demonstrates proper lifecycle management of NServiceBus endpoints with external containers, automatic message sending on startup, and clean shutdown handling.