### PR TITLE
Update cosmos snippets to supress required obsolute warning for v3.2.1 of Cosmos.

### DIFF
--- a/Snippets/CosmosDB/CosmosDB_3/Transactions.cs
+++ b/Snippets/CosmosDB/CosmosDB_3/Transactions.cs
@@ -124,6 +124,9 @@ class Transactions
 
     void ExtractContainerInfoFromMessageInstance(PersistenceExtensions<CosmosPersistence> persistence)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+        persistence.EnableContainerFromMessageExtractor();
+#pragma warning restore CS0618 // Type or member is obsolete
         #region ExtractContainerInfoFromMessageInstance
 
         var transactionInformation = persistence.TransactionInformation();
@@ -134,6 +137,9 @@ class Transactions
 
     void ExtractContainerInfoFromMessageExtractor(PersistenceExtensions<CosmosPersistence> persistence)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+        persistence.EnableContainerFromMessageExtractor();
+#pragma warning restore CS0618 // Type or member is obsolete
         #region ExtractContainerInfoFromMessageExtractor
 
         var transactionInformation = persistence.TransactionInformation();
@@ -144,6 +150,9 @@ class Transactions
 
     void ExtractContainerInfoFromMessageCustom(PersistenceExtensions<CosmosPersistence> persistence)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
+        persistence.EnableContainerFromMessageExtractor();
+#pragma warning restore CS0618 // Type or member is obsolete
         #region ExtractContainerInfoFromMessageCustom
 
         var transactionInformation = persistence.TransactionInformation();


### PR DESCRIPTION
The snippets use both a DefaultContainer and ExtractContainerInformationFromMessage. This causes a warning to be thrown. The snippets require the opt-in flag to remove the warning.