### PR TITLE
This PR adds the .NET 11.0 support for samples

### DIFF
--- a/components/tfm-mappings.txt
+++ b/components/tfm-mappings.txt
@@ -20,3 +20,5 @@ net9.0: .NET 9
 net9.0-windows: .NET 9
 net10.0: .NET 10
 net10.0-windows: .NET 10
+net11.0: .NET 11
+net11.0-windows: .NET 11

--- a/tests/IntegrityTests/ProjectFrameworks.cs
+++ b/tests/IntegrityTests/ProjectFrameworks.cs
@@ -36,7 +36,7 @@ namespace IntegrityTests
                 });
         }
 
-        public static readonly string[] sdkProjectAllowedTfmList = ["net10.0", "net10.0-windows", "net9.0", "net9.0-windows", "net8.0", "net8.0-windows", "net48", "netstandard2.0"];
+        public static readonly string[] sdkProjectAllowedTfmList = ["net11.0", "net11.0-windows", "net10.0", "net10.0-windows", "net9.0", "net9.0-windows", "net8.0", "net8.0-windows", "net48", "netstandard2.0"];
         static readonly string[] nonSdkProjectAllowedFrameworkList = ["v4.8"];
 
         [Test]

--- a/tests/IntegrityTests/ProjectLangVersion.cs
+++ b/tests/IntegrityTests/ProjectLangVersion.cs
@@ -163,7 +163,9 @@ namespace IntegrityTests
             { "net9.0", 13 },
             { "net9.0-windows", 13 },
             { "net10.0", 14 },
-            { "net10.0-windows", 14 }
+            { "net10.0-windows", 14 },
+            { "net11.0", 15 },
+            { "net11.0-windows", 15 }
         };
 
         // This needs to be kept up to date with the latest released version of C#


### PR DESCRIPTION
This PR adds the .NET 11.0 framework to the integrity tests and attempts to future-proof us for when C# 15 is no longer in preview.