### PR TITLE
fix: asb versioning typo

### DIFF
--- a/Snippets/ASBS/ASBS_5/Usage.cs
+++ b/Snippets/ASBS/ASBS_5/Usage.cs
@@ -90,10 +90,7 @@ class Usage
         #endregion
 
         #region asb-versioning-publisher-mapping
-        topology.PublishTo<OrderAcceptedV2>("Shipping.OrderAccepted");
-        #endregion
-
-        #region asb-versioning-publisher-mapping
+        topology.PublishTo<OrderAccepted>("Shipping.OrderAccepted");
         topology.PublishTo<OrderAcceptedV2>("Shipping.OrderAccepted");
         #endregion
 

--- a/Snippets/ASBS/ASBS_6/Usage.cs
+++ b/Snippets/ASBS/ASBS_6/Usage.cs
@@ -90,10 +90,8 @@ class Usage
         #endregion
 
         #region asb-versioning-publisher-mapping
-        topology.PublishTo<OrderAcceptedV2>("Shipping.OrderAccepted");
-        #endregion
 
-        #region asb-versioning-publisher-mapping
+        topology.PublishTo<OrderAccepted>("Shipping.OrderAccepted");
         topology.PublishTo<OrderAcceptedV2>("Shipping.OrderAccepted");
         #endregion
 


### PR DESCRIPTION
I believe the intention was to publish both message types to the same topicname.

Cleaned up the redundant duplicate region