### PR TITLE
[DO NOT MERGE] Document UseNonPersistentDeliveryMode for IBM MQ transport

### DIFF
--- a/Snippets/IBMMQ/IBMMQ_1/NonPersistentDeliveryMode.cs
+++ b/Snippets/IBMMQ/IBMMQ_1/NonPersistentDeliveryMode.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using NServiceBus;
+
+class NonPersistentDeliveryMode
+{
+    public async Task RequestNonPersistent(IMessageHandlerContext context)
+    {
+        #region ibmmq-non-persistent-delivery-mode
+        var options = new SendOptions();
+
+        options.UseNonPersistentDeliveryMode();
+
+        await context.Send(new MyMessage(), options);
+        #endregion
+    }
+
+    class MyMessage { }
+}

--- a/transports/ibmmq/index.md
+++ b/transports/ibmmq/index.md
@@ -54,3 +54,5 @@ By default, all messages are sent as persistent, meaning they survive queue mana
 
 > [!CAUTION]
 > Non-persistent messages are lost if the queue manager restarts before they are consumed.
+
+partial: nonpersistent

--- a/transports/ibmmq/index_nonpersistent_ibmmq_[1.1,).partial.md
+++ b/transports/ibmmq/index_nonpersistent_ibmmq_[1.1,).partial.md
@@ -1,0 +1,5 @@
+To request `non-persistent` delivery, use the following `{Send|Publish|Reply}Options` as shown below.
+
+snippet: ibmmq-non-persistent-delivery-mode
+
+See the [non-durable messaging documentation](/nservicebus/messaging/non-durable-messaging.md) for more details.


### PR DESCRIPTION
This should not be merged until IBMMQ 1.1 is released and more specifically the following PR:

- https://github.com/Particular/NServiceBus.Transport.IBMMQ/pull/80

When we built IBM MQ transport we were under the assumption the [Express] attribute still existed and unware all of that was removed. We had already added support for the NServiceBus header though, that should enable non-durable messages. We then created PR #80 in IBM MQ repo that adds configuration options to send non-durable messages, but decided not to do yet another release with that PR, since we were already wrapping up the task force and had already done a 1.0.1 release.

This is the PR that adds documentation for when that ability is released in IBM MQ 1.1.