### PR TITLE
Update note on message handler transaction scope

### DIFF
--- a/nservicebus/handlers/handler-ordering.md
+++ b/nservicebus/handlers/handler-ordering.md
@@ -16,7 +16,7 @@ In the past, message handlers used to be the only way to implement cross-cutting
 If it is not possible to migrate this kind of functionality out of message handlers, there are a number of ways to specify the order in which they will be executed.
 
 > [!NOTE]
-> All message handlers in the endpoint will execute in the same transaction scope.
+> All message handlers in the endpoint that handle the same message type will execute in the same transaction scope.
 
 ### Overview of the implementation
 


### PR DESCRIPTION
Clarified that all message handlers for the same message type execute in the same transaction scope.