### PR TITLE
Legacy docs review

### DIFF
--- a/nservicebus/messaging/claimcheck/index.md
+++ b/nservicebus/messaging/claimcheck/index.md
@@ -1,8 +1,8 @@
 ---
-title: NServiceBus DataBus feature
-summary: How to handle messages that are too large to be sent by a transport natively by using NServiceBus DataBus
+title: Claim Check (DataBus)
+summary: How to handle messages that are too large to be sent by a transport natively by using NServiceBus Claim Check
 component: DataBus
-reviewed: 2024-08-01
+reviewed: 2026-04-28
 redirects:
  - nservicebus/databus
  - samples/pipeline/stream-properties
@@ -13,7 +13,7 @@ related:
  - samples/databus/redis
 ---
 
-Although messaging systems work best with small message sizes, some scenarios require sending binary large objects ([blobs](https://en.wikipedia.org/wiki/Binary_large_object)) data along with a message (also known as a [_Claim Check_](https://learn.microsoft.com/en-us/azure/architecture/patterns/claim-check)). For this purpose, NServiceBus has a `DataBus` feature to overcome the message size limitations imposed by the underlying transport.
+Although messaging systems work best with small message sizes, some scenarios require sending [binary large object (blob)](https://en.wikipedia.org/wiki/Binary_large_object) data along with a message (also known as a [_Claim Check_](https://learn.microsoft.com/en-us/azure/architecture/patterns/claim-check)). For this purpose, NServiceBus has a `DataBus` feature to overcome message size limitations imposed by the underlying transport.
 
 partial: obsolete
 
@@ -25,7 +25,7 @@ If the location is not available upon sending, the send operation will fail. Whe
 
 ## Transport message size limits
 
-The `DataBus` may be used to send messages which exceed the transport's message size limit, which is determined by the message size limit of the underlying queuing/storage technologies.
+The `DataBus` may be used to send messages that exceed the transport's message size limit, which is determined by the message size limit of the underlying queuing/storage technologies.
 
 > [!NOTE]
 > Not all transports have message size limits and some technologies, such as Azure Service Bus or Amazon SQS, have increased over time. Current message size limits are stated in the documentation linked in the table below.
@@ -37,9 +37,9 @@ The `DataBus` may be used to send messages which exceed the transport's message 
 | Azure Storage Queues              | [64KB](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted#capacity-and-quotas) |
 | Azure Service Bus (Standard tier) | [256KB](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted#capacity-and-quotas) |
 | Azure Service Bus (Premium tier)  | [100MB](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#large-messages-support) |
-| RabbitMQ                          | Configured by [`max_message_size`](https://www.rabbitmq.com/configure.html#config-items) |
+| RabbitMQ                          | Configured by [`max_message_size`](https://www.rabbitmq.com/docs/configure#config-items) |
 | SQL Server                        | No limit |
-| Learning                          | No limit |
+| Learning Transport                | No limit |
 | MSMQ                              | [4MB](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/msmq/ms711436(v=vs.85)#maximum-message-size) |
 
 ## Enabling the `DataBus`
@@ -56,35 +56,7 @@ By default, blobs are stored with no set expiration. If messages have a [time to
 > [!NOTE]
 > The value used should be aligned with the [ServiceControl audit retention period](/servicecontrol/how-purge-expired-data.md) if it is required that `DataBus` blob keys in messages sent to the audit queue can still be fetched.
 
-## Specifying `DataBus` properties
-
-There are two ways to specify the message properties to be sent using the `DataBus`:
-
- 1. Using the `ClaimCheckProperty<T>` type
- 1. Message conventions
-
-> [!NOTE]
-> `DataBus` properties must be top-level properties on a message class.
->
-> Apart from `byte[]`, any data type is supported as long as it is serializable. For example, you can use `string`, custom classes, or other serializable types as `DataBus` properties.
-
-### Using `ClaimCheckProperty<T>`
-
-Set the type of the property to be sent over as `ClaimCheckProperty<byte[]>`, or any other serializable type:
-
-snippet: MessageWithLargePayload
-
-### Using message conventions
-
-NServiceBus also supports defining `DataBus` properties by convention. This allows data properties to be sent using the `DataBus` without using `ClaimCheckProperty<T>`, thus removing the need for having a dependency on NServiceBus from the message types.
-
-In the configuration of the endpoint include:
-
-snippet: DefineMessageWithLargePayloadUsingConvention
-
-Set the type of the property as `byte[]`, or any other serializable type:
-
-snippet: MessageWithLargePayloadUsingConvention
+partial: property-type
 
 partial: serialization
 
@@ -117,7 +89,7 @@ Automatically removing these attachments can cause problems in many situations. 
   - Read on demand: Attachments are only retrieved when read by a consumer.
   - Async enumeration: The package supports processing all data items using an `IAsyncEnumerable`.
   - No serialization: The serializer is not used, which may result in a significant reduction in memory usage.
-  - Direct stream access: This makes the package more suitable for [binary large objects (blobs](https://en.wikipedia.org/wiki/Binary_large_object) since stream contents do not necessarily have to be loaded into memory before storing them or when retrieving them.
+  - Direct stream access: This makes the package more suitable for [binary large objects (blobs)](https://en.wikipedia.org/wiki/Binary_large_object) since stream contents do not necessarily have to be loaded into memory before storing them or when retrieving them.
 
 ## Other considerations
 

--- a/nservicebus/messaging/claimcheck/index.md
+++ b/nservicebus/messaging/claimcheck/index.md
@@ -39,7 +39,7 @@ The `DataBus` may be used to send messages that exceed the transport's message s
 | Azure Service Bus (Premium tier)  | [100MB](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#large-messages-support) |
 | RabbitMQ                          | Configured by [`max_message_size`](https://www.rabbitmq.com/docs/configure#config-items) |
 | SQL Server                        | No limit |
-| Learning Transport                | No limit |
+| Learning                          | No limit |
 | MSMQ                              | [4MB](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/msmq/ms711436(v=vs.85)#maximum-message-size) |
 
 ## Enabling the `DataBus`

--- a/nservicebus/messaging/claimcheck/index_obsolete_core_[9,).partial.md
+++ b/nservicebus/messaging/claimcheck/index_obsolete_core_[9,).partial.md
@@ -1,3 +1,2 @@
 > [!WARNING]
 > As of NServiceBus 9.2, the `DataBus` feature is available as a [dedicated NuGet package](https://www.nuget.org/packages/NServiceBus.ClaimCheck/). The API documented on this page will continue to work for NServiceBus Version 9 but it will hint about its upcoming obsoletion with the following warning: *The DataBus feature is released as a dedicated 'NServiceBus.ClaimCheck' package.*.
-> The new documentation is [here](/nservicebus/messaging/claimcheck/).

--- a/nservicebus/messaging/claimcheck/index_property-type_core_[,10).partial.md
+++ b/nservicebus/messaging/claimcheck/index_property-type_core_[,10).partial.md
@@ -1,0 +1,29 @@
+## Specifying `DataBus` properties
+
+There are two ways to specify the message properties to be sent using the `DataBus`:
+
+1. Using the `DataBusProperty<T>` type
+1. Using message conventions
+
+> [!NOTE]
+> `DataBus` properties must be top-level properties on a message class.
+>
+> Apart from `byte[]`, any data type is supported as long as it is serializable. For example, `string`, custom classes, or other serializable types can be used.
+
+### Using `DataBusProperty<T>`
+
+Set the type of the property to be sent over as `DataBusProperty<byte[]>`, or any other serializable type:
+
+snippet: MessageWithLargePayload
+
+### Using message conventions
+
+NServiceBus also supports defining `DataBus` properties by convention. This allows data properties to be sent without using `DataBusProperty<T>`, thus removing the need for a dependency on NServiceBus from the message types.
+
+In the configuration of the endpoint include:
+
+snippet: DefineMessageWithLargePayloadUsingConvention
+
+Set the type of the property as `byte[]`, or any other serializable type:
+
+snippet: MessageWithLargePayloadUsingConvention

--- a/nservicebus/messaging/claimcheck/index_property-type_databus_[1,).partial.md
+++ b/nservicebus/messaging/claimcheck/index_property-type_databus_[1,).partial.md
@@ -1,0 +1,29 @@
+## Specifying property types
+
+There are two ways to specify the message properties to be sent using the Claim Check feature:
+
+1. Using the `ClaimCheckProperty<T>` type
+1. Using message conventions
+
+> [!NOTE]
+> Claim Check properties must be top-level properties on a message class.
+>
+> Apart from `byte[]`, any data type is supported as long as it is serializable. For example, `string`, custom classes, or other serializable types can be used.
+
+### Using `ClaimCheckProperty<T>`
+
+Set the type of the property to be sent over as `ClaimCheckProperty<byte[]>`, or any other serializable type:
+
+snippet: MessageWithLargePayload
+
+### Using message conventions
+
+NServiceBus also supports defining Claim Check properties by convention. This allows data properties to be sent without using `ClaimCheckProperty<T>`, thus removing the need for a dependency on NServiceBus from the message types.
+
+In the configuration of the endpoint include:
+
+snippet: DefineMessageWithLargePayloadUsingConvention
+
+Set the type of the property as `byte[]`, or any other serializable type:
+
+snippet: MessageWithLargePayloadUsingConvention

--- a/samples/open-telemetry/application-insights/sample.md
+++ b/samples/open-telemetry/application-insights/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring NServiceBus endpoints with Application Insights
 summary: How to configure NServiceBus to export OpenTelemetry traces and meters to Application Insights
-reviewed: 2024-07-26
+reviewed: 2026-04-28
 component: Core
 previewImage: trace-timeline.png
 related:
@@ -11,7 +11,7 @@ redirects:
   - samples/tracing
 ---
 
-[Azure Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) (App Insights) provides monitoring and alerting capabilities that can be leveraged to monitor the health of NServiceBus endpoints.
+[Azure Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) (App Insights) provides monitoring and alerting capabilities that can be leveraged to monitor the health of NServiceBus endpoints.
 
 This sample shows how to capture NServiceBus OpenTelemetry traces and export them to App Insights. The sample simulates message load as well as a 10% failure rate on processing messages.
 
@@ -31,22 +31,22 @@ This sample requires an App Insights connection string.
 
 ### Reviewing traces
 
-1. On the Azure portal dashboard, open the _Investigate_ → _Performance_ panel
+1. In the Azure portal Application Insights resource you just created, open the _Investigate_ → _Performance_ panel
 2. Drill into the samples
 3. Review the custom properties
 
 ![Timeline view of a trace in Application Insights](trace-timeline.png)
 
-### Reviewing meters
+### Reviewing metrics
 
-Navigate to _Monitoring_ → _Metrics_ on the Azure portal dashboard for the configured Application Insight instance to start creating graphs.
+Navigate to _Monitoring_ → _Metrics_ on the Azure portal dashboard for the configured Application Insights instance to start creating graphs.
 
 > [!NOTE]
-> It may take a few minutes for the meter data to populate to Azure. Meters will only appear on the dashboard once they have reported at least one value.
+> It may take a few minutes for the metrics data to populate to Azure. Metrics will only appear on the dashboard once they have reported at least one value.
 
 #### Message processing counters
 
-To monitor the rate of messages being fetched from the queuing system, processed successfully, retried, and failed for the endpoint use:
+To monitor the rate of messages being fetched from the queuing system, processed successfully, retried, and failed for the endpoint, use the following metrics:
 
 - `nservicebus.messaging.fetches`
 - `nservicebus.messaging.successes`
@@ -66,7 +66,7 @@ To monitor [recoverability](/nservicebus/recoverability/) metrics use:
 
 #### Handler time, critical time, and processing time
 
-To monitor [handler time, processing time, and critical time](/monitoring/metrics/definitions.md#metrics-captured) (in seconds) for successfully processed messages use:
+To monitor [handler time, processing time, and critical time](/monitoring/metrics/definitions.md#metrics-captured) (in seconds) for successfully processed messages, use:
 
 - `nservicebus.messaging.handler_time`
 - `nservicebus.messaging.processing_time`

--- a/samples/open-telemetry/logging/sample.md
+++ b/samples/open-telemetry/logging/sample.md
@@ -37,7 +37,7 @@ will lead to the following output:
 
 ```text
 info: MyMessageHandler[0]
-      Received message #54
+Received message #54
 LogRecord.Timestamp:               2022-06-28T09:02:34.5342602Z
 LogRecord.TraceId:                 964b320925ab08cd2134c02d0abe920d
 LogRecord.SpanId:                  066fce94c5438add

--- a/samples/open-telemetry/logging/sample.md
+++ b/samples/open-telemetry/logging/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Connecting OpenTelemetry traces and logs
 summary: How to connect OpenTelemetry traces to logs in an NServiceBus endpoint
-reviewed: 2024-07-26
+reviewed: 2026-04-28
 component: Core
 related:
  - nservicebus/operations/opentelemetry
@@ -22,7 +22,7 @@ Next, connect the logs emitted by the application to the traces as follows:
 
 snippet: otel-logging
 
-This will apply the OpenTelemetry logging format to all the logs. More importantly, it will [correlate all logs](https://opentelemetry.io/docs/reference/specification/logs/overview/#log-correlation) to the active traces.
+This will apply the OpenTelemetry logging format to all the logs. More importantly, it will [correlate all logs](https://opentelemetry.io/docs/specs/otel/logs/#log-correlation) to the active traces.
 This means that each log statement will include a `TraceId` and `SpanId` as part of the log entry.
 
 partial: enableotel
@@ -35,40 +35,48 @@ snippet: log-statement
 
 will lead to the following output:
 
-```
- info: MyMessageHandler[0]
- Received message #54
- LogRecord.Timestamp:               2022-06-28T09:02:34.5342602Z
- LogRecord.TraceId:                 964b320925ab08cd2134c02d0abe920d
- LogRecord.SpanId:                  066fce94c5438add
- LogRecord.TraceFlags:              Recorded
- LogRecord.CategoryName:            MyMessageHandler
- LogRecord.LogLevel:                Information
- LogRecord.FormattedMessage:        Received message #54
- LogRecord.StateValues (Key:Value):
- {OriginalFormat}: Received message #54
- LogRecord.ScopeValues (Key:Value):
- [Scope.0]:SpanId: 066fce94c5438add
- [Scope.0]:TraceId: 964b320925ab08cd2134c02d0abe920d
- [Scope.0]:ParentId: e595cc6a4d9b0768
+```text
+info: MyMessageHandler[0]
+      Received message #54
+LogRecord.Timestamp:               2022-06-28T09:02:34.5342602Z
+LogRecord.TraceId:                 964b320925ab08cd2134c02d0abe920d
+LogRecord.SpanId:                  066fce94c5438add
+LogRecord.TraceFlags:              Recorded
+LogRecord.CategoryName:            MyMessageHandler
+LogRecord.Severity:                Info
+LogRecord.SeverityText:            Information
+LogRecord.FormattedMessage:        Received message #54
+LogRecord.Body:                    Received message #{Number}
+LogRecord.Attributes (Key:Value):
+    Number: 54
+    OriginalFormat (a.k.a Body): Received message #{Number}
+LogRecord.ScopeValues (Key:Value):
+[Scope.0]:SpanId: 066fce94c5438add
+[Scope.0]:TraceId: 964b320925ab08cd2134c02d0abe920d
+[Scope.0]:ParentId: e595cc6a4d9b0768
 ```
 
 The console will also show information for the captured traces:
 
-```
-Activity.TraceId:          964b320925ab08cd2134c02d0abe920d
-Activity.SpanId:           066fce94c5438add
-Activity.TraceFlags:           Recorded
-Activity.ParentSpanId:    eb999a0dadc477ea
-Activity.ActivitySourceName: NServiceBus.Core
-Activity.DisplayName: MyMessageHandler
-Activity.Kind:        Internal
-Activity.StartTime:   2022-06-28T09:02:34.5322602Z
-Activity.Duration:    00:00:00.0017675
+```text
+Activity.TraceId:            964b320925ab08cd2134c02d0abe920d
+Activity.SpanId:             066fce94c5438add
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       e595cc6a4d9b0768
+Activity.DisplayName:        MyMessageHandler
+Activity.Kind:               Internal
+Activity.StartTime:          2022-06-28T09:02:34.5322602Z
+Activity.Duration:           00:00:00.0017675
 Activity.Tags:
     nservicebus.handler.handler_type: MyMessageHandler
-StatusCode : Ok
+StatusCode: Ok
+Instrumentation scope (ActivitySource):
+    Name: NServiceBus.Core
+    Version: 0.1.0
 Resource associated with Activity:
-    service.name: Samples.Hosting.GenericHost
+    service.name: Samples.OpenTelemetry.MyEndpoint
     service.instance.id: 93d66e53-7537-4e21-99f9-e62b579b5fa3
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.version: 1.15.3
 ```

--- a/servicecontrol/servicecontrol-instances/remotes.md
+++ b/servicecontrol/servicecontrol-instances/remotes.md
@@ -1,20 +1,20 @@
 ---
 title: ServiceControl remote instances
-summary: Aggregate data from other ServiceControl instances using the ServiceControl Remotes features
-reviewed: 2024-07-19
+summary: Aggregate data from other ServiceControl instances using the ServiceControl Remotes feature
+reviewed: 2026-04-28
 component: ServiceControl
 redirects:
 - servicecontrol/servicecontrol-instances/distributed-instances
 ---
 
-[ServicePulse](/servicepulse) retrieves data from a [ServiceControl instance](/servicecontrol/servicecontrol-instances/) using an HTTP API. In some installations, that data may reside in multiple ServiceControl instances. The ServiceControl Remotes features allows a ServiceControl instance to aggregate data from other ServiceControl instances, providing a unified experience in ServicePulse.
+[ServicePulse](/servicepulse/) retrieves data from a [ServiceControl instance](/servicecontrol/servicecontrol-instances/) using an HTTP API. In some installations, that data may reside in multiple ServiceControl instances. The ServiceControl Remotes feature allows a ServiceControl instance to aggregate data from other ServiceControl instances, providing a unified experience in ServicePulse.
 
 ## Overview
 
 One ServiceControl Error instance is designated as the _primary_ instance. All other ServiceControl instances are _remote_ instances. The HTTP API of the primary instance aggregates data from the primary instance and from all the remote instances. ServicePulse is configured to connect to the primary instance.
 
 > [!NOTE]
-> The term _remote_ refers to the fact that remote instances are run in separate processes. The primary instance and one or more remote instances can run on the same machine.
+> The term _remote_ refers to the fact that remote instances run in separate processes. The primary instance and one or more remote instances can run on the same machine.
 
 In ServiceControl version 4 and later, a ServiceControl Error instance can be configured with remote instances that are also [ServiceControl Error instances](/servicecontrol/servicecontrol-instances/) or are [ServiceControl Audit instances](/servicecontrol/audit-instances/). ServiceControl Audit instances cannot be configured as primary instances.
 
@@ -77,7 +77,7 @@ class ServiceControlAudit1,ServiceControlAudit2 ServiceControlRemote
 
 ### Sharding audit messages with split audit queues
 
-Endpoints are partitioned into groups. Each group sends messages to its own a different audit queue. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for specific groups of endpoints.
+Endpoints are partitioned into groups. Each group sends messages to a different audit queue. Each audit queue is managed by a different ServiceControl Audit instance. This approach is useful if different audit retention periods are required for specific groups of endpoints.
 
 ```mermaid
 graph TD
@@ -110,7 +110,7 @@ class ServiceControlAudit1,ServiceControlAudit2 ServiceControlRemote
 
 ### Multi-transport deployments
 
-When a system uses multiple transports, the [Messaging Bridge](/nservicebus/bridge/) can be used to allow management of the entire system by single instances of ServicePulse.
+When a system uses multiple transports, the [Messaging Bridge](/nservicebus/bridge/) can be used to allow management of the entire system by a single instance of ServicePulse.
 
 ```mermaid
 graph TD
@@ -197,7 +197,7 @@ class auditA,auditB ServiceControlRemote
 
 In this deployment, each region has a full ServiceControl installation with a primary Error instance and an Audit instance. Each region can be managed and controlled via a dedicated ServicePulse instance.
 
-A new cross-region primary instance is added to allow another ServicePulse instance to show messages from both regions. This cross-region instance includes each region-specific primary instance as a remote allowing it to query messages from both. The cross-region instance must disable error message ingestion management by setting with the value [`ServiceControl/IngestErrorMessages`](/servicecontrol/servicecontrol-instances/configuration.md#recoverability-servicecontrolingesterrormessages) option to `false`.
+A new cross-region primary instance is added to allow another ServicePulse instance to show messages from both regions. This cross-region instance includes each region-specific primary instance as a remote allowing it to query messages from both. The cross-region instance must disable error message ingestion management by setting the [`ServiceControl/IngestErrorMessages`](/servicecontrol/servicecontrol-instances/configuration.md#recoverability-servicecontrolingesterrormessages) option to `false`.
 
 ### Zero downtime upgrades
 
@@ -205,7 +205,7 @@ The remotes feature can be used to perform [zero downtime upgrades](/servicecont
 
 ## Configuration
 
-Remote instances are listed in the `ServiceControl/RemoteInstances` app setting in the primary instance [configuration file](/servicecontrol/servicecontrol-instances/configuration.md). The value of this setting is a JSON array of remote instances. Each entry requires an `api_url` property specifying the API URL of the remote instance. For ServiceControl version 3 and earlier, each entry requires a `queue_address` property specifying the queue address of the remote instance.
+Remote instances are listed in the `ServiceControl/RemoteInstances` app setting in the primary instance [configuration file](/servicecontrol/servicecontrol-instances/configuration.md). The value of this setting is a JSON array of remote instances. Each entry requires an `api_uri` property specifying the API URL of the remote instance. For ServiceControl version 3 and earlier, each entry requires a `queue_address` property specifying the queue address of the remote instance.
 
 > [!NOTE]
 > Changes to the configuration file do not take effect until the primary instance is restarted.
@@ -279,6 +279,6 @@ To change the address of a remote instance to a new host and/or port number:
 
 - Pagination in ServicePulse may not work as expected. For example, each page may contain a different number of items, depending on how those items are distributed across the various ServiceControl instances.
 - If the primary instance cannot contact a given remote instance, data from that remote instance will not be included in any views in ServicePulse.
-- Multi-instance configuration is not possible the ServiceControl Management utility.
+- Multi-instance configuration is not possible with the ServiceControl Management utility.
 - Incorrect configuration may cause cyclical dependencies. For example, instance A may attempt to get data from instance B, and instance B may attempt to get data from instance A.
 - It is recommended to run _only one_ primary instance. Multiple primary instances are _not recommended_.


### PR DESCRIPTION
Fixes minor typos and updates external links on:

- `servicecontrol/servicecontrol-instances/remotes`
- `samples/open-telemetry/application-insights/`
- `samples/open-telemetry/logging/`
- `nservicebus/messaging/claimcheck/`