### PR TITLE
Update Worker snippets and samples for 7.0.0-alpha.2

### DIFF
--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/ASBFunctionsWorker_7.csproj
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/ASBFunctionsWorker_7.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />
-    <PackageReference Include="NServiceBus.AzureFunctions.Worker.ServiceBus" Version="7.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.AzureFunctions.Worker.ServiceBus" Version="7.0.0-alpha.2" />
   </ItemGroup>
 
 </Project>

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/Sending.cs
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/Sending.cs
@@ -1,34 +1,26 @@
-﻿namespace ASBFunctionsWorker_5
+﻿namespace ASBFunctionsWorker;
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using NServiceBus;
+
+#region asb-function-isolated-dispatching-outside-message-handler
+public class HttpTrigger(IFunctionEndpoint functionEndpoint)
 {
-    using Microsoft.Azure.Functions.Worker;
-    using Microsoft.Azure.Functions.Worker.Http;
-    using NServiceBus;
-    using System.Net;
-    using System.Threading.Tasks;
-
-    #region asb-function-isolated-dispatching-outside-message-handler
-    public class HttpTrigger
+    [Function("HttpSender")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequestData req,
+        FunctionContext executionContext)
     {
-        readonly IFunctionEndpoint functionEndpoint;
+        await functionEndpoint.Send(new TriggerMessage(), executionContext);
 
-        public HttpTrigger(IFunctionEndpoint functionEndpoint)
-        {
-            this.functionEndpoint = functionEndpoint;
-        }
-
-        [Function("HttpSender")]
-        public async Task<HttpResponseData> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequestData req,
-            FunctionContext executionContext)
-        {
-            await functionEndpoint.Send(new TriggerMessage(), executionContext);
-
-            return req.CreateResponse(HttpStatusCode.OK);
-        }
+        return req.CreateResponse(HttpStatusCode.OK);
     }
-    #endregion
+}
+#endregion
 
-    class TriggerMessage
-    {
-    }
+class TriggerMessage
+{
 }

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/TopologyOptions.cs
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/TopologyOptions.cs
@@ -1,20 +1,20 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
+﻿namespace ASBFunctionsWorker;
+
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Configuration;
 using NServiceBus;
 
-namespace ASBFunctionsWorker_6
+class TopologyOptions
 {
-    class TopologyOptions
+    public void SetTopologyOptions(string[] args)
     {
-        public void SetTopologyOptions()
-        {
-            #region ASBFunctionsWorker-topology-options
-            var host = new HostBuilder()
-                .ConfigureFunctionsWorkerDefaults()
-                .ConfigureAppConfiguration(builder => builder.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true))
-                .UseNServiceBus()
-                .Build();
-            #endregion
-        }
+        #region ASBFunctionsWorker-topology-options
+        var builder = FunctionsApplication.CreateBuilder(args);
+
+        builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+        builder.AddNServiceBus();
+
+        var host = builder.Build();
+        #endregion
     }
 }

--- a/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/TriggerDefinition.cs
+++ b/Snippets/ASBFunctionsWorker/ASBFunctionsWorker_7/TriggerDefinition.cs
@@ -1,23 +1,17 @@
-namespace ASBFunctionsWorker_6;
+namespace ASBFunctionsWorker;
 
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
 #region custom-trigger-definition
 
-class CustomTriggerDefinition
+class CustomTriggerDefinition(IFunctionEndpoint functionEndpoint)
 {
-    IFunctionEndpoint functionEndpoint;
-
-    public CustomTriggerDefinition(IFunctionEndpoint functionEndpoint)
-    {
-        this.functionEndpoint = functionEndpoint;
-    }
-
     [Function("MyCustomTrigger")]
     public async Task Run(
         [ServiceBusTrigger("MyFunctionsEndpoint")]
@@ -30,12 +24,13 @@ class CustomTriggerDefinition
 
 public class Program
 {
-    public async Task Main()
+    public static async Task Main(string[] args)
     {
-        var host = new HostBuilder()
-            .ConfigureFunctionsWorkerDefaults()
-            .UseNServiceBus("MyFunctionsEndpoint")
-            .Build();
+        var builder = FunctionsApplication.CreateBuilder(args);
+
+        builder.AddNServiceBus("MyFunctionsEndpoint");
+
+        var host = builder.Build();
 
         await host.RunAsync();
     }

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_7/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_7/AzureFunctions.ASBTrigger.Worker/AzureFunctions.ASBTrigger.Worker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.50.0-preview1" />
-    <PackageReference Include="NServiceBus.AzureFunctions.Worker.ServiceBus" Version="7.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.AzureFunctions.Worker.ServiceBus" Version="7.0.0-alpha.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_7/AzureFunctions.ASBTrigger.Worker/Program.cs
+++ b/samples/azure-functions/service-bus-worker/ASBFunctionsWorker_7/AzureFunctions.ASBTrigger.Worker/Program.cs
@@ -1,12 +1,14 @@
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Hosting;
 
 #region configuration-with-function-host-builder
 [assembly: NServiceBusTriggerFunction("ASBWorkerEndpoint")]
 
-var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults()
-    .UseNServiceBus()
-    .Build();
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.AddNServiceBus();
+
+var host = builder.Build();
 
 await host.RunAsync();
 #endregion


### PR DESCRIPTION
 7.0.0-alpha.2 added overloads to work with `FunctionsApplication.CreateBuilder`, so the snippets and samples have been updated to use the more recent way of bootstrapping the application.