### PR TITLE
Add EndpointLoggingScope documentation for NServiceBus 10.2

### DIFF
--- a/Snippets/Core/Core_10/Core_10.csproj
+++ b/Snippets/Core/Core_10/Core_10.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
-    <PackageReference Include="NServiceBus" Version="10.2.0-alpha.5" />
+    <PackageReference Include="NServiceBus" Version="10.2.0-alpha.12" />
     <PackageReference Include="NServiceBus.Callbacks" Version="6.*" />
     <PackageReference Include="NServiceBus.ClaimCheck" Version="2.*" />
     <PackageReference Include="NServiceBus.Encryption.MessageProperty" Version="6.*" />

--- a/Snippets/Core/Core_10/Logging/ModernLogging.cs
+++ b/Snippets/Core/Core_10/Logging/ModernLogging.cs
@@ -1,10 +1,14 @@
 namespace Core.Logging;
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
+using NServiceBus.Logging;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 public class MyMessage : IMessage { }
 
@@ -49,3 +53,20 @@ class Startup
     }
     #endregion
 }
+
+#region UsingEndpointLoggingScope
+public class MyBackgroundService(
+    ILogger<MyBackgroundService> logger,
+    EndpointLoggingScope endpointScope) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using (logger.BeginEndpointScope(endpointScope))
+        {
+            logger.LogInformation("Doing background work");
+        }
+
+        await Task.CompletedTask;
+    }
+}
+#endregion

--- a/Snippets/Core/Core_10/Recoverability/Pipeline.cs
+++ b/Snippets/Core/Core_10/Recoverability/Pipeline.cs
@@ -21,8 +21,7 @@ public class EnableExternalBodyStorageBehavior : Behavior<IRecoverabilityContext
     {
         if (context.RecoverabilityAction is MoveToError errorAction)
         {
-            var message = context.FailedMessage;
-            var bodyUrl = await storage.StoreBody(message.MessageId, message.Body);
+            var bodyUrl = await storage.StoreBody(context.MessageId, context.Body);
 
             context.Metadata["body-url"] = bodyUrl;
 

--- a/nservicebus/logging/index.md
+++ b/nservicebus/logging/index.md
@@ -1,7 +1,7 @@
 ---
 title: Logging
 summary: NServiceBus logging
-reviewed: 2026-04-27
+reviewed: 2026-05-19
 component: Core
 isLearningPath: true
 redirects:

--- a/nservicebus/logging/index_modern_core_[10,).partial.md
+++ b/nservicebus/logging/index_modern_core_[10,).partial.md
@@ -37,3 +37,13 @@ snippet: UsingLoggerMessageSourceGenerator
 
 > [!WARNING]
 > The NServiceBus-specific logging APIs described in the next section below are still functional but produce obsolete warnings starting in version 10.2 and will be removed in version 12. Use the `Microsoft.Extensions.Logging` patterns shown earlier for new development.
+
+## Enriching logs outside the message pipeline
+
+Logs written from inside the message-processing pipeline automatically include the endpoint name and identifier as structured log properties. Logs written from code outside the pipeline, such as a hosted background task or a custom timer callback, do not include this context by default.
+
+To attach endpoint context to those logs, resolve the `EndpointLoggingScope` from the DI container and use the `BeginEndpointScope` extension method:
+
+snippet: UsingEndpointLoggingScope
+
+The `EndpointLoggingScope` instance is scoped to the endpoint and carries the endpoint name and identifier with it. The `BeginEndpointScope` extension method detects when the call occurs inside the message-processing pipeline and returns a no-op scope. This avoids duplicate scope entries when the pattern is used from message handlers.


### PR DESCRIPTION
Catches up with the changes in https://github.com/Particular/NServiceBus/pull/7758

- Add 'Enriching logs outside the message pipeline' section to logging docs
- Add MyBackgroundService snippet demonstrating BeginEndpointScope usage
- Update NServiceBus to 10.2.0-alpha.12 for EndpointLoggingScope type
- Refactor Recoverability/Pipeline.cs to use context.MessageId/context.Body instead of obsolete context.FailedMessage