### PR TITLE
Update Immutable-Messages to NET10

### DIFF
--- a/samples/immutable-messages/Core_10/ConventionExtensions.cs
+++ b/samples/immutable-messages/Core_10/ConventionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using NServiceBus;
+
+public static class ConventionExtensions
+{
+    public static void ApplyCustomConventions(this EndpointConfiguration endpointConfiguration)
+    {
+        var conventions = endpointConfiguration.Conventions();
+        conventions.DefiningCommandsAs(
+            type =>
+            {
+                return type.Namespace != null &&
+                       type.Namespace.EndsWith("Commands");
+            });
+        conventions.DefiningEventsAs(
+            type =>
+            {
+                return type.Namespace != null &&
+                       type.Namespace.EndsWith("Events");
+            });
+        conventions.DefiningMessagesAs(
+            type =>
+            {
+                return type.Namespace != null &&
+                       type.Namespace.EndsWith("Messages");
+            });
+    }
+}

--- a/samples/immutable-messages/Core_10/Immutable-messages.sln
+++ b/samples/immutable-messages/Core_10/Immutable-messages.sln
@@ -1,0 +1,29 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Receiver", "Receiver\Receiver.csproj", "{476D0A88-E281-4BC8-9617-93E53C1F9FE6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sender", "Sender\Sender.csproj", "{75424F0A-458B-42DA-9DDD-600367893A93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{DD0DC12D-D6DF-47C0-B75A-AEC351164196}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{476D0A88-E281-4BC8-9617-93E53C1F9FE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{476D0A88-E281-4BC8-9617-93E53C1F9FE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75424F0A-458B-42DA-9DDD-600367893A93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75424F0A-458B-42DA-9DDD-600367893A93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD0DC12D-D6DF-47C0-B75A-AEC351164196}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD0DC12D-D6DF-47C0-B75A-AEC351164196}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9FC8A922-FADC-447B-BA38-9F47C3FBB51C}
+	EndGlobalSection
+EndGlobal

--- a/samples/immutable-messages/Core_10/Receiver/MyMessageAsClassHandler.cs
+++ b/samples/immutable-messages/Core_10/Receiver/MyMessageAsClassHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using UsingClasses.Messages;
+
+#region immutable-messages-as-class-handling
+public class MyMessageAsClassHandler(ILogger<MyMessageAsClassHandler> logger) :
+    IHandleMessages<MyMessage>
+{
+     public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        logger.LogInformation("MyMessage (as class) received from server with data: {Data}", message.Data);
+        return Task.CompletedTask;
+    }
+}
+#endregion

--- a/samples/immutable-messages/Core_10/Receiver/MyMessageAsInterfaceHandler.cs
+++ b/samples/immutable-messages/Core_10/Receiver/MyMessageAsInterfaceHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+using UsingInterfaces.Messages;
+
+#region immutable-messages-as-interface-handling
+public class MyMessageAsInterfaceHandler(ILogger<MyMessageAsInterfaceHandler> logger) :
+    IHandleMessages<IMyMessage>
+{
+    public Task Handle(IMyMessage message, IMessageHandlerContext context)
+    {
+        logger.LogInformation("IMyMessage (as interface) received from server with data: {Data}", message.Data);
+        return Task.CompletedTask;
+    }
+}
+#endregion

--- a/samples/immutable-messages/Core_10/Receiver/Program.cs
+++ b/samples/immutable-messages/Core_10/Receiver/Program.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+Console.Title = "Receiver";
+var builder = Host.CreateApplicationBuilder(args);
+var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Receiver");
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UsePersistence<LearningPersistence>();
+endpointConfiguration.UseTransport(new LearningTransport());
+
+endpointConfiguration.ApplyCustomConventions();
+Console.WriteLine("Samples.ImmutableMessages.UsingInterfaces.Receiver started. Press any key to exit.");
+Console.ReadKey();
+
+builder.UseNServiceBus(endpointConfiguration);
+
+await builder.Build().RunAsync();

--- a/samples/immutable-messages/Core_10/Receiver/Receiver.csproj
+++ b/samples/immutable-messages/Core_10/Receiver/Receiver.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <Compile Include="..\ConventionExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/samples/immutable-messages/Core_10/Sender/MessageSender.cs
+++ b/samples/immutable-messages/Core_10/Sender/MessageSender.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+
+public class MessageSender(IMessageSession messageSession) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Console.WriteLine("Press 'C' to send a message (using a class with a non-default constructor");
+        Console.WriteLine("Press 'I' to send a message (using a private class that implements a shared interface");
+        Console.WriteLine("Press any other key to exit");
+
+        while (true)
+        {
+            var key = Console.ReadKey();
+            Console.WriteLine();
+
+            switch (key.Key)
+            {
+                case ConsoleKey.C:
+                    await SendMessageAsClass(messageSession);
+                    continue;
+                case ConsoleKey.I:
+                    await SendMessageAsInterface(messageSession);
+                    continue;
+            }
+            return;
+        }
+
+    }
+
+
+    static Task SendMessageAsClass(IMessageSession messageSession)
+    {
+        var data = Guid.NewGuid().ToString();
+
+        Console.WriteLine($"Message sent, data: {data}");
+        var myMessage = new UsingClasses.Messages.MyMessage(data);
+        return messageSession.Send(myMessage);
+    }
+
+    static Task SendMessageAsInterface(IMessageSession messageSession)
+    {
+        var data = Guid.NewGuid().ToString();
+
+        Console.WriteLine($"Message sent, data: {data}");
+        #region immutable-messages-as-interface-sending
+        var myMessage = new Messages.MyMessageImpl()
+        {
+            Data = data
+        };
+        return messageSession.Send(myMessage);
+        #endregion
+    }
+}

--- a/samples/immutable-messages/Core_10/Sender/MyMessageImpl.cs
+++ b/samples/immutable-messages/Core_10/Sender/MyMessageImpl.cs
@@ -1,0 +1,11 @@
+﻿using UsingInterfaces.Messages;
+
+namespace Messages
+{
+#region immutable-messages-as-interface-implementation
+    class MyMessageImpl : IMyMessage
+    {
+        public string Data { get; set; }
+    }
+#endregion
+}

--- a/samples/immutable-messages/Core_10/Sender/Program.cs
+++ b/samples/immutable-messages/Core_10/Sender/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Messages;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using UsingClasses.Messages;
+
+
+Console.Title = "Sender";
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<MessageSender>();
+var endpointConfiguration = new EndpointConfiguration("Samples.ImmutableMessages.UsingInterfaces.Sender");
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UsePersistence<LearningPersistence>();
+var routingConfiguration = endpointConfiguration.UseTransport(new LearningTransport());
+
+routingConfiguration.RouteToEndpoint(typeof(MyMessageImpl), "Samples.ImmutableMessages.UsingInterfaces.Receiver");
+routingConfiguration.RouteToEndpoint(typeof(MyMessage), "Samples.ImmutableMessages.UsingInterfaces.Receiver");
+
+endpointConfiguration.ApplyCustomConventions();
+Console.WriteLine("Press any key, the application is starting");
+Console.ReadKey();
+Console.WriteLine("Starting...");
+
+builder.UseNServiceBus(endpointConfiguration);
+await builder.Build().RunAsync();

--- a/samples/immutable-messages/Core_10/Sender/Sender.csproj
+++ b/samples/immutable-messages/Core_10/Sender/Sender.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
+    <Compile Include="..\ConventionExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/samples/immutable-messages/Core_10/Shared/Shared.csproj
+++ b/samples/immutable-messages/Core_10/Shared/Shared.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/samples/immutable-messages/Core_10/Shared/UsingClasses/MyMessage.cs
+++ b/samples/immutable-messages/Core_10/Shared/UsingClasses/MyMessage.cs
@@ -1,0 +1,14 @@
+﻿namespace UsingClasses.Messages
+{
+#region immutable-messages-as-class
+    public class MyMessage
+    {
+        public MyMessage(string data)
+        {
+            Data = data;
+        }
+
+        public string Data { get; private set; }
+    }
+#endregion
+}

--- a/samples/immutable-messages/Core_10/Shared/UsingInterfaces/IMyMessage.cs
+++ b/samples/immutable-messages/Core_10/Shared/UsingInterfaces/IMyMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace UsingInterfaces.Messages
+{
+#region immutable-messages-as-interface
+    public interface IMyMessage
+    {
+        string Data { get; }
+    }
+#endregion
+}


### PR DESCRIPTION
- Copied the `core_9` dir to `core_10`
- Updated to .NET 10
  - Updated TargetFramework to NET10.0
  - Updated LangVersion to preview
  - Updated package references to latest alphas.
  - Added prerelease.txt
  - Removed an unsued variable reference @ program.cs:10.
- Fixes #7548