### PR TITLE
Aspire sample net10

### DIFF
--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Billing\Billing.csproj" />
+    <ProjectReference Include="..\ClientUI\ClientUI.csproj" />
+    <ProjectReference Include="..\Sales\Sales.csproj" />
+    <ProjectReference Include="..\Shipping\Shipping.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.*" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="9.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -3,7 +3,7 @@
   <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -3,11 +3,11 @@
   <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/ExtensionMethods.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/ExtensionMethods.cs
@@ -1,0 +1,13 @@
+namespace AspireDemo.AppHost;
+
+public static class ExtensionMethods
+{
+    public static async Task<string> GetRabbitMqConnectionString(
+        this IResourceBuilder<RabbitMQServerResource> builder)
+    {
+        var rabbitEnvVariables = await builder.Resource.GetEnvironmentVariableValuesAsync();
+        var user = rabbitEnvVariables["RABBITMQ_DEFAULT_USER"];
+        var pass = rabbitEnvVariables["RABBITMQ_DEFAULT_PASS"];
+        return $"host={builder.Resource.Name}:{builder.Resource.PrimaryEndpoint.TargetPort};username={user};password={pass}";
+    }
+}

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
@@ -1,0 +1,87 @@
+#region app-host
+
+using AspireDemo.AppHost;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var transport = builder.AddRabbitMQ("transport")
+    .WithManagementPlugin(15672)
+    .WithUrlForEndpoint("management", url => url.DisplayText = "RabbitMQ Management");
+
+var rabbitMqConnectionString = await transport.GetRabbitMqConnectionString();
+
+var database = builder.AddPostgres("database");
+
+database.WithPgAdmin(resource =>
+{
+    resource.WithParentRelationship(database);
+    resource.WithUrlForEndpoint("http", url => url.DisplayText = "pgAdmin");
+});
+
+var shippingDb = database.AddDatabase("shipping-db");
+
+var ravenDb = builder.AddContainer("ServiceControl-RavenDB", "particular/servicecontrol-ravendb")
+    .WithHttpEndpoint(8080, 8080)
+    .WithUrlForEndpoint("http", url => url.DisplayText = "Management Studio");
+
+var audit = builder.AddContainer("ServiceControl-Audit", "particular/servicecontrol-audit")
+    .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
+    .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
+    .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
+    .WithArgs("--setup-and-run")
+    .WithHttpEndpoint(44444, 44444)
+    .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
+    .WithHttpHealthCheck("api/configuration")
+    .WaitFor(transport)
+    .WaitFor(ravenDb);
+
+var serviceControl = builder.AddContainer("ServiceControl", "particular/servicecontrol")
+    .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
+    .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
+    .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
+    .WithEnvironment("REMOTEINSTANCES", $"[{{\"api_uri\":\"{audit.GetEndpoint("http")}\"}}]")
+    .WithArgs("--setup-and-run")
+    .WithHttpEndpoint(33333, 33333)
+    .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
+    .WithHttpHealthCheck("api/configuration")
+    .WaitFor(transport)
+    .WaitFor(ravenDb);
+
+var monitoring = builder.AddContainer("ServiceControl-Monitoring", "particular/servicecontrol-monitoring")
+    .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
+    .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
+    .WithArgs("--setup-and-run")
+    .WithHttpEndpoint(33633, 33633)
+    .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
+    .WithHttpHealthCheck("connection")
+    .WaitFor(transport);
+
+var servicePulse = builder.AddContainer("ServicePulse", "particular/servicepulse")
+    .WithEnvironment("ENABLE_REVERSE_PROXY", "false")
+    .WithHttpEndpoint(9090, 9090)
+    .WithUrlForEndpoint("http", url => url.DisplayText = "ServicePulse")
+    .WaitFor(serviceControl)
+    .WaitFor(audit)
+    .WaitFor(monitoring);
+
+builder.AddProject<Projects.Billing>("Billing")
+    .WithReference(transport)
+    .WaitFor(servicePulse);
+
+var sales = builder.AddProject<Projects.Sales>("Sales")
+    .WithReference(transport)
+    .WaitFor(servicePulse);
+
+builder.AddProject<Projects.ClientUI>("ClientUI")
+    .WithReference(transport)
+    .WaitFor(sales)
+    .WaitFor(servicePulse);
+
+builder.AddProject<Projects.Shipping>("Shipping")
+    .WithReference(transport)
+    .WithReference(shippingDb)
+    .WaitFor(shippingDb)
+    .WaitFor(servicePulse);
+
+builder.Build().Run();
+#endregion

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Properties/launchSettings.json
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17290;http://localhost:15170",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21118",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22281"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15170",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19233",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20173"
+      }
+    }
+  }
+}

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.Development.json
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.json
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.*" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/AspireDemo.ServiceDefaults.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/Extensions.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/Extensions.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+        #region add-nsb-otel
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddMeter("NServiceBus.*")
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource("NServiceBus.*")
+                    .AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+        #endregion
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/samples/hosting/aspire/Core_10/AspireDemo.sln
+++ b/samples/hosting/aspire/Core_10/AspireDemo.sln
@@ -1,0 +1,57 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35303.130
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientUI", "ClientUI\ClientUI.csproj", "{D4DCF868-A625-4B0B-BB20-C150553A6548}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Messages", "Messages\Messages.csproj", "{F6DE8266-1F56-4241-965C-2DDBB76CEC1E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sales", "Sales\Sales.csproj", "{CD42E5DF-D4A7-4933-8017-1398B2E9560F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Billing", "Billing\Billing.csproj", "{9BF02A43-6D9D-4B49-A06D-603A66C6BCB5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shipping", "Shipping\Shipping.csproj", "{41F0D809-8FA4-4139-9131-09441D69AFB1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireDemo.AppHost", "AspireDemo.AppHost\AspireDemo.AppHost.csproj", "{392EA528-EF65-474D-93F3-330BC22052A1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireDemo.ServiceDefaults", "AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj", "{AAB033C1-22EA-410B-A237-25B9E832F0E5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D4DCF868-A625-4B0B-BB20-C150553A6548}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4DCF868-A625-4B0B-BB20-C150553A6548}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4DCF868-A625-4B0B-BB20-C150553A6548}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4DCF868-A625-4B0B-BB20-C150553A6548}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6DE8266-1F56-4241-965C-2DDBB76CEC1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6DE8266-1F56-4241-965C-2DDBB76CEC1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6DE8266-1F56-4241-965C-2DDBB76CEC1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6DE8266-1F56-4241-965C-2DDBB76CEC1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD42E5DF-D4A7-4933-8017-1398B2E9560F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD42E5DF-D4A7-4933-8017-1398B2E9560F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD42E5DF-D4A7-4933-8017-1398B2E9560F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD42E5DF-D4A7-4933-8017-1398B2E9560F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BF02A43-6D9D-4B49-A06D-603A66C6BCB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BF02A43-6D9D-4B49-A06D-603A66C6BCB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BF02A43-6D9D-4B49-A06D-603A66C6BCB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BF02A43-6D9D-4B49-A06D-603A66C6BCB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41F0D809-8FA4-4139-9131-09441D69AFB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41F0D809-8FA4-4139-9131-09441D69AFB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41F0D809-8FA4-4139-9131-09441D69AFB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41F0D809-8FA4-4139-9131-09441D69AFB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{392EA528-EF65-474D-93F3-330BC22052A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{392EA528-EF65-474D-93F3-330BC22052A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{392EA528-EF65-474D-93F3-330BC22052A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{392EA528-EF65-474D-93F3-330BC22052A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAB033C1-22EA-410B-A237-25B9E832F0E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAB033C1-22EA-410B-A237-25B9E832F0E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAB033C1-22EA-410B-A237-25B9E832F0E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAB033C1-22EA-410B-A237-25B9E832F0E5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/hosting/aspire/Core_10/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_10/Billing/Billing.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Messages\Messages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_10/Billing/Billing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hosting/aspire/Core_10/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_10/Billing/Billing.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,10 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics" Version="6.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_10/Billing/Billing.csproj
@@ -15,11 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="6.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Metrics" Version="6.0.0-alpha.1" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="11.0.0-alpha.1" />
     <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
 

--- a/samples/hosting/aspire/Core_10/Billing/OrderPlacedHandler.cs
+++ b/samples/hosting/aspire/Core_10/Billing/OrderPlacedHandler.cs
@@ -1,0 +1,19 @@
+﻿using Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Billing;
+
+public class OrderPlacedHandler(ILogger<OrderPlacedHandler> log) : IHandleMessages<OrderPlaced>
+{
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+    {
+        log.LogInformation("Received OrderPlaced, OrderId = {OrderId} - Charging credit card...", message.OrderId);
+
+        var orderBilled = new OrderBilled
+        {
+            OrderId = message.OrderId
+        };
+
+        return context.Publish(orderBilled);
+    }
+}

--- a/samples/hosting/aspire/Core_10/Billing/Program.cs
+++ b/samples/hosting/aspire/Core_10/Billing/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder();
+
+builder.AddServiceDefaults();
+
+var endpointConfiguration = new EndpointConfiguration("Billing");
+endpointConfiguration.EnableOpenTelemetry();
+
+var connectionString = builder.Configuration.GetConnectionString("transport");
+var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
+var routing = endpointConfiguration.UseTransport(transport);
+
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+
+var metrics = endpointConfiguration.EnableMetrics();
+metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));
+
+endpointConfiguration.EnableInstallers();
+
+builder.UseNServiceBus(endpointConfiguration);
+
+await builder.Build().RunAsync();

--- a/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Messages\Messages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="11.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/ClientUI/MessageSenderService.cs
+++ b/samples/hosting/aspire/Core_10/ClientUI/MessageSenderService.cs
@@ -1,0 +1,21 @@
+﻿using Messages;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ClientUI;
+
+class MessageSenderService(IMessageSession messageSession, ILogger<MessageSenderService> log) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var i = 1;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await messageSession.Send(new PlaceOrder { OrderId = Guid.NewGuid().ToString() }, cancellationToken: stoppingToken);
+            log.LogInformation("Sent a message");
+
+            await Task.Delay(i++ * 500, stoppingToken);
+        }
+    }
+}

--- a/samples/hosting/aspire/Core_10/ClientUI/Program.cs
+++ b/samples/hosting/aspire/Core_10/ClientUI/Program.cs
@@ -1,0 +1,31 @@
+﻿using ClientUI;
+using Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder();
+
+builder.AddServiceDefaults();
+
+var endpointConfiguration = new EndpointConfiguration("ClientUI");
+endpointConfiguration.EnableOpenTelemetry();
+
+var connectionString = builder.Configuration.GetConnectionString("transport");
+var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
+var routing = endpointConfiguration.UseTransport(transport);
+routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
+
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+
+var metrics = endpointConfiguration.EnableMetrics();
+metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));
+
+endpointConfiguration.EnableInstallers();
+
+builder.UseNServiceBus(endpointConfiguration);
+
+builder.Services.AddHostedService<MessageSenderService>();
+
+await builder.Build().RunAsync();

--- a/samples/hosting/aspire/Core_10/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_10/Messages/Messages.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_10/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/samples/hosting/aspire/Core_10/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_10/Messages/Messages.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/Messages/OrderBilled.cs
+++ b/samples/hosting/aspire/Core_10/Messages/OrderBilled.cs
@@ -1,0 +1,6 @@
+﻿namespace Messages;
+
+public class OrderBilled : IEvent
+{
+    public string? OrderId { get; set; }
+}

--- a/samples/hosting/aspire/Core_10/Messages/OrderPlaced.cs
+++ b/samples/hosting/aspire/Core_10/Messages/OrderPlaced.cs
@@ -1,0 +1,6 @@
+﻿namespace Messages;
+
+public class OrderPlaced : IEvent
+{
+    public string? OrderId { get; set; }
+}

--- a/samples/hosting/aspire/Core_10/Messages/PlaceOrder.cs
+++ b/samples/hosting/aspire/Core_10/Messages/PlaceOrder.cs
@@ -1,0 +1,6 @@
+﻿namespace Messages;
+
+public class PlaceOrder : ICommand
+{
+    public string? OrderId { get; set; }
+}

--- a/samples/hosting/aspire/Core_10/Messages/ShipOrder.cs
+++ b/samples/hosting/aspire/Core_10/Messages/ShipOrder.cs
@@ -1,0 +1,6 @@
+﻿namespace Messages;
+
+public class ShipOrder : ICommand
+{
+    public string? OrderId { get; set; }
+}

--- a/samples/hosting/aspire/Core_10/Sales/PlaceOrderHandler.cs
+++ b/samples/hosting/aspire/Core_10/Sales/PlaceOrderHandler.cs
@@ -1,0 +1,31 @@
+﻿using Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Sales;
+
+public class PlaceOrderHandler(ILogger<PlaceOrderHandler> log) : IHandleMessages<PlaceOrder>
+{
+    public Task Handle(PlaceOrder message, IMessageHandlerContext context)
+    {
+        log.LogInformation("Received PlaceOrder, OrderId = {OrderId}", message.OrderId);
+
+        // This is normally where some business logic would occur
+
+        // Force a transient exception to demonstrate failures in telemetry data
+        if (Random.Shared.Next(0, 5) == 0)
+        {
+            throw new Exception("Oops");
+        }
+
+        var publishOptions = new PublishOptions();
+        // https://docs.particular.net/nservicebus/operations/opentelemetry#traces-span-relationships-publish-operations
+        publishOptions.ContinueExistingTraceOnReceive();
+
+        var orderPlaced = new OrderPlaced
+        {
+            OrderId = message.OrderId
+        };
+
+        return context.Publish(orderPlaced, publishOptions);
+    }
+}

--- a/samples/hosting/aspire/Core_10/Sales/Program.cs
+++ b/samples/hosting/aspire/Core_10/Sales/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder();
+
+builder.AddServiceDefaults();
+
+var endpointConfiguration = new EndpointConfiguration("Sales");
+endpointConfiguration.EnableOpenTelemetry();
+
+var connectionString = builder.Configuration.GetConnectionString("transport");
+var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
+var routing = endpointConfiguration.UseTransport(transport);
+
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+
+var metrics = endpointConfiguration.EnableMetrics();
+metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));
+
+endpointConfiguration.EnableInstallers();
+
+builder.UseNServiceBus(endpointConfiguration);
+
+await builder.Build().RunAsync();

--- a/samples/hosting/aspire/Core_10/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_10/Sales/Sales.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Messages\Messages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_10/Sales/Sales.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hosting/aspire/Core_10/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_10/Sales/Sales.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="11.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/Shipping/Program.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/Program.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using NpgsqlTypes;
+
+#region always-config
+var builder = Host.CreateApplicationBuilder();
+
+var endpointConfiguration = new EndpointConfiguration("Shipping");
+endpointConfiguration.EnableOpenTelemetry();
+
+builder.AddServiceDefaults();
+#endregion
+
+#region transport-config
+var connectionString = builder.Configuration.GetConnectionString("transport");
+var transport = new RabbitMQTransport(RoutingTopology.Conventional(QueueType.Quorum), connectionString);
+#endregion
+
+var routing = endpointConfiguration.UseTransport(transport);
+
+#region persistence-config
+var persistenceConnection = builder.Configuration.GetConnectionString("shipping-db");
+var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
+persistence.ConnectionBuilder(
+    connectionBuilder: () =>
+    {
+        return new NpgsqlConnection(persistenceConnection);
+    });
+#endregion
+
+var dialect = persistence.SqlDialect<SqlDialect.PostgreSql>();
+dialect.JsonBParameterModifier(
+    modifier: parameter =>
+    {
+        var npgsqlParameter = (NpgsqlParameter)parameter;
+        npgsqlParameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+    });
+
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+
+var metrics = endpointConfiguration.EnableMetrics();
+metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));
+
+#region enable-installers
+endpointConfiguration.EnableInstallers();
+#endregion
+
+builder.UseNServiceBus(endpointConfiguration);
+
+await builder.Build().RunAsync();

--- a/samples/hosting/aspire/Core_10/Shipping/ShipOrderHandler.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/ShipOrderHandler.cs
@@ -1,0 +1,13 @@
+﻿using Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Shipping;
+
+class ShipOrderHandler(ILogger<ShipOrderHandler> log) : IHandleMessages<ShipOrder>
+{
+    public Task Handle(ShipOrder message, IMessageHandlerContext context)
+    {
+        log.LogInformation("Order [{OrderId}] - Successfully shipped.", message.OrderId);
+        return Task.CompletedTask;
+    }
+}

--- a/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,11 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="9.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
-    <PackageReference Include="NServiceBus.Persistence.Sql" Version="8.*" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="9.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="11.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Messages\Messages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="9.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="8.*" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+  </ItemGroup>
+
+</Project>

--- a/samples/hosting/aspire/Core_10/Shipping/ShippingPolicy.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/ShippingPolicy.cs
@@ -1,0 +1,41 @@
+﻿using Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Shipping;
+
+class ShippingPolicy(ILogger<ShippingPolicy> log) : Saga<ShippingPolicyData>,
+    IAmStartedByMessages<OrderBilled>,
+    IAmStartedByMessages<OrderPlaced>
+{
+    protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ShippingPolicyData> mapper)
+    {
+        mapper.MapSaga(sagaData => sagaData.OrderId)
+            .ToMessage<OrderPlaced>(message => message.OrderId)
+            .ToMessage<OrderBilled>(message => message.OrderId);
+    }
+
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context)
+    {
+        log.LogInformation("OrderPlaced message received.");
+        Data.IsOrderPlaced = true;
+
+        return ProcessOrder(context);
+    }
+
+    public Task Handle(OrderBilled message, IMessageHandlerContext context)
+    {
+        log.LogInformation("OrderBilled message received.");
+        Data.IsOrderBilled = true;
+
+        return ProcessOrder(context);
+    }
+
+    private async Task ProcessOrder(IMessageHandlerContext context)
+    {
+        if (Data.IsOrderPlaced && Data.IsOrderBilled)
+        {
+            await context.SendLocal(new ShipOrder() { OrderId = Data.OrderId });
+            MarkAsComplete();
+        }
+    }
+}

--- a/samples/hosting/aspire/Core_10/Shipping/ShippingPolicyData.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/ShippingPolicyData.cs
@@ -1,0 +1,10 @@
+﻿namespace Shipping;
+
+class ShippingPolicyData : ContainSagaData
+{
+    public string? OrderId { get; set; }
+
+    public bool IsOrderPlaced { get; set; }
+
+    public bool IsOrderBilled { get; set; }
+}

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/ExtensionMethods.cs
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/ExtensionMethods.cs
@@ -1,0 +1,13 @@
+namespace AspireDemo.AppHost;
+
+public static class ExtensionMethods
+{
+    public static async Task<string> GetRabbitMqConnectionString(
+        this IResourceBuilder<RabbitMQServerResource> builder)
+    {
+        var rabbitEnvVariables = await builder.Resource.GetEnvironmentVariableValuesAsync();
+        var user = rabbitEnvVariables["RABBITMQ_DEFAULT_USER"];
+        var pass = rabbitEnvVariables["RABBITMQ_DEFAULT_PASS"];
+        return $"host={builder.Resource.Name}:{builder.Resource.PrimaryEndpoint.TargetPort};username={user};password={pass}";
+    }
+}


### PR DESCRIPTION
- fixes #7314 

## Changes to Core_9 sample
 
* Updated the NET9 project because the ServiceControlMonitor does not accept the amqp:// format connection string.

## Created Core_10 sample
* Copied the `Core_9` sample to `Core_10`
* Updated csproj files
  * TargetFrameworks: NET10.0
  * LangVersion: preview
  * NServiceBus.* dependencies updated to `alpha.1`.