### PR TITLE
Fix ServiceInsight customer viewer sample

### DIFF
--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/CustomViewerModule.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/CustomViewerModule.cs
@@ -9,7 +9,7 @@ namespace ServiceInsight.CustomViewer.Plugin
         {
             builder.RegisterType<MyCustomDecryptionViewModel>().AsImplementedInterfaces().AsSelf().SingleInstance();
             builder.RegisterType<MyCustomDecryptionView>().AsImplementedInterfaces().AsSelf().SingleInstance();
-            builder.RegisterType<MessageEncryptor>().AsImplementedInterfaces().AsSelf().SingleInstance();
+            builder.RegisterType<MessageEncoder>().As<IMessageEncoder>().SingleInstance();
         }
     }
     #endregion

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/IMessageEncoder.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/IMessageEncoder.cs
@@ -1,0 +1,7 @@
+namespace ServiceInsight.CustomViewer.Plugin;
+
+public interface IMessageEncoder
+{
+    byte[] Encrypt(byte[] plainText);
+    byte[] Decrypt(byte[] cipherText);
+}

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/MessageEncoder.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/MessageEncoder.cs
@@ -1,0 +1,12 @@
+using System.Linq;
+
+namespace ServiceInsight.CustomViewer.Plugin;
+
+class MessageEncoder : IMessageEncoder
+{
+    public byte[] Decrypt(byte[] cipherText)
+        => [.. cipherText.Reverse()];
+
+    public byte[] Encrypt(byte[] plainText)
+        => [.. plainText.Reverse()];
+}

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/MyCustomDecryptionViewModel.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/MyCustomDecryptionViewModel.cs
@@ -5,7 +5,6 @@ namespace ServiceInsight.CustomViewer.Plugin
     using ServiceInsight.MessageViewers;
     using ServiceInsight.Models;
     using ServiceInsight.ServiceControl;
-    using Shared;
 
     public class MyCustomDecryptionViewModel : Screen, ICustomMessageBodyViewer
     {

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/ServiceInsight.Plugin/ServiceInsight.Plugin.csproj
@@ -12,10 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Autofac" Version="6.*" />
     <PackageReference Include="Autofac.Configuration" Version="6.*" />
     <PackageReference Include="AvalonEdit" Version="6.*" />

--- a/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/IMessageEncoder.cs
+++ b/samples/serviceinsight/messageviewer/ServiceInsight_3/Shared/IMessageEncoder.cs
@@ -1,8 +1,0 @@
-namespace Shared
-{
-    public interface IMessageEncoder
-    {
-        byte[] Encrypt(byte[] plainText);
-        byte[] Decrypt(byte[] cipherText);
-    }
-}

--- a/samples/serviceinsight/messageviewer/sample.md
+++ b/samples/serviceinsight/messageviewer/sample.md
@@ -4,7 +4,7 @@ summary: A sample showing how a ServiceInsight plugin can be created and used to
 component: ServiceInsight
 related:
  - samples/encryption/message-body-encryption
-reviewed: 2024-02-28
+reviewed: 2025-12-18
 ---
 
 This sample shows how to create a plugin for ServiceInsight. The plugin is designed to work as a custom message viewer and provides a new tab inside the existing Body tab. The plugin is useful when:
@@ -18,7 +18,7 @@ downloadbutton
 
 Running the project will result in 2 console windows. Wait a moment until the ServicePulse window opens in the browser. In the console output of the Endpoint2, note the ServiceControl connection URL. Finally, perform the following steps:
 
-1. Copy over the output of the plugin project (ServiceInsight.Plugin) to the paths specified in the [documentation](/serviceinsight/custom-message-viewers.md#plugin-installation).
+1. Copy over the output of the plugin project (`ServiceInsight.Plugin.dll` and `ICSharpCode.AvalonEdit.dll`) to the paths specified in the [documentation](/serviceinsight/custom-message-viewers.md#plugin-installation).
 2. Run ServiceInsight and connect to the noted ServiceControl connection URL from above.
 3. On the Messages window, click on a message row.
 4. Click on the Body tab and note that there is a new viewer tab called "Decryption Viewer".
@@ -31,7 +31,7 @@ Running the project will result in 2 console windows. Wait a moment until the Se
 
 The plugin project uses the "WindowsDesktop" SDK. The views are WPF user controls and are based on the MVVM pattern used by ServiceInsight. A naming convention is at play regarding the names of views and the respective view model classes.
 
-All the components, including the views and view models, must be registered in the container by an Autofac module class.
+All the components, including the views, view models, and any dependencies, must be registered in the container by an Autofac module class.
 
 snippet: IoCModule
 


### PR DESCRIPTION
Taking a dependency on `Shared` also takes dependencies on NServiceBus and its dependencies.

The implementation for `IMessageEncoder` was missing. At some point we swapped this for a message mutator and did not update the sample.