### PR TITLE
Remove references to ServiceInsight from samples

### DIFF
--- a/Snippets/ServiceControlContracts/ServiceControlContracts_5/MessageFailedHandler.cs
+++ b/Snippets/ServiceControlContracts/ServiceControlContracts_5/MessageFailedHandler.cs
@@ -16,7 +16,7 @@
 
             var chatMessage = $@"Message with id: {failedMessageId} failed.
 Reason: '{exceptionMessage}'.
-Open in ServiceInsight: {GetServiceInsightUri(failedMessageId)}";
+Open in ServicePulse: {GetServicePulseUri(failedMessageId)}";
 
             using (var client = new HipchatClient())
             {
@@ -26,9 +26,9 @@ Open in ServiceInsight: {GetServiceInsightUri(failedMessageId)}";
         }
 
         #endregion
-        string GetServiceInsightUri(string failedMessageId)
+        string GetServicePulseUri(string failedMessageId)
         {
-            return $"si://localhost:33333/api?Search={failedMessageId}";
+            return $"http://localhost:9090/#/messages/{failedMessageId}";
         }
     }
 

--- a/samples/encryption/basic-encryption/sample.md
+++ b/samples/encryption/basic-encryption/sample.md
@@ -3,8 +3,7 @@ title: Message property encryption
 summary: Encrypting specific parts of a message using the message property encryption feature.
 reviewed: 2025-08-26
 component: PropertyEncryption
-related:
-- serviceinsight/custom-message-viewers
+
 redirects:
 - nservicebus/encryption-sample
 ---

--- a/samples/encryption/encryption-conventions/sample.md
+++ b/samples/encryption/encryption-conventions/sample.md
@@ -3,8 +3,6 @@ title: Unobtrusive property encryption
 summary: Encrypting specific parts of a message using conventions.
 reviewed: 2025-08-19
 component: PropertyEncryption
-related:
-- serviceinsight/custom-message-viewers
 ---
 
 This sample demonstrates how to use conventions to encrypt and decrypt specific properties of a message as it passes through the pipeline.

--- a/samples/encryption/message-body-encryption/sample.md
+++ b/samples/encryption/message-body-encryption/sample.md
@@ -7,7 +7,6 @@ related:
 - nservicebus/security
 - nservicebus/security/property-encryption
 - nservicebus/pipeline/message-mutators
-- serviceinsight/custom-message-viewers
 ---
 
 

--- a/samples/platform-connector/code-first/sample.md
+++ b/samples/platform-connector/code-first/sample.md
@@ -36,7 +36,7 @@ snippet: configureConnection
 
 The endpoint contains:
 
-- A saga that processes messages triggered by the user, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServiceInsight or ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
+- A saga that processes messages triggered by the user, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
 - A custom check that toggles the state between success and failure every 30 seconds. Check the Custom Checks tab in ServicePulse to see failures reported here.
 - A message handler that waits half a second before returning a response. This simulates real-world message processing in the Monitoring tab of ServicePulse.
 
@@ -48,4 +48,4 @@ Sets up three instances of ServiceControl (Primary, Audit, and Monitoring) and r
 
 Run the sample. Once running, press <kbd>Esc</kbd> to quit or any other key to send messages. Each message will trigger a saga, which will send a request message to a message handler and wait for a response.
 
-Note the ServiceControl API address in the PlatformLauncher window to connect ServiceInsight or ServicePulse to the sample and view message audit and saga audit details.
+Note the ServiceControl API address in the PlatformLauncher window to connect ServicePulse to the sample and view message audit and saga audit details.

--- a/samples/platform-connector/json/sample.md
+++ b/samples/platform-connector/json/sample.md
@@ -38,7 +38,7 @@ Features can be turned on and off, and configured, by adjusting the configuratio
 
 The endpoint contains:
 
-- A saga that processes messages triggered by the user, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServiceInsight or ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
+- A saga that processes messages triggered by the user, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
 - A custom check that toggles the state between success and failure every 30 seconds. Check the Custom Checks tab in ServicePulse to see failures reported here.
 - A message handler that waits half a second before returning a response. This simulates real-world message processing in the Monitoring tab of ServicePulse.
 
@@ -50,4 +50,4 @@ Sets up three instances of ServiceControl (Primary, Audit, and Monitoring) and r
 
 Run the sample. Once running, press <kbd>Esc</kbd> to quit or any other key to send messages. Each message will trigger a saga, which will send a request message to a message handler and wait for a response.
 
-Note the ServiceControl API address in the PlatformLauncher window to connect ServiceInsight or ServicePulse to the sample and view message audit and saga audit details.
+Note the ServiceControl API address in the PlatformLauncher window to connect ServicePulse to the sample and view message audit and saga audit details.

--- a/samples/platform-connector/ms-config/sample.md
+++ b/samples/platform-connector/ms-config/sample.md
@@ -46,7 +46,7 @@ Note that configuration details are stored in a section called `ServicePlatformC
 
 The endpoint contains:
 
-- A saga that processes messages triggered generated 5 times per second, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServiceInsight or ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
+- A saga that processes messages triggered generated 5 times per second, sends a request to a message handler, and waits for a result before marking the saga instance as complete. Connect ServicePulse to the ServiceControl instance created by PlatformLauncher to view saga audit data.
 - A custom check that toggles the state between success and failure every 30 seconds. Check the Custom Checks tab in ServicePulse to see failures reported here.
 - A message handler that waits half a second before returning a response. This simulates real-world message processing in the Monitoring tab of ServicePulse.
 
@@ -58,4 +58,4 @@ Sets up three instances of ServiceControl (Primary, Audit, and Monitoring) and r
 
 Run the sample. Once running, a message is generated once every 200ms. Each message will trigger a saga, which will send a request message to a message handler and wait for a response.
 
-Note the ServiceControl API address in the PlatformLauncher window to connect ServiceInsight or ServicePulse to the sample and view message audit and saga audit details.
+Note the ServiceControl API address in the PlatformLauncher window to connect ServicePulse to the sample and view message audit and saga audit details.

--- a/samples/scheduling/timer/sample.md
+++ b/samples/scheduling/timer/sample.md
@@ -7,6 +7,6 @@ related:
  - nservicebus/scheduling
 ---
 
-This sample illustrates the use of a [.NET Timer](https://docs.microsoft.com/en-us/dotnet/api/system.threading.timer) to trigger scheduled tasks. To leverage the benefits of [NServiceBus retries](/nservicebus/recoverability/) and [consistency of outgoing messages with the transport transaction](/transports/transactions.md), the tasks are implemented as regular message handlers. This also gives full traceability of the invoked tasks in platform tools like [ServicePulse](/servicepulse/) and [ServiceInsight](/serviceinsight/).
+This sample illustrates the use of a [.NET Timer](https://docs.microsoft.com/en-us/dotnet/api/system.threading.timer) to trigger scheduled tasks. To leverage the benefits of [NServiceBus retries](/nservicebus/recoverability/) and [consistency of outgoing messages with the transport transaction](/transports/transactions.md), the tasks are implemented as regular message handlers. This also gives full traceability of the invoked tasks in platform tools like [ServicePulse](/servicepulse/).
 
 snippet: ScheduleUsingTimer


### PR DESCRIPTION
ServiceInsight has been sunset, and its features have been moved to ServicePulse.  This removes references to ServiceInsight from the samples that aren't specifically for ServiceInsight.