### PR TITLE
Add NServiceBus 10 Sample: Recoverability Policy Testing

### DIFF
--- a/samples/recoverabilitypolicytesting/Core_10/CustomRecoverabilityPolicyTesting.sln
+++ b/samples/recoverabilitypolicytesting/Core_10/CustomRecoverabilityPolicyTesting.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30517.126
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.csproj", "{4F668155-D626-44B5-982A-97F28919047A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4F668155-D626-44B5-982A-97F28919047A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F668155-D626-44B5-982A-97F28919047A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {39A033B2-4D06-46C8-8455-C42891F2A956}
+	EndGlobalSection
+EndGlobal

--- a/samples/recoverabilitypolicytesting/Core_10/Dockerfile
+++ b/samples/recoverabilitypolicytesting/Core_10/Dockerfile
@@ -1,0 +1,45 @@
+# Build from repository root:
+# podman build -f samples/recoverabilitypolicytesting/Core_10/Dockerfile -t recoverabilitypolicytesting-core10 .
+# docker build -f samples/recoverabilitypolicytesting/Core_10/Dockerfile -t recoverabilitypolicytesting-core10 .
+#
+# Run:
+# podman run --rm recoverabilitypolicytesting-core10
+# docker run --rm recoverabilitypolicytesting-core10
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
+
+# Set environment variable for .NET 10 preview issue
+ENV DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true
+
+# Install expect and process management tools
+RUN apt-get update && apt-get install -y expect procps && rm -rf /var/lib/apt/lists/*
+
+# Copy build configuration files
+COPY nuget.config Directory.Build.props BannedSymbols.txt ./
+
+# Copy the sample source code
+COPY samples/recoverabilitypolicytesting/Core_10/ /app/sample/
+
+WORKDIR /app/sample
+
+# Restore dependencies
+RUN dotnet restore --no-cache
+
+# Build the sample
+RUN dotnet build --no-restore
+
+# Run the tests in the build stage (only .NET 10 to avoid missing runtime issues)
+RUN dotnet test --no-build --logger:console --verbosity:normal --framework net10.0 Sample/Sample.csproj
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0-preview AS runtime
+
+# Set environment variable for .NET 10 preview issue
+ENV DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true
+
+# This is a unit testing sample - tests are executed during the build stage
+# The runtime stage just provides confirmation that the tests passed
+RUN mkdir -p /app && echo "Custom Recoverability Policy tests completed successfully during build stage" > /app/test-results.txt
+
+WORKDIR /app
+
+CMD ["cat", "/app/test-results.txt"]

--- a/samples/recoverabilitypolicytesting/Core_10/Sample/CustomizedRecoverabilityPolicy.cs
+++ b/samples/recoverabilitypolicytesting/Core_10/Sample/CustomizedRecoverabilityPolicy.cs
@@ -1,0 +1,28 @@
+﻿using NServiceBus;
+using NServiceBus.Transport;
+
+public class CustomizedRecoverabilityPolicy
+{
+    public static RecoverabilityAction MyCustomRetryPolicy(RecoverabilityConfig config, ErrorContext context)
+    {
+        // early decisions and return before custom policy is invoked
+        // i.e. all unrecoverable exceptions should always go to customized error queue
+        foreach (var exceptionType in config.Failed.UnrecoverableExceptionTypes)
+        {
+            if (exceptionType.IsInstanceOfType(context.Exception))
+            {
+                return RecoverabilityAction.MoveToError("customErrorQueue");
+            }
+        }
+
+        // If it does not make sense to have this message around anymore
+        // it can be discarded with a reason.
+        if (context.Exception is MyBusinessTimedOutException)
+        {
+            return RecoverabilityAction.Discard("Business operation timed out.");
+        }
+
+        // in all other cases No Immediate or Delayed Retries, go to default error queue
+        return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);
+    }
+}

--- a/samples/recoverabilitypolicytesting/Core_10/Sample/MyBusinessTimedOutException.cs
+++ b/samples/recoverabilitypolicytesting/Core_10/Sample/MyBusinessTimedOutException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+public class MyBusinessTimedOutException : Exception
+{
+    public MyBusinessTimedOutException()
+    {
+    }
+
+    public MyBusinessTimedOutException(string message)
+        : base(message)
+    {
+    }
+
+    public MyBusinessTimedOutException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/samples/recoverabilitypolicytesting/Core_10/Sample/RecoverabilityTests.cs
+++ b/samples/recoverabilitypolicytesting/Core_10/Sample/RecoverabilityTests.cs
@@ -26,7 +26,7 @@ public class RecoverabilityTests
     [Test]
     public void ShouldFailImmediatelyAndSendToCustomErrorQueue()
     {
-        var unrecoverableExceptions = new HashSet<Type> { typeof(DivideByZeroException) };
+        HashSet<Type> unrecoverableExceptions = [typeof(DivideByZeroException)];
 
         var policy = CreatePolicy(unrecoverableExceptions: unrecoverableExceptions);
         var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exception: new DivideByZeroException());
@@ -65,9 +65,9 @@ public class RecoverabilityTests
             exception ?? new Exception(),
             retryNumber.HasValue
                 ? new Dictionary<string, string> { { Headers.DelayedRetries, retryNumber.ToString() } }
-                : headers ?? new Dictionary<string, string>(),
+                : headers ?? [],
             "message-id",
-            new ReadOnlyMemory<byte>(new byte[0]),
+            new ReadOnlyMemory<byte>([]),
             new TransportTransaction(),
             numberOfDeliveryAttempts,
             "receive-address",
@@ -79,7 +79,7 @@ public class RecoverabilityTests
 
     static Func<ErrorContext, RecoverabilityAction> CreatePolicy(int maxImmediateRetries = 2, int maxDelayedRetries = 2, TimeSpan? delayedRetryDelay = null, HashSet<Type> unrecoverableExceptions = null)
     {
-        var failedConfig = new FailedConfig("errorQueue", unrecoverableExceptions ?? new HashSet<Type>());
+        var failedConfig = new FailedConfig("errorQueue", unrecoverableExceptions ?? []);
         var config = new RecoverabilityConfig(new ImmediateConfig(maxImmediateRetries), new DelayedConfig(maxDelayedRetries, delayedRetryDelay.GetValueOrDefault(TimeSpan.FromSeconds(2))), failedConfig);
         return context => CustomizedRecoverabilityPolicy.MyCustomRetryPolicy(config, context);
     }

--- a/samples/recoverabilitypolicytesting/Core_10/Sample/RecoverabilityTests.cs
+++ b/samples/recoverabilitypolicytesting/Core_10/Sample/RecoverabilityTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using NServiceBus;
+using NServiceBus.Extensibility;
+using NServiceBus.Transport;
+using NUnit.Framework;
+
+[TestFixture]
+public class RecoverabilityTests
+{
+    #region test-example
+
+    [Test]
+    public void ShouldDiscardBecauseOfCustomException()
+    {
+        var policy = CreatePolicy();
+        var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exception: new MyBusinessTimedOutException());
+
+        var recoverabilityAction = policy(errorContext);
+
+        Assert.That(recoverabilityAction, Is.InstanceOf<Discard>(), "Message should be discarded");
+    }
+
+    #endregion
+
+    [Test]
+    public void ShouldFailImmediatelyAndSendToCustomErrorQueue()
+    {
+        var unrecoverableExceptions = new HashSet<Type> { typeof(DivideByZeroException) };
+
+        var policy = CreatePolicy(unrecoverableExceptions: unrecoverableExceptions);
+        var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exception: new DivideByZeroException());
+
+        var recoverabilityAction = policy(errorContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(recoverabilityAction, Is.InstanceOf<MoveToError>(), "Should ignore policies and move directly to custom error queue.");
+            Assert.That(((MoveToError)recoverabilityAction).ErrorQueue, Is.EqualTo(CustomErrorQueue));
+        });
+    }
+
+    [Test]
+    public void ShouldBeMovedToDefaultErrorQueue()
+    {
+        var policy = CreatePolicy();
+        var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exception: new Exception());
+
+        var recoverabilityAction = policy(errorContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(recoverabilityAction, Is.InstanceOf<MoveToError>(), "Should be moved to error queue.");
+            Assert.That(((MoveToError)recoverabilityAction).ErrorQueue, Is.EqualTo(DefaultErrorQueue), "Should be moved to default error queue.");
+        });
+    }
+
+    private const string DefaultErrorQueue = "errorQueue";
+    private const string CustomErrorQueue = "customErrorQueue";
+
+    #region create-error-context
+
+    static ErrorContext CreateErrorContext(int numberOfDeliveryAttempts = 1, int? retryNumber = null, Dictionary<string, string> headers = null, Exception exception = null) =>
+        new ErrorContext(
+            exception ?? new Exception(),
+            retryNumber.HasValue
+                ? new Dictionary<string, string> { { Headers.DelayedRetries, retryNumber.ToString() } }
+                : headers ?? new Dictionary<string, string>(),
+            "message-id",
+            new ReadOnlyMemory<byte>(new byte[0]),
+            new TransportTransaction(),
+            numberOfDeliveryAttempts,
+            "receive-address",
+            new ContextBag());
+
+    #endregion
+
+    #region create-policy
+
+    static Func<ErrorContext, RecoverabilityAction> CreatePolicy(int maxImmediateRetries = 2, int maxDelayedRetries = 2, TimeSpan? delayedRetryDelay = null, HashSet<Type> unrecoverableExceptions = null)
+    {
+        var failedConfig = new FailedConfig("errorQueue", unrecoverableExceptions ?? new HashSet<Type>());
+        var config = new RecoverabilityConfig(new ImmediateConfig(maxImmediateRetries), new DelayedConfig(maxDelayedRetries, delayedRetryDelay.GetValueOrDefault(TimeSpan.FromSeconds(2))), failedConfig);
+        return context => CustomizedRecoverabilityPolicy.MyCustomRetryPolicy(config, context);
+    }
+
+    #endregion
+}

--- a/samples/recoverabilitypolicytesting/Core_10/Sample/Sample.csproj
+++ b/samples/recoverabilitypolicytesting/Core_10/Sample/Sample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.2" />
+    <PackageReference Include="NServiceBus.Testing" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+  </ItemGroup>
+</Project>

--- a/samples/recoverabilitypolicytesting/Core_9/Dockerfile
+++ b/samples/recoverabilitypolicytesting/Core_9/Dockerfile
@@ -1,0 +1,39 @@
+# Build from repository root:
+# podman build -f samples/recoverabilitypolicytesting/Core_9/Dockerfile -t recoverabilitypolicytesting-core9 .
+# docker build -f samples/recoverabilitypolicytesting/Core_9/Dockerfile -t recoverabilitypolicytesting-core9 .
+#
+# Run:
+# podman run --rm recoverabilitypolicytesting-core9
+# docker run --rm recoverabilitypolicytesting-core9
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+# Install expect and process management tools
+RUN apt-get update && apt-get install -y expect procps && rm -rf /var/lib/apt/lists/*
+
+# Copy build configuration files
+COPY nuget.config Directory.Build.props BannedSymbols.txt ./
+
+# Copy the sample source code
+COPY samples/recoverabilitypolicytesting/Core_9/ /app/sample/
+
+WORKDIR /app/sample
+
+# Restore dependencies
+RUN dotnet restore --no-cache
+
+# Build the sample
+RUN dotnet build --no-restore
+
+# Run the tests in the build stage (only .NET 9 to avoid missing runtime issues)
+RUN dotnet test --no-build --logger:console --verbosity:normal --framework net9.0 Sample/Sample.csproj
+
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS runtime
+
+# This is a unit testing sample - tests are executed during the build stage
+# The runtime stage just provides confirmation that the tests passed
+RUN mkdir -p /app && echo "Custom Recoverability Policy tests completed successfully during build stage" > /app/test-results.txt
+
+WORKDIR /app
+
+CMD ["cat", "/app/test-results.txt"]


### PR DESCRIPTION
This pull request adds a new sample for Recoverability Policy Testing for NServiceBus 10.

Fixes: #7372

## Changes Made

### Core_9 Sample Updates

• Added Dockerfile for containerized testing of unit tests
• Simplified approach for testing sample (no console applications or startup script needed)
• Tests execute during Docker build stage to validate custom recoverability policy behavior

### Core_10 Sample Creation

• Created new Core_10 version targeting .NET 10
• Updated to NServiceBus 10.0.0-alpha.2 and NServiceBus.Testing 10.0.0-alpha.3 from Feedz.io
• Updated Dockerfile for .NET 10 preview with required DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT environment variable
• Applied C# 12 language features:
  ◦ Collection expressions for HashSet initialization: [typeof(DivideByZeroException)]
  ◦ Collection expressions for empty collections: [] instead of new HashSet<Type>()
  ◦ Collection expressions for empty byte arrays: [] instead of new byte[0]
• Added prerelease.txt file
• Verified full functionality with containerized testing

## Testing

Both Core_9 and Core_10 versions have been thoroughly tested with automated container-based testing that validates all custom recoverability policy scenarios:

1. **Discard Policy**: Messages with MyBusinessTimedOutException are discarded with reason "Business operation timed out."
2. **Custom Error Queue**: Unrecoverable exceptions (like DivideByZeroException) are moved to "customErrorQueue"
3. **Default Error Queue**: All other exceptions are moved to the default "errorQueue"

All 3 unit tests pass successfully, confirming the custom recoverability policy works correctly as described in the sample.md documentation.