### PR TITLE
Docs review skill updates for partials and snippets

### DIFF
--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -169,7 +169,17 @@ To locate snippet code for a given `snippet: KEY` directive:
 1. Note the key name after `snippet:`
 2. Find the component from the document's `component:` frontmatter field
 3. Component keys are defined in `components/components.yaml`
-4. Search `Snippets/{ComponentKey}/` for files containing `#region KEY` (C#) or `// startcode KEY`
+4. Search `Snippets/{ComponentKey}/` for files containing the snippet key using the appropriate marker for the file type:
+
+   | File type | Open marker | Close marker |
+   |-----------|-------------|--------------|
+   | C# (region) | `#region KEY` | `#endregion` |
+   | C# (comment) | `// startcode KEY` | `// endcode` |
+   | XML-based | `<!-- startcode KEY -->` | `<!-- endcode -->` |
+   | PowerShell | `# startcode KEY` | `# endcode` |
+   | SQL | `-- startcode KEY` | `-- endcode` |
+   | Plain text | `startcode KEY` | `endcode` |
+   | Dockerfile / YAML | `# startcode KEY` | `# endcode` |
 5. Snippet files live in versioned subdirectories, e.g. `Snippets/Core_7/` or `Snippets/MsmqTransport_1/`
 
 ---

--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -119,6 +119,61 @@ Code samples should:
 
 ---
 
+# Partials
+
+Partials are version-specific markdown files included in a document using:
+
+```markdown
+partial: KEY
+```
+
+Reviewing a document includes reviewing all of its referenced partials. Partials are rendered inline — the reader sees them as part of the page. Review each partial as if it were content in the parent document: consider how it reads in context, whether it flows with the surrounding content, and apply the full review process (language, style, technical accuracy, content quality, and link validation).
+
+## Finding partials
+
+Partial files are stored in the same directory as the document that references them.
+
+Convention: `{filePrefix}_{key}_{nugetAlias}_{version}.partial.md`
+
+Where `{filePrefix}` is the filename of the referencing document without the `.md` extension.
+
+To locate partials for a given `partial: KEY` directive:
+
+1. Note the key name after `partial:`
+2. Note the filename of the document being reviewed (without `.md`) — this is the file prefix
+3. Search the same directory for files matching `{filePrefix}_{key}_*.partial.md`
+4. Review every matching file — one may exist per supported version
+
+Example: `partial: endpointname` in `nservicebus/messaging/index.md` matches:
+- `index_endpointname_Core_7.partial.md`
+- `index_endpointname_Core_8.partial.md`
+
+---
+
+# Snippets
+
+Snippets are code samples referenced in a document using:
+
+```markdown
+snippet: KEY
+```
+
+Reviewing a document includes checking all of its referenced snippets. Snippets are excerpts from larger code files, so the focus is narrow: verify that the snippet content is relevant to the surrounding documentation and that it illustrates what the text claims it does.
+
+## Finding snippets
+
+Snippet code lives in versioned directories under `Snippets/`.
+
+To locate snippet code for a given `snippet: KEY` directive:
+
+1. Note the key name after `snippet:`
+2. Find the component from the document's `component:` frontmatter field
+3. Component keys are defined in `components/components.yaml`
+4. Search `Snippets/{ComponentKey}/` for files containing `#region KEY` (C#) or `// startcode KEY`
+5. Snippet files live in versioned subdirectories, e.g. `Snippets/Core_7/` or `Snippets/MsmqTransport_1/`
+
+---
+
 # Terminology
 
 Use consistent terminology.

--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -158,7 +158,7 @@ Snippets are code samples referenced in a document using:
 snippet: KEY
 ```
 
-Reviewing a document includes checking all of its referenced snippets. Snippets are excerpts from larger code files, so the focus is narrow: verify that the snippet content is relevant to the surrounding documentation and that it illustrates what the text claims it does.
+Reviewing a document includes checking all of its referenced snippets. Snippets are excerpts from larger code files, so the focus is narrow: verify that the snippet content is relevant to the surrounding documentation and that it illustrates what the text claims it does. If a snippet is changed during the review, apply the full [Code Review Checklist](#code-review-checklist) to the changed snippet.
 
 ## Finding snippets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,1 @@
-# Claude Instructions
-
-Use `AGENTS.md` in this repository root as the canonical instruction file.
-
-When reviewing or editing documentation, use the `particular-docs-review` skill:
-- `.github/skills/particular-docs-review/SKILL.MD`
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,1 @@
-# Gemini Instructions
-
-Use `AGENTS.md` in this repository root as the canonical instruction file.
-
-When reviewing or editing documentation, use the `particular-docs-review` skill:
-- `.github/skills/particular-docs-review/SKILL.MD`
+@AGENTS.md


### PR DESCRIPTION
This adds instructions to the `particular-docs-review` skill for identifying/reviewing partials and snippets.

It also directly references the `AGENTS.md` file in the `CLAUDE.md` and `GEMINI.md` files.