### PR TITLE
Update supported versions table format

### DIFF
--- a/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
+++ b/servicecontrol/upgrades/supported-versions-servicecontrol.include.md
@@ -1,16 +1,15 @@
 ### ServiceControl
 
-| Version   | Status         | Released     | [Mainstream Until](support-policy.md) | [Extended Until](support-policy.md#extended-support) |
-|:---------:|:--------------:|:------------:|:-------------------------------------:|:----------------------------------------------------:|
-| [6.14.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.14.1)| **Current** | 2026-04-01     | Active            | Active                            |
-| [~~6.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.13.1)| ~~Unsupported~~ | ~~2026-03-04~~ | ~~2026-04-01~~    | ~~2028-04-01~~                    |
-| [~~6.12.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.12.0)| ~~Unsupported~~ | ~~2026-02-17~~ | ~~2026-03-04~~    | ~~2028-03-04~~                    |
-| [~~6.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.11.0)| ~~Unsupported~~ | ~~2026-02-09~~ | ~~2026-02-17~~    | ~~2028-02-17~~                    |
-| [~~6.10.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.10.1)| ~~Unsupported~~ | ~~2026-02-04~~ | ~~2026-02-09~~    | ~~2028-02-09~~                    |
-| [~~6.9.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.9.1)| ~~Unsupported~~ | ~~2026-01-14~~ | ~~2026-02-04~~    | ~~2028-02-04~~                    |
-| [~~6.8.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.8.1)| ~~Unsupported~~ | ~~2025-12-05~~ | ~~2026-01-14~~    | ~~2028-01-14~~                    |
-| [~~6.7.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.7.7)| ~~Unsupported~~ | ~~2025-07-03~~ | ~~2025-12-05~~    | ~~2027-12-05~~                    |
-| [~~6.6.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.6.4)| ~~Unsupported~~ | ~~2025-04-16~~ | ~~2025-07-03~~    | ~~2027-07-03~~                    |
-| [~~6.5.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.5.3)| ~~Unsupported~~ | ~~2025-03-17~~ | ~~2025-04-16~~    | ~~2027-04-16~~                    |
-| [~~5.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/5.11.11)| ~~Unsupported~~ | ~~2024-10-04~~ | ~~2025-10-17~~    | ~~2027-10-17~~                    |
-
+| Version   | Status         | Released     | [Mainstream Until](support-policy.md) |
+|:---------:|:--------------:|:------------:|:-------------------------------------:|
+| [6.14.x](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.14.1)| **Current** | 2026-04-01     | Active            |
+| [~~6.13.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.13.1)| ~~Unsupported~~ | ~~2026-03-04~~ | ~~2026-04-01~~    |
+| [~~6.12.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.12.0)| ~~Unsupported~~ | ~~2026-02-17~~ | ~~2026-03-04~~    |
+| [~~6.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.11.0)| ~~Unsupported~~ | ~~2026-02-09~~ | ~~2026-02-17~~    | 
+| [~~6.10.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.10.1)| ~~Unsupported~~ | ~~2026-02-04~~ | ~~2026-02-09~~    |
+| [~~6.9.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.9.1)| ~~Unsupported~~ | ~~2026-01-14~~ | ~~2026-02-04~~    |
+| [~~6.8.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.8.1)| ~~Unsupported~~ | ~~2025-12-05~~ | ~~2026-01-14~~    |
+| [~~6.7.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.7.7)| ~~Unsupported~~ | ~~2025-07-03~~ | ~~2025-12-05~~    |
+| [~~6.6.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.6.4)| ~~Unsupported~~ | ~~2025-04-16~~ | ~~2025-07-03~~    |
+| [~~6.5.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/6.5.3)| ~~Unsupported~~ | ~~2025-03-17~~ | ~~2025-04-16~~    |
+| [~~5.11.x~~](https://www.nuget.org/packages/Particular.PlatformSample.ServiceControl/5.11.11)| ~~Unsupported~~ | ~~2024-10-04~~ | ~~2025-10-17~~    |


### PR DESCRIPTION
Removed the 'Extended Until' column from the supported versions table for ServiceControl