### PR TITLE
Add persistence options for saga state storage

### DIFF
--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -28,11 +28,12 @@ The general recommendation is to use the native services for each cloud provider
 
 [For components hosted in AWS](/architecture/aws/messaging.md), [Amazon SQS](/transports/sqs/) is the recommended option. It is fully managed, scales automatically, and integrates with other AWS services. NServiceBus uses Amazon SNS alongside SQS to support the publish/subscribe pattern. When messages exceed the SQS size limit (256 KB for events, 1 MiB for commands), the transport can offload payloads to Amazon S3.
 
-#### Persistence options
+### Persistence options
+
 Depending on the scenario, different persistence options can be used for storing saga state and outbox records:
+
 - [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
 - [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
-
 
 ### Cloud-agnostic environments
 

--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -35,7 +35,7 @@ Depending on the scenario, different persistence options can be used for storing
 - [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
 - [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
 - [SQL-based](/persistence/sql)
-- [Other storage technologies](https://docs.particular.net/persistence/#supported-persisters)
+- [Other storage technologies](/persistence/#supported-persisters)
  
 ### Cloud-agnostic environments
 

--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -51,15 +51,15 @@ In the following example, endpoints running on AWS (using Amazon SQS) communicat
 
 ```mermaid
 flowchart LR
-Br(Bridge)
-OrderService[Order Service] <---> Br
-Br <---> BillingService[Billing Service]
-subgraph AWS
-  OrderService
-end
-subgraph Azure
-  BillingService
-end
+ Br(Bridge)
+ OrderService[Order Service] <---> Br
+ Br <---> BillingService[Billing Service]
+ subgraph AWS
+   OrderService
+ end
+ subgraph Azure
+   BillingService
+ end
 ```
 
 Because the bridge handles message routing, endpoints on both sides require [no changes](/samples/bridge/simple/) to communicate across clouds.
@@ -72,19 +72,19 @@ The simplest topology connects two cloud environments with a single bridge insta
 
 ```mermaid
 flowchart LR
-Br(Bridge)
-A[Endpoint A] <---> Br
-B[Endpoint B] <---> Br
-Br <---> C[Endpoint C]
-Br <---> D[Endpoint D]
-subgraph AWS
-  A
-  B
-end
-subgraph Azure
-  C
-  D
-end
+ Br(Bridge)
+ A[Endpoint A] <---> Br
+ B[Endpoint B] <---> Br
+ Br <---> C[Endpoint C]
+ Br <---> D[Endpoint D]
+ subgraph AWS
+   A
+   B
+ end
+ subgraph Azure
+   C
+   D
+ end
 ```
 
 ### Multiple clouds
@@ -93,23 +93,23 @@ When endpoints span three or more cloud environments, multiple bridges can be ch
 
 ```mermaid
 flowchart LR
-Br1(Bridge 1)
-Br2(Bridge 2)
-A[Endpoint A] <---> Br1
-Br1 <---> B[Endpoint B]
-B <---> Br2
-Br2 <---> C[Endpoint C]
-subgraph AWS
-  A
-  Br1
-end
-subgraph Azure Business Unit 1
-  B
-  Br2
-end
-subgraph Azure Business Unit 2
-  C
-end
+    Br1(Bridge 1)
+    Br2(Bridge 2)
+    A[Endpoint A] <---> Br1
+    Br1 <---> B[Endpoint B]
+    B <---> Br2
+    Br2 <---> C[Endpoint C]
+    subgraph AWS
+      A
+      Br1
+    end
+    subgraph "Azure<br>Business Unit 1"
+      B
+      Br2
+    end
+    subgraph "Azure<br>Business Unit 2"
+      C
+    end
 ```
 
 Alternatively, a single bridge instance can be configured with more than two transports, acting as a hub that routes between all connected environments without chaining.
@@ -126,13 +126,11 @@ The Particular Platform tools support polycloud deployments. The NServiceBus Mes
 
 ```mermaid
 flowchart LR
-Br(Bridge)
-SC[ServiceControl]
-A[Endpoint A
-AWS SQS] -->|audit/error| Br
-B[Endpoint B
-Azure ASB] -->|audit/error| Br
-Br --> SC
+    Br(Bridge)
+    SC[ServiceControl]
+    A["Endpoint A<br>AWS SQS"] -->|audit/error| Br
+    B["Endpoint B<br>Azure ASB"] -->|audit/error| Br
+    Br --> SC
 ```
 
 [The bridge forwards audit and error messages](/samples/bridge/service-control/) across transport boundaries. ServicePulse then provides a unified view of all endpoints, failed messages, and message flows across the entire polycloud system.

--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -34,7 +34,9 @@ Depending on the scenario, different persistence options can be used for storing
 
 - [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
 - [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
-
+- [SQL-based](/persistence/sql)
+- [Other storage technologies](https://docs.particular.net/persistence/#supported-persisters)
+ 
 ### Cloud-agnostic environments
 
 In environments not tied to a specific cloud provider, other technologies like [RabbitMQ](/transports/rabbitmq/), [PostgreSQL](/transports/postgresql/), or [SQL Server](/transports/sql/) [can be selected based on specific requirements](/transports/selecting.md).

--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -24,13 +24,15 @@ The general recommendation is to use the native services for each cloud provider
 
 [For Azure deployments](/architecture/azure/messaging.md), [Azure Service Bus](/transports/azure-service-bus/) is the recommended default. It supports cross-entity transactions on the Premium tier, message sizes up to 100 MB, and native publish/subscribe via topics and subscriptions.
 
-For persistence, [Azure Cosmos DB](/persistence/cosmosdb/) is the native option for storing saga state and outbox records. See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
-
 ### On AWS
 
 [For components hosted in AWS](/architecture/aws/messaging.md), [Amazon SQS](/transports/sqs/) is the recommended option. It is fully managed, scales automatically, and integrates with other AWS services. NServiceBus uses Amazon SNS alongside SQS to support the publish/subscribe pattern. When messages exceed the SQS size limit (256 KB for events, 1 MiB for commands), the transport can offload payloads to Amazon S3.
 
-For persistence, [Amazon DynamoDB](/persistence/dynamodb/) stores saga state and outbox records without leaving the AWS ecosystem. See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
+#### Persistence options
+Depending on the scenario, different persistence options can be used for storing saga state and outbox records:
+ - [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
+ - [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
+
 
 ### Cloud-agnostic environments
 

--- a/architecture/polycloud.md
+++ b/architecture/polycloud.md
@@ -30,8 +30,8 @@ The general recommendation is to use the native services for each cloud provider
 
 #### Persistence options
 Depending on the scenario, different persistence options can be used for storing saga state and outbox records:
- - [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
- - [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
+- [Azure Cosmos DB](/persistence/cosmosdb/). See the [simple Cosmos DB sample](/samples/cosmosdb/simple/) to get started.
+- [Amazon DynamoDB](/persistence/dynamodb/). See the [simple DynamoDB persistence sample](/samples/aws/dynamodb-simple/) or the [sagas with SQS and Lambda sample](/samples/aws/sagas/) to get started.
 
 
 ### Cloud-agnostic environments


### PR DESCRIPTION
Added a section on persistence options for saga state and outbox records, detailing Azure Cosmos DB and Amazon DynamoDB.
https://github.com/Particular/CloudPlatformExperience/issues/413