### PR TITLE
Preinstall docstool for Copilot agent sessions

### DIFF
--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -301,6 +301,8 @@ Rules:
 
 Run the docs tool before submitting changes.
 
+In Copilot cloud agent sessions for this repository, `docstool` is preinstalled by `.github/workflows/copilot-setup-steps.yml`.
+
 Install:
 
 ```bash
@@ -316,7 +318,7 @@ dotnet tool update -g Particular.DocsTool --add-source https://f.feedz.io/partic
 Run:
 
 ```bash
-docstool test
+docstool test --no-version-check
 ```
 
 If you encounter stale files:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,49 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    name: Copilot setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_ROLL_FORWARD: Major
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          global-json-file: global.json
+
+      # Caching is done to limit data transfer for Copilot sessions.
+      - name: Check docstool version for cache
+        run: |
+          curl --connect-timeout 5 --max-time 15 --silent --show-error https://s3.amazonaws.com/particular.downloads/Particular.DocsTool/version.json >> docstool-version.json
+
+      - name: Cache docstool
+        id: cache-docstool
+        uses: actions/cache@v5.0.4
+        with:
+          path: |
+            ~/.dotnet/tools/docstool
+            ~/.dotnet/tools/.store/particular.docstool
+          key: docstool-${{ hashFiles('docstool-version.json') }}
+
+      - name: Install docstool
+        if: steps.cache-docstool.outputs.cache-hit != 'true'
+        run: dotnet tool install Particular.DocsTool --global --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
+
+      - name: Verify docstool is available
+        run: docstool --version


### PR DESCRIPTION
Add a copilot setup workflow that provisions and caches Particular.DocsTool so cloud agent sessions can run docs validation deterministically. Update the docs-review skill to reflect preinstallation and use the same no-version-check invocation as CI.