### PR TITLE
Review NHibernate Multi-tenant sample

### DIFF
--- a/samples/multi-tenant/nhibernate/sample.md
+++ b/samples/multi-tenant/nhibernate/sample.md
@@ -1,7 +1,7 @@
 ---
 title: NHibernate persistence in multi-tenant systems
 summary: Configure NHibernate persistence to support multi-tenant scenarios.
-reviewed: 2024-03-01
+reviewed: 2025-12-23
 component: NHibernate
 related:
 - persistence/nhibernate
@@ -10,7 +10,7 @@ related:
 
 This sample demonstrates how to configure NHibernate persistence to store tenant-specific data in separate catalogs for each tenant. The tenant-specific information includes saga state and business entities that are accessed using [NServiceBus-managed session](/persistence/nhibernate/accessing-data.md).
 
-This sample uses [Outbox](/nservicebus/outbox/) to guarantee consistency between the saga state and the business entity. Outbox and timeout data are stored in a dedicated catalog shared by all tenants.
+This sample uses [Outbox](/nservicebus/outbox/) to guarantee consistency between the saga state and the business entity. Outbox data is stored in a dedicated catalog shared by all tenants.
 
 The sample assumes the tenant information is passed as a custom message header `tenant_id`.
 
@@ -36,7 +36,7 @@ The default NHibernate persistence installers create all schema objects in a sin
 
 snippet: CreateSchema
 
-The above code ensures that business entity and saga tables are created in the tenant databases while the timeouts and outbox are in the shared database.
+The above code ensures that business entity and saga tables are created in the tenant databases while the outbox table is in the shared database.
 
 Because the outbox table is stored in the shared catalog, the NHibernate persistence cannot access it when using the tenant connection string. Synonyms (a feature of SQL Server) provide a way to solve this problem. The following code creates synonyms for the `OutboxRecord` table in both tenant databases. These synonyms instruct the query processor to use the outbox table in the shared database whenever it encounters a reference to `OutboxRecord`.
 
@@ -52,7 +52,7 @@ snippet: NHibernateConfiguration
 
 To allow database isolation between tenants, the connection to the database needs to be created based on the message being processed. This requires the cooperation of two components:
 
- * A behavior that inspects an incoming message and extracts the tenant's information 
+ * A behavior that inspects an incoming message and extracts the tenant's information
  * A custom `ConnectionProvider` for NHibernate
 
 The custom connection provider has to be registered with NHibernate


### PR DESCRIPTION
Removes references to timeout data. The sample uses the learning transport which does not need separate timeout persistence.