### PR TITLE
Document rationale for host identifier algorithm change

### DIFF
--- a/nservicebus/upgrades/10to11/index.md
+++ b/nservicebus/upgrades/10to11/index.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Version 10 to 11
 summary: Instructions on how to upgrade NServiceBus from version 10 to version 11.
-reviewed: 2026-04-14
+reviewed: 2026-06-08
 component: Core
 isUpgradeGuide: true
 upgradeGuideCoreVersions:
@@ -197,6 +197,14 @@ The following APIs are deprecated:
 ## Host identifier algorithm change
 
 In version 11, the default algorithm for generating deterministic host identifiers changes from MD5 to XxHash128 (RFC 9562 version 8 GUIDs). This produces different host identifiers, which affects how endpoints are identified in [ServicePulse](/servicepulse/) and [ServiceControl](/servicecontrol/).
+
+### Rationale
+
+This change provides a path for customers who require **FIPS-compliant** host identifiers (see [FIPS compliance](/nservicebus/compliance/fips.md)). The legacy MD5-based algorithm is not FIPS-compliant; by moving to the new `XxHash128` algorithm, the framework uses a compliant standard by default.
+
+To ensure a predictable transition, this is designed as a multi-phase migration. In version 11, the new algorithm becomes the default. By making this an explicit switch rather than an automatic change, there is a clear "escape hatch" to preserve legacy host IDs if correlation with older monitoring data (such as ServicePulse) must be maintained during the transition.
+
+This approach allows the framework to move toward a compliant default while providing the necessary flexibility to manage existing integrations before the legacy algorithm is removed in version 12.
 
 ### Impact
 


### PR DESCRIPTION
This PR adds a Rationale section to the host identifier algorithm change in the 10→11 upgrade guide, addressing the feedback that the upgrade guide explained *what* was changing but not *why*.

### Background

The original question from a user was:

> "What is the value of this change? ... it explains what is changing, but not the why. From a consumer perspective it currently reads like 'here is more work you need to do, for zero value'"

### The rationale (now documented in the guide)

The primary driver for this change is to provide a path for customers who require **FIPS-compliant** host identifiers. The legacy MD5-based algorithm is not FIPS-compliant; by moving to the new XxHash128 algorithm, the framework uses a compliant standard by default.

Even though users could already achieve FIPS compliance by manually setting a host identifier via the existing API, the framework default was still non-compliant. This change cleans up the default so that compliance is the framework's responsibility, not the user's.

This is a deliberate [multi-phase migration](https://github.com/Particular/NServiceBus/issues/7734) to ensure a smooth transition:
- **v10 (current):** New algorithm available as opt-in
- **v11:** New algorithm becomes the default, with an escape hatch to preserve legacy IDs
- **v12:** Legacy MD5 algorithm removed entirely

The explicit switch rather than an automatic "merge both" approach ensures that we can actually remove the non-compliant MD5 algorithm in v12 rather than maintaining two algorithms forever.

### Additional questions addressed

**Why can't ServicePulse and ServiceControl handle this seamlessly?**
The roadmap involves removing the legacy MD5 algorithm in v12. Maintaining dual-support in the tooling would create significant long-term complexity for a feature that is being deprecated. The explicit switch ensures a clean, unified migration path.

**Why no strongly-typed API?**
- There is already an API to set a host identifier manually for users who need a specific, static ID
- A global AppContext switch allows enabling the new algorithm across an entire project (via Directory.Build.props or environment variables) without changing every endpoint configuration
- Avoids the burden of maintaining wire compatibility for multiple algorithms long-term
- While we received customer requests for FIPS, we aren't claiming "full FIPS compliance" as a product feature — the switch is the most pragmatic way to satisfy those requirements without over-engineering the core

**Will the redundant UseV2DeterministicGuid switch be detected/logged?**
The switch is checked at startup via AppContext logic. If it's already set to the new behavior, the redundant switch won't cause a functional failure. Users are advised to remove it when migrating to v11 since the new behavior becomes the default.