### PR TITLE
Add a -FullBuild option to samples and snippets build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more information about devcontainers visit the [official documentation](http
 
 ### Building samples and snippets
 
-To build all samples and snippets run `.\tools\build-samples-and-snippets.ps1` from the repository root folder.
+To build all samples and snippets run `.\tools\build-samples-and-snippets.ps1 -FullBuild` from the repository root folder. Without `-FullBuild`, the script only builds affected solutions unless it is running on `master`.
 
 ## Conventions
 

--- a/tools/build-samples-and-snippets.ps1
+++ b/tools/build-samples-and-snippets.ps1
@@ -1,3 +1,8 @@
+[CmdletBinding()]
+param(
+    [switch] $FullBuild
+)
+
 # Assumes working directory is Docs repository root folder
 function CombinePaths()
 {
@@ -11,10 +16,45 @@ function CombinePaths()
     return $fullPath
 }
 
+function Write-GitHubStepSummary()
+{
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]] $Lines
+    )
+
+    if([string]::IsNullOrWhiteSpace($Env:GITHUB_STEP_SUMMARY))
+    {
+        return
+    }
+
+    $Lines | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+}
+
 # Assumes that the current working directory is the root of the docs repo
 function Get-BuildSolutions
 {
+    param(
+        [switch] $FullBuild
+    )
+
+    if($FullBuild)
+    {
+        Write-Host "Full build requested; building every solution file in repo"
+        $result = Get-ChildItem -Filter *.sln -Recurse | Sort-Object LastWriteTime -Descending
+        return $result
+    }
+
     $branch = $env:GITHUB_REF
+    if(-not $branch)
+    {
+        $localBranch = git branch --show-current
+        if( -not $? -or [string]::IsNullOrWhiteSpace($localBranch) ) {
+            throw "Unable to determine current branch"
+        }
+
+        $branch = "refs/heads/$localBranch"
+    }
     Write-Host "Current branch is $branch"
 
     if($branch -eq "refs/heads/master")
@@ -81,7 +121,7 @@ $failedSolutions = New-Object Collections.Generic.List[String]
 $failedSolutionsOutput = CombinePaths $pwd.Path "failed-samples-and-snippets.log"
 $executionDirectory = Get-Location
 
-$solutions = Get-BuildSolutions
+$solutions = Get-BuildSolutions -FullBuild:$FullBuild
 
 # Don't really need this polluting the console output when we have Actions Summary output for failed jobs
 # but leaving it commented here in case there's a problem in the future with the git diff logic
@@ -104,10 +144,10 @@ foreach($solution in $solutions) {
         if( -not $? ) {
             $exitCode = 1
             Write-Output ("::error::Build failed: {0}" -f $solution.FullName)
-            Write-Output ("🔴 Build failed: {0}" -f $solution.FullName) | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
-            Write-Output ('```txt') | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
-            Write-Output $out | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
-            Write-Output ('```') | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+            Write-GitHubStepSummary ("🔴 Build failed: {0}" -f $solution.FullName)
+            Write-GitHubStepSummary '```txt'
+            Write-GitHubStepSummary $out
+            Write-GitHubStepSummary '```'
             $failedSolutions.Add($solution.FullName)
         }
     }

--- a/tools/build-samples-and-snippets.ps1
+++ b/tools/build-samples-and-snippets.ps1
@@ -16,21 +16,6 @@ function CombinePaths()
     return $fullPath
 }
 
-function Write-GitHubStepSummary()
-{
-    param(
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $Lines
-    )
-
-    if([string]::IsNullOrWhiteSpace($Env:GITHUB_STEP_SUMMARY))
-    {
-        return
-    }
-
-    $Lines | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
-}
-
 # Assumes that the current working directory is the root of the docs repo
 function Get-BuildSolutions
 {
@@ -143,12 +128,17 @@ foreach($solution in $solutions) {
 
         if( -not $? ) {
             $exitCode = 1
-            Write-Output ("::error::Build failed: {0}" -f $solution.FullName)
-            Write-GitHubStepSummary ("🔴 Build failed: {0}" -f $solution.FullName)
-            Write-GitHubStepSummary '```txt'
-            Write-GitHubStepSummary $out
-            Write-GitHubStepSummary '```'
             $failedSolutions.Add($solution.FullName)
+   
+            Write-Output ("::error::Build failed: {0}" -f $solution.FullName)
+   
+            if(-not [string]::IsNullOrWhiteSpace($Env:GITHUB_STEP_SUMMARY))
+            {           
+                Write-Output ("🔴 Build failed: {0}" -f $solution.FullName) | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+                Write-Output ('```txt') | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+                Write-Output $out | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+                Write-Output ('```') | Out-File -FilePath $Env:GITHUB_STEP_SUMMARY -Encoding utf-8 -Append
+            }
         }
     }
     finally


### PR DESCRIPTION
 This updates tools/build-samples-and-snippets.ps1 to support explicit full builds and to run safely outside GitHub Actions.

  What changed

   - Added a -FullBuild switch to force building all .sln files found in the repo, regardless of branch or git diff state.
   - Kept existing default behavior intact: on non-master branches without -FullBuild, the script still builds only affected solutions.
   - Added a Write-GitHubStepSummary helper so failure details are only written when GITHUB_STEP_SUMMARY is available.
   - Prevented local PowerShell failures caused by attempting to write to $Env:GITHUB_STEP_SUMMARY when the script is run outside GitHub Actions.

