### PR TITLE
Snippets reference update

### DIFF
--- a/Snippets/ABSDataBus/ABSDataBus_7/ABSDataBus_7.csproj
+++ b/Snippets/ABSDataBus/ABSDataBus_7/ABSDataBus_7.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.*" />
     <PackageReference Include="NServiceBus.DataBus.AzureBlobStorage" Version="7.0.0-alpha.1" />
   </ItemGroup>
 

--- a/Snippets/ASBS/ASBS_3/ASBS_3.csproj
+++ b/Snippets/ASBS/ASBS_3/ASBS_3.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/ASBS/ASBS_4/ASBS_4.csproj
+++ b/Snippets/ASBS/ASBS_4/ASBS_4.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/ASBS/ASBS_5/ASBS_5.csproj
+++ b/Snippets/ASBS/ASBS_5/ASBS_5.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="5.*" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/ASBS/ASBS_6/ASBS_6.csproj
+++ b/Snippets/ASBS/ASBS_6/ASBS_6.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.15.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="6.0.0-alpha.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/Bridge/Bridge_5/Bridge_5.csproj
+++ b/Snippets/Bridge/Bridge_5/Bridge_5.csproj
@@ -5,6 +5,6 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.MessagingBridge" Version="5.0.0-alpha.1" />
     <PackageReference Include="NServiceBus.MessagingBridge.Msmq" Version="5.0.0-alpha.1" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="6.0.0-alpha.1" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="6.0.0-alpha.2" />
   </ItemGroup>
 </Project>

--- a/Snippets/GatewaySql/GatewaySql_4/GatewaySql_4.csproj
+++ b/Snippets/GatewaySql/GatewaySql_4/GatewaySql_4.csproj
@@ -4,6 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Gateway.Sql" Version="4.0.0-alpha.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.*" />
   </ItemGroup>
 </Project>

--- a/Snippets/LearningPersistence/Core_10/Core_10.csproj
+++ b/Snippets/LearningPersistence/Core_10/Core_10.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
   </ItemGroup>
 </Project>

--- a/Snippets/LearningTransport/Core_10/Core_10.csproj
+++ b/Snippets/LearningTransport/Core_10/Core_10.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
   </ItemGroup>
 </Project>

--- a/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/PostgreSqlTransport_8.csproj
+++ b/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/PostgreSqlTransport_8.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="8.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
   </ItemGroup>

--- a/Snippets/PostgreSqlTransport/PostgreSqlTransport_9/PostgreSqlTransport_9.csproj
+++ b/Snippets/PostgreSqlTransport/PostgreSqlTransport_9/PostgreSqlTransport_9.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="9.0.0-alpha.2" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="6.0.0-alpha.2" />
   </ItemGroup>

--- a/Snippets/RawMessaging/Core_10/Core_10.csproj
+++ b/Snippets/RawMessaging/Core_10/Core_10.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
   </ItemGroup>
 </Project>

--- a/Snippets/SystemJson/Core_10/Core_10.csproj
+++ b/Snippets/SystemJson/Core_10/Core_10.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
   </ItemGroup>
 </Project>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS.sln
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32602.215
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11018.127 d18.0
 MinimumVisualStudioVersion = 15.0.26730.12
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MongoTS_2", "MongoTS_2\MongoTS_2.csproj", "{34E49F9B-04E5-45AF-9009-2A5B88B9203B}"
 EndProject
@@ -11,6 +11,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoTS_5", "MongoTS_5\MongoTS_5.csproj", "{B278DCC1-DAC0-4536-AAB4-CB21CAD7E120}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoTS_6", "MongoTS_6\MongoTS_6.csproj", "{1C1812F8-F58A-48A0-9A48-0EC7902741F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoTS_7", "MongoTS_7\MongoTS_7.csproj", "{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -82,6 +84,18 @@ Global
 		{1C1812F8-F58A-48A0-9A48-0EC7902741F1}.Release|x64.Build.0 = Release|Any CPU
 		{1C1812F8-F58A-48A0-9A48-0EC7902741F1}.Release|x86.ActiveCfg = Release|Any CPU
 		{1C1812F8-F58A-48A0-9A48-0EC7902741F1}.Release|x86.Build.0 = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Debug|x86.Build.0 = Debug|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|x64.Build.0 = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{01E7FD88-AF42-FA16-18A9-7ABF80AEC1AF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_6/MongoTS_6.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_6/MongoTS_6.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NServiceBus.Storage.MongoDB.TransactionalSession" Version="6.0.0-alpha.2" />
+		<PackageReference Include="NServiceBus.Storage.MongoDB.TransactionalSession" Version="6.*" />
 	</ItemGroup>
 </Project>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_7/MongoDBConfig.cs
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_7/MongoDBConfig.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+using NServiceBus.TransactionalSession;
+using System;
+using System.Threading.Tasks;
+
+public class MongoDBConfig
+{
+    public void Configure(EndpointConfiguration config)
+    {
+        #region enabling-transactional-session-mongo
+
+        var persistence = config.UsePersistence<MongoPersistence>();
+        persistence.EnableTransactionalSession();
+
+        #endregion
+    }
+
+    public async Task OpenDefault(IServiceProvider serviceProvider)
+    {
+        #region open-transactional-session-mongo
+
+        using var childScope = serviceProvider.CreateScope();
+        var session = childScope.ServiceProvider.GetService<ITransactionalSession>();
+        await session.Open();
+
+        // use the session
+
+        await session.Commit();
+
+        #endregion
+    }
+
+    public async Task UseSession(ITransactionalSession session)
+    {
+        #region use-transactional-session-mongo
+        await session.Open();
+
+        // add messages to the transaction:
+        await session.Send(new MyMessage());
+
+        // access the database:
+        var mongoSession = session.SynchronizedStorageSession.MongoPersistenceSession();
+
+        await session.Commit();
+        #endregion
+    }
+}

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_7/MongoTS_7.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_7/MongoTS_7.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="NServiceBus.Storage.MongoDB.TransactionalSession" Version="7.0.0-alpha.1" />
+	</ItemGroup>
+</Project>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_7/MyMessage.cs
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_7/MyMessage.cs
@@ -1,0 +1,5 @@
+﻿using NServiceBus;
+
+public class MyMessage : ICommand
+{
+}

--- a/Snippets/Xml/Core_10/Core_10.csproj
+++ b/Snippets/Xml/Core_10/Core_10.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
+    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request corrects package references in Snippets projects that were using explicit references in lieu of relative (wildcard) references, and updates existing Particular/NServiceBus package references to their latest versions. 

Additionally, NServiceBus.TransactionalSession.MongoDB had a major release (v6) which pushed the NSB 10 version up a major (to v7). The corresponding snippet was not updated, so I fixed the v6 snippets version and created a new v7 version. 