### PR TITLE
Fix samples not referencing Core package properly

### DIFF
--- a/samples/databus/custom-serializer/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Receiver/Receiver.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/custom-serializer/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Sender/Sender.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/custom-serializer/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/DataBus_1/Shared/Shared.csproj
@@ -1,11 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/custom-serializer/DataBus_2/Receiver/Receiver.csproj
+++ b/samples/databus/custom-serializer/DataBus_2/Receiver/Receiver.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/custom-serializer/DataBus_2/Sender/Sender.csproj
+++ b/samples/databus/custom-serializer/DataBus_2/Sender/Sender.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/custom-serializer/DataBus_2/Shared/Shared.csproj
+++ b/samples/databus/custom-serializer/DataBus_2/Shared/Shared.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.*" />
     <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Receiver/Receiver.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Sender/Sender.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/Core_9/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/Core_9/Shared/Shared.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Receiver/Receiver.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Sender/Sender.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_1/Shared/Shared.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_2/Receiver/Receiver.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_2/Receiver/Receiver.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_2/Sender/Sender.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_2/Sender/Sender.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/databus-custom-serializer-converter/DataBus_2/Shared/Shared.csproj
+++ b/samples/databus/databus-custom-serializer-converter/DataBus_2/Shared/Shared.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_1/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Receiver/Receiver.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_1/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Sender/Sender.csproj
@@ -1,12 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_1/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/DataBus_1/Shared/Shared.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_2/Receiver/Receiver.csproj
+++ b/samples/databus/file-share-databus/DataBus_2/Receiver/Receiver.csproj
@@ -1,13 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_2/Sender/Sender.csproj
+++ b/samples/databus/file-share-databus/DataBus_2/Sender/Sender.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/samples/databus/file-share-databus/DataBus_2/Shared/Shared.csproj
+++ b/samples/databus/file-share-databus/DataBus_2/Shared/Shared.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/databus/redis/Core_10/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_10/Receiver/Receiver.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_10/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_10/Sender/Sender.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_10/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_10/Shared/Shared.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.*" />
     <PackageReference Include="NServiceBus" Version="10.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
+    <PackageReference Include="StackExchange.Redis" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_9/Receiver/Receiver.csproj
+++ b/samples/databus/redis/Core_9/Receiver/Receiver.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_9/Sender/Sender.csproj
+++ b/samples/databus/redis/Core_9/Sender/Sender.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/databus/redis/Core_9/Shared/Shared.csproj
+++ b/samples/databus/redis/Core_9/Shared/Shared.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.*" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="1.*" />
+    <PackageReference Include="StackExchange.Redis" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/ebcdic/IBMMQ_1/Contracts/Contracts.csproj
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/Contracts/Contracts.csproj
@@ -4,10 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/ebcdic/IBMMQ_1/Contracts/PlaceOrder.cs
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/Contracts/PlaceOrder.cs
@@ -1,1 +1,3 @@
-﻿public record PlaceOrder(Guid OrderId, string Product, int Quantity) : ICommand;
+﻿using NServiceBus;
+
+public record PlaceOrder(Guid OrderId, string Product, int Quantity) : ICommand;

--- a/samples/ibmmq/ebcdic/IBMMQ_1/LegacySender/LegacySender.csproj
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/LegacySender/LegacySender.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5" />
+    <PackageReference Include="IBMMQDotnetClient" Version="9.4.5.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/ebcdic/IBMMQ_1/Sales/PlaceOrderHandler.cs
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/Sales/PlaceOrderHandler.cs
@@ -2,16 +2,16 @@ using Microsoft.Extensions.Logging;
 
 #region PlaceOrderHandler
 sealed class PlaceOrderHandler(ILogger<PlaceOrderHandler> logger)
-    :IHandleMessages<PlaceOrder>
+    : IHandleMessages<PlaceOrder>
 {
     public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
     {
         Console.WriteLine("In the handler");
         logger.LogInformation("""
-            Published PlaceOrder 
+            Published PlaceOrder
                 OrderId  = {OrderId},
                 Product  = {Product},
-                Quantity = {Quantity}           
+                Quantity = {Quantity}
             """,
             message.OrderId,
             message.Product,

--- a/samples/ibmmq/ebcdic/IBMMQ_1/Sales/Program.cs
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/Sales/Program.cs
@@ -3,35 +3,32 @@ using Microsoft.Extensions.Hosting;
 using NServiceBus.MessageMutator;
 using NServiceBus.Transport.IBMMQ;
 
-var host = Host
-    .CreateDefaultBuilder(args)
-    .UseNServiceBus(context =>
-    {
-        var endpointConfiguration = new EndpointConfiguration("DEV.RECEIVER");
+var builder = Host.CreateApplicationBuilder(args);
 
-        endpointConfiguration.UseSerialization<SystemJsonSerializer>();
-        endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(0));
-        endpointConfiguration.EnableInstallers();
+var endpointConfiguration = new EndpointConfiguration("DEV.RECEIVER");
 
-        var transport = new IBMMQTransport()
-        {
-            QueueManagerName = "QM1",
-            Channel = "DEV.ADMIN.SVRCONN",
-            User = "admin",
-            Password = "passw0rd"
-        };
-        endpointConfiguration.UseTransport(transport);
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.Recoverability().Delayed(settings => settings.NumberOfRetries(0));
+endpointConfiguration.EnableInstallers();
 
-        #region FixedLengthEBCDICToJsonMutatorRegistration
-        //in order to use IBM500 EBCDIC encoding, we need to register the code page provider
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+var transport = new IBMMQTransport()
+{
+    QueueManagerName = "QM1",
+    Channel = "DEV.ADMIN.SVRCONN",
+    User = "admin",
+    Password = "passw0rd"
+};
+endpointConfiguration.UseTransport(transport);
 
-        endpointConfiguration.RegisterMessageMutator(new FixedLengthEBCDICToJsonMutator());
+#region FixedLengthEBCDICToJsonMutatorRegistration
+//in order to use IBM500 EBCDIC encoding, we need to register the code page provider
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
-        #endregion
-      
-        return endpointConfiguration;
-    })
-    .Build();
+endpointConfiguration.RegisterMessageMutator(new FixedLengthEBCDICToJsonMutator());
 
+#endregion
+
+builder.UseNServiceBus(endpointConfiguration);
+
+var host = builder.Build();
 await host.RunAsync();

--- a/samples/ibmmq/ebcdic/IBMMQ_1/Sales/Receiver.csproj
+++ b/samples/ibmmq/ebcdic/IBMMQ_1/Sales/Receiver.csproj
@@ -1,19 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
-    <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
+    <ProjectReference Include="..\Contracts\Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Contracts\Contracts.csproj" />
+    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+    <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/polymorphic-events/IBMMQ_1/Orders/Orders.csproj
+++ b/samples/ibmmq/polymorphic-events/IBMMQ_1/Orders/Orders.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
   </ItemGroup>

--- a/samples/ibmmq/polymorphic-events/IBMMQ_1/Shared/Messages.cs
+++ b/samples/ibmmq/polymorphic-events/IBMMQ_1/Shared/Messages.cs
@@ -1,6 +1,7 @@
+using NServiceBus;
+
 #region Events
 public record OrderPlaced(Guid OrderId, string Product) : IEvent;
 
-public record ExpressOrderPlaced(Guid OrderId, string Product)
-    : OrderPlaced(OrderId, Product);
+public record ExpressOrderPlaced(Guid OrderId, string Product) : OrderPlaced(OrderId, Product);
 #endregion

--- a/samples/ibmmq/polymorphic-events/IBMMQ_1/Shared/Shared.csproj
+++ b/samples/ibmmq/polymorphic-events/IBMMQ_1/Shared/Shared.csproj
@@ -4,10 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/polymorphic-events/IBMMQ_1/Shipping/Shipping.csproj
+++ b/samples/ibmmq/polymorphic-events/IBMMQ_1/Shipping/Shipping.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
   </ItemGroup>

--- a/samples/ibmmq/polymorphic-events/IBMMQ_1/sample.slnx
+++ b/samples/ibmmq/polymorphic-events/IBMMQ_1/sample.slnx
@@ -1,10 +1,8 @@
 <Solution>
-    <Folder Name="/sample/">
-        <Project Path="Shipping\Shipping.csproj"/>
-        <Project Path="Orders\Orders.csproj"/>
-        <Project Path="Shared\Shared.csproj"/>
-    </Folder>
     <Folder Name="/Solution Items/">
-        <File Path="docker-compose.yml"/>
+        <File Path="docker-compose.yml" />
     </Folder>
+    <Project Path="Orders\Orders.csproj" />
+    <Project Path="Shared\Shared.csproj" />
+    <Project Path="Shipping\Shipping.csproj" />
 </Solution>

--- a/samples/ibmmq/simple/IBMMQ_1/Receiver/Receiver.csproj
+++ b/samples/ibmmq/simple/IBMMQ_1/Receiver/Receiver.csproj
@@ -1,23 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Remove="appsettings*.json" />
-    <ProjectCapability Include="DynamicFileNestingEnabled" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="DynamicFileNestingEnabled" />
+    <None Update="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/simple/IBMMQ_1/Sender/Program.cs
+++ b/samples/ibmmq/simple/IBMMQ_1/Sender/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NServiceBus.Transport.IBMMQ;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 Console.Title = "Sender";
 var builder = Host.CreateApplicationBuilder(args);
@@ -66,6 +65,4 @@ while (!cts.IsCancellationRequested)
     Console.WriteLine("Done");
 }
 
-
 await host.StopAsync();
-

--- a/samples/ibmmq/simple/IBMMQ_1/Sender/Sender.csproj
+++ b/samples/ibmmq/simple/IBMMQ_1/Sender/Sender.csproj
@@ -1,23 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Remove="appsettings*.json" />
-    <ProjectCapability Include="DynamicFileNestingEnabled" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.IBMMQ" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="DynamicFileNestingEnabled" />
+    <None Update="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/simple/IBMMQ_1/Shared/MyMessage.cs
+++ b/samples/ibmmq/simple/IBMMQ_1/Shared/MyMessage.cs
@@ -1,3 +1,5 @@
-﻿#region Message
+﻿using NServiceBus;
+
+#region Message
 public record MyMessage(string Data) : IMessage;
 #endregion

--- a/samples/ibmmq/simple/IBMMQ_1/Shared/Shared.csproj
+++ b/samples/ibmmq/simple/IBMMQ_1/Shared/Shared.csproj
@@ -4,11 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>Messages</RootNamespace>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/ibmmq/simple/IBMMQ_1/sample.slnx
+++ b/samples/ibmmq/simple/IBMMQ_1/sample.slnx
@@ -1,10 +1,8 @@
 <Solution>
-    <Folder Name="/sample/">
-        <Project Path="Receiver\Receiver.csproj"/>
-        <Project Path="Sender\Sender.csproj"/>
-        <Project Path="Shared\Shared.csproj"/>
-    </Folder>
     <Folder Name="/Solution Items/">
-        <File Path="docker-compose.yml"/>
+        <File Path="docker-compose.yml" />
     </Folder>
+    <Project Path="Receiver\Receiver.csproj" />
+    <Project Path="Sender\Sender.csproj" />
+    <Project Path="Shared\Shared.csproj" />
 </Solution>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Receiver/Receiver.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Receiver/Receiver.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="8.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Sender/Sender.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Sender/Sender.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="8.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_8/Shared/Shared.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_8/Shared/Shared.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="8.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_9/Receiver/Receiver.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_9/Receiver/Receiver.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
-    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="9.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_9/Sender/Sender.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_9/Sender/Sender.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
-    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="9.*" />
   </ItemGroup>
+
 </Project>

--- a/samples/postgresqltransport/simple/PostgreSqlTransport_9/Shared/Shared.csproj
+++ b/samples/postgresqltransport/simple/PostgreSqlTransport_9/Shared/Shared.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <LangVersion>14.0</LangVersion>
     <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.PostgreSql" Version="9.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This cleans up some problems that some samples in that they weren't properly referencing Core, so they weren't picking up the new package version that fixes the `System.Security.Cryptography.Xml`
 reference.

This also includes some additional changes to the IBM MQ samples.