### PR TITLE
Remove old reference to SqlVarient

### DIFF
--- a/persistence/sql/dialect-oracle.md
+++ b/persistence/sql/dialect-oracle.md
@@ -22,17 +22,8 @@ Using the [Oracle.ManagedDataAccess NuGet Package](https://www.nuget.org/package
 
 snippet: SqlPersistenceUsageOracle
 
-In Versions 2.2.0 and above it's possible to specify custom schema using the following code:
-
-```
-var persistence = endpointConfiguration.UsePersistence<SqlPersistence>();
-persistence.SqlVariant(SqlVariant.Oracle);
-persistence.Schema("custom_schema");
-```
-
 > [!NOTE]
 > The ODP.NET managed driver requires the `Enlist=false` or `Enlist=dynamic` setting in the [Oracle connection string](https://docs.oracle.com/database/121/ODPNT/featConnecting.htm) to allow the persister to enlist in a [Distributed Transaction](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681205.aspx) at the correct moment.
-
 
 ## Unicode support
 
@@ -97,7 +88,6 @@ where INDEX_NAME = 'SAGAIDX_525D1D4DC0C3DCD96947E1';
 > If either the saga name or correlation property name change, the name of the index will also change.
 
 If a saga name is longer than 27 characters, an exception will be thrown, and a [substitute table name must be specified](saga.md#table-structure-table-name).
-
 
 ### Custom Finders
 


### PR DESCRIPTION
SqlVarient was [replaced by SqlDialect](https://docs.particular.net/persistence/upgrades/sql-2to3#variant-renamed-to-dialect) in v3