### PR TITLE
Update file-share-databus sample to add MS extension hosting in the receiver endpoint

### DIFF
--- a/samples/databus/file-share-databus/DataBus_2/Receiver/MessageWithLargePayloadHandler.cs
+++ b/samples/databus/file-share-databus/DataBus_2/Receiver/MessageWithLargePayloadHandler.cs
@@ -1,17 +1,13 @@
-using System.Threading.Tasks;
-using NServiceBus;
-using NServiceBus.Logging;
-
+using Microsoft.Extensions.Logging;
 #region MessageWithLargePayloadHandler
 
-public class MessageWithLargePayloadHandler :
+public class MessageWithLargePayloadHandler(ILogger<MessageWithLargePayloadHandler> logger) :
     IHandleMessages<MessageWithLargePayload>
 {
-    static ILog log = LogManager.GetLogger<MessageWithLargePayloadHandler>();
 
     public Task Handle(MessageWithLargePayload message, IMessageHandlerContext context)
     {
-        log.Info($"Message received, size of blob property: {message.LargeBlob.Value.Length} Bytes");
+        logger.LogInformation("Message received, size of blob property: {BlobSize} Bytes", message.LargeBlob.Value.Length);
         return Task.CompletedTask;
     }
 }

--- a/samples/databus/file-share-databus/DataBus_2/Receiver/Program.cs
+++ b/samples/databus/file-share-databus/DataBus_2/Receiver/Program.cs
@@ -1,6 +1,9 @@
 using Shared;
+using Microsoft.Extensions.Hosting;
 
 Console.Title = "Receiver";
+
+var builder = Host.CreateApplicationBuilder(args);
 
 var endpointConfiguration = new EndpointConfiguration("Samples.ClaimCheck.Receiver");
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
@@ -10,9 +13,13 @@ var claimCheck = endpointConfiguration.UseClaimCheck<FileShareClaimCheck, System
 var storagePath = new SolutionDirectoryFinder().GetDirectory("storage");
 claimCheck.BasePath(storagePath);
 
-var endpointInstance = await Endpoint.Start(endpointConfiguration);
+builder.UseNServiceBus(endpointConfiguration);
+
+var host = builder.Build();
+await host.StartAsync();
 
 Console.WriteLine("Press any key to exit");
 Console.ReadKey();
 
-await endpointInstance.Stop();
+await host.StopAsync();
+

--- a/samples/databus/file-share-databus/DataBus_2/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/DataBus_2/Receiver/Receiver.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0-alpha.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Amend to #7512

Update file-share-databus sample to add MS extension hosting in the receiver endpoint. In order to add back usage of structured logging in the message handler, just like DataBus_1. 

