### PR TITLE
Spike: Document IBM MQ broker throughput collection

### DIFF
--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -1232,6 +1232,51 @@ The password to access the RabbitMQ management interface.
 | --- | --- |
 | string | obtained from ServiceControl |
 
+## Usage Reporting when using the IBM MQ transport
+
+ServiceControl reads broker-side throughput data from IBM MQ statistics events. The queue manager must have queue statistics gathering enabled (`ALTER QMGR STATQ(ON)`) and the queues being measured must inherit or override that setting (`STATQ(QMGR)` or `STATQ(ON)`). When statistics are not enabled, ServiceControl will continue to start and operate, and audit-based throughput collection will act as a fallback.
+
+The connecting MQ user requires `+connect` on the queue manager, `+get +inq +browse` on the configured statistics queue, `+put +inq` on `SYSTEM.ADMIN.COMMAND.QUEUE`, `+put +get +browse +dsp` on `SYSTEM.DEFAULT.MODEL.QUEUE`, and `+inq` on user queues. If a forwarding queue is configured, `+put` is also required on it.
+
+### LicensingComponent/IBMMQ/ConnectionString
+
+Optional URI-style IBM MQ connection string used by the throughput collection. When omitted, the connection string configured for the ServiceControl Primary instance is used.
+
+| Context | Name |
+| --- | --- |
+| **Environment variable** | `LICENSINGCOMPONENT_IBMMQ_CONNECTIONSTRING` |
+| **App config key** | `LicensingComponent/IBMMQ/ConnectionString` |
+
+| Type | Default value |
+| --- | --- |
+| string | obtained from ServiceControl |
+
+### LicensingComponent/IBMMQ/StatisticsQueue
+
+The name of the queue from which IBM MQ statistics PCF messages are read. Override the default when another consumer owns the system statistics queue and a forwarder, MQ topic subscription, or cluster channel delivers a per-consumer copy of stats messages to a dedicated queue.
+
+| Context | Name |
+| --- | --- |
+| **Environment variable** | `LICENSINGCOMPONENT_IBMMQ_STATISTICSQUEUE` |
+| **App config key** | `LicensingComponent/IBMMQ/StatisticsQueue` |
+
+| Type | Default value |
+| --- | --- |
+| string | `SYSTEM.ADMIN.STATISTICS.QUEUE` |
+
+### LicensingComponent/IBMMQ/StatisticsForwardingQueue
+
+Optional. When set, ServiceControl re-publishes each consumed statistics message verbatim to this queue inside the same transactional unit, so other tools can consume their own copy downstream. Mirrors the NServiceBus error/audit forwarding pattern. Leave unset for single-consumer setups.
+
+| Context | Name |
+| --- | --- |
+| **Environment variable** | `LICENSINGCOMPONENT_IBMMQ_STATISTICSFORWARDINGQUEUE` |
+| **App config key** | `LicensingComponent/IBMMQ/StatisticsForwardingQueue` |
+
+| Type | Default value |
+| --- | --- |
+| string | |
+
 ## Usage Reporting when using the SqlServer transport
 
 ### LicensingComponent/SqlServer/ConnectionString

--- a/servicepulse/usage-config.md
+++ b/servicepulse/usage-config.md
@@ -192,6 +192,9 @@ User with monitoring tag and read permission.
 
 Refer to the [Usage Reporting when using the IBM MQ transport](/servicecontrol/servicecontrol-instances/configuration.md#usage-reporting-when-using-the-ibm-mq-transport) section of the ServiceControl config file for an explanation of the IBM MQ-specific settings.
 
+> [!NOTE]
+> Broker-side throughput collection on IBM MQ is most useful as a **fallback** for environments where ServiceControl Monitoring is not deployed or where some endpoints cannot enable NServiceBus metrics. When every NServiceBus endpoint is configured with monitoring and a Monitoring instance is running, the monitoring source already provides per-day throughput data for the usage report — without requiring any queue manager configuration changes. In that case, enabling IBM MQ statistics events adds operational overhead (`STATQ` administration, `MAXDEPTH` tuning, additional permissions on the connecting user) for limited additional value.
+
 ServiceControl reads broker-side throughput data from IBM MQ statistics events. Before enabling broker-side usage reporting, run the following on the queue manager (one-time setup):
 
 ```mqsc

--- a/servicepulse/usage-config.md
+++ b/servicepulse/usage-config.md
@@ -193,9 +193,9 @@ User with monitoring tag and read permission.
 Refer to the [Usage Reporting when using the IBM MQ transport](/servicecontrol/servicecontrol-instances/configuration.md#usage-reporting-when-using-the-ibm-mq-transport) section of the ServiceControl config file for an explanation of the IBM MQ-specific settings.
 
 > [!NOTE]
-> Broker-side throughput collection on IBM MQ is most useful as a **fallback** for environments where ServiceControl Monitoring is not deployed or where some endpoints cannot enable NServiceBus metrics. When every NServiceBus endpoint is configured with monitoring and a Monitoring instance is running, the monitoring source already provides per-day throughput data for the usage report — without requiring any queue manager configuration changes. In that case, enabling IBM MQ statistics events adds operational overhead (`STATQ` administration, `MAXDEPTH` tuning, additional permissions on the connecting user) for limited additional value.
+> Broker-side throughput collection on IBM MQ is most useful as a **fallback** for environments where ServiceControl Monitoring is not deployed or where some endpoints cannot enable NServiceBus metrics. When every NServiceBus endpoint is configured with metrics (see [Monitoring NServiceBus endpoints](/monitoring/) and [Configure metrics](/monitoring/metrics/)) and a [Monitoring instance](/servicecontrol/monitoring-instances/) is running, the monitoring source already provides per-day throughput data for the usage report — without requiring any queue manager configuration changes. In that case, enabling IBM MQ statistics events adds operational overhead (`STATQ` administration, `MAXDEPTH` tuning, additional permissions on the connecting user) for limited additional value.
 
-ServiceControl reads broker-side throughput data from IBM MQ statistics events. Before enabling broker-side usage reporting, run the following on the queue manager (one-time setup):
+The following section applies when broker-side collection is needed. ServiceControl reads broker-side throughput data from IBM MQ statistics events. Before enabling broker-side usage reporting, run the following on the queue manager (one-time setup):
 
 ```mqsc
 ALTER QMGR STATQ(ON) STATINT(1800)

--- a/servicepulse/usage-config.md
+++ b/servicepulse/usage-config.md
@@ -186,6 +186,49 @@ Refer to the [Usage Reporting when using the RabbitMQ transport](/servicecontrol
 
 User with monitoring tag and read permission.
 
+### IBM MQ
+
+#### Settings
+
+Refer to the [Usage Reporting when using the IBM MQ transport](/servicecontrol/servicecontrol-instances/configuration.md#usage-reporting-when-using-the-ibm-mq-transport) section of the ServiceControl config file for an explanation of the IBM MQ-specific settings.
+
+ServiceControl reads broker-side throughput data from IBM MQ statistics events. Before enabling broker-side usage reporting, run the following on the queue manager (one-time setup):
+
+```mqsc
+ALTER QMGR STATQ(ON) STATINT(1800)
+```
+
+Queues created with the default `STATQ(QMGR)` setting will then participate automatically. Queues that were created with `STATQ(OFF)` or `STATQ(ON)` explicitly set need to be reset to inherit. The following bash snippet enables statistics for all non-system user queues on a queue manager:
+
+```bash
+QM=QM1   # queue manager name
+
+# 1. Enable queue-manager-wide statistics with a 30-minute interval
+echo "ALTER QMGR STATQ(ON) STATINT(1800)" | runmqsc "$QM"
+
+# 2. Reset every user queue with an explicit STATQ override back to QMGR-inherit.
+#    Skips SYSTEM.* queues; lets the queue manager setting take effect everywhere.
+echo "DISPLAY QLOCAL(*) WHERE(STATQ NE QMGR)" | runmqsc "$QM" \
+    | grep -oP 'QUEUE\(\K[^)]+' \
+    | grep -v '^SYSTEM\.' \
+    | while read -r q; do
+        echo "ALTER QLOCAL($q) STATQ(QMGR)" | runmqsc "$QM"
+    done
+```
+
+The same effect can be achieved per queue with `ALTER QLOCAL(QUEUE.NAME) STATQ(QMGR)` (inherit from queue manager) or `STATQ(ON)` (force on regardless of QMGR setting).
+
+If another tool already drains `SYSTEM.ADMIN.STATISTICS.QUEUE`, ServiceControl can either:
+
+- read from a dedicated queue populated by an external forwarder, MQ topic subscription, or cluster channel — set `LicensingComponent/IBMMQ/StatisticsQueue` to that queue name; or
+- own the system statistics queue and forward a copy of each consumed message to the other tool's queue — set `LicensingComponent/IBMMQ/StatisticsForwardingQueue` to that queue name. The forwarding happens inside the same transactional unit as the read, so each statistics message is delivered exactly once to the downstream consumer.
+
+When statistics are not enabled on the queue manager, ServiceControl still starts and runs; audit-based throughput collection acts as the fallback.
+
+#### Minimum permissions
+
+User with `+connect` on the queue manager, `+get +inq +browse` on the configured statistics queue, `+put +inq` on `SYSTEM.ADMIN.COMMAND.QUEUE`, `+put +get +browse +dsp` on `SYSTEM.DEFAULT.MODEL.QUEUE`, and `+inq` on user queues. If a forwarding queue is configured, also `+put` on that queue.
+
 ### MSMQ & Azure Storage Queues
 
 MSMQ and Azure Storage Queues do not support querying of metrics. To enable the automatic usage reporting functionality for these systems, auditing and/or monitoring must be set up:


### PR DESCRIPTION
Pairs with:

- Particular/ServiceControl#5463.

## Summary

- Adds an "IBM MQ" entry to the usage-reporting connection setup, with the queue manager prerequisites, multi-consumer fan-out patterns, and minimum permission set.
- Adds an "Usage Reporting when using the IBM MQ transport" section to the ServiceControl configuration reference, documenting the three new settings:
  - `LicensingComponent/IBMMQ/ConnectionString`
  - `LicensingComponent/IBMMQ/StatisticsQueue`
  - `LicensingComponent/IBMMQ/StatisticsForwardingQueue`
- Includes a `runmqsc`/`bash` script that enables `STATQ` on the queue manager and resets every existing user queue with an explicit `STATQ` override back to QMGR-inherit, so operators can opt every queue in without scripting it themselves.
- Frames broker-side IBM MQ collection as a **fallback** for environments where the monitoring source isn't fully deployed, and cross-links to the existing monitoring / metrics / Monitoring-instance setup pages so readers know where to start if they want to avoid the broker path entirely.

