### PR TITLE
Review of /servicepulse/endpoint-connection

### DIFF
--- a/servicepulse/endpoint-connection.md
+++ b/servicepulse/endpoint-connection.md
@@ -2,7 +2,7 @@
 title: Endpoint connection settings
 summary: How to retrieve settings when connecting an endpoint to the Particular Service Platform
 component: ServicePulse
-reviewed: 2024-09-26
+reviewed: 2026-06-04
 related:
 ---
 
@@ -11,8 +11,8 @@ Settings required for [connecting an endpoint to the Platform](/platform/connect
 > [!NOTE]
 > Platform connection settings require ServicePulse version 1.31 or later, and ServiceControl version 4.21 or later.
 
-![Endpoint connection tab](images/endpoint-connection.png 'width=500')
+![Endpoint connection tab](images/endpoint-connection.png)
 
 The tab can be also be accessed from a link in the footer.
 
-![Endpoint connection tab](images/endpoint-connection-link.png 'width=500')
+![Footer endpoint connection link](images/endpoint-connection-link.png)


### PR DESCRIPTION
The image width setting was making them so small that they had to be clicked on. This makes it easier to read and updates the reviewed date.