### PR TITLE
Added Config info

### DIFF
--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
@@ -13,6 +14,27 @@ class Configuration
             {
                 var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                 // configure endpoint here
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    async Task ReadAppSettings()
+    {
+        #region extensions-host-appsettings
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var endpointName = ctx.Configuration.GetValue<string>("NServiceBus:EndpointName")
+                    ?? "MyEndpoint";
+
+                var endpointConfiguration = new EndpointConfiguration(endpointName);
+                // configure endpoint, passing values from ctx.Configuration as needed
                 return endpointConfiguration;
             })
             .Build();

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -43,4 +43,58 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var transportConnectionString = ctx.Configuration.GetConnectionString("Transport");
+
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+                // Pass transportConnectionString to the transport, for example:
+                //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+                //   transport.ConnectionString(transportConnectionString);
+                _ = transportConnectionString;
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var settings = ctx.Configuration
+                    .GetSection("NServiceBus")
+                    .Get<EndpointSettings>() ?? new EndpointSettings();
+
+                var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+                endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/MinimalApi.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/MinimalApi.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using NServiceBus;
 
 public class MinimalApi
@@ -15,6 +16,31 @@ public class MinimalApi
 
             // configure the endpoint
 
+            return endpointConfiguration;
+        });
+
+        var host = builder.Build();
+
+        // further ASP.NET configuration
+
+        host.Run();
+
+        #endregion
+    }
+
+    void MinimalHostReadAppSettings()
+    {
+        #region asp-net-minimal-host-appsettings
+
+        var builder = WebApplication.CreateBuilder();
+
+        var endpointName = builder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyWebAppEndpoint";
+
+        builder.Host.UseNServiceBus(context =>
+        {
+            var endpointConfiguration = new EndpointConfiguration(endpointName);
+            // configure endpoint, passing values from context.Configuration as needed
             return endpointConfiguration;
         });
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
@@ -13,6 +14,27 @@ class Configuration
             {
                 var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
                 // configure endpoint here
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    async Task ReadAppSettings()
+    {
+        #region extensions-host-appsettings
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var endpointName = ctx.Configuration.GetValue<string>("NServiceBus:EndpointName")
+                    ?? "MyEndpoint";
+
+                var endpointConfiguration = new EndpointConfiguration(endpointName);
+                // configure endpoint, passing values from ctx.Configuration as needed
                 return endpointConfiguration;
             })
             .Build();

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -43,4 +43,58 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var transportConnectionString = ctx.Configuration.GetConnectionString("Transport");
+
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+                // Pass transportConnectionString to the transport, for example:
+                //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+                //   transport.ConnectionString(transportConnectionString);
+                _ = transportConnectionString;
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var settings = ctx.Configuration
+                    .GetSection("NServiceBus")
+                    .Get<EndpointSettings>() ?? new EndpointSettings();
+
+                var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+                endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/MinimalApi.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/MinimalApi.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using NServiceBus;
 
 public class MinimalApi
@@ -15,6 +16,31 @@ public class MinimalApi
 
             // configure the endpoint
 
+            return endpointConfiguration;
+        });
+
+        var host = builder.Build();
+
+        // further ASP.NET configuration
+
+        host.Run();
+
+        #endregion
+    }
+
+    void MinimalHostReadAppSettings()
+    {
+        #region asp-net-minimal-host-appsettings
+
+        var builder = WebApplication.CreateBuilder();
+
+        var endpointName = builder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyWebAppEndpoint";
+
+        builder.Host.UseNServiceBus(context =>
+        {
+            var endpointConfiguration = new EndpointConfiguration(endpointName);
+            // configure endpoint, passing values from context.Configuration as needed
             return endpointConfiguration;
         });
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
@@ -13,6 +14,27 @@ class Configuration
         var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
         // configure endpoint here
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    async Task ReadAppSettings()
+    {
+        #region extensions-host-appsettings
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var endpointName = hostBuilder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyEndpoint";
+
+        var endpointConfiguration = new EndpointConfiguration(endpointName);
+        // configure endpoint, passing values from hostBuilder.Configuration as needed
 
         hostBuilder.UseNServiceBus(endpointConfiguration);
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -44,4 +44,56 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var transportConnectionString = hostBuilder.Configuration.GetConnectionString("Transport");
+
+        var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+        // Pass transportConnectionString to the transport, for example:
+        //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+        //   transport.ConnectionString(transportConnectionString);
+        _ = transportConnectionString;
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var settings = hostBuilder.Configuration
+            .GetSection("NServiceBus")
+            .Get<EndpointSettings>() ?? new EndpointSettings();
+
+        var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+        endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_3/MinimalApi.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_3/MinimalApi.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using NServiceBus;
 
 public class MinimalApi
@@ -12,6 +13,29 @@ public class MinimalApi
         var endpointConfiguration = new EndpointConfiguration("MyWebAppEndpoint");
 
         // configure the endpoint
+
+        builder.UseNServiceBus(endpointConfiguration);
+
+        var app = builder.Build();
+
+        // further ASP.NET configuration
+
+        app.Run();
+
+        #endregion
+    }
+
+    void MinimalHostReadAppSettings()
+    {
+        #region asp-net-minimal-host-appsettings
+
+        var builder = WebApplication.CreateBuilder();
+
+        var endpointName = builder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyWebAppEndpoint";
+
+        var endpointConfiguration = new EndpointConfiguration(endpointName);
+        // configure endpoint, passing values from builder.Configuration as needed
 
         builder.UseNServiceBus(endpointConfiguration);
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
@@ -13,6 +14,27 @@ class Configuration
         var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
         // configure endpoint here
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    async Task ReadAppSettings()
+    {
+        #region extensions-host-appsettings
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var endpointName = hostBuilder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyEndpoint";
+
+        var endpointConfiguration = new EndpointConfiguration(endpointName);
+        // configure endpoint, passing values from hostBuilder.Configuration as needed
 
         hostBuilder.UseNServiceBus(endpointConfiguration);
 

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -44,4 +44,56 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var transportConnectionString = hostBuilder.Configuration.GetConnectionString("Transport");
+
+        var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+        // Pass transportConnectionString to the transport, for example:
+        //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+        //   transport.ConnectionString(transportConnectionString);
+        _ = transportConnectionString;
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var settings = hostBuilder.Configuration
+            .GetSection("NServiceBus")
+            .Get<EndpointSettings>() ?? new EndpointSettings();
+
+        var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+        endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_4/MinimalApi.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_4/MinimalApi.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using NServiceBus;
 
 public class MinimalApi
@@ -12,6 +13,29 @@ public class MinimalApi
         var endpointConfiguration = new EndpointConfiguration("MyWebAppEndpoint");
 
         // configure the endpoint
+
+        builder.UseNServiceBus(endpointConfiguration);
+
+        var app = builder.Build();
+
+        // further ASP.NET configuration
+
+        app.Run();
+
+        #endregion
+    }
+
+    void MinimalHostReadAppSettings()
+    {
+        #region asp-net-minimal-host-appsettings
+
+        var builder = WebApplication.CreateBuilder();
+
+        var endpointName = builder.Configuration.GetValue<string>("NServiceBus:EndpointName")
+            ?? "MyWebAppEndpoint";
+
+        var endpointConfiguration = new EndpointConfiguration(endpointName);
+        // configure endpoint, passing values from builder.Configuration as needed
 
         builder.UseNServiceBus(endpointConfiguration);
 

--- a/nservicebus/hosting/asp-net.md
+++ b/nservicebus/hosting/asp-net.md
@@ -1,7 +1,7 @@
 ---
 title: NServiceBus in ASP.NET
 summary: Hosting NServiceBus in ASP.NET Core applications
-reviewed: 2025-01-13
+reviewed: 2026-05-05
 component: Extensions.Hosting
 related:
  - nservicebus/hosting/web-application
@@ -21,6 +21,20 @@ snippet: asp-net-minimal-host-endpoint
 Starting with ASP.NET 3, the [NServiceBus Generic Host support](/nservicebus/hosting/extensions-hosting.md) provides integration with ASP.NET Core applications:
 
 snippet: asp-net-generic-host-endpoint
+
+## Reading application settings
+
+NServiceBus uses code-based configuration. To use values from `appsettings.json` or other sources, read them via `IConfiguration` and pass them to the NServiceBus configuration API.
+
+snippet: extensions-host-appsettings
+
+Both `WebApplication.CreateBuilder()` and `Host.CreateApplicationBuilder()` automatically load configuration from:
+
+- `appsettings.json`
+- `appsettings.{Environment}.json` (e.g., `appsettings.Development.json`)
+- Environment variables
+
+No additional setup is required to enable these sources.
 
 ## Dependency injection
 

--- a/nservicebus/hosting/asp-net.md
+++ b/nservicebus/hosting/asp-net.md
@@ -24,17 +24,23 @@ snippet: asp-net-generic-host-endpoint
 
 ## Reading application settings
 
-NServiceBus uses code-based configuration. To use values from `appsettings.json` or other sources, read them via `IConfiguration` and pass them to the NServiceBus configuration API.
+NServiceBus is configured in code. Values such as endpoint names, connection strings, and feature flags can be sourced from `appsettings.json` or any other configuration provider by reading them via `IConfiguration` and passing them to the NServiceBus configuration API.
+
+When using the Minimal API host, read configuration via `builder.Configuration`:
+
+snippet: asp-net-minimal-host-appsettings
+
+When using the Generic Host, read configuration via the `HostBuilderContext` (or `hostBuilder.Configuration`):
 
 snippet: extensions-host-appsettings
 
 Both `WebApplication.CreateBuilder()` and `Host.CreateApplicationBuilder()` automatically load configuration from:
 
 - `appsettings.json`
-- `appsettings.{Environment}.json` (e.g., `appsettings.Development.json`)
+- `appsettings.{Environment}.json` (for example, `appsettings.Development.json`)
 - Environment variables
 
-No additional setup is required to enable these sources.
+No additional setup is required to enable these sources. See [Reading application settings](/nservicebus/hosting/extensions-hosting.md#reading-application-settings) for guidance on connection strings, the options pattern, and other configuration providers.
 
 ## Dependency injection
 

--- a/nservicebus/hosting/docker-host/index.md
+++ b/nservicebus/hosting/docker-host/index.md
@@ -8,7 +8,7 @@ related:
 component: Templates
 isLearningPath: true
 versions: '[2,]'
-reviewed: 2025-05-19
+reviewed: 2026-05-05
 ---
 
 Hosting endpoints in Docker containers provides self-contained artifacts that can be deployed to multiple environments or managed by orchestration technologies such as [Kubernetes](https://kubernetes.io/docs/home/). To create and host an endpoint in a Docker container, use the `dotnet new` template from the [ParticularTemplates package](/nservicebus/dotnet-templates/). The generated project includes all required endpoint setup infrastructure, along with a `Dockerfile` needed to build and deploy a container hosting one endpoint.
@@ -49,3 +49,15 @@ ENTRYPOINT ["dotnet", "MyEndpoint.dll"]
 ```
 
 partial: program
+
+## Configuration
+
+Endpoints hosted in Docker use the same [.NET configuration system](/nservicebus/hosting/extensions-hosting.md#reading-application-settings) as any other host. Connection strings and other settings can be placed in `appsettings.json` and overridden at runtime using environment variables.
+
+Environment variable names use `__` (double underscore) as the section separator. For example, to override `ConnectionStrings:Transport` from `appsettings.json`, set:
+
+```
+ConnectionStrings__Transport=host=rabbitmq
+```
+
+This is the standard approach for injecting environment-specific configuration into Docker containers and Kubernetes pods, without modifying the image.

--- a/nservicebus/hosting/docker-host/index.md
+++ b/nservicebus/hosting/docker-host/index.md
@@ -50,7 +50,7 @@ ENTRYPOINT ["dotnet", "MyEndpoint.dll"]
 
 partial: program
 
-## Configuration
+## Reading application settings
 
 Endpoints hosted in Docker use the same [.NET configuration system](/nservicebus/hosting/extensions-hosting.md#reading-application-settings) as any other host. Connection strings and other settings can be placed in `appsettings.json` and overridden at runtime using environment variables.
 
@@ -60,4 +60,4 @@ Environment variable names use `__` (double underscore) as the section separator
 ConnectionStrings__Transport=host=rabbitmq
 ```
 
-This is the standard approach for injecting environment-specific configuration into Docker containers and Kubernetes pods, without modifying the image.
+This is the standard approach for injecting environment-specific configuration into Docker containers and Kubernetes pods, without modifying the image. See the [.NET environment variable configuration provider documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider) for details on the naming convention.

--- a/nservicebus/hosting/extensions-hosting.md
+++ b/nservicebus/hosting/extensions-hosting.md
@@ -2,7 +2,7 @@
 title: NServiceBus.Extensions.Hosting
 summary: NServiceBus integration with Microsoft.Extensions.Hosting
 component: Extensions.Hosting
-reviewed: 2025-08-19
+reviewed: 2026-05-05
 related:
  - samples/hosting/generic-host
  - samples/dependency-injection/aspnetcore
@@ -20,6 +20,20 @@ This registers the endpoint with the hosting infrastructure and starts/stops it 
 > Call `UseNServiceBus` **before** registering any component that needs `IMessageSession`. Placing it later can cause a `System.InvalidOperationException`:
 >
 > > The message session can't be used before NServiceBus is started. Place `UseNServiceBus()` on the host builder before registering any hosted service (e.g. `services.AddHostedService<HostedServiceAccessingTheSession>()`) or the web host configuration (e.g. `builder.ConfigureWebHostDefaults`) if hosted services or controllers require access to the session.
+
+## Reading application settings
+
+NServiceBus uses code-based configuration. To use values from `appsettings.json` or other sources, read them via `IConfiguration` and pass them to the NServiceBus configuration API.
+
+snippet: extensions-host-appsettings
+
+The Generic Host automatically loads configuration from:
+
+- `appsettings.json`
+- `appsettings.{Environment}.json` (e.g., `appsettings.Development.json`)
+- Environment variables
+
+No additional setup is required to enable these sources.
 
 ## Logging integration
 

--- a/nservicebus/hosting/extensions-hosting.md
+++ b/nservicebus/hosting/extensions-hosting.md
@@ -37,11 +37,36 @@ No additional setup is required to enable these sources.
 
 ### Connection strings
 
-Connection strings can be read from the `ConnectionStrings` section of `appsettings.json` using `IConfiguration.GetConnectionString("Transport")` and passed to the transport configuration API.
+Transport and persistence connection strings are typically stored in the `ConnectionStrings` section of `appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "Transport": "host=localhost;username=guest;password=guest"
+  }
+}
+```
+
+Read them with `IConfiguration.GetConnectionString("Transport")` and pass the result to the transport configuration:
+
+snippet: extensions-host-connection-string
+
+The exact transport API depends on the transport package in use; see the documentation for the [transport](/transports/) being configured.
 
 ### Strongly-typed settings
 
-For more complex configuration, bind a settings class to a configuration section using the [.NET options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) and use the bound values during endpoint configuration.
+For more complex configuration, bind a settings class to a configuration section using the [.NET options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) and use the bound values during endpoint setup:
+
+```json
+{
+  "NServiceBus": {
+    "EndpointName": "Sales",
+    "MaxConcurrency": 8
+  }
+}
+```
+
+snippet: extensions-host-options-pattern
 
 ### Other configuration sources
 
@@ -50,7 +75,11 @@ Because the entry point is `IConfiguration`, any configuration provider works wi
 > [!NOTE]
 > Endpoint configuration values are read once at startup. The reload-on-change behavior provided by `IOptionsMonitor<T>` does not apply to endpoint configuration after the endpoint has started.
 
-When hosting in Azure Functions, NServiceBus accesses the same `IConfiguration` instance provided by the Functions runtime. See [Azure Functions hosting](/nservicebus/hosting/azure-functions-service-bus/) for details.
+### Azure Functions and other hosts
+
+The same `IConfiguration`-based pattern applies when hosting in [Azure Functions](/nservicebus/hosting/azure-functions-service-bus/). `ServiceBusTriggeredEndpointConfiguration` reads values from the Functions host's `IConfiguration` (and falls back to environment variables), so settings flow through `local.settings.json` in development and through Function app settings in Azure. See the [Azure Functions configuration reference](/nservicebus/hosting/azure-functions-service-bus/#configuration) for the keys recognized by the Azure Service Bus integration, including connection-string and identity-based connection options.
+
+When connecting endpoints across transports using the [NServiceBus.Transport.Bridge](/nservicebus/bridge/), the same `HostBuilderContext.Configuration` access is available during bridge setup; see [Bridge configuration](/nservicebus/bridge/configuration.md).
 
 ## Logging integration
 

--- a/nservicebus/hosting/extensions-hosting.md
+++ b/nservicebus/hosting/extensions-hosting.md
@@ -23,17 +23,34 @@ This registers the endpoint with the hosting infrastructure and starts/stops it 
 
 ## Reading application settings
 
-NServiceBus uses code-based configuration. To use values from `appsettings.json` or other sources, read them via `IConfiguration` and pass them to the NServiceBus configuration API.
+NServiceBus is configured in code. Values such as endpoint names, connection strings, and feature flags can be sourced from `appsettings.json` or any other configuration provider by reading them via `IConfiguration` and passing them to the NServiceBus configuration API.
 
 snippet: extensions-host-appsettings
 
 The Generic Host automatically loads configuration from:
 
 - `appsettings.json`
-- `appsettings.{Environment}.json` (e.g., `appsettings.Development.json`)
+- `appsettings.{Environment}.json` (for example, `appsettings.Development.json`)
 - Environment variables
 
 No additional setup is required to enable these sources.
+
+### Connection strings
+
+Connection strings can be read from the `ConnectionStrings` section of `appsettings.json` using `IConfiguration.GetConnectionString("Transport")` and passed to the transport configuration API.
+
+### Strongly-typed settings
+
+For more complex configuration, bind a settings class to a configuration section using the [.NET options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) and use the bound values during endpoint configuration.
+
+### Other configuration sources
+
+Because the entry point is `IConfiguration`, any configuration provider works without additional integration, including [User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets), [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/overview), and AWS Systems Manager Parameter Store. See the [.NET configuration providers documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers) for the full list.
+
+> [!NOTE]
+> Endpoint configuration values are read once at startup. The reload-on-change behavior provided by `IOptionsMonitor<T>` does not apply to endpoint configuration after the endpoint has started.
+
+When hosting in Azure Functions, NServiceBus accesses the same `IConfiguration` instance provided by the Functions runtime. See [Azure Functions hosting](/nservicebus/hosting/azure-functions-service-bus/) for details.
 
 ## Logging integration
 

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -2,7 +2,7 @@
 title: Hosting
 summary: Describes the various approaches to endpoint hosting
 component: Core
-reviewed: 2025-01-13
+reviewed: 2026-05-05
 redirects:
 - nservicebus/hosting/self-hosting
 - nservicebus/hosting/self-hosting-v4.x
@@ -16,7 +16,7 @@ There are several approaches to hosting.
 
 ## Microsoft Generic Host
 
-The [Microsoft Generic Host](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) is the most common way to host NServiceBus on .NET Core. NServiceBus can be integrated with the generic host using the [NServiceBus.Extensions.Hosting package](/nservicebus/hosting/extensions-hosting.md).
+The [Microsoft Generic Host](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) is the most common way to host NServiceBus on .NET Core. NServiceBus can be integrated with the generic host using the [NServiceBus.Extensions.Hosting package](/nservicebus/hosting/extensions-hosting.md). The Generic Host also provides access to `IConfiguration`, making it straightforward to read connection strings and other settings from `appsettings.json` or environment variables. See [Reading application settings](/nservicebus/hosting/extensions-hosting.md#reading-application-settings) for details.
 
 ## Self-hosting
 


### PR DESCRIPTION
Resolves https://github.com/Particular/docs.particular.net/issues/6644

## Summary

Documents how to read application settings (e.g., from `appsettings.json`) and pass them to NServiceBus when hosting with `Microsoft.Extensions.Hosting`.

- Adds a "Reading application settings" section to:
  - [`nservicebus/hosting/extensions-hosting.md`](nservicebus/hosting/extensions-hosting.md) - canonical guidance for the Generic Host
  - [`nservicebus/hosting/asp-net.md`](nservicebus/hosting/asp-net.md) - covers both `WebApplication.CreateBuilder` (Minimal APIs) and the Generic Host
  - [`nservicebus/hosting/docker-host/index.md`](nservicebus/hosting/docker-host/index.md) - covers environment-variable overrides for containerized hosts
- Cross-links from [`nservicebus/hosting/index.md`](nservicebus/hosting/index.md) so the entry point mentions `IConfiguration` access
- Introduces the `extensions-host-appsettings` snippet across all four versioned `Extensions.Hosting_N` projects (v1/v2 use `Host.CreateDefaultBuilder` with the callback context; v3/v4 use `Host.CreateApplicationBuilder` directly)
- Adds an ASP.NET Minimal API variant (`asp-net-minimal-host-appsettings`) that reads from `builder.Configuration` before `builder.UseNServiceBus(...)`
- Updates `reviewed` dates to 2026-05-05 on the touched pages