### PR TITLE
Update the SI support policy to clarify how long support is available

### DIFF
--- a/serviceinsight/support-policy.md
+++ b/serviceinsight/support-policy.md
@@ -14,9 +14,9 @@ related:
 ---
 
 > [!WARNING]
-> ServiceInsight has been sunset and will receive no further updates.  
+> ServiceInsight has been sunset and will receive no further improvements or features.  
 >
-> The latest version of ServiceControl is supported until migration instructions to ServicePulse are available.
+> The latest version of ServiceControl is supported (including bug fixes) until migration instructions to ServicePulse are available.
 
 The latest version can be found on the [downloads page](https://particular.net/downloads), however, it is recommended to install the latest version of [ServicePulse](/servicepulse/installation.md) for the latest features and full support.
 


### PR DESCRIPTION
ServiceInsight has been sunset, but it isn't clear what that means for support.  This PR clarifies that until a migration path to ServicePulse is defined and ServiceInsight is moved to a Deprecated status, support will still be offered.