### PR TITLE
Weekly docs review - Service Control event subscription

### DIFF
--- a/monitoring/metrics/raw.md
+++ b/monitoring/metrics/raw.md
@@ -1,7 +1,7 @@
 ---
 title: Consume raw data from Metrics
 summary: Use the public API in the Metrics package to consume raw metrics data
-reviewed: 2023-11-30
+reviewed: 2025-08-28
 component: Metrics
 related:
  - nservicebus/operations

--- a/samples/servicecontrol/events-subscription/sample.md
+++ b/samples/servicecontrol/events-subscription/sample.md
@@ -2,7 +2,7 @@
 title: Monitor with ServiceControl events
 summary: A sample showing how to monitor events in ServiceControl
 component: ServiceControlContracts
-reviewed: 2023-11-30
+reviewed: 2025-08-28
 related:
  - servicecontrol
  - servicecontrol/contracts
@@ -76,7 +76,7 @@ The `MessageFailed` event is published whenever ServiceControl detects a new mes
 In order to receive `HeartbeatStopped` and `HeartbeatRestored` events, the endpoint must use the [heartbeats plugin](/monitoring/heartbeats).
 
 > [!NOTE]
-> Heartbeat control messages are sent [every 30 seconds by default](/monitoring/heartbeats/install-plugin.md#heartbeat-interval) so there will be up to a 30 second delay before ServiceControl realizes that it lost or restored connection with the endpoint.
+> Heartbeat control messages are sent [every 10 seconds by default](/monitoring/heartbeats/install-plugin.md#heartbeat-interval) so there will be up to a 30 second delay before ServiceControl realizes that it lost or restored connection with the endpoint.
 
 
 ### EndpointsMonitor

--- a/tutorials/monitoring-demo/walkthrough-1.md
+++ b/tutorials/monitoring-demo/walkthrough-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring NServiceBus Demo - Slow handlers"
-reviewed: 2023-11-07
+reviewed: 2025-08-28
 summary: Using the Particular Service Platform to measure individual endpoint performance with the throughput and processing time metrics
 suppressRelated: true
 ---


### PR DESCRIPTION
Revised the default heartbeat control message interval from 30 seconds to 10 seconds in the ServiceControl events subscription sample documentation for improved accuracy.