### PR TITLE
Update to Aspire 13.3

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1819,7 +1819,7 @@
     Url: shape-the-future/cloudevents
   - Title: NServiceBus and Apache Avro
     Url: shape-the-future/avro
-  - Title: NServiceBus and .NET Aspire
+  - Title: NServiceBus and Aspire
     Url: shape-the-future/aspire
   - Title: NServiceBus and Redis
     Url: shape-the-future/redis

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Properties/launchSettings.json
+++ b/samples/hosting/aspire/Core_10/AspireDemo.AppHost/Properties/launchSettings.json
@@ -9,9 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21118",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22281"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21118",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22281"
       }
     },
     "http": {
@@ -22,9 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19233",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18241",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20173"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19233",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20173"
       }
     }
   }

--- a/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/Extensions.cs
+++ b/samples/hosting/aspire/Core_10/AspireDemo.ServiceDefaults/Extensions.cs
@@ -9,9 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
-// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+// To learn more about using this project, see https://aka.ms/aspire/service-defaults
 public static class Extensions
 {
     private const string HealthEndpointPath = "/health";
@@ -112,7 +112,7 @@ public static class Extensions
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
         // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        // See https://aka.ms/aspire/healthchecks for details before enabling these endpoints in non-development environments.
         if (app.Environment.IsDevelopment())
         {
             // All health checks must pass for app to be considered ready to accept traffic after starting

--- a/samples/hosting/aspire/Core_10/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_10/Billing/Billing.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="6.*" />
     <PackageReference Include="NServiceBus.Metrics" Version="6.*" />

--- a/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_10/ClientUI/ClientUI.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="6.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.*" />

--- a/samples/hosting/aspire/Core_10/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_10/Messages/Messages.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_10/Messages/OrderBilled.cs
+++ b/samples/hosting/aspire/Core_10/Messages/OrderBilled.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class OrderBilled : IEvent
 {

--- a/samples/hosting/aspire/Core_10/Messages/OrderPlaced.cs
+++ b/samples/hosting/aspire/Core_10/Messages/OrderPlaced.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class OrderPlaced : IEvent
 {

--- a/samples/hosting/aspire/Core_10/Messages/PlaceOrder.cs
+++ b/samples/hosting/aspire/Core_10/Messages/PlaceOrder.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class PlaceOrder : ICommand
 {

--- a/samples/hosting/aspire/Core_10/Messages/ShipOrder.cs
+++ b/samples/hosting/aspire/Core_10/Messages/ShipOrder.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class ShipOrder : ICommand
 {

--- a/samples/hosting/aspire/Core_10/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_10/Sales/Sales.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="6.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.*" />

--- a/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_10/Shipping/Shipping.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.*" />
+    <PackageReference Include="NServiceBus" Version="10.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="6.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="6.*" />

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>

--- a/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Properties/launchSettings.json
+++ b/samples/hosting/aspire/Core_9/AspireDemo.AppHost/Properties/launchSettings.json
@@ -9,9 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21118",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22281"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21118",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22281"
       }
     },
     "http": {
@@ -22,9 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19233",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18241",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20173"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19233",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20173"
       }
     }
   }

--- a/samples/hosting/aspire/Core_9/AspireDemo.ServiceDefaults/Extensions.cs
+++ b/samples/hosting/aspire/Core_9/AspireDemo.ServiceDefaults/Extensions.cs
@@ -9,9 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
-// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+// To learn more about using this project, see https://aka.ms/aspire/service-defaults
 public static class Extensions
 {
     private const string HealthEndpointPath = "/health";
@@ -112,7 +112,7 @@ public static class Extensions
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
         // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        // See https://aka.ms/aspire/healthchecks for details before enabling these endpoints in non-development environments.
         if (app.Environment.IsDevelopment())
         {
             // All health checks must pass for app to be considered ready to accept traffic after starting

--- a/samples/hosting/aspire/Core_9/Billing/Billing.csproj
+++ b/samples/hosting/aspire/Core_9/Billing/Billing.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />

--- a/samples/hosting/aspire/Core_9/ClientUI/ClientUI.csproj
+++ b/samples/hosting/aspire/Core_9/ClientUI/ClientUI.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />

--- a/samples/hosting/aspire/Core_9/Messages/Messages.csproj
+++ b/samples/hosting/aspire/Core_9/Messages/Messages.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/samples/hosting/aspire/Core_9/Messages/OrderBilled.cs
+++ b/samples/hosting/aspire/Core_9/Messages/OrderBilled.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class OrderBilled : IEvent
 {

--- a/samples/hosting/aspire/Core_9/Messages/OrderPlaced.cs
+++ b/samples/hosting/aspire/Core_9/Messages/OrderPlaced.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class OrderPlaced : IEvent
 {

--- a/samples/hosting/aspire/Core_9/Messages/PlaceOrder.cs
+++ b/samples/hosting/aspire/Core_9/Messages/PlaceOrder.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class PlaceOrder : ICommand
 {

--- a/samples/hosting/aspire/Core_9/Messages/ShipOrder.cs
+++ b/samples/hosting/aspire/Core_9/Messages/ShipOrder.cs
@@ -1,4 +1,6 @@
-﻿namespace Messages;
+﻿using NServiceBus;
+
+namespace Messages;
 
 public class ShipOrder : ICommand
 {

--- a/samples/hosting/aspire/Core_9/Sales/Sales.csproj
+++ b/samples/hosting/aspire/Core_9/Sales/Sales.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />

--- a/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
+++ b/samples/hosting/aspire/Core_9/Shipping/Shipping.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.*" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.*" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />

--- a/samples/hosting/aspire/Core_9/aspire.config.json
+++ b/samples/hosting/aspire/Core_9/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "AspireDemo.AppHost/AspireDemo.AppHost.csproj"
+  }
+}

--- a/samples/hosting/aspire/sample.md
+++ b/samples/hosting/aspire/sample.md
@@ -1,18 +1,18 @@
 ---
-title: Hosting endpoints in .NET Aspire
-summary: Hosting multiple NServiceBus endpoints in an .NET Aspire application host
+title: Hosting endpoints in Aspire
+summary: Hosting multiple NServiceBus endpoints in an Aspire application host
 component: Core
-reviewed: 2024-09-20
+reviewed: 2026-05-07
 ---
 
-[.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/) is a stack for developing distributed applications provided by Microsoft.
+[Aspire](https://aspire.dev/) is a stack for developing distributed applications provided by Microsoft.
 
-This sample shows a .NET Aspire AppHost project that orchestrates multiple NServiceBus endpoints, wiring up the required infrastructure pieces including a RabbitMQ broker and PostgreSQL database.
+This sample shows an Aspire AppHost project that orchestrates multiple NServiceBus endpoints, wiring up the required infrastructure pieces including a RabbitMQ broker and PostgreSQL database.
 
 ## Running the sample
 
 1. Run the AspireDemo.AppHost project
-2. Open the .NET Aspire dashboard
+2. Open the Aspire dashboard
 3. Review the metrics, traces, and structured log entries of each of the resources
 
 > [!NOTE]
@@ -22,7 +22,7 @@ This sample shows a .NET Aspire AppHost project that orchestrates multiple NServ
 
 ### AspireDemo.AppHost
 
-The [.NET Aspire orchestration project](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview) defines multiple resources and the relationships between them:
+The [Aspire orchestration project](https://aspire.dev/get-started/app-host/?lang=csharp) defines multiple resources and the relationships between them:
 
 - A RabbitMQ instance named `transport`
 - A PostgreSQL server named `database`
@@ -40,7 +40,7 @@ snippet: app-host
 
 ### AspireDemo.ServiceDefaults
 
-The [.NET Aspire service defaults](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/service-defaults) project provides extension methods to configure application hosts in a standardized way. This project is referenced by all of the NServiceBus endpoint projects.
+The [Aspire service defaults](https://aspire.dev/get-started/csharp-service-defaults/) project provides extension methods to configure application hosts in a standardized way. This project is referenced by all of the NServiceBus endpoint projects.
 
 The OpenTelemetry configuration has been updated to include NServiceBus metrics and traces.
 
@@ -64,4 +64,4 @@ Finally, each endpoint enables NServiceBus installers. Every time the applicatio
 
 snippet: enable-installers
 
-If you're missing certain capabilities to use .NET Aspire with NServiceBus, [share them and help shape the future of the platform](/shape-the-future/aspire.md).
+If you're missing certain capabilities to use Aspire with NServiceBus, [share them and help shape the future of the platform](/shape-the-future/aspire.md).

--- a/shape-the-future/aspire.md
+++ b/shape-the-future/aspire.md
@@ -1,11 +1,11 @@
 ---
-title: NServiceBus and .NET Aspire
-summary: How to use NServiceBus with .NET Aspire
-reviewed: 2024-09-16
+title: NServiceBus and Aspire
+summary: How to use NServiceBus with Aspire
+reviewed: 2026-05-07
 ---
 
-[.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview) is an opinionated, cloud-ready stack for building observable, production ready, distributed applications.​
+[Aspire](https://aspire.dev/get-started/what-is-aspire/) is a code-first orchestration and observability layer for distributed applications.
 
-NServiceBus endpoints can run under a .NET Aspire AppHost orchestrator, we have [a sample that shows you how it all works](/samples/hosting/aspire/).
+NServiceBus endpoints can run under an Aspire AppHost orchestrator. We have [a sample that shows you how it all works](/samples/hosting/aspire/).
 
-If you are using NServiceBus with .NET Aspire today, [tell us what's missing](https://github.com/Particular/NServiceBus/issues/6941).
+If you are using NServiceBus with Aspire today, [tell us what's missing](https://github.com/Particular/NServiceBus/issues/6941).


### PR DESCRIPTION
This PR updates the Aspire sample to Aspire 13.3 and changes the sample to use the message interfaces package for the `Messages` project.

It also revises the documentation to refer to "Aspire" instead of the old ".NET Aspire" name.