### PR TITLE
Update aws/sagas-lambda-aurora sample: removed DI for Logger to accommodate for AWS

### DIFF
--- a/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/OrderSaga.cs
+++ b/samples/aws/sagas-lambda-aurora/SQSLambda_2/Sales/OrderSaga.cs
@@ -1,7 +1,6 @@
 ﻿
 #region OrderSaga
 
-using Microsoft.Extensions.Logging;
 using NServiceBus.Logging;
 
 public class OrderSaga : Saga<OrderSagaData>,


### PR DESCRIPTION
Removed using DI through a primary constructor to make sure that the sample works on AWS