### PR TITLE
Review gateway multi-site deployment

### DIFF
--- a/nservicebus/gateway/multi-site-deployments.md
+++ b/nservicebus/gateway/multi-site-deployments.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Site Deployments
-reviewed: 2023-09-15
+reviewed: 2025-08-01
 summary: How to handle multi-site communication.
 component: Gateway
 redirects:
@@ -99,10 +99,10 @@ Follow the steps for [configuring SSL](https://docs.microsoft.com/en-us/dotnet/f
 
 ## Automatic de-duplication
 
-Going through alternate channels like HTTP(S) means that the MSMQ safety guarantees of exactly-once message delivery are not available. This means that communication errors resulting in retries can lead to receiving messages more than once. To avoid being burdened with de-duplication, the NServiceBus gateway supports this out of the box. Message IDs are stored in the configured [Persistence](/persistence) so duplicates can be detected and discarded.
+Going through alternate channels like HTTP(S) means that the MSMQ safety guarantees of exactly-once message delivery are not available. This means that communication errors resulting in retries can lead to receiving messages more than once. To avoid being burdened with de-duplication, the NServiceBus gateway supports this out of the box. Message IDs are stored in the configured de-duplication persistence so duplicates can be detected and discarded.
 
-
-partial: dedup
+- [SQL deduplication persistence](/nservicebus/gateway/sql/)
+- [RavenDB deduplication persistence](/nservicebus/gateway/ravendb/)
 
 
 ## Incoming channels

--- a/nservicebus/gateway/multi-site-deployments_dedup_gateway_[1.0,].partial.md
+++ b/nservicebus/gateway/multi-site-deployments_dedup_gateway_[1.0,].partial.md
@@ -1,1 +1,0 @@
-The gateway will use the storage type configured. At this stage [InMemory](/persistence/non-durable/), [NHibernate](/persistence/nhibernate/) and [RavenDB](/persistence/ravendb/) are supported.


### PR DESCRIPTION
NServiceBus persistence no longer supports gateway. There is a specific gateway de-duplication persistence abstraction instead. SQL and RavenDB are supported.