### PR TITLE
add documentation for new property ThrowIfUnmappedEventTypes

### DIFF
--- a/Snippets/ASBS/ASBS_5/topology-options.json
+++ b/Snippets/ASBS/ASBS_5/topology-options.json
@@ -9,6 +9,7 @@
   },
   "QueueNameToSubscriptionNameMap": {
     "Publisher": "PublisherSubscriptionName"
-  }
+  },
+  "ThrowIfUnmappedEventTypes": false
 }
 # endcode topology-options

--- a/Snippets/ASBS/ASBS_6/topology-options.json
+++ b/Snippets/ASBS/ASBS_6/topology-options.json
@@ -9,6 +9,7 @@
   },
   "QueueNameToSubscriptionNameMap": {
     "Publisher": "PublisherSubscriptionName"
-  }
+  },
+  "ThrowIfUnmappedEventTypes": false
 }
 # endcode topology-options

--- a/transports/azure-service-bus/configuration.md
+++ b/transports/azure-service-bus/configuration.md
@@ -3,6 +3,8 @@ title: Configuration
 summary: Explains the configuration options
 component: ASBS
 reviewed: 2025-03-21
+related:
+ - samples/azure-service-bus-netstandard/options
 ---
 
 ## Configuring an endpoint

--- a/transports/azure-service-bus/configuration_entity-topology_asbs_[5,).partial.md
+++ b/transports/azure-service-bus/configuration_entity-topology_asbs_[5,).partial.md
@@ -22,6 +22,8 @@ The topology json document for the topic-per-event topology looks like:
 
 snippet: topology-options
 
+If it is desired to enforce that each event type published has an explicit topic name mapping in `PublishedEventToTopicsMap` then `ThrowIfUnmappedEventTypes` can be set to `true`. This property defaults to `false`.
+
 In order to support polymorphic event types, one event (base type) can be mapped to multiple topics (where the derived events are published):
 
 snippet: topology-options-inheritance


### PR DESCRIPTION
property added in 5.1 in change /Particular/NServiceBus.Transport.AzureServiceBus/pull/1242

Not to be merged until 5.1 is released