### PR TITLE
Delete include for DTC warning for RavenDB

### DIFF
--- a/persistence/ravendb/dtc-warning.include.md
+++ b/persistence/ravendb/dtc-warning.include.md
@@ -1,2 +1,0 @@
-> [!WARNING]
-> In RavenDB 3.5, the client implementation of distributed transactions contains a bug that could cause an endpoint to lose data under rare conditions. If RavenDB is configured to enlist in distributed transactions with RavenDB 3.5, read [DTC not supported for RavenDB Persistence](/persistence/ravendb/dtc.md).

--- a/persistence/ravendb/index.md
+++ b/persistence/ravendb/index.md
@@ -1,7 +1,6 @@
 ---
 title: RavenDB Persistence
 component: raven
-versions: '[2,)'
 related:
  - samples/ravendb
  - samples/multi-tenant/ravendb
@@ -11,10 +10,6 @@ redirects:
  - persistence/ravendb/licensing
  - nservicebus/ravendb/licensing
 ---
-
-include: dtc-warning
-
-include: cluster-configuration-info
 
 Uses the [RavenDB document database](https://ravendb.net/) for storage.
 

--- a/persistence/ravendb/installation.md
+++ b/persistence/ravendb/installation.md
@@ -2,18 +2,13 @@
 title: Installing RavenDB
 summary: How to install RavenDB when using RavenDB persistence for various versions of NServiceBus.
 component: core
-versions: "[3,)"
-reviewed: 2024-10-01
+reviewed: 2026-06-09
 related:
  - nservicebus/operations
 redirects:
  - nservicebus/using-ravendb-in-nservicebus-installing
  - nservicebus/ravendb/installation
 ---
-
-include: dtc-warning
-
-include: cluster-configuration-info
 
 To install RavenDB, [download the server](https://ravendb.net/download) and install as described in the [RavenDB documentation](https://ravendb.net/docs/) or use a hosted RavenDB provider such as [RavenHQ](https://www.ravenhq.com/).
 

--- a/persistence/ravendb/reroute-existing-timeouts.md
+++ b/persistence/ravendb/reroute-existing-timeouts.md
@@ -10,8 +10,6 @@ redirects:
  - nservicebus/ravendb/reroute-existing-timeouts
 ---
 
-include: dtc-warning
-
 include: cluster-configuration-info
 
 After moving an endpoint from one machine to another or changing an endpoint's name, existing timeouts must be manually modified to end up in the new endpoint. To do that, follow these steps:

--- a/persistence/upgrades/ravendb-3to4.md
+++ b/persistence/upgrades/ravendb-3to4.md
@@ -14,7 +14,8 @@ upgradeGuideCoreVersions:
  - 6
 ---
 
-include: dtc-warning
+> [!WARNING]
+> In RavenDB 3.5, the client implementation of distributed transactions contains a bug that could cause an endpoint to lose data under rare conditions. If RavenDB is configured to enlist in distributed transactions with RavenDB 3.5, read [DTC not supported for RavenDB Persistence](/persistence/ravendb/dtc.md).
 
 include: cluster-configuration-info
 

--- a/persistence/upgrades/ravendb-4to5.md
+++ b/persistence/upgrades/ravendb-4to5.md
@@ -11,7 +11,8 @@ upgradeGuideCoreVersions:
  - 7
 ---
 
-include: dtc-warning
+> [!WARNING]
+> In RavenDB 3.5, the client implementation of distributed transactions contains a bug that could cause an endpoint to lose data under rare conditions. If RavenDB is configured to enlist in distributed transactions with RavenDB 3.5, read [DTC not supported for RavenDB Persistence](/persistence/ravendb/dtc.md).
 
 include: cluster-configuration-info
 

--- a/samples/multi-tenant/ravendb/sample.md
+++ b/samples/multi-tenant/ravendb/sample.md
@@ -1,16 +1,12 @@
 ---
 title: RavenDB Persistence in multi-tenant systems
 summary: Configure RavenDB Persistence to support multi-tenant scenarios.
-reviewed: 2024-10-01
+reviewed: 2026-06-09
 component: Raven
 related:
 - persistence/ravendb
 - nservicebus/outbox
 ---
-
-include: dtc-warning
-
-include: cluster-configuration-info
 
 This sample demonstrates how to configure RavenDB Persistence to store tenant-specific data in separate databases. The tenant-specific information includes the saga state, the business documents that are accessed using [RavenDB-managed session](/persistence/ravendb/#shared-session), and the outbox records.
 

--- a/samples/ravendb/index.md
+++ b/samples/ravendb/index.md
@@ -1,9 +1,5 @@
 ---
 title: RavenDB Persistence Samples
-reviewed: 2026-03-09
+reviewed: 2026-06-09
 component: Raven
 ---
-
-include: dtc-warning
-
-include: cluster-configuration-info

--- a/samples/ravendb/simple/sample.md
+++ b/samples/ravendb/simple/sample.md
@@ -5,10 +5,8 @@ component: Raven
 related:
  - nservicebus/sagas
  - persistence/ravendb
-reviewed: 2026-03-09
+reviewed: 2026-06-09
 ---
-
-include: dtc-warning
 
 include: cluster-configuration-info
 


### PR DESCRIPTION
Delete a warning for a version of RavenDB that we no longer support.