### PR TITLE
Update aws/sagas-lambda-aurora sample target framework to match the CloudFormation template

### DIFF
--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/ClientUI.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/ClientUI/ClientUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/DeployDatabase/DeployDatabase.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/DeployDatabase/DeployDatabase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Messages/Messages.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Messages/Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/Sales.csproj
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/Sales.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
switching from multi target to single target in order to match the CloudFormation template framework value in aws-lambda-tools-defaults.json (since docs engine cannot dynamically inject the target framework when generating different zip files for each targeted framework)