### PR TITLE
Enable saga and message audit to the .NET Aspire demo

### DIFF
--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
@@ -28,6 +28,7 @@ var audit = builder.AddContainer("ServiceControl-Audit", "particular/servicecont
     .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
     .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
     .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
+    .WithEnvironment("SERVICEBUS_AUDITQUEUE", "Particular.ServiceControl.Audit")
     .WithArgs("--setup-and-run")
     .WithHttpEndpoint(44444, 44444)
     .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
@@ -28,7 +28,6 @@ var audit = builder.AddContainer("ServiceControl-Audit", "particular/servicecont
     .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
     .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
     .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
-    .WithEnvironment("SERVICEBUS_AUDITQUEUE", "Particular.ServiceControl.Audit")
     .WithArgs("--setup-and-run")
     .WithHttpEndpoint(44444, 44444)
     .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Program.cs
@@ -4,7 +4,10 @@ using AspireDemo.AppHost;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var transport = builder.AddRabbitMQ("transport")
+var rabbitUser = builder.AddParameterFromConfiguration("rabbitUser", "RabbitMQ:UserName", true);
+var rabbitPassword = builder.AddParameterFromConfiguration("rabbitPassword", "RabbitMQ:Password", true);
+
+var transport = builder.AddRabbitMQ("transport", rabbitUser, rabbitPassword)
     .WithManagementPlugin(15672)
     .WithUrlForEndpoint("management", url => url.DisplayText = "RabbitMQ Management");
 

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.json
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "RabbitMQ": {
+    "UserName": "guest",
+    "Password": "guest"
   }
 }

--- a/samples/hosting/aspire/Core_10/Billing/Program.cs
+++ b/samples/hosting/aspire/Core_10/Billing/Program.cs
@@ -14,6 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Billing/Program.cs
+++ b/samples/hosting/aspire/Core_10/Billing/Program.cs
@@ -14,7 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/ClientUI/Program.cs
+++ b/samples/hosting/aspire/Core_10/ClientUI/Program.cs
@@ -18,6 +18,7 @@ routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/ClientUI/Program.cs
+++ b/samples/hosting/aspire/Core_10/ClientUI/Program.cs
@@ -18,7 +18,7 @@ routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Sales/Program.cs
+++ b/samples/hosting/aspire/Core_10/Sales/Program.cs
@@ -14,6 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Sales/Program.cs
+++ b/samples/hosting/aspire/Core_10/Sales/Program.cs
@@ -14,7 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Shipping/Program.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/Program.cs
@@ -39,8 +39,8 @@ dialect.JsonBParameterModifier(
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
-endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
+endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Shipping/Program.cs
+++ b/samples/hosting/aspire/Core_10/Shipping/Program.cs
@@ -39,6 +39,8 @@ dialect.JsonBParameterModifier(
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="9.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="11.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.SagaAudit" Version="6.0.0-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
@@ -28,6 +28,7 @@ var audit = builder.AddContainer("ServiceControl-Audit", "particular/servicecont
     .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
     .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
     .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
+    .WithEnvironment("SERVICEBUS_AUDITQUEUE", "Particular.ServiceControl.Audit")
     .WithArgs("--setup-and-run")
     .WithHttpEndpoint(44444, 44444)
     .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
@@ -28,7 +28,6 @@ var audit = builder.AddContainer("ServiceControl-Audit", "particular/servicecont
     .WithEnvironment("TRANSPORTTYPE", "RabbitMQ.QuorumConventionalRouting")
     .WithEnvironment("CONNECTIONSTRING", rabbitMqConnectionString)
     .WithEnvironment("RAVENDB_CONNECTIONSTRING", ravenDb.GetEndpoint("http"))
-    .WithEnvironment("SERVICEBUS_AUDITQUEUE", "Particular.ServiceControl.Audit")
     .WithArgs("--setup-and-run")
     .WithHttpEndpoint(44444, 44444)
     .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Program.cs
@@ -4,7 +4,10 @@ using AspireDemo.AppHost;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var transport = builder.AddRabbitMQ("transport")
+var rabbitUser = builder.AddParameterFromConfiguration("rabbitUser", "RabbitMQ:UserName", true);
+var rabbitPassword = builder.AddParameterFromConfiguration("rabbitPassword", "RabbitMQ:Password", true);
+
+var transport = builder.AddRabbitMQ("transport", rabbitUser, rabbitPassword)
     .WithManagementPlugin(15672)
     .WithUrlForEndpoint("management", url => url.DisplayText = "RabbitMQ Management");
 

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/appsettings.json
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "RabbitMQ": {
+    "UserName": "guest",
+    "Password": "guest"
   }
 }

--- a/samples/hosting/aspire/Core_9/Billing/Program.cs
+++ b/samples/hosting/aspire/Core_9/Billing/Program.cs
@@ -14,6 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Billing/Program.cs
+++ b/samples/hosting/aspire/Core_9/Billing/Program.cs
@@ -14,7 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/ClientUI/Program.cs
+++ b/samples/hosting/aspire/Core_9/ClientUI/Program.cs
@@ -18,6 +18,7 @@ routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/ClientUI/Program.cs
+++ b/samples/hosting/aspire/Core_9/ClientUI/Program.cs
@@ -18,7 +18,7 @@ routing.RouteToEndpoint(typeof(PlaceOrder), "Sales");
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Sales/Program.cs
+++ b/samples/hosting/aspire/Core_9/Sales/Program.cs
@@ -14,6 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Sales/Program.cs
+++ b/samples/hosting/aspire/Core_9/Sales/Program.cs
@@ -14,7 +14,7 @@ var routing = endpointConfiguration.UseTransport(transport);
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Shipping/Program.cs
+++ b/samples/hosting/aspire/Core_9/Shipping/Program.cs
@@ -39,8 +39,8 @@ dialect.JsonBParameterModifier(
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
-endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
-endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "Particular.ServiceControl.Audit");
+endpointConfiguration.AuditProcessedMessagesTo("audit");
+endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Shipping/Program.cs
+++ b/samples/hosting/aspire/Core_9/Shipping/Program.cs
@@ -39,6 +39,8 @@ dialect.JsonBParameterModifier(
 
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
+endpointConfiguration.AuditProcessedMessagesTo("Particular.ServiceControl.Audit");
+endpointConfiguration.AuditSagaStateChanges(serviceControlQueue: "Particular.ServiceControl.Audit");
 
 var metrics = endpointConfiguration.EnableMetrics();
 metrics.SendMetricDataToServiceControl("Particular.Monitoring", TimeSpan.FromSeconds(1));

--- a/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
     <PackageReference Include="NServiceBus.Persistence.Sql" Version="8.*" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="10.*" />
+    <PackageReference Include="NServiceBus.SagaAudit" Version="5.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This enables message and saga auditing for the Aspire demo, making the ServiceInsight features now available in ServicePulse accessible:

<img width="1571" height="1012" alt="Screenshot 2025-07-31 at 10 55 24 AM" src="https://github.com/user-attachments/assets/c5ca2a2c-36d1-4bfc-994a-b928d10d39af" />

<img width="1570" height="1011" alt="Screenshot 2025-07-31 at 10 56 30 AM" src="https://github.com/user-attachments/assets/758383a9-f1a0-41b5-8389-6b8a24805881" />
