### PR TITLE
Improve documentation around Windows failover cluster and MSMQ

### DIFF
--- a/servicecontrol/configure-non-privileged-service-account.md
+++ b/servicecontrol/configure-non-privileged-service-account.md
@@ -25,8 +25,6 @@ Both read and send permissions are required for each of these queues:
 
  * `{InstanceName}`:
  * `{InstanceName}.errors`
- * `{InstanceName}.timeouts` (only when using [MSMQ](/servicecontrol/transports.md#msmq))
- * `{InstanceName}.timeoutsdispatcher` (only when using [MSMQ](/servicecontrol/transports.md#msmq))
 
 ### [Error instances](/servicecontrol/servicecontrol-instances/):
 

--- a/servicecontrol/deploying-servicecontrol-in-a-cluster.md
+++ b/servicecontrol/deploying-servicecontrol-in-a-cluster.md
@@ -16,36 +16,35 @@ The following procedure is a high-level guide on how to deploy ServiceControl on
 
 ## Infrastructure setup
 
-- Set up a [Windows Failover Cluster](https://learn.microsoft.com/en-us/windows-server/failover-clustering/create-failover-cluster?pivots=failover-cluster-manager),
-  - Make sure to set up clustered storage for the cluster. 
-- Install ServiceControl on each node.
-- Add each instance as "Generic service" to the cluster using Failover Cluster Manager.
-  - Check "Use network name as computer name".
-- On the cluster, create all the queues that were created locally for all of the instances of ServiceControl.
-- Set up a [Message Queuing role on the cluster](https://learn.microsoft.com/en-us/windows-server/failover-clustering/create-failover-cluster?pivots=failover-cluster-manager#create-clustered-roles-in-failover-cluster-manager)
-  - Make sure it uses the clustered storage.
+1. Create a [Windows Failover Cluster](https://learn.microsoft.com/en-us/windows-server/failover-clustering/create-failover-cluster?pivots=failover-cluster-manager),
+1. Create a [Message Queuing role on the cluster](https://learn.microsoft.com/en-us/windows-server/failover-clustering/create-failover-cluster?pivots=failover-cluster-manager#create-clustered-roles-in-failover-cluster-manager)
+1. Install ServiceControl on each node of the cluster.
+1. Add the ServiceControl Windows Service as a Generic Service resource to the MSMQ cluster role.
+    1. Ensure it depends on the MSMQ role and the MSMQ network name
+    1. After setting up the dependencies, check the "Use Network Name as computer name" option
+
+Before bringing the service resource online, all of the [required queues](/servicecontrol/queues.md#queue-setup) must be created and given the appropriate permissions manually in the cluster.
 
 ### Database high availability
 
-The internal ServiceControl database (normally a RavenDB database) must be located in a shared storage that is highly available and fault tolerant. Shared storage does not mean a network share, but a cluster storage that allows low latency and exclusive access. 
-Access to the data should always be local, although physically that data could be stored on a SAN. When this disk is mounted, ServiceControl must be configured to use that location. 
+The internal ServiceControl RavenDB database must be located in a shared storage that is highly available and fault tolerant. Shared storage does not mean a network share, but a cluster storage that allows low latency and exclusive access.
+Access to the data should always be local, although physically that data could be stored on a SAN. When this disk is mounted, ServiceControl must be configured to use that location.
 
 ## ServiceControl configuration
 
-The following steps must be applied to all ServiceControl instances on every node in the cluster.
+The following settings must be applied to all ServiceControl instances on every node in the cluster.
 
 ### Configuration
 
-ServiceControl configuration file (for example, ServiceControl.exe.config) must be modified by defining:
+The ServiceControl configuration must be customized by changing the following settings:
 
-- `DbPath` to define the path to the shared location of the database.
-- `Hostname` to reflect `cluster name`.
+- The database path needs to set to the path to the shared location of the database.
+  - `ServiceControl/DBPath` for error instances
+  - `ServiceControl.Audit/DBPath` for audit instances
+- The host name needs to be set to the MSMQ network name
+  - `ServiceControl/HostName` for error instances
+  - `ServiceControl.Audit/HostName` for audit instances
+  - `Monitoring/HttpHostName` for monitoring instances
+- The `ServiceControl/RemoteInstances` setting should use the MSMQ network name to refer to the audit instance
 
-For example:
-
-```xml
-<add key="ServiceControl/DbPath" value="drive:\SomeDir\" />
-<add key="ServiceControl/Hostname" value="clusterName" />
-```
-
-See [Customizing ServiceControl Configuration](/servicecontrol/servicecontrol-instances/configuration.md) for more information on what each setting means.
+See [Customizing ServiceControl Configuration](/servicecontrol/servicecontrol-instances/configuration.md) for more information on each setting.

--- a/servicecontrol/queues.md
+++ b/servicecontrol/queues.md
@@ -38,8 +38,8 @@ The following is an overview of all queues based on the default instance names.
 | [particular.monitoring](#monitoring-instance-input-queue)          |       |       |     CR     |Receives heartbeats, checks |
 | [particular.servicecontrol](#error-instance-input-queue)           |  CR   |   W   |            |Input queue for error/heartbeat |
 | [particular.servicecontrol.audit](#audit-instance-input-queue)           |  CR   |   W   |            |Input queue for audit instance |
-| [particular.servicecontrol.error](#error-instance-error-queue)    |  CW   |       |            |Internal error queue |
-| [particular.servicecontrol.audit.error](#audit-instance-error-queue)    |  CW   |       |            |Internal error queue for audit |
+| [particular.servicecontrol.errors](#error-instance-error-queue)    |  CW   |       |            |Internal error queue |
+| [particular.servicecontrol.audit.errors](#audit-instance-error-queue)    |  CW   |       |            |Internal error queue for audit |
 | [particular.servicecontrol.staging](#error-instance-staging-queue) |  CRW  |       |            |Temporary queue for retries |
 | [servicecontrol.throughputdata](#error-instance-throughput-data)   |  CR   |       |     W      |Tracks metrics / throughput |
 

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -526,10 +526,9 @@ The queue on which throughput data is received by the ServiceControl Error insta
 
 In most instances these settings do not need to be modified.
 
-If running multiple setups of the Platform Tools (i.e. multiple versions of ServiceControl error and monitoring instances) then modify these settings so that the queue on each monitoring instance is matched to the queue of its error instance.
+If running multiple setups of the Platform Tools (i.e. multiple versions of ServiceControl error and monitoring instances), then modify these settings so that the queue on each monitoring instance is matched to the queue of its error instance.
 
 If using [MSMQ transport](/transports/msmq) and the monitoring instance is installed on a different machine than the ServiceControl error instance, only the monitoring instance setting needs to be modified to include the machine name of the error instance in the queue address.
-If using [MSMQ transport](/transports/msmq) and [ServiceControl is deployed as a cluster](/servicecontrol/deploying-servicecontrol-in-a-cluster.md), this queue needs to be created for each node on the cluster.
 
 | Context | Name |
 | --- | --- |

--- a/servicecontrol/transports.md
+++ b/servicecontrol/transports.md
@@ -165,8 +165,8 @@ Region=<REGION>;QueueNamePrefix=<prefix>;TopicNamePrefix=<prefix>;AccessKeyId=<A
 
 To configure MSMQ as the transport, ensure the MSMQ service has been installed and configured as outlined in [MSMQ configuration](/transports/msmq/#msmq-configuration).
 
-When [ServiceControl instances are installed on a different machine than an endpoint](/transports/msmq/routing.md#when-servicecontrol-is-installed-on-a-different-server) `queuename@machinename` addresses must be used.
-When [ServiceControl is installed on a cluster](/servicecontrol/deploying-servicecontrol-in-a-cluster.md), all queues must be created on all nodes of the cluster.
+> [!NOTE]
+> Any settings that specify a queue name for a queue that is not located on the same machine as the ServiceControl instance must use `queuename@machinename` addresses to refer to that queue.
 
 > [!WARNING]
 > MSMQ transport is not available when running ServiceControl on containers.

--- a/transports/msmq/routing_content_msmqtransport_[1,).partial.md
+++ b/transports/msmq/routing_content_msmqtransport_[1,).partial.md
@@ -51,12 +51,11 @@ snippet: InstanceMappingFile-FilePath
 
 Specifies a URI path of the instance mapping file. Relative paths are assumed to be file paths.
 
-
 snippet: InstanceMappingFile-UriPath
 
-## When ServiceControl is installed on a different server
+## Queues that are not configured with the instance mapping file
 
-The [instance mapping file](#instance-mapping-file) will have no effect on the error, audit, metrics, and plugin queues, so if a ServiceControl instance is installed on a different machine than the endpoint the physical mapping must be specified during configuration using `queuename@machinename` addresses:
+The [instance mapping file](#instance-mapping-file) will have no effect on the error, audit, metrics, or plugin queues. If those queues are located on a different machine, then the physical mapping must be specified during configuration using `queuename@machinename` addresses:
 
 ### Configuring recoverability
 
@@ -80,6 +79,6 @@ snippet: ConfigureCustomChecksRemoteQueue
 
 ## Overriding physical routing
 
-When [overriding the default routing](/nservicebus/messaging/send-a-message.md#overriding-the-default-routing) to a queue on a different server the machine name must also be provided:
+When [overriding the default routing](/nservicebus/messaging/send-a-message.md#overriding-the-default-routing) to a queue on a different server, the machine name must also be provided:
 
 snippet: OverridingPhysicalRouting


### PR DESCRIPTION
This PR improves the documentation on how to set up ServiceControl when using Windows failover cluster and MSMQ