### PR TITLE
Link IBM MQ circuit breaker to critical errors guidance

### DIFF
--- a/transports/ibmmq/connection-settings.md
+++ b/transports/ibmmq/connection-settings.md
@@ -98,7 +98,7 @@ snippet: ibmmq-resource-sanitization
 
 ## Circuit breaker
 
-If the transport cannot communicate with the queue manager for a sustained period, it triggers a critical error. The default timeout is 2 minutes:
+If the transport cannot communicate with the queue manager for a sustained period, it triggers a [critical error](/nservicebus/hosting/critical-errors.md). The default timeout is 2 minutes:
 
 snippet: ibmmq-circuit-breaker
 


### PR DESCRIPTION
## Summary
- The IBM MQ transport's circuit breaker section mentions that a critical error is triggered, but gives readers no way to learn what that means.
- Link the phrase "critical error" to `/nservicebus/hosting/critical-errors.md` so readers can discover the default action (endpoint shutdown) and how to customize it.

## Test plan
- [x] `docstool test` passes locally — `Validation successful` (internal link resolution validated, confirming the new link resolves)
- [x] Target file exists at `nservicebus/hosting/critical-errors.md`