### PR TITLE
Change version check back to excluding 11+

### DIFF
--- a/nservicebus/serialization/xml.md
+++ b/nservicebus/serialization/xml.md
@@ -64,6 +64,6 @@ The XML serializer in NServiceBus is a custom implementation. As such it does no
 * [ArrayList](https://msdn.microsoft.com/en-us/library/system.collections.arraylist.aspx)
 * [HashTable](https://msdn.microsoft.com/en-us/library/system.collections.hashtable.aspx)
 #if-version [,11)
-* [DateOnly](https://learn.microsoft.com/en-us/dotnet/api/system.dateonly) _(Supported from 10.2)_
-* [TimeOnly](https://learn.microsoft.com/en-us/dotnet/api/system.timeonly) _(Supported from 10.2)_
+* [DateOnly](https://learn.microsoft.com/en-us/dotnet/api/system.dateonly) _(Supported starting in version 10.2)_
+* [TimeOnly](https://learn.microsoft.com/en-us/dotnet/api/system.timeonly) _(Supported starting in version 10.2)_
 #end-if

--- a/nservicebus/serialization/xml.md
+++ b/nservicebus/serialization/xml.md
@@ -63,7 +63,7 @@ The XML serializer in NServiceBus is a custom implementation. As such it does no
 * Types with non-default constructors. Types must have a public constructor with no parameters.
 * [ArrayList](https://msdn.microsoft.com/en-us/library/system.collections.arraylist.aspx)
 * [HashTable](https://msdn.microsoft.com/en-us/library/system.collections.hashtable.aspx)
-#if-version [10,)
+#if-version [,11)
 * [DateOnly](https://learn.microsoft.com/en-us/dotnet/api/system.dateonly) _(Supported from 10.2)_
 * [TimeOnly](https://learn.microsoft.com/en-us/dotnet/api/system.timeonly) _(Supported from 10.2)_
 #end-if


### PR DESCRIPTION
This flips the display of these unsupported types to 

* appear in the unsupported list in versions `< 10` 
* show a note saying they are supported from version 10.2
* remove them from the list from version 11 (as all versions of v11 will support them)