### PR TITLE
Sort upgrade guides

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -319,7 +319,7 @@
         Title: Version 5 to 6
       - Url: nservicebus/upgrades/azure-functions-service-bus-in-process-3to4
         Title: Version 3 to 4
-        - Url: nservicebus/upgrades/azure-functions-service-bus-in-process-2to3
+      - Url: nservicebus/upgrades/azure-functions-service-bus-in-process-2to3
         Title: Version 2 to 3
       - Url: nservicebus/upgrades/azure-functions-service-bus-in-process-1to2
         Title: Version 1 to 2


### PR DESCRIPTION
This PR sorts how the list of upgrade guides are displayed on the left menu. I sorted them by newest first.