### PR TITLE
Move send-only endpoint documentation to /endpoints#send-only

### DIFF
--- a/Snippets/Core/Core_10/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_10/Hosting/Hosting.cs
@@ -6,16 +6,6 @@ using NServiceBus;
 
 class Hosting
 {
-    void SendOnly()
-    {
-        #region Hosting-SendOnly
-
-        var endpointConfiguration = new EndpointConfiguration("EndpointName");
-        endpointConfiguration.SendOnly();
-
-        #endregion
-    }
-
 #pragma warning disable CS0618 // Type or member is obsolete
     async Task Startup()
     {

--- a/Snippets/Core/Core_10/SendOnly.cs
+++ b/Snippets/Core/Core_10/SendOnly.cs
@@ -1,0 +1,16 @@
+﻿namespace Core;
+
+using NServiceBus;
+
+class SendOnly
+{
+    void Configure()
+    {
+        #region send-only-endpoint
+
+        var endpointConfiguration = new EndpointConfiguration("EndpointName");
+        endpointConfiguration.SendOnly();
+
+        #endregion
+    }
+}

--- a/Snippets/Core/Core_7/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_7/Hosting/Hosting.cs
@@ -7,18 +7,6 @@
 
     class Hosting
     {
-        async Task SendOnly()
-        {
-            #region Hosting-SendOnly
-
-            var endpointConfiguration = new EndpointConfiguration("EndpointName");
-            endpointConfiguration.SendOnly();
-            // Apply other necessary endpoint configuration, e.g. transport
-            var endpointInstance = await Endpoint.Start(endpointConfiguration);
-
-            #endregion
-        }
-
         async Task Startup()
         {
             #region Hosting-Startup

--- a/Snippets/Core/Core_7/SendOnly.cs
+++ b/Snippets/Core/Core_7/SendOnly.cs
@@ -1,0 +1,20 @@
+﻿namespace Core7
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    class SendOnly
+    {
+        async Task Configure()
+        {
+            #region send-only-endpoint
+
+            var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            endpointConfiguration.SendOnly();
+            // Apply other necessary endpoint configuration, e.g. transport
+            var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+            #endregion
+        }
+    }
+}

--- a/Snippets/Core/Core_8/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_8/Hosting/Hosting.cs
@@ -6,18 +6,6 @@
 
     class Hosting
     {
-        async Task SendOnly()
-        {
-            #region Hosting-SendOnly
-
-            var endpointConfiguration = new EndpointConfiguration("EndpointName");
-            endpointConfiguration.SendOnly();
-            // Apply other necessary endpoint configuration, e.g. transport
-            var endpointInstance = await Endpoint.Start(endpointConfiguration);
-
-            #endregion
-        }
-
         async Task Startup()
         {
             #region Hosting-Startup

--- a/Snippets/Core/Core_8/SendOnly.cs
+++ b/Snippets/Core/Core_8/SendOnly.cs
@@ -1,0 +1,20 @@
+﻿namespace Core8
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    class SendOnly
+    {
+        async Task Configure()
+        {
+            #region send-only-endpoint
+
+            var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            endpointConfiguration.SendOnly();
+            // Apply other necessary endpoint configuration, e.g. transport
+            var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+            #endregion
+        }
+    }
+}

--- a/Snippets/Core/Core_9/Hosting/Hosting.cs
+++ b/Snippets/Core/Core_9/Hosting/Hosting.cs
@@ -6,18 +6,6 @@
 
     class Hosting
     {
-        async Task SendOnly()
-        {
-            #region Hosting-SendOnly
-
-            var endpointConfiguration = new EndpointConfiguration("EndpointName");
-            endpointConfiguration.SendOnly();
-            // Apply other necessary endpoint configuration, e.g. transport
-            var endpointInstance = await Endpoint.Start(endpointConfiguration);
-
-            #endregion
-        }
-
         async Task Startup()
         {
             #region Hosting-Startup

--- a/Snippets/Core/Core_9/SendOnly.cs
+++ b/Snippets/Core/Core_9/SendOnly.cs
@@ -1,0 +1,20 @@
+﻿namespace Core9
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    class SendOnly
+    {
+        async Task Configure()
+        {
+            #region send-only-endpoint
+
+            var endpointConfiguration = new EndpointConfiguration("EndpointName");
+            endpointConfiguration.SendOnly();
+            // Apply other necessary endpoint configuration, e.g. transport
+            var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+            #endregion
+        }
+    }
+}

--- a/monitoring/metrics/performance-counters.md
+++ b/monitoring/metrics/performance-counters.md
@@ -1,7 +1,7 @@
 ---
 title: Windows Performance Counters
 summary: Monitor NServiceBus endpoint performance on Windows using Performance Counters for message flow, and queue length
-reviewed: 2025-10-22
+reviewed: 2026-05-23
 component: PerfCounters
 redirects:
  - nservicebus/monitoring-nservicebus-endpoints
@@ -28,4 +28,4 @@ partial: counters
 partial: installing
 
 > [!NOTE]
-> [Send-only endpoints](/nservicebus/hosting/#send-only-hosting) are currently not supported since they don't receive messages.
+> [Send-only endpoints](/nservicebus/endpoints/#send-only) are currently not supported since they don't receive messages.

--- a/nservicebus/endpoints/index.md
+++ b/nservicebus/endpoints/index.md
@@ -1,10 +1,11 @@
 ---
 title: Endpoints and endpoint instances
 summary: Defines the concepts of endpoint and endpoint instance.
-reviewed: 2026-03-09
+reviewed: 2026-05-23
 component: Core
 redirects:
 - nservicebus/endpoint
+- nservicebus/hosting/send-only-endpoints
 ---
 
 An _endpoint_ is a logical component that communicates with other components using [_messages_](/nservicebus/messaging). Each endpoint has an identifying name, contains a collection of [_message handlers_](/nservicebus/handlers/) and/or [_sagas_](/nservicebus/sagas/), and is deployed to a given _environment_ (e.g. development, testing, production).
@@ -20,3 +21,13 @@ A collection of endpoint instances represents a single logical endpoint if and o
 - The endpoint instances have the same name.
 - The endpoint instances contain the same collection of handlers and/or sagas.
 - The endpoint instances are deployed to the same environment.
+
+## Send-only
+
+A send-only endpoint is used when the only purpose is sending messages, and no message processing is required. Common use cases include websites, console applications, and Windows applications.
+
+To configure an endpoint in send-only mode:
+
+snippet: send-only-endpoint
+
+Send-only endpoints do not initialize receiving infrastructure. The only additional configuration required when running in this mode is the destination when [sending a message](/nservicebus/messaging/send-a-message.md).

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -2,11 +2,10 @@
 title: Hosting
 summary: Describes the various approaches to endpoint hosting
 component: Core
-reviewed: 2026-05-05
+reviewed: 2026-05-23
 redirects:
 - nservicebus/hosting/self-hosting
 - nservicebus/hosting/self-hosting-v4.x
-- nservicebus/hosting/send-only-endpoints
 - nservicebus/hosting/service-fabric-hosting
 ---
 
@@ -37,14 +36,6 @@ Related:
  * [Hosting endpoints in Docker Linux containers](/samples/hosting/docker/)
  * [Generic host](/samples/hosting/generic-host)
 
-## Send-only hosting
-
-A "Send-only endpoint" is used when the only purpose is sending messages, and no message processing is required. Common use cases include websites, console applications, and Windows applications. This is the code for starting an endpoint in send-only mode.
-
-snippet: Hosting-SendOnly
-
-The only configuration required when running in this mode is the destination when [sending a message](/nservicebus/messaging/send-a-message.md).
-
 ## Hosting technologies
 
 ### Web hosting
@@ -66,3 +57,7 @@ NServiceBus endpoints have certain requirements for the hosting environment:
 * The endpoint process needs write access to write log files. See the [logging documentation](/nservicebus/logging) for more details about the default log file location and how to configure logging.
 * The endpoint process needs write access to write the startup diagnostics file. See the [startup diagnostics documentation](/nservicebus/hosting/startup-diagnostics.md) for more details about the diagnostic file.
 * Since NServiceBus makes assumptions on aspects like assembly names, ILMerging any of the NServiceBus* assemblies is not supported.
+
+## Send-only hosting
+
+Send-only is documented as an [endpoint concept](/nservicebus/endpoints/#send-only), rather than a hosting approach.

--- a/nservicebus/hosting/index.md
+++ b/nservicebus/hosting/index.md
@@ -57,7 +57,3 @@ NServiceBus endpoints have certain requirements for the hosting environment:
 * The endpoint process needs write access to write log files. See the [logging documentation](/nservicebus/logging) for more details about the default log file location and how to configure logging.
 * The endpoint process needs write access to write the startup diagnostics file. See the [startup diagnostics documentation](/nservicebus/hosting/startup-diagnostics.md) for more details about the diagnostic file.
 * Since NServiceBus makes assumptions on aspects like assembly names, ILMerging any of the NServiceBus* assemblies is not supported.
-
-## Send-only hosting
-
-Send-only is documented as an [endpoint concept](/nservicebus/endpoints/#send-only), rather than a hosting approach.

--- a/nservicebus/hosting/publishing-from-web-applications.md
+++ b/nservicebus/hosting/publishing-from-web-applications.md
@@ -4,7 +4,7 @@ summary: Guidelines for publishing messages from within web applications
 component: core
 related:
 - samples/web
-reviewed: 2024-11-05
+reviewed: 2026-05-23
 ---
 
 Publishing events from a web application is possible with NServiceBus, but it should be carefully considered before implementation. This article will describe the guidelines for publishing messages from within web applications under different circumstances.
@@ -55,7 +55,7 @@ Although this speaks specifically to web applications, it's worth noting that th
 
 ## Storage-driven transport topology
 
-For storage-driven transports, it is not recommended to have one of the web applications receive subscription requests. Instead, each web application instance can be implemented as a [send-only endpoint](/nservicebus/hosting/#send-only-hosting), and a back-end service endpoint can be responsible for receiving the subscription request messages and updating the subscription storage.
+For storage-driven transports, it is not recommended to have one of the web applications receive subscription requests. Instead, each web application instance can be implemented as a [send-only endpoint](/nservicebus/endpoints/#send-only), and a back-end service endpoint can be responsible for receiving the subscription request messages and updating the subscription storage.
 
 ![Storage-driven transport publishing topology](storage-based-publish-topology.png "width=400")
 

--- a/nservicebus/hosting/selecting.md
+++ b/nservicebus/hosting/selecting.md
@@ -1,7 +1,7 @@
 ---
 title: Selecting a host
 summary: A guide for selecting a host for NServiceBus endpoints.
-reviewed: 2026-05-04
+reviewed: 2026-05-23
 isLearningPath: true
 ---
 This document provides guidance for deciding how to [host](/nservicebus/hosting) [NServiceBus endpoints](/nservicebus/endpoints/).
@@ -33,7 +33,7 @@ In Windows, IIS is a reliable host for web-based applications. An NServiceBus en
 
 This restricts IIS as a choice for hosting NServiceBus endpoints to two specific scenarios:
 
-- [Send-only endpoints](/nservicebus/hosting/#send-only-hosting), which can send but don't receive messages and, therefore, don't need to initialize any receiving infrastructure. Messages are sent while handling incoming HTTP requests or after user input in an interactive application.
+- [Send-only endpoints](/nservicebus/endpoints/#send-only), which can send but don't receive messages and, therefore, don't need to initialize any receiving infrastructure. Messages are sent while handling incoming HTTP requests or after user input in an interactive application.
 - Web applications which provide [near real-time feedback](/samples/near-realtime-clients/) using queues for asynchronous and reliable communication.
 
 See [Web Application Hosting](/nservicebus/hosting/web-application.md) for details.

--- a/nservicebus/messaging/callbacks.md
+++ b/nservicebus/messaging/callbacks.md
@@ -1,7 +1,7 @@
 ---
 title: Client-side callbacks
 summary: Gradually transition applications from synchronous to a messaging architecture
-reviewed: 2024-12-06
+reviewed: 2026-05-23
 component: Callbacks
 redirects:
 - nservicebus/how-do-i-handle-responses-on-the-client-side
@@ -29,7 +29,7 @@ When sending a message, a callback can be registered that will be invoked when a
 > [!CAUTION]
 > If the server process returns multiple responses, NServiceBus does not know which response message will be last. To prevent memory leaks, the callback is invoked only for the first response. Callbacks won't survive a process restart (e.g. a crash or an [IIS recycle](https://msdn.microsoft.com/en-us/library/ms525803.aspx)) as they are held in memory, so they are less suitable for server-side development where fault-tolerance is required. In those cases, [sagas are preferred](/nservicebus/sagas/).
 
-To handle responses from the processing endpoint, the sending endpoint must have its own queue. Therefore, the sending endpoint cannot be configured as a [SendOnly endpoint](/nservicebus/hosting/#send-only-hosting). Messages arriving in this queue are handled using a message handler, similar to that of the processing endpoint, as shown:
+To handle responses from the processing endpoint, the sending endpoint must have its own queue. Therefore, the sending endpoint cannot be configured as a [send-only endpoint](/nservicebus/endpoints/#send-only). Messages arriving in this queue are handled using a message handler, similar to that of the processing endpoint, as shown:
 
 snippet: EmptyHandler
 

--- a/nservicebus/transactional-session/index_remote-processor_transactionalsession_[3,).partial.md
+++ b/nservicebus/transactional-session/index_remote-processor_transactionalsession_[3,).partial.md
@@ -1,6 +1,6 @@
 ## Remote processor
 
-When used together with the [outbox](/nservicebus/outbox/) in a [send-only](/nservicebus/hosting/#send-only-hosting) endpoint, the transactional session must be configured with a remote processor endpoint that will manage the outbox on behalf of the send-only endpoint.
+When used together with the [outbox](/nservicebus/outbox/) in a [send-only](/nservicebus/endpoints/#send-only) endpoint, the transactional session must be configured with a remote processor endpoint that will manage the outbox on behalf of the send-only endpoint.
 
 snippet: configure-remote-processor
 

--- a/nservicebus/upgrades/5to6/moving-away-from-ibus.md
+++ b/nservicebus/upgrades/5to6/moving-away-from-ibus.md
@@ -1,6 +1,6 @@
 ---
 title: Moving away from IBus in Version 6
-reviewed: 2021-02-16
+reviewed: 2026-05-23
 component: Core
 summary: Describes how to send messages without the IBus interface
 redirects:
@@ -65,7 +65,7 @@ using (var bus = startableBus.Start())
 
 Starting the endpoint provides access to `IMessageSession` or `IEndpointInstance` respectively which can be used to send messages during endpoint startup instead of using the `IBus` interface.
 
-["Send-only" endpoints](/nservicebus/hosting/#send-only-hosting) were created by calling the `CreateSendOnly` method on the `Bus` class in previous versions. In version 6 there is no longer a separate method to create or start "Send-Only" endpoints. Configure the endpoint to be "Send-Only" with the `SendOnly` method on `EndpointConfiguration` and create/start it with the `Endpoint` class.
+["Send-only" endpoints](/nservicebus/endpoints/#send-only) were created by calling the `CreateSendOnly` method on the `Bus` class in previous versions. In version 6 there is no longer a separate method to create or start "send-only" endpoints. Configure the endpoint to be send-only with the `SendOnly` method on `EndpointConfiguration` and create/start it with the `Endpoint` class.
 
 ### Accessing the CurrentMessageContext
 

--- a/samples/transactional-session/aspnetcore-webapi/sample.md
+++ b/samples/transactional-session/aspnetcore-webapi/sample.md
@@ -2,7 +2,7 @@
 title: Using TransactionalSession with Entity Framework and ASP.NET Core
 summary: Transactional Session sample that illustrates how to send messages and modify data with Entity Framework in an atomic manner using ASP.NET Core.
 component: TransactionalSession.SqlPersistence
-reviewed: 2025-06-04
+reviewed: 2026-05-23
 related:
 - nservicebus/transactional-session
 - nservicebus/transactional-session/persistences/sql-persistence
@@ -11,7 +11,7 @@ related:
 
 include: webhost-warning
 
-This sample shows how to send messages and modify data in a database atomically within the scope of a web request using the `NServiceBus.TransactionalSession` package with ASP.NET Core. The ASP.NET Core application hosts a [send-only endpoint](/nservicebus/hosting/#send-only-hosting). The operations are triggered by an incoming HTTP request to ASP.NET Core that will manage the `ITransactionalSession` lifetime using a request middleware.
+This sample shows how to send messages and modify data in a database atomically within the scope of a web request using the `NServiceBus.TransactionalSession` package with ASP.NET Core. The ASP.NET Core application hosts a [send-only endpoint](/nservicebus/endpoints/#send-only). The operations are triggered by an incoming HTTP request to ASP.NET Core that will manage the `ITransactionalSession` lifetime using a request middleware.
 
 > [!NOTE]
 > Starting in version 8.2.0, `NServiceBus.Persistence.Sql.TransactionalSession` is supported in send-only endpoints. Refer to the [documentation](/nservicebus/transactional-session/#remote-processor) for more details.

--- a/servicepulse/usage.md
+++ b/servicepulse/usage.md
@@ -1,7 +1,7 @@
 ---
 title: Measuring system usage
 summary: Use ServicePulse to track NServiceBus endpoints, throughput, and queues, creating usage reports for licensing
-reviewed: 2025-01-10
+reviewed: 2026-05-23
 redirects:
 - nservicebus/usage
 ---
@@ -79,7 +79,7 @@ An [endpoint that is only processing transactional session dispatch messages](/n
 
 #### Send-Only Endpoint
 
-An endpoint that [only sends](/nservicebus/hosting/#send-only-hosting) messages and does not process any messages. These endpoints have different licensing considerations since they don't process incoming messages.
+An endpoint that [only sends](/nservicebus/endpoints/#send-only) messages and does not process any messages. These endpoints have different licensing considerations since they don't process incoming messages.
 
 #### Planned to be decommissioned
 

--- a/transports/sql/native-delayed-delivery.md
+++ b/transports/sql/native-delayed-delivery.md
@@ -1,7 +1,7 @@
 ---
 title: SQL Server Native Delayed Delivery
 summary: Describes the native delayed delivery implementation in the SQL Server transport
-reviewed: 2026-02-01
+reviewed: 2026-05-23
 component: SqlTransport
 versions: '[3,)'
 ---
@@ -10,7 +10,7 @@ The SQL Server transport supports [delayed delivery](/nservicebus/messaging/dela
 This means that the exact delivery time for a delayed message can be a bit later.
 
 > [!NOTE]
-> The native delayed delivery feature of the SQL Server transport is not available to [send-only](/nservicebus/hosting/#send-only-hosting) endpoints. This is because the delay logic is currently embedded in the receive component which is not initialized for send-only endpoints.
+> The native delayed delivery feature of the SQL Server transport is not available to [send-only](/nservicebus/endpoints/#send-only) endpoints. This is because the delay logic is currently embedded in the receive component which is not initialized for send-only endpoints.
 
 ## Configuration
 


### PR DESCRIPTION
Hosting was never the right place for it