### PR TITLE
Review /persistence/ravendb

### DIFF
--- a/Snippets/Raven/Raven_7/MultiTenantSupport.cs
+++ b/Snippets/Raven/Raven_7/MultiTenantSupport.cs
@@ -10,7 +10,7 @@ namespace Raven_7
             var persistence = endpointConfiguration.UsePersistence<RavenDBPersistence>();
             persistence.SetMessageToDatabaseMappingConvention(headers =>
             {
-                //based on incoming message headers select the correct RavenDB Database
+                // based on incoming message headers select the correct RavenDB Database
                 return "selected-database-name";
             });
             #endregion

--- a/persistence/ravendb/index.md
+++ b/persistence/ravendb/index.md
@@ -5,7 +5,7 @@ versions: '[2,)'
 related:
  - samples/ravendb
  - samples/multi-tenant/ravendb
-reviewed: 2024-10-01
+reviewed: 2026-06-05
 redirects:
  - nservicebus/ravendb
  - persistence/ravendb/licensing
@@ -29,7 +29,7 @@ Specific versions of RavenDB Persistence are tied to a major version of NService
 
 See the [NServiceBus Packages Supported Versions](/nservicebus/upgrades/supported-versions.md#persistence-packages-nservicebus-ravendb) to see the support details for each version of RavenDB Persistence.
 
-RavenDB client are compatible with their corresponding server version and newer versions:
+RavenDB clients are compatible with their corresponding server version and newer versions:
 
 - [FAQ: Backward Compatibility | RavenDB 6.2 Documentation](https://ravendb.net/docs/article-page/6.2/csharp/client-api/faq/backward-compatibility#ravendb-4.2-and-higher-compatibility)
 
@@ -49,22 +49,26 @@ To use the shared session in a message handler:
 
 snippet: ravendb-persistence-shared-session-for-handler
 
-Although additional database operations inside a saga handler are not recommended (see warning below) the shared session can also be accessed from a saga handler:
+Although additional database operations inside a saga handler are not recommended (see warning below), the shared session can also be accessed from a saga handler:
 
 include: saga-business-data-access
 
 snippet: ravendb-persistence-shared-session-for-saga
 
 
-## Customizing the IDocumentSession
+## Customizing the IAsyncDocumentSession
 
-The creation of the RavenDB `IDocumentSession` instance used by NServiceBus and made available as the [shared session](#shared-session) can be customized as shown in the following snippet. Despite the name of the method, this option *does not enable the shared session* but only affects the customization of that session.
+The creation of the RavenDB `IAsyncDocumentSession` instance used by NServiceBus and made available as the [shared session](#shared-session) can be customized as shown in the following snippet. Despite the name of the method, this option *does not enable the shared session* but only affects the customization of that session.
 
 snippet: ravendb-persistence-customize-document-session
 
 include: raven-dispose-warning
 
-partial: multitenant
+## Multi-tenant support
+
+It is possible to select the database used to store NServiceBus-related data, such as saga data and outbox records, based on information stored in the incoming message headers:
+
+snippet: multi-tenant-support
 
 
 ## Viewing the data

--- a/persistence/ravendb/index_glance_raven_[7,8).partial.md
+++ b/persistence/ravendb/index_glance_raven_[7,8).partial.md
@@ -3,7 +3,7 @@ For a description of each feature, see the [persistence at a glance legend](/per
 |Feature                    |   |
 |:---                       |---
 |Supported storage types    |Sagas, Outbox, Subscriptions, Timeouts
-|Transactions               |via `IDocumentSession.SaveChanges()` or cluster-wide transactions
+|Transactions               |via `IAsyncDocumentSession.SaveChangesAsync()` or cluster-wide transactions
 |Concurrency control        |Pessimistic concurrency, optional optimistic concurrency
 |Scripted deployment        |Not supported
 |Installers                 |None. Required indexes are created in the database as needed.

--- a/persistence/ravendb/index_glance_raven_[8,).partial.md
+++ b/persistence/ravendb/index_glance_raven_[8,).partial.md
@@ -3,7 +3,7 @@ For a description of each feature, see the [persistence at a glance legend](/per
 |Feature                    |   |
 |:---                       |---
 |Supported storage types    |Sagas, Outbox, Subscriptions
-|Transactions               |via `IDocumentSession.SaveChanges()` or cluster-wide transactions
+|Transactions               |via `IAsyncDocumentSession.SaveChangesAsync()` or cluster-wide transactions
 |Concurrency control        |Pessimistic concurrency, optional optimistic concurrency
 |Scripted deployment        |Not supported
 |Installers                 |None. Required indexes are created in the database as needed.

--- a/persistence/ravendb/index_multitenant_raven_[4,).partial.md
+++ b/persistence/ravendb/index_multitenant_raven_[4,).partial.md
@@ -1,5 +1,0 @@
-## Multi-tenant support
-
-Starting with version 4.2, it's possible to select the database used to store NServiceBus-related data, such as saga data and outbox records, based on information stored in the incoming messages headers:
-
-snippet: multi-tenant-support


### PR DESCRIPTION
Fixes typos, incorrect reference to `IDocumentSession`, and removes an obsolete partial in:
- `/persistence/ravendb`