### PR TITLE
Supress CosmosDB v3.2.1 specific analyser warning. Not needed for the sample.

### DIFF
--- a/samples/cosmosdb/container/CosmosDB_3/Server/Program.cs
+++ b/samples/cosmosdb/container/CosmosDB_3/Server/Program.cs
@@ -45,15 +45,17 @@ class Program
         endpointConfiguration.UseTransport(new LearningTransport());
         endpointConfiguration.UseSerialization<SystemJsonSerializer>();
         endpointConfiguration.EnableInstallers();
-
+#pragma warning disable NSBC001 // EnableContainerFromMessageExtractor should be called when using both default container and message extractors
         #region ContainerInformationFromLogicalMessage
         var transactionInformation = persistence.TransactionInformation();
+
         transactionInformation.ExtractContainerInformationFromMessage<ShipOrder>(m =>
         {
             logger.LogInformation($"Message '{m.GetType().AssemblyQualifiedName}' destined to be handled by '{nameof(ShipOrderSaga)}' will use 'ShipOrderSagaData' container.");
             return new ContainerInformation("ShipOrderSagaData", new PartitionKeyPath("/id"));
         });
         #endregion
+#pragma warning restore NSBC001 // EnableContainerFromMessageExtractor should be called when using both default container and message extractors
         #region ContainerInformationFromHeaders
         transactionInformation.ExtractContainerInformationFromHeaders(headers =>
         {


### PR DESCRIPTION
This analyser warning is not needed for what the sample is showcasing. Disabling it so samples in docs can build successfully.