### PR TITLE
Document Messaging Bridge critical error handling

### DIFF
--- a/Snippets/Bridge/Bridge_5/Configuration.cs
+++ b/Snippets/Bridge/Bridge_5/Configuration.cs
@@ -47,6 +47,32 @@ public class Configuration
         #endregion
     }
 
+    public void CriticalErrorAction()
+    {
+        var bridgeConfiguration = new BridgeConfiguration();
+
+        #region bridge-critical-error-action
+
+        bridgeConfiguration.DefineCriticalErrorAction(async (context, cancellationToken) =>
+        {
+            var fatalMessage =
+                $"The following critical error was encountered:{Environment.NewLine}" +
+                $"{context.Error}{Environment.NewLine}" +
+                "The bridge is shutting down.";
+
+            try
+            {
+                await context.Stop(cancellationToken);
+            }
+            finally
+            {
+                Environment.FailFast(fatalMessage, context.Exception);
+            }
+        });
+
+        #endregion
+    }
+
     public async Task EndpointRegistration()
     {
         #region endpoint-registration

--- a/nservicebus/bridge/configuration.md
+++ b/nservicebus/bridge/configuration.md
@@ -2,7 +2,7 @@
 title: Bridge configuration options
 summary: Configuration options for the messaging bridge.
 component: Bridge
-reviewed: 2026-05-13
+reviewed: 2026-06-01
 ---
 
 ## Hosting
@@ -14,6 +14,8 @@ snippet: generic-host
 The overload that accepts a [`HostBuilderContext`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.hostbuildercontext) provides access to the [`IConfiguration` type](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration) and other host-related details.
 
 snippet: generic-host-builder-context
+
+partial: critical-error-action
 
 ## Registering endpoints
 
@@ -154,7 +156,6 @@ partial: failed-messages
 Special considerations are required for the audit queue due to potentially high message volume. For example, a [dedicated ServiceControl audit instance](/servicecontrol/audit-instances/) could be created for each bridged transport, to make audit ingestion more efficient.
 
 partial: monitoring
-
 
 
 

--- a/nservicebus/bridge/configuration_critical-error-action_bridge_[5,).partial.md
+++ b/nservicebus/bridge/configuration_critical-error-action_bridge_[5,).partial.md
@@ -1,6 +1,6 @@
 ## Critical error handling
 
-A bridge can encounter a [critical error](/nservicebus/hosting/critical-errors.md) when a transport cannot recover from an infrastructure failure. Use `DefineCriticalErrorAction` to stop the affected bridge endpoint and terminate the process:
+A bridge can encounter a [critical error](/nservicebus/hosting/critical-errors.md) when a transport cannot recover from an infrastructure failure. Starting with version 5.1, `DefineCriticalErrorAction` can be used to stop the affected bridge endpoint and terminate the process:
 
 snippet: bridge-critical-error-action
 

--- a/nservicebus/bridge/configuration_critical-error-action_bridge_[5.1,).partial.md
+++ b/nservicebus/bridge/configuration_critical-error-action_bridge_[5.1,).partial.md
@@ -1,0 +1,7 @@
+## Critical error handling
+
+A bridge can encounter a [critical error](/nservicebus/hosting/critical-errors.md) when a transport cannot recover from an infrastructure failure. Use `DefineCriticalErrorAction` to stop the affected bridge endpoint and terminate the process:
+
+snippet: bridge-critical-error-action
+
+Configure the hosting environment to [restart the terminated process](/nservicebus/hosting/critical-errors.md#how-do-i-deal-with-persistent-critical-errors-terminate-and-restart-the-process). Calling `context.Stop` without terminating the process stops only the bridge endpoint that raised the critical error.


### PR DESCRIPTION
## Summary

Documents the `BridgeConfiguration.DefineCriticalErrorAction(...)` API introduced in NServiceBus.MessagingBridge 5.1.

- Adds a Bridge 5.1+ versioned section to the bridge configuration page.
- Adds a compiled snippet that stops the affected bridge endpoint and terminates the process with `Environment.FailFast`.
- Links to the existing critical error guidance for configuring the hosting environment to restart the process.

Related implementation: [NServiceBus.MessagingBridge#858](https://github.com/Particular/NServiceBus.MessagingBridge/pull/858)
