### PR TITLE
Elevate dependencies to direct for MongoDB Snippets

### DIFF
--- a/Snippets/MongoDB/MongoDB_2/MongoDB_2.csproj
+++ b/Snippets/MongoDB/MongoDB_2/MongoDB_2.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup Label="Resolves vulnerabilities">
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="SharpCompress" Version="0.*" />
+    <PackageReference Include="Snappier" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
+++ b/Snippets/TransactionalSession.MongoDB/MongoTS_2/MongoTS_2.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="MongoDB.Driver" Version="2.*" />
     <PackageReference Include="System.Drawing.Common" Version="4.*" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.*" />
+    <PackageReference Include="SharpCompress" Version="0.*" />
+    <PackageReference Include="Snappier" Version="1.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The snippets for version 2 of MongoDB have some transtive dependecies related to MongoDB driver.
This PR elevates them to direct dependencies to prevent using the vulnerable versions.