### PR TITLE
Weekly legacy docs review

### DIFF
--- a/servicecontrol/db-compaction.md
+++ b/servicecontrol/db-compaction.md
@@ -1,9 +1,10 @@
 ---
 title: Compacting RavenDB instances
-summary: How to compact the RavenDB database backing ServiceControl for RavenDB 3.5 instances
-reviewed: 2024-07-19
+summary: How to compact the RavenDB database backing ServiceControl for RavenDB 5 and RavenDB 3.5 instances
+reviewed: 2026-04-20
+component: ServiceControl
 redirects:
-  - servciecontrol/db-compaction-v5
+  - servicecontrol/db-compaction-v5
 ---
 
 If a ServiceControl instance's retention period, message throughput, or average message size have been reduced, it may be possible to compact the database. If none of these have changed, compacting may not provide a significant reduction in database size, or it may have only a small, temporary effect.
@@ -12,13 +13,13 @@ If a ServiceControl instance's retention period, message throughput, or average 
 
 The following applies to all databases used with ServiceControl version 5 and above, as well as audit instances that were originally created with ServiceControl 4.26.0 or later.
 
-ServiceControl's RavenDB 5 database can be compacted by [accessing the database](/servicecontrol/ravendb/accessing-database.md), then following the [RavenDB process for compacting a database](https://ravendb.net/docs/article-page/5.4/csharp/studio/database/stats/storage-report).
+ServiceControl's RavenDB 5 database can be compacted by [accessing the database](/servicecontrol/ravendb/accessing-database.md), then following the [RavenDB process for compacting a database](https://docs.ravendb.net/5.4/studio/database/stats/storage-report).
 
 ## RavenDB 3.5 databases
 
 The following applies to ServiceControl Error and Audit instances using RavenDB 3.5 as the storage option.
 
-ServiceControl's embedded RavenDB 3.5 database can be compacted in one of two ways: with the  [Extensible Storage Engine Utility (esentutl)](https://technet.microsoft.com/en-us/library/hh875546.aspx), or by using the RavenDB management portal.
+ServiceControl's embedded RavenDB 3.5 database can be compacted in one of two ways: with the  [Extensible Storage Engine Utility (esentutl)](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh875546(v=ws.11)), or by using the RavenDB management portal.
 
 ### Using EsentUtl (Preferred approach)
 

--- a/servicecontrol/migrations/replacing-error-instances/containers.md
+++ b/servicecontrol/migrations/replacing-error-instances/containers.md
@@ -1,7 +1,7 @@
 ---
 title: Replacing an Error instance using Containers
 summary: Instructions on how to replace a ServiceControl Error instance with zero downtime
-reviewed: 2024-07-10
+reviewed: 2026-04-20
 component: ServiceControl
 related:
   - servicecontrol/migrations/replacing-error-instances/scmu
@@ -26,7 +26,7 @@ This article describes how to replace an Error instance with zero downtime when 
 >
 > This guide assumes this is true, and that the user knows how to create routable URLs to allow the communication, even if one instance is hosted on a virtual machine and another instance is running on containerized infrastructure.
 >
-> Additionally, If the old Error instance is not deployed on containers, refer to the instructions for [ServiceControl Management](scmu.md#disable-error-message-ingestion) or [PowerShell](powershell.md#disable-error-message-ingestion).
+> Additionally, if the old Error instance is not deployed on containers, refer to the instructions for [ServiceControl Management](scmu.md#disable-error-message-ingestion) or [PowerShell](powershell.md#disable-error-message-ingestion).
 
 Modify the old Error instance container by specifying the [`INGESTERRORMESSAGES` environment variable](/servicecontrol/servicecontrol-instances/configuration.md#recoverability-servicecontrolingesterrormessages) with a value of `false`.
 
@@ -35,6 +35,6 @@ Modify the old Error instance container by specifying the [`INGESTERRORMESSAGES`
 
 [Deploy a new Error instance container](/servicecontrol/servicecontrol-instances/deployment/containers.md) with its own [database container](/servicecontrol/ravendb/containers.md). The [`REMOTEINSTANCES` environment variable](/servicecontrol/servicecontrol-instances/configuration.md#host-settings-servicecontrolremoteinstances) should match the configuration of the old Error instance so that it can communicate to the same Audit instance(s).
 
-Now, the old and new Error instance's are both available, but the old Error instance is not ingesting messages.
+Now, the old and new Error instances are both available, but the old Error instance is not ingesting messages.
 
 When confident of a successful upgrade, the old Error instance can be removed. If the old Error instance is not deployed in a container, refer to the instructions for removing the old instance in the [ServiceControl Management](scmu.md#replace-the-error-instance-create-a-new-error-instance) or [PowerShell](powershell.md#replace-the-error-instance-create-a-new-error-instance) guides.

--- a/servicecontrol/migrations/windows-to-containers.md
+++ b/servicecontrol/migrations/windows-to-containers.md
@@ -1,10 +1,13 @@
 ---
 title: Migrate ServiceControl to container deployment
 summary: Instructions on how to migrate ServiceControl instances from Windows to container-based hosting.
-reviewed: 2024-07-15
+reviewed: 2026-04-20
 isUpgradeGuide: true
 component: ServiceControl
 related:
+  - servicecontrol/migrations/replacing-error-instances
+  - servicecontrol/migrations/replacing-audit-instances
+  - servicecontrol/monitoring-instances/deployment/containers
 ---
 
 ServiceControl 5.3.0 adds the ability to host ServiceControl instances in Linux containers. This article describes how to migrate from ServiceControl hosted on Windows hosting to new ServiceControl instances hosted in containerized infrastructure.

--- a/servicecontrol/ravendb/accessing-database.md
+++ b/servicecontrol/ravendb/accessing-database.md
@@ -1,7 +1,8 @@
 ---
 title: Accessing the ServiceControl database
 summary: How to get direct access to the database used by ServiceControl Error and Audit instances
-reviewed: 2024-07-11
+reviewed: 2026-04-20
+component: ServiceControl
 redirects:
   - servicecontrol/maintenance-mode
   - servicecontrol/audit-instances/maintenance-mode


### PR DESCRIPTION
Fixes minor typos and updates external links on:
- `servicecontrol/migrations/replacing-error-instances/containers`
- `servicecontrol/ravendb/accessing-database`
- `servicecontrol/migrations/windows-to-containers`
- `servicecontrol/db-compaction`