### PR TITLE
Remove add-source parameter from tool install commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"forwardPorts": [
 		55666
 	],
-	"postCreateCommand": "dotnet tool install -g Particular.DocsTool --add-source https://f.feedz.io/particular-software/packages/nuget/index.json",
+	"postCreateCommand": "dotnet tool install -g Particular.DocsTool",
 	"postStartCommand": "docstool update",
 	"postAttachCommand": "docstool serve --port 55666",
 	"remoteEnv": {

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install docstool
         if: steps.cache-docstool.outputs.cache-hit != 'true'
-        run: dotnet tool install Particular.DocsTool --global --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
+        run: dotnet tool install Particular.DocsTool --global
 
       - name: Verify docstool is available
         run: docstool --version

--- a/.github/workflows/publish-samples.yml
+++ b/.github/workflows/publish-samples.yml
@@ -37,7 +37,7 @@ jobs:
           key: docstool-${{ hashFiles('docstool-versions.json') }}
       - name: Install docstool
         if: steps.cache-docstool.outputs.cache-hit != 'true'
-        run: dotnet tool install Particular.DocsTool --global --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
+        run: dotnet tool install Particular.DocsTool --global
       - name: Run docstool
         run: docstool test --no-version-check --zipfiles --out ~/build-output
       - name: Azure Login

--- a/.github/workflows/validate-pull-requests.yml
+++ b/.github/workflows/validate-pull-requests.yml
@@ -28,7 +28,7 @@ jobs:
           key: docstool-${{ hashFiles('docstool-version.json') }}
       - name: Install docstool
         if: steps.cache-docstool.outputs.cache-hit != 'true'
-        run: dotnet tool install Particular.DocsTool --global --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
+        run: dotnet tool install Particular.DocsTool --global
       - name: Run docstool
         run: docstool test --no-version-check
   integrity-tests:

--- a/.github/workflows/verify-master.yml
+++ b/.github/workflows/verify-master.yml
@@ -31,7 +31,7 @@ jobs:
           key: docstool-${{ hashFiles('docstool-versions.json') }}
       - name: Install docstool
         if: steps.cache-docstool.outputs.cache-hit != 'true'
-        run: dotnet tool install Particular.DocsTool --global --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
+        run: dotnet tool install Particular.DocsTool --global
       - name: Run docstool
         run: docstool test --no-version-check
       - name: Notify Slack on failure


### PR DESCRIPTION
There appears to be a change in the 10.0.300 SDK where the `dotnet tool install -g` command for global tool installations is now picking up settings from nuget.config files in the current working directory.

This means that the command already sees the Feedz feed in the file, but also causes the following problem because we also have package mapping settings defined:

```
The --add-source option cannot be combined with package source mapping. To use an additional source, update your NuGet configuration file's source mapping settings. Learn more: https://aka.ms/nuget-package-source-mapping
```

At this point, it's unclear if this is an intentional change or a bug, but to get things working again for now, I've removed the `--add-source` parameter from the commands.

