### PR TITLE
Improve logging section with a nudge towards the Microsoft.Extension.Logging

### DIFF
--- a/Snippets/Core/Core_10/Core_10.csproj
+++ b/Snippets/Core/Core_10/Core_10.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus" Version="10.2.0-alpha.4" />
     <PackageReference Include="NServiceBus.Callbacks" Version="6.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="6.*" />

--- a/Snippets/Core/Core_10/Logging/ModernLogging.cs
+++ b/Snippets/Core/Core_10/Logging/ModernLogging.cs
@@ -1,0 +1,51 @@
+namespace Core.Logging;
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
+
+public class MyMessage : IMessage { }
+
+#region InjectingILoggerInterface
+
+public class MyHandler(ILogger<MyHandler> logger) : IHandleMessages<MyMessage>
+{
+    public Task Handle(MyMessage message, IMessageHandlerContext context)
+    {
+        logger.LogInformation("Handling message");
+        return Task.CompletedTask;
+    }
+}
+
+#endregion
+
+partial class HighPerformanceLogging
+{
+    #region UsingLoggerMessageSourceGenerator
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Information,
+        Message = "Processing message {MessageId}")]
+    static partial void LogProcessingMessage(ILogger logger, string messageId);
+    #endregion
+}
+
+class Startup
+{
+    #region ConfiguringRollingFileLogger
+    void ConfigureHost()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.Services.Configure<RollingLoggerProviderOptions>(options =>
+        {
+            options.Directory = @"C:\logs";
+            options.LogLevel = LogLevel.Debug;
+            options.NumberOfArchiveFilesToKeep = 10;
+            options.MaxFileSizeInBytes = 10L * 1024 * 1024;
+        });
+    }
+    #endregion
+}

--- a/nservicebus/logging/index.md
+++ b/nservicebus/logging/index.md
@@ -1,7 +1,7 @@
 ---
 title: Logging
 summary: NServiceBus logging
-reviewed: 2026-02-19
+reviewed: 2026-04-27
 component: Core
 isLearningPath: true
 redirects:
@@ -12,13 +12,11 @@ related:
 - samples/logging
 ---
 
-> [!NOTE]
-> It is recommended to directly use the [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) to log entries as it also supports semantic logging. Please see [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/) for further details.
+partial: modern
 
-## Default Logging
+## Default logging
 
-NServiceBus has a built-in logging mechanism that does not depend on any external libraries. While limited in terms of available log targets, this built-in mechanism is production-ready and offers defaults that are reasonable for most deployments. The built-in framework is available and used as default in all NServiceBus hosting modes (e.g. self-hosting or Windows Service). Regardless of whether the built-in logging or a custom logging library is used under the hood, the NServiceBus logging abstractions can be used for [logging in the user code](#writing-a-log-entry). By default NServiceBus has three log targets configured:
-
+NServiceBus has a built-in logging mechanism that does not depend on any external libraries. While limited in terms of available log targets, this built-in mechanism is production-ready and offers defaults that are reasonable for most deployments. The built-in framework is available and used as default in all NServiceBus hosting modes. Regardless of whether the built-in logging or a custom logging library is used under the hood, the NServiceBus logging abstractions can be used for writing log messages in user code. By default NServiceBus has three log targets configured:
 
 ### Console
 
@@ -26,11 +24,9 @@ All `Info` (and above) messages are written to the current console if one is ava
 
 Errors will be written with `ConsoleColor.Red`. Warnings will be written with `ConsoleColor.DarkYellow`. All other messages will be written with `ConsoleColor.White`.
 
-
 ### Trace
 
 All `Warn` (and above) messages are written to `Trace.WriteLine` and therefore can be forwarded to any [trace listener](https://docs.microsoft.com/en-us/dotnet/framework/debug-trace-profile/trace-listeners).
-
 
 ### Rolling file
 
@@ -40,13 +36,11 @@ The default logging directory is `HttpContext.Current.Server.MapPath("~/App_Data
 
 The default file name is `nsb_log_yyyy-MM-dd_N.txt`, where `N` is a sequence number for when the log file reaches the max size.
 
-
 ### Changing the defaults
 
 The built-in logging mechanism allows customizing the logging directory and applying a global filter/threshold for log entries.
 
-
-#### Changing the Logging Level
+#### Changing the logging level
 
 Each log entry is associated with a _level_ that describes how important and critical that entry is. The built-in levels are following (in order of increasing importance)
 
@@ -62,18 +56,13 @@ The `LogManager` class is the entry point for the logging configuration. If need
 
 partial: level
 
-
 #### Changing the log path
 
 snippet: OverrideLoggingDirectoryInCode
 
-
-## Custom Logging
+## Custom logging
 
 partial: custom
-
-> [!NOTE]
-> Moving to custom logging means the [default logging](#default-logging) approaches are replaced.
 
 ## When to configure logging
 
@@ -83,9 +72,6 @@ For example:
 
  * At the start of the `Main` method in console applications or Windows services
  * During application startup configuration in ASP.NET Core applications
-
-
-partial: exception-data
 
 ## Writing a log entry
 
@@ -97,9 +83,11 @@ snippet: UsingLogging
 
 Make sure that logging is correctly initialized before resolving the `ILog` instance. Not doing so can result in a logger using an incorrect configuration.
 
-Since `LogManager.GetLogger(..);` is a relatively expensive call, it is important that the field is `static` so that the call happens only once per class and has the best possible performance. In addition, wrapping logging messages in conditional statements prevents unnecessary processing when a given level of logging is not needed. For example, when writing debug messsages, ensure `log.IsDebugEnabled` before proceeding. 
+Since `LogManager.GetLogger(..);` is a relatively expensive call, it is important that the field is `static` so that the call happens only once per class and has the best possible performance. In addition, wrapping logging messages in conditional statements prevents unnecessary processing when a given level of logging is not needed. For example, when writing debug messsages, ensure `log.IsDebugEnabled` before proceeding.
 
 The `*Format` APIs pass the message template and its arguments to the underlying logging framework, so their behavior can vary depending on the framework being used. Some frameworks, such as NLog, support special formatting syntax that allows structured log entries to be created. Refer to the documentation for the specific logging framework for details. When using the built-in logger, the message is formatted using `string.Format` before it is written.
+
+partial: exception-data
 
 ## Logging message contents
 

--- a/nservicebus/logging/index_level_core_[7,).partial.md
+++ b/nservicebus/logging/index_level_core_[7,).partial.md
@@ -1,4 +1,5 @@
-include: configurationWarning
+Configuring the global threshold to one of the levels described above means that all messages below that level are discarded. For example setting the threshold value to `Warn` means that only `Warn`, `Error` and `Fatal` messages are written.
+
+The `LogManager` class is the entry point for the logging configuration. If needed, it allows using custom logging integrations (see below). It also allows customization of the default built-in logging. The `Use` generic method returns the `LoggingFactoryDefinition`-derived object that provides the customization APIs.
 
 snippet: OverrideLoggingLevelInCode
-

--- a/nservicebus/logging/index_modern_core_[10,).partial.md
+++ b/nservicebus/logging/index_modern_core_[10,).partial.md
@@ -1,0 +1,39 @@
+NServiceBus endpoints integrate with the standard .NET logging infrastructure. [Microsoft.Extensions.Logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/) provides rich filtering, structured logging, and [works seamlessly with ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/), the Generic Host, and many third-party providers.
+
+
+## Using `ILogger<T>` in handlers
+
+The recommended way to write log entries inside message handlers is to inject `ILogger<T>` through the constructor:
+
+snippet: InjectingILoggerInterface
+
+`ILogger<T>` is automatically wired into the dependency injection container when hosting with the .NET Generic Host.
+
+## Configuring the default rolling file logger
+
+When no external logging providers are registered, NServiceBus supplies backward-compatible defaults: a colored console provider and a rolling file provider. Consider registering standard [Microsoft logging providers](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/providers) such as Console, Debug, or EventLog for new applications.
+
+If continuing with the built-in NServiceBus providers, configure the rolling file logger through `RollingLoggerProviderOptions`:
+
+snippet: ConfiguringRollingFileLogger
+
+When external logging providers are added to the host, the built-in providers automatically disable themselves so the external configuration takes over without any manual opt-out.
+
+## Using custom logging providers
+
+Register custom logging frameworks directly with the `Microsoft.Extensions.Logging` infrastructure on the host:
+
+```csharp
+var builder = Host.CreateApplicationBuilder();
+
+builder.Logging.AddSerilog();
+```
+
+## High-performance logging
+
+For scenarios that require minimal allocations, use the [`LoggerMessage`](https://learn.microsoft.com/en-us/dotnet/core/extensions/loggermessage-generator) source generator:
+
+snippet: UsingLoggerMessageSourceGenerator
+
+> [!WARNING]
+> The NServiceBus-specific logging APIs described in the next section below are still functional but produce obsolete warnings starting in version 10.2 and will be removed in version 12. Use the `Microsoft.Extensions.Logging` patterns shown earlier for new development.

--- a/persistence/upgrades/nhibernate-10to11.md
+++ b/persistence/upgrades/nhibernate-10to11.md
@@ -14,6 +14,6 @@ upgradeGuideCoreVersions:
 
 ## Saga mapping loading with disabled assembly scanning
 
-When [assembly scanning is disabled](/nservicebus/hosting/assembly-scanning.md#disable-assembly-scanning), saga mapping discovery has been tightened. Previously, all assemblies discovered via GetAvailableTypes() were registered with NHibernate, allowing saga mappings to be picked up from any scanned assembly, even if it did not contain saga entities. Now, saga entity types are resolved first from the registered saga metadata, and only assemblies that actually contain those saga entities are treated as the authoritative source of mappings.
+When [assembly scanning is disabled](/nservicebus/hosting/assembly-scanning.md?version=core_10#disable-assembly-scanning), saga mapping discovery has been tightened. Previously, all assemblies discovered via GetAvailableTypes() were registered with NHibernate, allowing saga mappings to be picked up from any scanned assembly, even if it did not contain saga entities. Now, saga entity types are resolved first from the registered saga metadata, and only assemblies that actually contain those saga entities are treated as the authoritative source of mappings.
 
 As a result, NHibernate no longer pulls in unrelated mappings from arbitrary scanned assemblies. If you rely on saga-related mappings that live in assemblies which do not directly contain saga entities, those mappings must now be manually registered with NHibernate to ensure they are included.


### PR DESCRIPTION
This pull request updates the NServiceBus logging documentation and adds new code samples to reflect modern .NET logging practices. The changes clarify the recommended use of `Microsoft.Extensions.Logging`, provide guidance on using `ILogger<T>` in message handlers, and explain how to configure logging providers in .NET Core 10 and above. The documentation is reorganized for clarity, with legacy and modern approaches more clearly separated.

**Documentation and Guidance Updates:**

* Updated the logging documentation in `nservicebus/logging/index.md` to recommend direct use of `Microsoft.Extensions.Logging`, clarify default and custom logging options, and improve organization and readability. [[1]](diffhunk://#diff-0cb57b931abb10f949b7669dfce028000a0aa7adcaa8cbff20dc21bceb326823L15-L34) [[2]](diffhunk://#diff-0cb57b931abb10f949b7669dfce028000a0aa7adcaa8cbff20dc21bceb326823L43-R43) [[3]](diffhunk://#diff-0cb57b931abb10f949b7669dfce028000a0aa7adcaa8cbff20dc21bceb326823L65-L77) [[4]](diffhunk://#diff-0cb57b931abb10f949b7669dfce028000a0aa7adcaa8cbff20dc21bceb326823L87-L89) [[5]](diffhunk://#diff-0cb57b931abb10f949b7669dfce028000a0aa7adcaa8cbff20dc21bceb326823R90-R91)
* Added a new partial, `index_modern_core_[10,).partial.md`, providing guidance for NServiceBus Core 10+ on integrating with the .NET logging infrastructure, injecting `ILogger<T>`, configuring rolling file logging, and using high-performance logging patterns. ([nservicebus/logging/index_modern_core_[10,).partial.mdR1-R39](diffhunk://#diff-301970be133a17bfd78bdc0d521b7ce2c0c36a90e15c73e42091a9ec04795c13R1-R39))
* Improved the explanation of configuring logging levels in `index_level_core_[7,).partial.md` to clarify how to set thresholds and customize logging with `LogManager`. ([nservicebus/logging/index_level_core_[7,).partial.mdL1-R5](diffhunk://#diff-cf3b228f1f42b2f0af96a04b992231c6439adc6d92879ec9adfccb02061b803eL1-R5))

**Code Samples:**

* Added `ModernLogging.cs` with examples of injecting `ILogger<T>` into handlers, configuring the rolling file logger, and using the `LoggerMessage` source generator for high-performance logging.

**Dependency Updates:**

* Updated the `NServiceBus` package reference in `Core_10.csproj` to version `10.2.0-alpha.4` for compatibility with the latest logging features.