### PR TITLE
Document header anchor behavior

### DIFF
--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -191,6 +191,14 @@ Ensure:
 
 ---
 
+# Anchor Stability
+
+The docs engine generates anchors from a heading stack. A new H2 resets the stack; sub-headings append to it. `## Heading 1` followed by `### Heading 1.1` produces `#heading-1-heading-1-1`. Reparenting a heading under a new H2 changes its slug and breaks external links.
+
+When restructuring pages, keep headings at their original level or verify cross-page links. Prefer versioned partials over wrapping legacy sections under new H2s.
+
+---
+
 # Common Issues
 
 ## Spelling

--- a/README.md
+++ b/README.md
@@ -955,6 +955,28 @@ Which means elsewhere in the page you can link to it with this:
 [Goto My Heading](#My-Heading)
 ```
 
+#### Anchor hierarchy
+
+The docs tool generates anchors by maintaining a stack of headings. When a new top-level heading (`##`) is encountered, the stack resets; when a sub-heading (`###`, `####`, etc.) is encountered, it is appended to the current stack.
+
+For example:
+
+```markdown
+## Heading 1
+### Heading 1.1
+## Heading 2
+```
+
+produces these anchors:
+
+| Heading | Generated anchor |
+|---------|-----------------|
+| Heading 1 | `#heading-1` |
+| Heading 1.1 | `#heading-1-heading-1-1` |
+| Heading 2 | `#heading-2` |
+
+This means **reparenting a heading under a new `##` changes its anchor slug**, which will break existing external links. If you need to keep a stable anchor for backward compatibility, keep the heading at its original level in the hierarchy.
+
 ### Images
 
 Images can be added using the following markdown syntax


### PR DESCRIPTION
This pull request adds documentation to clarify how anchor generation works in the docs engine, with a focus on anchor stability and hierarchy. These updates help contributors understand how heading structure affects anchor slugs and external links, reducing the risk of breaking links when reorganizing documentation.

Documentation improvements:

* Added a new "Anchor Stability" section to `.github/skills/particular-docs-review/SKILL.MD`, explaining how anchors are generated from heading stacks, and highlighting the risks of reparenting headings under new H2s.
* Expanded the `README.md` with an "Anchor hierarchy" section, including examples and a table to illustrate how headings map to generated anchors, and warning about the impact of heading level changes on anchor stability.