### PR TITLE
Add worked examples for IConfiguration patterns

### DIFF
--- a/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_1/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -43,4 +43,58 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var transportConnectionString = ctx.Configuration.GetConnectionString("Transport");
+
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+                // Pass transportConnectionString to the transport, for example:
+                //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+                //   transport.ConnectionString(transportConnectionString);
+                _ = transportConnectionString;
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var settings = ctx.Configuration
+                    .GetSection("NServiceBus")
+                    .Get<EndpointSettings>() ?? new EndpointSettings();
+
+                var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+                endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_2/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -43,4 +43,58 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var transportConnectionString = ctx.Configuration.GetConnectionString("Transport");
+
+                var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+                // Pass transportConnectionString to the transport, for example:
+                //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+                //   transport.ConnectionString(transportConnectionString);
+                _ = transportConnectionString;
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseNServiceBus(ctx =>
+            {
+                var settings = ctx.Configuration
+                    .GetSection("NServiceBus")
+                    .Get<EndpointSettings>() ?? new EndpointSettings();
+
+                var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+                endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+                return endpointConfiguration;
+            })
+            .Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_3/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -44,4 +44,56 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var transportConnectionString = hostBuilder.Configuration.GetConnectionString("Transport");
+
+        var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+        // Pass transportConnectionString to the transport, for example:
+        //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+        //   transport.ConnectionString(transportConnectionString);
+        _ = transportConnectionString;
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var settings = hostBuilder.Configuration
+            .GetSection("NServiceBus")
+            .Get<EndpointSettings>() ?? new EndpointSettings();
+
+        var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+        endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
+++ b/Snippets/Extensions.Hosting/Extensions.Hosting_4/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
@@ -44,4 +44,56 @@ class Configuration
 
         #endregion
     }
+
+    async Task ReadConnectionString()
+    {
+        #region extensions-host-connection-string
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var transportConnectionString = hostBuilder.Configuration.GetConnectionString("Transport");
+
+        var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+        // Pass transportConnectionString to the transport, for example:
+        //   var transport = endpointConfiguration.UseTransport<YourTransport>();
+        //   transport.ConnectionString(transportConnectionString);
+        _ = transportConnectionString;
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+
+        #endregion
+    }
+
+    #region extensions-host-options-pattern
+
+    class EndpointSettings
+    {
+        public string EndpointName { get; set; } = "MyEndpoint";
+        public int MaxConcurrency { get; set; } = 4;
+    }
+
+    async Task UseOptionsPattern()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var settings = hostBuilder.Configuration
+            .GetSection("NServiceBus")
+            .Get<EndpointSettings>() ?? new EndpointSettings();
+
+        var endpointConfiguration = new EndpointConfiguration(settings.EndpointName);
+        endpointConfiguration.LimitMessageProcessingConcurrencyTo(settings.MaxConcurrency);
+
+        hostBuilder.UseNServiceBus(endpointConfiguration);
+
+        var host = hostBuilder.Build();
+
+        await host.RunAsync();
+    }
+
+    #endregion
 }

--- a/nservicebus/hosting/extensions-hosting.md
+++ b/nservicebus/hosting/extensions-hosting.md
@@ -37,11 +37,36 @@ No additional setup is required to enable these sources.
 
 ### Connection strings
 
-Connection strings can be read from the `ConnectionStrings` section of `appsettings.json` using `IConfiguration.GetConnectionString("Transport")` and passed to the transport configuration API.
+Transport and persistence connection strings are typically stored in the `ConnectionStrings` section of `appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "Transport": "host=localhost;username=guest;password=guest"
+  }
+}
+```
+
+Read them with `IConfiguration.GetConnectionString("Transport")` and pass the result to the transport configuration:
+
+snippet: extensions-host-connection-string
+
+The exact transport API depends on the transport package in use; see the documentation for the [transport](/transports/) being configured.
 
 ### Strongly-typed settings
 
-For more complex configuration, bind a settings class to a configuration section using the [.NET options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) and use the bound values during endpoint configuration.
+For more complex configuration, bind a settings class to a configuration section using the [.NET options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) and use the bound values during endpoint setup:
+
+```json
+{
+  "NServiceBus": {
+    "EndpointName": "Sales",
+    "MaxConcurrency": 8
+  }
+}
+```
+
+snippet: extensions-host-options-pattern
 
 ### Other configuration sources
 
@@ -50,7 +75,11 @@ Because the entry point is `IConfiguration`, any configuration provider works wi
 > [!NOTE]
 > Endpoint configuration values are read once at startup. The reload-on-change behavior provided by `IOptionsMonitor<T>` does not apply to endpoint configuration after the endpoint has started.
 
-When hosting in Azure Functions, NServiceBus accesses the same `IConfiguration` instance provided by the Functions runtime. See [Azure Functions hosting](/nservicebus/hosting/azure-functions-service-bus/) for details.
+### Azure Functions and other hosts
+
+The same `IConfiguration`-based pattern applies when hosting in [Azure Functions](/nservicebus/hosting/azure-functions-service-bus/). `ServiceBusTriggeredEndpointConfiguration` reads values from the Functions host's `IConfiguration` (and falls back to environment variables), so settings flow through `local.settings.json` in development and through Function app settings in Azure. See the [Azure Functions configuration reference](/nservicebus/hosting/azure-functions-service-bus/#configuration) for the keys recognized by the Azure Service Bus integration, including connection-string and identity-based connection options.
+
+When connecting endpoints across transports using the [NServiceBus.Transport.Bridge](/nservicebus/bridge/), the same `HostBuilderContext.Configuration` access is available during bridge setup; see [Bridge configuration](/nservicebus/bridge/configuration.md).
 
 ## Logging integration
 


### PR DESCRIPTION
Builds on [#8252](https://github.com/Particular/docs.particular.net/pull/8252) with worked examples for three of the suggestions raised during review:

- **Connection strings** - `extensions-host-connection-string` snippet showing `IConfiguration.GetConnectionString("Transport")` paired with the `ConnectionStrings` section of `appsettings.json`. Transport-agnostic; points to the transport docs for the final wiring step.
- **Options pattern** - `extensions-host-options-pattern` snippet defining an `EndpointSettings` class bound via `GetSection("NServiceBus").Get<EndpointSettings>()` and applied to `EndpointConfiguration`.
- **Azure Functions cross-reference** - expanded the brief mention into its own subsection cross-linking to the existing Azure Service Bus Functions configuration partial, unifying the `IConfiguration` story across hosting models. Bridge cross-link added for symmetry.

All four versioned `Extensions.Hosting_N` snippet projects compile clean (v1/v2 use `Host.CreateDefaultBuilder` with the callback context; v3/v4 use `Host.CreateApplicationBuilder` directly).

> [!NOTE]
> Targets `config`, not `master` - merge after #8252 lands (or retarget once that PR is merged).