### PR TITLE
Skill compress and small updates after skill opt

### DIFF
--- a/.github/skills/particular-docs-review/SKILL.MD
+++ b/.github/skills/particular-docs-review/SKILL.MD
@@ -6,13 +6,7 @@ invocable: false
 
 # Particular Documentation Review
 
-Review Particular Platform documentation for language accuracy, technical correctness, and consistency.
-
-When reviewing a file, update the `reviewed` field in frontmatter using ISO format:
-
-```yaml
-reviewed: 2026-02-23
-```
+Review docs for language accuracy, technical correctness, and consistency. Update `reviewed` field in frontmatter: `reviewed: 2026-06-01`
 
 ---
 
@@ -20,126 +14,62 @@ reviewed: 2026-02-23
 
 ## Spelling
 
-Use American English spelling.
+Use en-US American English. Common: -ize (organize, realize, analyze), -or (color, behavior), -er (center, meter), -ence (defense, license), practice (both noun/verb). Corrections: colour→color, centre→center, organise→organize, licence→license, defence→defense, programme→program, practise→practice.
 
-Examples:
-- organize, realize, analyze
-- color, flavor, behavior
-- center, meter, theater
-- defense, offense, license
-- practice (noun and verb)
-
-Common corrections:
-
-- colour -> color
-- centre -> center
-- organise -> organize
-- licence -> license
-- defence -> defense
-- programme -> program
-- practise -> practice
+When correcting, explicitly state alignment with en-US American English.
 
 ---
 
 ## Grammar
 
-- Use serial comma: "A, B, and C"
-- Collective nouns are singular: "The team is"
-- Restrictive clauses use "that"
-- Non‑restrictive clauses use "which"
-- Prefer active voice
+Serial comma ("A, B, and C"). Collective nouns singular ("The team is"). Restrictive clauses use "that"; non-restrictive use "which" (with comma). Prefer active voice: "processes" not "are processed by".
 
 ---
 
 ## Dates and Time
 
-- Dates: Month Day, Year (January 15, 2025)
-- Time: 12-hour with AM/PM
-- Avoid 24-hour format in user docs
-- Write months fully
+Dates: Month Day, Year (January 15, 2025). Time: 12-hour with AM/PM. Write months fully.
 
 ---
 
 ## Numbers
 
-- Use commas for thousands: 1,000
-- Use periods for decimals: 3.14
-- Spell out numbers 0-10
-- Use numerals for 11+ and measurements
+Commas for thousands (1,000). Periods for decimals (3.14). Spell 0-10 as words. Numerals for 11+ and measurements (15 MB).
 
 ---
 
 # Writing Principles
 
-Write for experienced software developers.
-
-- Explain why before how
-- Start with a high‑level overview
-- Define terms on first use
-- Use consistent terminology
-- Provide concrete examples
-- One idea per paragraph
-- Prefer sentences under ~25 words
-- Use lists for 3+ items
-- Use clear heading hierarchy
+Write for experienced devs. Explain why before how. Start with overview. Define terms on first use. Concrete examples. One idea per paragraph. Sentences ~25 words max. Lists for 3+ items. Clear heading hierarchy.
 
 ## Versioned Product Documentation
 
-Review version-specific documentation from the perspective of a reader using that version after it is released, not from the perspective of the transition that created the change.
+Review from the reader's perspective for that version, not the transition that created the change.
 
-- Present the recommended API or pattern as the way to use the product for that version
+- Present the recommended API/pattern as the way to use it for that version
 - Avoid framing the recommended path as one more choice unless there are supported alternatives for new work
-- Move migration details, obsolete APIs, and compatibility notes to upgrade guides when they primarily help existing users move forward
-- Use versioned partials or callout boxes for temporary notes that apply only to older supported versions
-- Consider support windows: content that is useful only while an older minor version is supported should not dominate pages for a newer major version
-- Prefer direct guidance over historical explanation; include history only when it helps the reader make a current decision
-- For multi-version pages, make it clear which guidance applies to each version without forcing new users through legacy options
+- Move migration details, obsolete APIs, and compatibility notes to upgrade guides when they help existing users move forward
+- Use versioned partials or callout boxes for older-supported-version notes
+- Content useful only while old minor is supported should not dominate newer major version pages
+- Include history only when it helps current decisions
+- For multi-version pages, scope guidance per version without forcing new users through legacy options
+- **Configuration examples:** outdated config syntax is a critical issue even if still valid — update to current patterns
 
 ---
 
 # Code Samples
 
-Prefer snippet projects over inline code blocks.
+Prefer snippets from `Snippets/{ComponentKey}/` referenced via `snippet:` key over inline blocks. Component keys in `components/component.yaml`. Inline only for very small examples.
 
-Rules:
-
-- Use snippets from `snippets/{ComponentKey}/`
-- Reference them with the `snippet:` key
-- Component keys come from `components/component.yaml`
-- Inline fenced blocks only for very small examples
-
-Code samples should:
-
-- Compile or clearly state pseudo‑code
-- Use current APIs
-- Include required imports
-- Use clear variable names
-- Explain non‑obvious logic
-- Avoid hardcoded configuration values
+Samples must: compile (or mark pseudo-code), use current APIs, include required imports, use clear names, explain non-obvious logic, avoid hardcoded values.
 
 ---
 
 # Includes
 
-Includes are shared markdown files inserted into a document using:
+`include: KEY` references a shared markdown file. MUST find and review every include. Includes are rendered inline and shared — changes affect every page referencing them.
 
-```markdown
-include: KEY
-```
-
-Reviewing a document includes reviewing all of its referenced includes. Includes are rendered inline — the reader sees them as part of the page. Apply the full review process (language, style, technical accuracy, content quality, and link validation) to each include, and be aware that includes are shared across many pages — changes affect every page that references them.
-
-## Finding includes
-
-Include files use the naming convention `{key}.include.md` and may live in the same directory as the referencing document or in a parent directory.
-
-To locate an include for a given `include: KEY` directive:
-
-1. Note the key name after `include:`
-2. Search from the document's directory upward for `{key}.include.md`
-
-Example: `include: non-null-task` in `nservicebus/pipeline/message-mutators.md` resolves to `nservicebus/non-null-task.include.md`.
-
+**To find:** search from document directory upward for `{key}.include.md`:
 ```bash
 find . -name "{key}.include.md"
 ```
@@ -148,209 +78,82 @@ find . -name "{key}.include.md"
 
 # Partials
 
-Partials are version-specific markdown files included in a document using:
-
-```markdown
-partial: KEY
-```
-
-Reviewing a document includes reviewing all of its referenced partials. Partials are rendered inline — the reader sees them as part of the page. Review each partial as if it were content in the parent document: consider how it reads in context, whether it flows with the surrounding content, and apply the full review process (language, style, technical accuracy, content quality, and link validation).
-
-## Finding partials
-
-Partial files are stored in the same directory as the document that references them.
-
-Convention: `{filePrefix}_{key}_{nugetAlias}_{version}.partial.md`
-
-Where `{filePrefix}` is the filename of the referencing document without the `.md` extension.
-
-To locate partials for a given `partial: KEY` directive:
-
-1. Note the key name after `partial:`
-2. Note the filename of the document being reviewed (without `.md`) — this is the file prefix
-3. Search the same directory for files matching `{filePrefix}_{key}_*.partial.md`
-4. Review every matching file — one may exist per supported version
-
-Example: `partial: endpointname` in `nservicebus/messaging/index.md` matches:
-- `index_endpointname_Core_7.partial.md`
-- `index_endpointname_Core_8.partial.md`
+`partial: KEY` inserts version-specific content. MUST find and review every partial. Convention: `{filePrefix}_{key}_{nugetAlias}_{version}.partial.md` (same dir as document, filePrefix = document filename without .md). Search for `{filePrefix}_{key}_*.partial.md` and review all versions.
 
 ---
 
 # Snippets
 
-Snippets are code samples referenced in a document using:
+`snippet: KEY` references code from `Snippets/{ComponentKey}/`. MUST check all referenced snippets. Focus: verify snippet is relevant to surrounding docs and illustrates what text claims. If changed, apply full Code Review Checklist.
 
-```markdown
-snippet: KEY
-```
+**To find:** note key after `snippet:`, get component from frontmatter `component:`, look up key in `components/components.yaml`, search `Snippets/{ComponentKey}/` for the marker type:
 
-Reviewing a document includes checking all of its referenced snippets. Snippets are excerpts from larger code files, so the focus is narrow: verify that the snippet content is relevant to the surrounding documentation and that it illustrates what the text claims it does. If a snippet is changed during the review, apply the full [Code Review Checklist](#code-review-checklist) to the changed snippet.
+| File type | Open | Close |
+|-----------|------|-------|
+| C# (region) | `#region KEY` | `#endregion` |
+| C# (comment) | `// startcode KEY` | `// endcode` |
+| XML | `<!-- startcode KEY -->` | `<!-- endcode -->` |
+| PowerShell | `# startcode KEY` | `# endcode` |
+| SQL | `-- startcode KEY` | `-- endcode` |
+| Plain text | `startcode KEY` | `endcode` |
+| Docker / YAML | `# startcode KEY` | `# endcode` |
 
-## Finding snippets
-
-Snippet code lives in versioned directories under `Snippets/`.
-
-To locate snippet code for a given `snippet: KEY` directive:
-
-1. Note the key name after `snippet:`
-2. Find the component from the document's `component:` frontmatter field
-3. Component keys are defined in `components/components.yaml`
-4. Search `Snippets/{ComponentKey}/` for files containing the snippet key using the appropriate marker for the file type:
-
-   | File type | Open marker | Close marker |
-   |-----------|-------------|--------------|
-   | C# (region) | `#region KEY` | `#endregion` |
-   | C# (comment) | `// startcode KEY` | `// endcode` |
-   | XML-based | `<!-- startcode KEY -->` | `<!-- endcode -->` |
-   | PowerShell | `# startcode KEY` | `# endcode` |
-   | SQL | `-- startcode KEY` | `-- endcode` |
-   | Plain text | `startcode KEY` | `endcode` |
-   | Dockerfile / YAML | `# startcode KEY` | `# endcode` |
-5. Snippet files live in versioned subdirectories, e.g. `Snippets/Core_7/` or `Snippets/MsmqTransport_1/`
+Specify marker type when locating snippet code.
 
 ---
 
 # Terminology
 
-Use consistent terminology.
-
-Rules:
-
-- One term per concept
-- Avoid synonyms that cause ambiguity
-- Use standard industry terminology
-- Keep casing consistent
-
-Example:
-
-Correct: message handler  
-Incorrect: handler / messageprocessor
+One term per concept. Avoid synonyms that confuse. Use standard industry terms. Keep casing consistent. Fix every occurrence, not some.
 
 ---
 
 # Markdown Rules
 
-- Use ATX headers (`## Header`)
-- Leave a blank line before and after headers
-- Use `-` for lists
-- Use numbered lists for sequences
-- Leave a blank line before and after lists
-- Include language identifiers in code fences
-- Use `code` formatting for variables
-- Use descriptive link text
-
-Example:
-
-Correct: `[Message handler configuration](/nservicebus/messaging/handlers.md)`  
-Incorrect: `[click here](/page)`
+ATX headers (`## Header`). Blank line before/after headers. Use `-` for lists, numbered for sequences. Blank line before/after lists. Language identifiers in code fences. Use `code` for variables. Descriptive link text — never "click here".
 
 ---
 
 # Content Quality Checks
 
-Verify:
+Verify: API signatures correct, config syntax valid, versions current, deprecated APIs removed/marked, namespaces/packages correct.
 
-- API signatures are correct
-- Configuration syntax is valid
-- Versions are current
-- Deprecated APIs are removed or marked
-- Namespaces and packages are correct
-
-Documentation should include:
-
-- What the feature does
-- When to use it
-- How to use it
-- Configuration options
-- Pitfalls or edge cases
-- Troubleshooting guidance
+Docs must include: what feature does, when to use, how to use, config options, pitfalls/edge cases, troubleshooting.
 
 ---
 
 # Code Review Checklist
 
-Check each sample:
+Per sample: compiles, imports present, naming clear, current conventions, error handling where relevant, logic comments where needed, formatting consistent, no deprecated patterns.
 
-- Code compiles
-- Imports are included
-- Naming is clear
-- Current conventions are used
-- Error handling appears where relevant
-- Logic comments exist where needed
-- Formatting is consistent
-- No deprecated patterns
+When reviewing a code sample, explicitly reference this checklist and note verification of each item.
 
 ---
 
 # Link Validation
 
-Ensure:
-
-- Internal links resolve
-- External links work
-- API links reference correct versions
-- No broken URLs
-- Link text describes destination
+Internal links resolve. External links work. API links reference correct versions. No broken URLs. Link text describes destination.
 
 ---
 
 # Anchor Stability
 
-The docs engine generates anchors from a heading stack. A new H2 resets the stack; sub-headings append to it. `## Heading 1` followed by `### Heading 1.1` produces `#heading-1-heading-1-1`. Reparenting a heading under a new H2 changes its slug and breaks external links.
-
-When restructuring pages, keep headings at their original level or verify cross-page links. Prefer versioned partials over wrapping legacy sections under new H2s.
-
----
-
-# Common Issues
-
-## Spelling
-
-- British spelling variants
-- Grammar mistakes
-- Homophone confusion
-- Run-on sentences
-
-## Style
-
-- Mixed terminology
-- Inconsistent headers
-- Curly quotes instead of straight quotes
-- Mixed list styles
-
-## Technical
-
-- Outdated APIs
-- Deprecated patterns
-- Missing imports
-- Incorrect configuration
-- Version mismatches
+Docs engine generates anchors from heading stack. New H2 resets the stack; sub-headings append. Reparenting a heading under a new H2 changes its slug and breaks external links. When restructuring, keep headings at original level or verify cross-page links.
 
 ---
 
 # Review Output
 
-Use this format:
+Format: Summary, Critical Issues, Improvements, Technical Updates, Suggestions.
 
-1. Summary
-2. Critical Issues
-3. Improvements
-4. Technical Updates
-5. Suggestions
+**Distinguish:** broken code/missing imports/deprecated API/wrong config = critical. British spelling/passive voice/missing blank line/awkward phrasing = improvement/suggestion. Do not elevate style to critical.
 
 Example:
-
 ```markdown
-## Review of: /path/to/file.md
-
 ### Critical Issues
-- Line 45: Non‑existent method `GetMessageAsync()`
-  Suggestion: Use `GetMessage()`
-
+- Line 45: Non‑existent method `GetMessageAsync()` → use `GetMessage()`
 ### Improvements
-- Line 23: "colour" -> "color"
-
+- Line 23: "colour" → "color"
 ### Technical Updates
 - Line 100: Obsolete `.ConfigureAwait(false)`
 ```
@@ -359,74 +162,27 @@ Example:
 
 # Review Focus
 
-## New Docs
-
-Prioritize:
-
-- Technical correctness
-- Completeness
-- Clarity
-- Working code samples
-
-## Updated Docs
-
-Check:
-
-- What changed
-- Issues fixed
-- New problems introduced
-- Consistency with surrounding docs
-
-## Legacy Docs
-
-Evaluate:
-
-- Technical currency and accuracy
-- Opportunities to modernize
-- Removal of obsolete content
-- Deprecated features
+**New docs:** technical correctness, completeness, clarity, working code samples.
+**Updated docs:** what changed, previous issues fixed, new problems, consistency with surrounding content.
+**Legacy docs:** technical currency, modernization opportunities, obsolete content removal, deprecated features.
 
 ---
 
 # Conservative Change Philosophy
 
-Avoid unnecessary edits.
-
-Rules:
-
-- Only suggest changes backed by rules in this file
-- If text is correct and understandable, leave it
-- Prefer consistency with existing docs
-- Avoid churn in diffs and reviews
+Only suggest changes backed by rules in this file. If text is correct and understandable, leave it. Prefer consistency with existing docs. Avoid churn.
 
 ---
 
 # Local Validation
 
-Run the docs tool before submitting changes.
-
-In Copilot cloud agent sessions for this repository, `docstool` is preinstalled by `.github/workflows/copilot-setup-steps.yml`.
-
-Install:
-
+Run `docstool test --no-version-check` before submitting.
 ```bash
 dotnet tool install -g Particular.DocsTool --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
-```
-
-Update:
-
-```bash
 dotnet tool update -g Particular.DocsTool --add-source https://f.feedz.io/particular-software/packages/nuget/index.json
-```
-
-Run:
-
-```bash
 docstool test --no-version-check
+git clean -dxf  # if stale files
 ```
 
-If you encounter stale files:
-
-```bash
-git clean -dxf
+`docstool test` passing is necessary but not sufficient — it does not validate external links or content quality. Link validation and content review must be done manually.
 ```


### PR DESCRIPTION
I ran the docs review skill through SkillOpt (Microsoft's automated skill optimizer) to see if I could improve workflow compliance on a held-out benchmark. The optimizer overfit to the validation set — hard score went up on selection but dropped on test from 3/8 to 1/8 — which tracks with what I saw during the mnemonic RPIR skill exercise.

What actually moved the needle was compressing the skill and cherry-picking three small operational improvements from the automated suggestions:

**Changes in this PR:**

- **Compressed the skill from ~12KB to ~7.5KB** (~38% reduction) by removing redundant explanations and consolidating sections. Eval scores stayed within noise (still 3/8 hard on the 8-item test set), so no regression on model understanding.

- **Cherry-picked SkillOpt findings** as concise rules rather than accepting the bloated slow-update output:
  - State en-US alignment explicitly when correcting spelling (not just "colour → color" but "correcting to en-US American English")
  - Reference the Code Review Checklist by name and note per-item verification when reviewing code samples
  - Specify the marker type (startcode/endcode, region/endregion) when locating snippet code — makes the review output more verifiable

- **Added human-written guidance** based on failure patterns from the benchmark:
  - Distinguish critical issues from style improvements (broken code = critical, British spelling = improvement)
  - Docstool passing is necessary but not sufficient — link validation must still be done manually
  - Active vs passive voice guidance with concrete examples to prevent the model from "correcting" active to passive

The benchmark setup (custom data split + evaluator) is in the SkillOpt project, separate from this repo. Happy to share more details if anyone wants to run their own evaluation or experiment with the skill optimization flow.