### PR TITLE
Weekly legacy docs review

### DIFF
--- a/nservicebus/gateway/scale-out.md
+++ b/nservicebus/gateway/scale-out.md
@@ -1,22 +1,22 @@
 ---
 title: Scale out
 summary: Information on scaling out the NServiceBus Gateway
-reviewed: 2024-07-26
+reviewed: 2026-04-30
 related:
  - samples/gateway
 ---
 
 Due to specifics of the protocol used, the gateway is designed to run on at most one instance of each endpoint. Depending on the transport there are different strategies for designating a gateway hosting endpoint instance.
 
-### Brokered transports - RabbitMQ, SQL Server, Azure and MSMQ scaled-out with unified scalability model
+## Brokered transports
 
-With brokered transports or bus transports with sender-side distribution, all instances are equal. All can host the gateway, but one instance must be explicitly selected as the receiver of the incoming HTTP gateway traffic. Any endpoints sending to the gateway of that endpoint must be configured to use the HTTP address of the selected endpoint instance.
+With brokered transports (RabbitMQ, SQL Server, Azure, and MSMQ scaled-out with the unified scalability model) or bus transports with sender-side distribution, all instances are equal. All can host the gateway, but one instance must be explicitly selected as the receiver of the incoming HTTP gateway traffic. Any endpoints sending to the gateway of that endpoint must be configured to use the HTTP address of the selected endpoint instance.
 
 Use an HTTP load balancer to avoid hard-coding individual endpoint instance gateway HTTP addresses in the gateway senders. Configure sending endpoints to send to the load balancer and let the load balancer forward the traffic to the HTTP address of the selected endpoint instance.
 
 Handle high availability requirements by setting the load balancer to fail over to another endpoint instance if it detects endpoint failure.
 
-![Gateway with Version 6 scaleout](/nservicebus/gateway/scaleoutv6.png 'width=400')
+![Gateway scale-out](/nservicebus/gateway/scaleoutv6.png 'width=400')
 
 ## Caveats
 

--- a/nservicebus/sagas/saga-not-found.md
+++ b/nservicebus/sagas/saga-not-found.md
@@ -1,8 +1,7 @@
 ---
-title: Sagas Not Found
-summary: How is a message handled when a saga could execute it but no saga could be found?
+title: Saga Not Found
 component: Core
-reviewed: 2024-08-01
+reviewed: 2026-04-30
 related:
 - samples/saga
 ---

--- a/samples/open-telemetry/customizing/sample.md
+++ b/samples/open-telemetry/customizing/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing OpenTelemetry tracing
 summary: Demonstrates how to add data to existing OpenTelemetry traces
-reviewed: 2024-07-26
+reviewed: 2026-04-30
 component: Core
 related:
 - nservicebus/operations/opentelemetry
@@ -17,7 +17,7 @@ Press <kbd>O</kbd> to send a `CreateOrder` message with a randomized `OrderId`. 
 
 As the messages are sent and processed, trace data is exported to the console. Some of the trace data originates from NServiceBus and some from custom code in the sample.
 
-## Code walk through
+## Code walkthrough
 
 ### Global configuration
 

--- a/samples/open-telemetry/prometheus-grafana/Core_10/Endpoint/Program.cs
+++ b/samples/open-telemetry/prometheus-grafana/Core_10/Endpoint/Program.cs
@@ -24,7 +24,7 @@ public class Program
         #endregion
 
         #region enable-prometheus-http-listener
-        meterProviderBuilder.AddPrometheusHttpListener(options => options.UriPrefixes = new[] { "http://127.0.0.1:9464" });
+        meterProviderBuilder.AddPrometheusHttpListener(options => options.UriPrefixes = new[] { "http://*:9464/" });
         #endregion
 
         var meterProvider = meterProviderBuilder.Build();

--- a/samples/open-telemetry/prometheus-grafana/Core_9/Endpoint/Program.cs
+++ b/samples/open-telemetry/prometheus-grafana/Core_9/Endpoint/Program.cs
@@ -29,7 +29,7 @@ public class Program
         #endregion
 
         #region enable-prometheus-http-listener
-        meterProviderBuilder.AddPrometheusHttpListener(options => options.UriPrefixes = new[] { "http://127.0.0.1:9464" });
+        meterProviderBuilder.AddPrometheusHttpListener(options => options.UriPrefixes = new[] { "http://*:9464/" });
         #endregion
 
         var meterProvider = meterProviderBuilder.Build();

--- a/samples/open-telemetry/prometheus-grafana/sample.md
+++ b/samples/open-telemetry/prometheus-grafana/sample.md
@@ -3,7 +3,7 @@ title: Monitoring NServiceBus endpoints with Prometheus and Grafana
 summary: How to configure NServiceBus to export OpenTelemetry metrics to Prometheus and Grafana
 component: Core
 isLearningPath: true
-reviewed: 2024-07-26
+reviewed: 2026-04-30
 previewImage: grafana.png
 related:
 - nservicebus/operations/opentelemetry
@@ -70,7 +70,7 @@ To monitor [handler time, processing time, and critical time](/monitoring/metric
 
 The metrics are gathered using OpenTelemetry standards on the endpoint and must be reported and collected by an external service. A Prometheus HTTP listener exposes this data so the Prometheus service, hosted as a docker service, can retrieve and store this information.
 
-The listener is available via the `OpenTelemetry.Exporter.Prometheus.HttpListener"` NuGet package. In this sample, the service that exposes the data to scrape is hosted on `http://127.0.0.1:9464/metrics`:
+The listener is available via the `OpenTelemetry.Exporter.Prometheus.HttpListener` NuGet package. In this sample, the service that exposes the data to scrape is hosted on `http://127.0.0.1:9464/metrics`:
 
 snippet: enable-prometheus-http-listener
 
@@ -101,7 +101,7 @@ graph TD
     B -->|Expose| C{Metric Endpoint}
     C -->|No Metrics| D[Status 200]
     C -->|Has Metrics| E[Return Metrics]
-    F[Promethus Service] --> |Poll Metrics| E
+    F[Prometheus Service] --> |Poll Metrics| E
     F --> |Store Metrics| F
     G[Grafana] --> |Query Data| F
 ```
@@ -126,11 +126,11 @@ avg(rate(nservicebus_messaging_successes_total[5m]))
 
 Open Grafana on `http://localhost:3000`, which is made available as part of the [Docker stack](#prerequisites)
 
-For a production environment, Grafana must be installed and configured to display the data scraped and stored in Prometheus. For more information on how to install Grafana, refer to the [Grafana installation guide](https://docs.grafana.org/installation).
+For a production environment, Grafana must be installed and configured to display the data scraped and stored in Prometheus. For more information on how to install Grafana, refer to the [Grafana installation guide](https://grafana.com/docs/grafana/latest/setup-grafana/installation/).
 
 ### Dashboard
 
-This sample includes an [export of the Grafana dashboard](grafana-endpoints-dashboard.json) which can be [imported](https://docs.grafana.org/reference/export_import/) as a reference.
+This sample includes an [export of the Grafana dashboard](grafana-endpoints-dashboard.json) which can be [imported](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/import-dashboards/) as a reference.
 
 To create a custom dashboard using Prometheus data, the following steps must be performed:
 

--- a/samples/open-telemetry/prometheus-grafana/sample.md
+++ b/samples/open-telemetry/prometheus-grafana/sample.md
@@ -70,12 +70,9 @@ To monitor [handler time, processing time, and critical time](/monitoring/metric
 
 The metrics are gathered using OpenTelemetry standards on the endpoint and must be reported and collected by an external service. A Prometheus HTTP listener exposes this data so the Prometheus service, hosted as a docker service, can retrieve and store this information.
 
-The listener is available via the `OpenTelemetry.Exporter.Prometheus.HttpListener` NuGet package. In this sample, the service that exposes the data to scrape is hosted on `http://127.0.0.1:9464/metrics`:
+The listener is available via the `OpenTelemetry.Exporter.Prometheus.HttpListener` NuGet package. In this sample, the service that exposes the data to scrape is hosted on `http://*:9464/metrics`, allowing the Prometheus service running in Docker to reach it via `host.docker.internal:9464`:
 
 snippet: enable-prometheus-http-listener
-
-> [!NOTE]
-> `127.0.0.1` is used so that the Prometheus service running in Docker can reach it over the network.
 
 The raw metrics retrieved through the scraping endpoint look as follows:
 


### PR DESCRIPTION

## smoke test samples/open-telemetry/customizing/

- [x] Core_9 | net10.0 | customizing_core_9_net10_0.zip 
- [x] Core_9 | net9.0 | customizing_core_9_net9_0.zip 
- [x] Core_9 | net8.0 | customizing_core_9_net8_0.zip
- [x] Core_10 | net10.0 | customizing_core_10.zip

## smoke test samples/open-telemetry/prometheus-grafana/

- [x] Core_9 | net10.0 | prometheus-grafana_core_9_net10_0.zip
- [x] Core_9 | net9.0 | prometheus-grafana_core_9_net9_0.zip 
- [x] Core_9 | net8.0 | prometheus-grafana_core_9_net8_0.zip 
- [x] Core_10 | net10.0 | prometheus-grafana_core_10.zip 

**NOTE:**
In the NServiceBus OpenTelemetry Prometheus sample, the AddPrometheusHttpListener call was binding the metrics HTTP listener to http://127.0.0.1:9464, which is loopback-only. This causes Prometheus to receive a 404 when scraping from inside Docker via host.docker.internal:9464, even though the endpoint is running on the host machine. Fixed in https://github.com/Particular/docs.particular.net/pull/8231/changes/d99b9749fe3211f4ea4700e9f7fc0d3aa49a0a96