### PR TITLE
Edit & Retry - docs clarifications

### DIFF
--- a/servicepulse/intro-editing-messages.md
+++ b/servicepulse/intro-editing-messages.md
@@ -11,7 +11,7 @@ If a message cannot be successfully retried it is possible to fix the malformed 
 
 > [!NOTE]
 > This feature works in the following way:
-> 1. A copy of the failed message with new [message ID](/nservicebus/messaging/message-identity) is created.
+> 1. A copy of the failed message with new [message ID](/nservicebus/messaging/message-identity.md) is created.
 > 2. The headers and body of the newly created copy can be edited.
 > 3. The copied message is dispatched, and the original failed message is marked as resolved.
 


### PR DESCRIPTION
What needs to be addressed:
- [x] How Edit & Retry works (points)
- [x] Emphasize that the 'retried' message has a different ID
- [x] No ServiceControl events
- [x] failing silently (?)
  - this will be addressed soon by https://github.com/Particular/ServiceControl/issues/5122  
- [x] situations when Edit & Retry is discarded (logs a warning, but doesn't communicate the reason to the ServicePulse user - to be checked if already covered)
  - this can occur when 
    - the message editing feature is disabled (so the action has not been initiated through the user interface) - safe to ignore
    - the original failed message cannot be loaded - safe to ignore
    - locked headers are changed (not possible through UI) - safe to ignore
    - the message body is empty (not possible through UI) - safe to ignore