### PR TITLE
Elevate transitive dependencies to avoid vulnerable AWSSDK.Core package version

### DIFF
--- a/Snippets/DynamoDB/DynamoDB_3/DynamoDB_3.csproj
+++ b/Snippets/DynamoDB/DynamoDB_3/DynamoDB_3.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="NServiceBus.Testing" Version="9.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/Snippets/SQSLambda/SQSLambda_3/SQSLambda_3.csproj
+++ b/Snippets/SQSLambda/SQSLambda_3/SQSLambda_3.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/Snippets/Sqs/Sqs_8/Sqs_8.csproj
+++ b/Snippets/Sqs/Sqs_8/Sqs_8.csproj
@@ -5,4 +5,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AmazonSQS" Version="8.*" />
   </ItemGroup>
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
 </Project>

--- a/Snippets/TransactionalSession.DynamoDB/DynamoTS_3/DynamoTS_3.csproj
+++ b/Snippets/TransactionalSession.DynamoDB/DynamoTS_3/DynamoTS_3.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="NServiceBus.Persistence.DynamoDB.TransactionalSession" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/dynamodb-simple/DynamoDB_3/Server/Server.csproj
+++ b/samples/aws/dynamodb-simple/DynamoDB_3/Server/Server.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />
   </ItemGroup>
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
 </Project>

--- a/samples/aws/dynamodb-transactions/DynamoDB_3/Server/Server.csproj
+++ b/samples/aws/dynamodb-transactions/DynamoDB_3/Server/Server.csproj
@@ -12,4 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SharedMessages\SharedMessages.csproj" />
   </ItemGroup>
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
 </Project>

--- a/samples/aws/lambda-sqs-annotations/SQSLambda_3/ServerlessEndpoint/ServerlessEndpoint.csproj
+++ b/samples/aws/lambda-sqs-annotations/SQSLambda_3/ServerlessEndpoint/ServerlessEndpoint.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="NServiceBus.AwsLambda.SQS" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/lambda-sqs/SQSLambda_3/RegularEndpoint/RegularEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_3/RegularEndpoint/RegularEndpoint.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/lambda-sqs/SQSLambda_3/ServerlessEndpoint/ServerlessEndpoint.csproj
+++ b/samples/aws/lambda-sqs/SQSLambda_3/ServerlessEndpoint/ServerlessEndpoint.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/sqs-native-integration/Sqs_8/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-native-integration/Sqs_8/Receiver/Receiver.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="4.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/sqs-simple/Sqs_8/Receiver/Receiver.csproj
+++ b/samples/aws/sqs-simple/Sqs_8/Receiver/Receiver.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>

--- a/samples/aws/sqs-simple/Sqs_8/Sender/Sender.csproj
+++ b/samples/aws/sqs-simple/Sqs_8/Sender/Sender.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="NServiceBus.AmazonSQS" Version="8.*" />
   </ItemGroup>
 
+  <ItemGroup Label="Elevated transitive dependencies">
+    <PackageReference Include="AWSSDK.Core" Version="4.0.3.8" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
When new patch releases are out, this commit can be reverted.