### PR TITLE
Add an upgrade guide dedicated snippet for the Messaging Bridge Upgrade guide 3 to 4

### DIFF
--- a/Snippets/Bridge/Bridge_4/UpgradeGuides/3to4/DoNotTranslateReplyToAddressForFailedMessages.cs
+++ b/Snippets/Bridge/Bridge_4/UpgradeGuides/3to4/DoNotTranslateReplyToAddressForFailedMessages.cs
@@ -1,0 +1,15 @@
+using NServiceBus;
+
+class DoNotTranslateReplyToAddressForFailedMessages
+{
+    public void Usage()
+    {
+        var bridgeConfiguration = new BridgeConfiguration();
+
+        #region bridge-3to4-do-not-translate-reply-to-address
+
+        bridgeConfiguration.DoNotTranslateReplyToAddressForFailedMessages();
+
+        #endregion
+    }
+}

--- a/nservicebus/upgrades/bridge-3to4.md
+++ b/nservicebus/upgrades/bridge-3to4.md
@@ -23,5 +23,5 @@ Since the header may contain a physical address of any endpoint in the system, t
 
 Users who still want to prevent the need to register all endpoints with the bridge can use a dedicated API option:
 
-snippet: do-not-translate-reply-to-address-for-failed-messages
+snippet: bridge-3to4-do-not-translate-reply-to-address
 


### PR DESCRIPTION
This is the smallest change I could made to fix the Messaging Bridge Upgrade guide 3 to 4, so it doesn't show version 5 unintentionally