### PR TITLE
Backport of the announcements for CVEs

### DIFF
--- a/security-advisories/dependency-vulnerabilities.md
+++ b/security-advisories/dependency-vulnerabilities.md
@@ -4,5 +4,25 @@ reviewed: 2026-05-29
 suppressRelated: true
 ---
 
-* [Security Advisory 2022-12-06](cryptography-xml-vulnerability.md)
-  * System.Security.Cryptography.Xml vulnerability (CVE-2022-34716) in NServiceBus
+- [Security Advisory 2022-12-06](cryptography-xml-vulnerability.md)
+  - System.Security.Cryptography.Xml vulnerability (CVE-2022-34716) in NServiceBus
+- [GHSA-9cvc-h2w8-phrp](SecurityAdvisories/GHSA-9cvc-h2w8-phrp.md)
+  - AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value
+- [GHSA-6c8g-7p36-r338](SecurityAdvisories/GHSA-6c8g-7p36-r338.md)
+  - SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)
+- [GHSA-g94r-2vxg-569j](SecurityAdvisories/GHSA-g94r-2vxg-569j.md)
+  - OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers
+- [GHSA-q834-8qmm-v933](SecurityAdvisories/GHSA-q834-8qmm-v933.md)
+  - OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies
+- [GHSA-4625-4j76-fww9](SecurityAdvisories/GHSA-4625-4j76-fww9.md)
+  - OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter
+- [GHSA-mr8r-92fq-pj8p](SecurityAdvisories/GHSA-mr8r-92fq-pj8p.md)
+  - OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling
+- [GHSA-g4vj-cjjj-v7hg](SecurityAdvisories/GHSA-g4vj-cjjj-v7hg.md)
+  - Defense in Depth update for NuGet Client
+- [GHSA-pggp-6c3x-2xmx](SecurityAdvisories/GHSA-pggp-6c3x-2xmx.md)
+  - Snappier has an infinite loop during SnappyStream decompression with malformed framed input
+- [GHSA-w3x6-4m5h-cxqf](SecurityAdvisories/GHSA-w3x6-4m5h-cxqf.md)
+  - Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability
+- [GHSA-37gx-xxp4-5rgx](SecurityAdvisories/GHSA-37gx-xxp4-5rgx.md)
+  - Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability

--- a/security-advisories/dependency-vulnerabilities.md
+++ b/security-advisories/dependency-vulnerabilities.md
@@ -6,23 +6,23 @@ suppressRelated: true
 
 - [Security Advisory 2022-12-06](cryptography-xml-vulnerability.md)
   - System.Security.Cryptography.Xml vulnerability (CVE-2022-34716) in NServiceBus
-- [GHSA-9cvc-h2w8-phrp](SecurityAdvisories/GHSA-9cvc-h2w8-phrp.md)
+- [GHSA-9cvc-h2w8-phrp](security-advisories/ghsa-9cvc-h2w8-phrp.md)
   - AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value
-- [GHSA-6c8g-7p36-r338](SecurityAdvisories/GHSA-6c8g-7p36-r338.md)
+- [GHSA-6c8g-7p36-r338](security-advisories/ghsa-6c8g-7p36-r338.md)
   - SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)
-- [GHSA-g94r-2vxg-569j](SecurityAdvisories/GHSA-g94r-2vxg-569j.md)
+- [GHSA-g94r-2vxg-569j](security-advisories/ghsa-g94r-2vxg-569j.md)
   - OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers
-- [GHSA-q834-8qmm-v933](SecurityAdvisories/GHSA-q834-8qmm-v933.md)
+- [GHSA-q834-8qmm-v933](security-advisories/ghsa-q834-8qmm-v933.md)
   - OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies
-- [GHSA-4625-4j76-fww9](SecurityAdvisories/GHSA-4625-4j76-fww9.md)
+- [GHSA-4625-4j76-fww9](security-advisories/ghsa-4625-4j76-fww9.md)
   - OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter
-- [GHSA-mr8r-92fq-pj8p](SecurityAdvisories/GHSA-mr8r-92fq-pj8p.md)
+- [GHSA-mr8r-92fq-pj8p](security-advisories/ghsa-mr8r-92fq-pj8p.md)
   - OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling
-- [GHSA-g4vj-cjjj-v7hg](SecurityAdvisories/GHSA-g4vj-cjjj-v7hg.md)
+- [GHSA-g4vj-cjjj-v7hg](security-advisories/ghsa-g4vj-cjjj-v7hg.md)
   - Defense in Depth update for NuGet Client
-- [GHSA-pggp-6c3x-2xmx](SecurityAdvisories/GHSA-pggp-6c3x-2xmx.md)
+- [GHSA-pggp-6c3x-2xmx](security-advisories/ghsa-pggp-6c3x-2xmx.md)
   - Snappier has an infinite loop during SnappyStream decompression with malformed framed input
-- [GHSA-w3x6-4m5h-cxqf](SecurityAdvisories/GHSA-w3x6-4m5h-cxqf.md)
+- [GHSA-w3x6-4m5h-cxqf](security-advisories/ghsa-w3x6-4m5h-cxqf.md)
   - Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability
-- [GHSA-37gx-xxp4-5rgx](SecurityAdvisories/GHSA-37gx-xxp4-5rgx.md)
+- [GHSA-37gx-xxp4-5rgx](security-advisories/ghsa-37gx-xxp4-5rgx.md)
   - Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability

--- a/security-advisories/dependency-vulnerabilities.md
+++ b/security-advisories/dependency-vulnerabilities.md
@@ -6,23 +6,23 @@ suppressRelated: true
 
 - [Security Advisory 2022-12-06](cryptography-xml-vulnerability.md)
   - System.Security.Cryptography.Xml vulnerability (CVE-2022-34716) in NServiceBus
-- [GHSA-9cvc-h2w8-phrp](security-advisories/ghsa-9cvc-h2w8-phrp.md)
+- [GHSA-9cvc-h2w8-phrp](ghsa-9cvc-h2w8-phrp.md)
   - AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value
-- [GHSA-6c8g-7p36-r338](security-advisories/ghsa-6c8g-7p36-r338.md)
+- [GHSA-6c8g-7p36-r338](ghsa-6c8g-7p36-r338.md)
   - SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)
-- [GHSA-g94r-2vxg-569j](security-advisories/ghsa-g94r-2vxg-569j.md)
+- [GHSA-g94r-2vxg-569j](ghsa-g94r-2vxg-569j.md)
   - OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers
-- [GHSA-q834-8qmm-v933](security-advisories/ghsa-q834-8qmm-v933.md)
+- [GHSA-q834-8qmm-v933](ghsa-q834-8qmm-v933.md)
   - OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies
-- [GHSA-4625-4j76-fww9](security-advisories/ghsa-4625-4j76-fww9.md)
+- [GHSA-4625-4j76-fww9](ghsa-4625-4j76-fww9.md)
   - OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter
-- [GHSA-mr8r-92fq-pj8p](security-advisories/ghsa-mr8r-92fq-pj8p.md)
+- [GHSA-mr8r-92fq-pj8p](ghsa-mr8r-92fq-pj8p.md)
   - OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling
-- [GHSA-g4vj-cjjj-v7hg](security-advisories/ghsa-g4vj-cjjj-v7hg.md)
+- [GHSA-g4vj-cjjj-v7hg](ghsa-g4vj-cjjj-v7hg.md)
   - Defense in Depth update for NuGet Client
-- [GHSA-pggp-6c3x-2xmx](security-advisories/ghsa-pggp-6c3x-2xmx.md)
+- [GHSA-pggp-6c3x-2xmx](ghsa-pggp-6c3x-2xmx.md)
   - Snappier has an infinite loop during SnappyStream decompression with malformed framed input
-- [GHSA-w3x6-4m5h-cxqf](security-advisories/ghsa-w3x6-4m5h-cxqf.md)
+- [GHSA-w3x6-4m5h-cxqf](ghsa-w3x6-4m5h-cxqf.md)
   - Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability
-- [GHSA-37gx-xxp4-5rgx](security-advisories/ghsa-37gx-xxp4-5rgx.md)
+- [GHSA-37gx-xxp4-5rgx](ghsa-37gx-xxp4-5rgx.md)
   - Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability

--- a/security-advisories/ghsa-37gx-xxp4-5rgx.md
+++ b/security-advisories/ghsa-37gx-xxp4-5rgx.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-37gx-xxp4-5rgx: Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability"
+title: "GHSA-37gx-xxp4-5rgx"
 summary: "Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-37gx-xxp4-5rgx.md
+++ b/security-advisories/ghsa-37gx-xxp4-5rgx.md
@@ -190,7 +190,7 @@ Patches for components to update their dependencies to avoid references that hav
 |NServiceBus.UniformSession.Testing|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/4.0.2)|
 |NServiceBus.UniformSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/5.0.1)|
 |NServiceBus.UniformSession.Testing|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/5.0.1)|
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|

--- a/security-advisories/ghsa-37gx-xxp4-5rgx.md
+++ b/security-advisories/ghsa-37gx-xxp4-5rgx.md
@@ -1,0 +1,212 @@
+---
+title: "GHSA-37gx-xxp4-5rgx: Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability"
+summary: "Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id GHSA-37gx-xxp4-5rgx
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/ghsa-37gx-xxp4-5rgx) security advisory: Microsoft Security Advisory CVE-2026-33116 - .NET, .NET Framework, and Visual Studio Denial of Service Vulnerability.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|NServiceBus|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus/10.0.3)|
+|NServiceBus.AcceptanceTesting|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/10.0.3)|
+|NServiceBus.AcceptanceTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/10.0.3)|
+|NServiceBus.PersistenceTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/10.0.3)|
+|NServiceBus.TransportTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/10.0.3)|
+|NServiceBus|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus/10.1.4)|
+|NServiceBus.AcceptanceTesting|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/10.1.4)|
+|NServiceBus.AcceptanceTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/10.1.4)|
+|NServiceBus.PersistenceTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/10.1.4)|
+|NServiceBus.TransportTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/10.1.4)|
+|NServiceBus|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus/8.2.7)|
+|NServiceBus.AcceptanceTesting|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/8.2.7)|
+|NServiceBus.AcceptanceTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/8.2.7)|
+|NServiceBus.PersistenceTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/8.2.7)|
+|NServiceBus.TransportTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/8.2.7)|
+|NServiceBus|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus/9.2.11)|
+|NServiceBus.AcceptanceTesting|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/9.2.11)|
+|NServiceBus.AcceptanceTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/9.2.11)|
+|NServiceBus.PersistenceTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/9.2.11)|
+|NServiceBus.TransportTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/9.2.11)|
+|NServiceBus.AmazonSQS|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/6.2.2)|
+|NServiceBus.AmazonSQS.CommandLine|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/6.2.2) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 6.2.2`|
+|NServiceBus.AmazonSQS|7.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/7.3.1)|
+|NServiceBus.AmazonSQS.CommandLine|7.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/7.3.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 7.3.1`|
+|NServiceBus.AmazonSQS|8.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/8.0.2)|
+|NServiceBus.AmazonSQS.CommandLine|8.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/8.0.2) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 8.0.2`|
+|NServiceBus.AmazonSQS|8.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/8.1.1)|
+|NServiceBus.AmazonSQS.CommandLine|8.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/8.1.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 8.1.1`|
+|NServiceBus.AmazonSQS|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/9.0.1)|
+|NServiceBus.AmazonSQS.CommandLine|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/9.0.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 9.0.1`|
+|NServiceBus.AwsLambda.SQS|1.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/1.1.3)|
+|NServiceBus.AwsLambda.SQS|2.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/2.1.1)|
+|NServiceBus.AwsLambda.SQS|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/3.0.2)|
+|NServiceBus.AwsLambda.SQS|3.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/3.1.1)|
+|NServiceBus.AwsLambda.SQS|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/4.0.1)|
+|NServiceBus.AzureFunctions.InProcess.ServiceBus|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/5.0.2)|
+|NServiceBus.AzureFunctions.InProcess.ServiceBus|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/6.0.2)|
+|NServiceBus.AzureFunctions.Worker.ServiceBus|4.2.8|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.Worker.ServiceBus/4.2.8)|
+|NServiceBus.AzureFunctions.Worker.ServiceBus|5.2.4|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.Worker.ServiceBus/5.2.4)|
+|NServiceBus.AzureFunctions.Worker.ServiceBus|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.Worker.ServiceBus/6.0.2)|
+|NServiceBus.AzureFunctions.Worker.ServiceBus|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.Worker.ServiceBus/7.0.1)|
+|NServiceBus.Transport.AzureStorageQueues|12.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/12.0.6)|
+|NServiceBus.Transport.AzureStorageQueues|13.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/13.0.5)|
+|NServiceBus.Transport.AzureStorageQueues|14.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/14.0.1)|
+|NServiceBus.Callbacks|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks/5.0.3)|
+|NServiceBus.Callbacks.Testing|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks.Testing/5.0.3)|
+|NServiceBus.Callbacks|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks/6.0.1)|
+|NServiceBus.Callbacks.Testing|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks.Testing/6.0.1)|
+|NServiceBus.ClaimCheck|1.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.ClaimCheck/1.0.2)|
+|NServiceBus.ClaimCheck|2.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.ClaimCheck/2.0.1)|
+|NServiceBus.CustomChecks|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/4.0.2)|
+|NServiceBus.CustomChecks|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/5.0.2)|
+|NServiceBus.CustomChecks|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/6.0.1)|
+|NServiceBus.DataBus.AzureBlobStorage|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/5.0.2)|
+|NServiceBus.DataBus.AzureBlobStorage|6.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/6.1.4)|
+|NServiceBus.DataBus.AzureBlobStorage|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/7.0.1)|
+|NServiceBus.Encryption.MessageProperty|4.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/4.0.3)|
+|NServiceBus.Encryption.MessageProperty|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/5.0.3)|
+|NServiceBus.Encryption.MessageProperty|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/6.0.2)|
+|NServiceBus.Envelope.CloudEvents|1.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Envelope.CloudEvents/1.0.1)|
+|NServiceBus.Extensions.Hosting|2.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Extensions.Hosting/2.0.2)|
+|NServiceBus.Metrics.PerformanceCounters|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.PerformanceCounters/7.0.1)|
+|NServiceBus.Metrics.ServiceControl|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.ServiceControl/4.0.2)|
+|NServiceBus.Metrics.ServiceControl|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.ServiceControl/5.0.2)|
+|NServiceBus.Metrics.ServiceControl|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.ServiceControl/6.0.1)|
+|NServiceBus.Metrics.ServiceControl.Msmq|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.ServiceControl.Msmq/4.0.2)|
+|NServiceBus.Newtonsoft.Json|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/3.0.2)|
+|NServiceBus.Newtonsoft.Json|4.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/4.1.1)|
+|NServiceBus.Newtonsoft.Json|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/5.0.1)|
+|NServiceBus.NHibernate|10.1.2|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate/10.1.2)|
+|NServiceBus.NHibernate.TransactionalSession|10.1.2|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate.TransactionalSession/10.1.2)|
+|NServiceBus.NHibernate|9.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate/9.0.6)|
+|NServiceBus.NHibernate.TransactionalSession|9.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate.TransactionalSession/9.0.6)|
+|NServiceBus.Persistence.AzureTable|6.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable/6.1.3)|
+|NServiceBus.Persistence.AzureTable.TransactionalSession|6.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable.TransactionalSession/6.1.3)|
+|NServiceBus.Persistence.AzureTable|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable/7.0.2)|
+|NServiceBus.Persistence.AzureTable.TransactionalSession|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable.TransactionalSession/7.0.2)|
+|NServiceBus.Persistence.CosmosDB|2.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/2.0.5)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|2.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/2.0.5)|
+|NServiceBus.Persistence.CosmosDB|3.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/3.2.2)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|3.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/3.2.2)|
+|NServiceBus.Persistence.CosmosDB|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/4.0.1)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/4.0.1)|
+|NServiceBus.Persistence.DynamoDB|1.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/1.0.3)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|1.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/1.0.3)|
+|NServiceBus.Persistence.DynamoDB|2.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/2.2.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|2.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/2.2.2)|
+|NServiceBus.Persistence.DynamoDB|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/3.0.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/3.0.2)|
+|NServiceBus.Persistence.DynamoDB|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/4.0.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/4.0.2)|
+|NServiceBus.Persistence.NonDurable|1.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.NonDurable/1.0.2)|
+|NServiceBus.Persistence.NonDurable|2.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.NonDurable/2.0.2)|
+|NServiceBus.Persistence.NonDurable|3.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.NonDurable/3.0.1)|
+|NServiceBus.Persistence.Sql|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/7.0.8)|
+|NServiceBus.Persistence.Sql.CommandLine|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/7.0.8) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 7.0.8`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/7.0.8)|
+|NServiceBus.Persistence.Sql.TransactionalSession|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/7.0.8)|
+|NServiceBus.Persistence.Sql|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/8.2.1)|
+|NServiceBus.Persistence.Sql.CommandLine|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/8.2.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 8.2.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/8.2.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/8.2.1)|
+|NServiceBus.Persistence.Sql|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/8.3.1)|
+|NServiceBus.Persistence.Sql.CommandLine|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/8.3.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 8.3.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/8.3.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/8.3.1)|
+|NServiceBus.Persistence.Sql|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/9.0.1)|
+|NServiceBus.Persistence.Sql.CommandLine|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/9.0.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 9.0.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/9.0.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/9.0.1)|
+|NServiceBus.RabbitMQ|10.1.8|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/10.1.8)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|10.1.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/10.1.8) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 10.1.8`|
+|NServiceBus.RabbitMQ|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.0.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.0.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.0.1`|
+|NServiceBus.RabbitMQ|11.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.1.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.1.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.1.1`|
+|NServiceBus.RabbitMQ|11.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.2.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.2.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.2.1`|
+|NServiceBus.RabbitMQ|8.0.10|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/8.0.10)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|8.0.10|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/8.0.10) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 8.0.10`|
+|NServiceBus.RabbitMQ|9.2.3|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/9.2.3)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|9.2.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/9.2.3) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 9.2.3`|
+|NServiceBus.RavenDB|10.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/10.1.1)|
+|NServiceBus.RavenDB.TransactionalSession|10.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/10.1.1)|
+|NServiceBus.RavenDB|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/11.0.1)|
+|NServiceBus.RavenDB.TransactionalSession|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/11.0.1)|
+|NServiceBus.RavenDB|8.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/8.2.2)|
+|NServiceBus.RavenDB.TransactionalSession|8.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/8.2.2)|
+|NServiceBus.RavenDB|9.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/9.1.1)|
+|NServiceBus.RavenDB.TransactionalSession|9.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/9.1.1)|
+|NServiceBus.SagaAudit|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/4.0.2)|
+|NServiceBus.SagaAudit|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/5.0.3)|
+|NServiceBus.SagaAudit|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/6.0.1)|
+|NServiceBus.ServicePlatform.Connector|2.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/2.0.4)|
+|NServiceBus.ServicePlatform.Connector|3.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/3.0.3)|
+|NServiceBus.ServicePlatform.Connector|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/4.0.1)|
+|NServiceBus.Transport.PostgreSql|7.0.13|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/7.0.13)|
+|NServiceBus.Transport.SqlServer|7.0.13|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/7.0.13)|
+|NServiceBus.Transport.PostgreSql|8.1.12|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/8.1.12)|
+|NServiceBus.Transport.SqlServer|8.1.12|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/8.1.12)|
+|NServiceBus.Transport.PostgreSql|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/9.0.1)|
+|NServiceBus.Transport.SqlServer|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/9.0.1)|
+|NServiceBus.Storage.MongoDB|3.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/3.0.6)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|3.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/3.0.6)|
+|NServiceBus.Storage.MongoDB|4.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/4.2.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|4.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/4.2.1)|
+|NServiceBus.Storage.MongoDB|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/5.0.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/5.0.1)|
+|NServiceBus.Storage.MongoDB|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/6.0.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/6.0.2)|
+|NServiceBus.Storage.MongoDB|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/7.0.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/7.0.1)|
+|NServiceBus.Testing|10.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/10.0.2)|
+|NServiceBus.Testing|8.1.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/8.1.2)|
+|NServiceBus.Testing|9.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/9.0.2)|
+|NServiceBus.TransactionalSession|2.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/2.0.4)|
+|NServiceBus.TransactionalSession|3.4.2|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/3.4.2)|
+|NServiceBus.TransactionalSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/4.0.2)|
+|NServiceBus.Transport.AzureServiceBus|3.2.9|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/3.2.9)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|3.2.9|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/3.2.9) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 3.2.9`|
+|NServiceBus.Transport.AzureServiceBus|5.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/5.1.3)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|5.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/5.1.3) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 5.1.3`|
+|NServiceBus.Transport.AzureServiceBus|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/6.0.1)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/6.0.1) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 6.0.1`|
+|NServiceBus.Transport.AzureServiceBus|6.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/6.1.1)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|6.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/6.1.1) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 6.1.1`|
+|NServiceBus.Transport.AzureServiceBus|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/6.2.2)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/6.2.2) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 6.2.2`|
+|NServiceBus.Transport.IBMMQ|1.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.IBMMQ/1.0.1)|
+|NServiceBus.Transport.IBMMQ.CommandLine|1.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.IBMMQ.CommandLine/1.0.1) or `dotnet tool update --g NServiceBus.Transport.IBMMQ.CommandLine --v 1.0.1`|
+|NServiceBus.Transport.Msmq|2.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.Msmq/2.0.7)|
+|NServiceBus.UniformSession|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/3.0.2)|
+|NServiceBus.UniformSession.Testing|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/3.0.2)|
+|NServiceBus.UniformSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/4.0.2)|
+|NServiceBus.UniformSession.Testing|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/4.0.2)|
+|NServiceBus.UniformSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/5.0.1)|
+|NServiceBus.UniformSession.Testing|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/5.0.1)|
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-4625-4j76-fww9.md
+++ b/security-advisories/ghsa-4625-4j76-fww9.md
@@ -4,7 +4,7 @@ summary: "OpenTelemetry's disk retry default temp path enables local blob inject
 reviewed: "2026-05-13"
 ---
 
-## Security Advisory Id {{GitHubAdvisoryId}}
+## Security Advisory Id GHSA-4625-4j76-fww9
 
 This advisory discloses a security vulnerability 
 Patches for components to update their dependencies to avoid references that have the [GHSA-4625-4j76-fww9](https://github.com/advisories/ghsa-4625-4j76-fww9) security advisory: OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter.
@@ -13,7 +13,7 @@ Patches for components to update their dependencies to avoid references that hav
 
 | Component | Version | Where to get it |
 | --------- | ------- | --------------- |
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|

--- a/security-advisories/ghsa-4625-4j76-fww9.md
+++ b/security-advisories/ghsa-4625-4j76-fww9.md
@@ -1,0 +1,35 @@
+---
+title: "GHSA-4625-4j76-fww9: OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter"
+summary: "OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id {{GitHubAdvisoryId}}
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-4625-4j76-fww9](https://github.com/advisories/ghsa-4625-4j76-fww9) security advisory: OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-4625-4j76-fww9.md
+++ b/security-advisories/ghsa-4625-4j76-fww9.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-4625-4j76-fww9: OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter"
+title: "GHSA-4625-4j76-fww9"
 summary: "OpenTelemetry's disk retry default temp path enables local blob injection via OTLP Exporter"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-6c8g-7p36-r338.md
+++ b/security-advisories/ghsa-6c8g-7p36-r338.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-6c8g-7p36-r338: SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)"
+title: "GHSA-6c8g-7p36-r338"
 summary: "SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-6c8g-7p36-r338.md
+++ b/security-advisories/ghsa-6c8g-7p36-r338.md
@@ -1,0 +1,39 @@
+---
+title: "GHSA-6c8g-7p36-r338: SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)"
+summary: "SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant)"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id GHSA-6c8g-7p36-r338
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-6c8g-7p36-r338](https://github.com/advisories/ghsa-6c8g-7p36-r338) security advisory: SharpCompress has directory traversal via directory entries in WriteToDirectory (zip slip variant).
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|NServiceBus.Storage.MongoDB|3.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/3.0.7)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|3.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/3.0.7)|
+|NServiceBus.Storage.MongoDB|4.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/4.2.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|4.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/4.2.2)|
+|NServiceBus.Storage.MongoDB|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/5.0.3)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/5.0.3)|
+|NServiceBus.Storage.MongoDB|6.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/6.0.4)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|6.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/6.0.4)|
+|NServiceBus.Storage.MongoDB|7.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/7.0.3)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|7.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/7.0.3)|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-9cvc-h2w8-phrp.md
+++ b/security-advisories/ghsa-9cvc-h2w8-phrp.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-9cvc-h2w8-phrp: AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value"
+title: "GHSA-9cvc-h2w8-phrp"
 summary: "AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value"
 reviewed: "2026-01-14"
 ---

--- a/security-advisories/ghsa-9cvc-h2w8-phrp.md
+++ b/security-advisories/ghsa-9cvc-h2w8-phrp.md
@@ -1,0 +1,34 @@
+---
+title: "GHSA-9cvc-h2w8-phrp: AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value"
+summary: "AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value"
+reviewed: "2026-01-14"
+---
+
+## Security Advisory Id GHSA-9cvc-h2w8-phrp
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-9cvc-h2w8-phrp](https://github.com/advisories/ghsa-9cvc-h2w8-phrp) security advisory: AWS SDK for .NET V4 adopted defense in depth enhancement for region parameter value.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|NServiceBus.AmazonSQS|8.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/8.0.1)|
+|NServiceBus.AmazonSQS.CommandLine|8.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/8.0.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 8.0.1`|
+|NServiceBus.Persistence.DynamoDB|3.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/3.0.1)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|3.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/3.0.1)|
+|NServiceBus.AwsLambda.Sqs|3.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/3.0.1)|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-g4vj-cjjj-v7hg.md
+++ b/security-advisories/ghsa-g4vj-cjjj-v7hg.md
@@ -1,0 +1,30 @@
+---
+title: "GHSA-g4vj-cjjj-v7hg: Defense in Depth update for NuGet Client"
+summary: "Defense in Depth update for NuGet Client"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id GHSA-g4vj-cjjj-v7hg
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/ghsa-g4vj-cjjj-v7hg) security advisory: Defense in Depth update for NuGet Client.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|Particular.AzureTable.Export|1.2.1|[NuGet](https://www.nuget.org/packages/Particular.AzureTable.Export/1.2.1) or `dotnet tool update --g Particular.AzureTable.Export --v 1.2.1`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-g4vj-cjjj-v7hg.md
+++ b/security-advisories/ghsa-g4vj-cjjj-v7hg.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-g4vj-cjjj-v7hg: Defense in Depth update for NuGet Client"
+title: "GHSA-g4vj-cjjj-v7hg"
 summary: "Defense in Depth update for NuGet Client"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-g94r-2vxg-569j.md
+++ b/security-advisories/ghsa-g94r-2vxg-569j.md
@@ -13,7 +13,7 @@ Patches for components to update their dependencies to avoid references that hav
 
 | Component | Version | Where to get it |
 | --------- | ------- | --------------- |
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|

--- a/security-advisories/ghsa-g94r-2vxg-569j.md
+++ b/security-advisories/ghsa-g94r-2vxg-569j.md
@@ -1,0 +1,35 @@
+---
+title: "GHSA-g94r-2vxg-569j: OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers"
+summary: "OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers"
+reviewed: "2026-05-14"
+---
+
+## Security Advisory Id GHSA-g94r-2vxg-569j
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-g94r-2vxg-569j](https://github.com/advisories/ghsa-g94r-2vxg-569j) security advisory: OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-g94r-2vxg-569j.md
+++ b/security-advisories/ghsa-g94r-2vxg-569j.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-g94r-2vxg-569j: OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers"
+title: "GHSA-g94r-2vxg-569j"
 summary: "OpenTelemetry dotnet: Excessive memory allocation when parsing OpenTelemetry propagation headers"
 reviewed: "2026-05-14"
 ---

--- a/security-advisories/ghsa-mr8r-92fq-pj8p.md
+++ b/security-advisories/ghsa-mr8r-92fq-pj8p.md
@@ -1,0 +1,35 @@
+---
+title: "GHSA-mr8r-92fq-pj8p: OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling"
+summary: "OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling"
+reviewed: "2026-05-14"
+---
+
+## Security Advisory Id GHSA-mr8r-92fq-pj8p
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/ghsa-mr8r-92fq-pj8p) security advisory: OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-mr8r-92fq-pj8p.md
+++ b/security-advisories/ghsa-mr8r-92fq-pj8p.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-mr8r-92fq-pj8p: OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling"
+title: "GHSA-mr8r-92fq-pj8p"
 summary: "OpenTelemetry dotnet: Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling"
 reviewed: "2026-05-14"
 ---

--- a/security-advisories/ghsa-mr8r-92fq-pj8p.md
+++ b/security-advisories/ghsa-mr8r-92fq-pj8p.md
@@ -13,7 +13,7 @@ Patches for components to update their dependencies to avoid references that hav
 
 | Component | Version | Where to get it |
 | --------- | ------- | --------------- |
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|

--- a/security-advisories/ghsa-pggp-6c3x-2xmx.md
+++ b/security-advisories/ghsa-pggp-6c3x-2xmx.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-pggp-6c3x-2xmx: Snappier has an infinite loop during SnappyStream decompression with malformed framed input"
+title: "GHSA-pggp-6c3x-2xmx"
 summary: "Snappier has an infinite loop during SnappyStream decompression with malformed framed input"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-pggp-6c3x-2xmx.md
+++ b/security-advisories/ghsa-pggp-6c3x-2xmx.md
@@ -1,0 +1,39 @@
+---
+title: "GHSA-pggp-6c3x-2xmx: Snappier has an infinite loop during SnappyStream decompression with malformed framed input"
+summary: "Snappier has an infinite loop during SnappyStream decompression with malformed framed input"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id GHSA-pggp-6c3x-2xmx
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/ghsa-pggp-6c3x-2xmx) security advisory: Snappier has an infinite loop during SnappyStream decompression with malformed framed input.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|NServiceBus.Storage.MongoDB|3.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/3.0.7)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|3.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/3.0.7)|
+|NServiceBus.Storage.MongoDB|4.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/4.2.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|4.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/4.2.2)|
+|NServiceBus.Storage.MongoDB|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/5.0.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/5.0.2)|
+|NServiceBus.Storage.MongoDB|6.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/6.0.3)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|6.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/6.0.3)|
+|NServiceBus.Storage.MongoDB|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/7.0.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/7.0.2)|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-q834-8qmm-v933.md
+++ b/security-advisories/ghsa-q834-8qmm-v933.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-q834-8qmm-v933: OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
+title: "GHSA-q834-8qmm-v933"
 summary: "OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
 reviewed: "2026-05-14"
 ---

--- a/security-advisories/ghsa-q834-8qmm-v933.md
+++ b/security-advisories/ghsa-q834-8qmm-v933.md
@@ -1,7 +1,7 @@
 ---
 title: "GHSA-q834-8qmm-v933: OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
 summary: "OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
-reviewed: "{{AnnouncementDate}}"
+reviewed: "2026-05-14"
 ---
 
 ## Security Advisory Id GHSA-q834-8qmm-v933

--- a/security-advisories/ghsa-q834-8qmm-v933.md
+++ b/security-advisories/ghsa-q834-8qmm-v933.md
@@ -13,7 +13,7 @@ Patches for components to update their dependencies to avoid references that hav
 
 | Component | Version | Where to get it |
 | --------- | ------- | --------------- |
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|

--- a/security-advisories/ghsa-q834-8qmm-v933.md
+++ b/security-advisories/ghsa-q834-8qmm-v933.md
@@ -1,0 +1,35 @@
+---
+title: "GHSA-q834-8qmm-v933: OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
+summary: "OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies"
+reviewed: "{{AnnouncementDate}}"
+---
+
+## Security Advisory Id GHSA-q834-8qmm-v933
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-q834-8qmm-v933](https://github.com/advisories/ghsa-q834-8qmm-v933) security advisory: OpenTelemetry dotnet: OTLP exporter reads unbounded HTTP response bodies.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-w3x6-4m5h-cxqf.md
+++ b/security-advisories/ghsa-w3x6-4m5h-cxqf.md
@@ -1,0 +1,212 @@
+---
+title: "GHSA-w3x6-4m5h-cxqf: Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability"
+summary: "Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability"
+reviewed: "2026-05-13"
+---
+
+## Security Advisory Id GHSA-w3x6-4m5h-cxqf
+
+This advisory discloses a security vulnerability 
+Patches for components to update their dependencies to avoid references that have the [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/ghsa-w3x6-4m5h-cxqf) security advisory: Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability.
+
+### Patch releases
+
+| Component | Version | Where to get it |
+| --------- | ------- | --------------- |
+|NServiceBus|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus/10.0.3)|
+|NServiceBus.AcceptanceTesting|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/10.0.3)|
+|NServiceBus.AcceptanceTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/10.0.3)|
+|NServiceBus.PersistenceTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/10.0.3)|
+|NServiceBus.TransportTests.Sources|10.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/10.0.3)|
+|NServiceBus|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus/10.1.4)|
+|NServiceBus.AcceptanceTesting|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/10.1.4)|
+|NServiceBus.AcceptanceTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/10.1.4)|
+|NServiceBus.PersistenceTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/10.1.4)|
+|NServiceBus.TransportTests.Sources|10.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/10.1.4)|
+|NServiceBus|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus/8.2.7)|
+|NServiceBus.AcceptanceTesting|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/8.2.7)|
+|NServiceBus.AcceptanceTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/8.2.7)|
+|NServiceBus.PersistenceTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/8.2.7)|
+|NServiceBus.TransportTests.Sources|8.2.7|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/8.2.7)|
+|NServiceBus|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus/9.2.11)|
+|NServiceBus.AcceptanceTesting|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTesting/9.2.11)|
+|NServiceBus.AcceptanceTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.AcceptanceTests.Sources/9.2.11)|
+|NServiceBus.PersistenceTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.PersistenceTests.Sources/9.2.11)|
+|NServiceBus.TransportTests.Sources|9.2.11|[NuGet](https://www.nuget.org/packages/NServiceBus.TransportTests.Sources/9.2.11)|
+|NServiceBus.AmazonSQS|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/6.2.2)|
+|NServiceBus.AmazonSQS.CommandLine|6.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/6.2.2) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 6.2.2`|
+|NServiceBus.AmazonSQS|7.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/7.3.1)|
+|NServiceBus.AmazonSQS.CommandLine|7.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/7.3.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 7.3.1`|
+|NServiceBus.AmazonSQS|8.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/8.0.2)|
+|NServiceBus.AmazonSQS.CommandLine|8.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/8.0.2) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 8.0.2`|
+|NServiceBus.AmazonSQS|8.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/8.1.1)|
+|NServiceBus.AmazonSQS.CommandLine|8.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/8.1.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 8.1.1`|
+|NServiceBus.AmazonSQS|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS/9.0.1)|
+|NServiceBus.AmazonSQS.CommandLine|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AmazonSQS.CommandLine/9.0.1) or `dotnet tool update --g NServiceBus.AmazonSQS.CommandLine --v 9.0.1`|
+|NServiceBus.AwsLambda.SQS|1.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/1.1.3)|
+|NServiceBus.AwsLambda.SQS|2.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/2.1.1)|
+|NServiceBus.AwsLambda.SQS|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/3.0.2)|
+|NServiceBus.AwsLambda.SQS|3.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/3.1.1)|
+|NServiceBus.AwsLambda.SQS|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.AwsLambda.SQS/4.0.1)|
+|NServiceBus.AzureFunctions.InProcess.ServiceBus|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/5.0.2)|
+|NServiceBus.AzureFunctions.InProcess.ServiceBus|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.InProcess.ServiceBus/6.0.2)|
+|NServiceBus.AzureFunctions.Worker.ServiceBus|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.AzureFunctions.Worker.ServiceBus/6.0.2)|
+|NServiceBus.Transport.AzureStorageQueues|12.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/12.0.6)|
+|NServiceBus.Transport.AzureStorageQueues|13.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/13.0.5)|
+|NServiceBus.Transport.AzureStorageQueues|14.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureStorageQueues/14.0.1)|
+|NServiceBus.Callbacks|4.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks/4.0.3)|
+|NServiceBus.Callbacks.Testing|4.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks.Testing/4.0.3)|
+|NServiceBus.Callbacks|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks/6.0.1)|
+|NServiceBus.Callbacks.Testing|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Callbacks.Testing/6.0.1)|
+|NServiceBus.ClaimCheck|1.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.ClaimCheck/1.0.2)|
+|NServiceBus.ClaimCheck|2.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.ClaimCheck/2.0.1)|
+|NServiceBus.CustomChecks|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/4.0.2)|
+|NServiceBus.CustomChecks|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/5.0.2)|
+|NServiceBus.CustomChecks|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.CustomChecks/6.0.1)|
+|NServiceBus.DataBus.AzureBlobStorage|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/5.0.2)|
+|NServiceBus.DataBus.AzureBlobStorage|6.1.4|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/6.1.4)|
+|NServiceBus.DataBus.AzureBlobStorage|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/7.0.1)|
+|NServiceBus.Encryption.MessageProperty|4.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/4.0.3)|
+|NServiceBus.Encryption.MessageProperty|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/5.0.3)|
+|NServiceBus.Encryption.MessageProperty|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Encryption.MessageProperty/6.0.2)|
+|NServiceBus.Envelope.CloudEvents|1.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Envelope.CloudEvents/1.0.1)|
+|NServiceBus.Extensions.Hosting|2.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Extensions.Hosting/2.0.2)|
+|NServiceBus.Extensions.Hosting|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Extensions.Hosting/3.0.2)|
+|NServiceBus.Extensions.Hosting|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Extensions.Hosting/4.0.1)|
+|NServiceBus.Extensions.Logging|2.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Extensions.Logging/2.0.2)|
+|NServiceBus.Heartbeat|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Heartbeat/6.0.1)|
+|NServiceBus.MessagingBridge|2.3.4|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge/2.3.4)|
+|NServiceBus.MessagingBridge.Msmq|2.3.4|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge.Msmq/2.3.4)|
+|NServiceBus.MessagingBridge|4.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge/4.0.5)|
+|NServiceBus.MessagingBridge.Msmq|4.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge.Msmq/4.0.5)|
+|NServiceBus.MessagingBridge|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge/5.0.2)|
+|NServiceBus.MessagingBridge.Msmq|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.MessagingBridge.Msmq/5.0.2)|
+|NServiceBus.Metrics|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics/4.0.2)|
+|NServiceBus.Metrics|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics/5.0.2)|
+|NServiceBus.Metrics|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics/6.0.1)|
+|NServiceBus.Metrics.PerformanceCounters|5.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.PerformanceCounters/5.0.2)|
+|NServiceBus.Metrics.PerformanceCounters|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.PerformanceCounters/6.0.1)|
+|NServiceBus.Metrics.PerformanceCounters|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Metrics.PerformanceCounters/7.0.1)|
+|NServiceBus.Newtonsoft.Json|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/3.0.2)|
+|NServiceBus.Newtonsoft.Json|4.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/4.1.1)|
+|NServiceBus.Newtonsoft.Json|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Newtonsoft.Json/5.0.1)|
+|NServiceBus.NHibernate|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate/11.0.1)|
+|NServiceBus.NHibernate.TransactionalSession|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.NHibernate.TransactionalSession/11.0.1)|
+|NServiceBus.Persistence.AzureTable|6.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable/6.1.3)|
+|NServiceBus.Persistence.AzureTable.TransactionalSession|6.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable.TransactionalSession/6.1.3)|
+|NServiceBus.Persistence.AzureTable|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable/7.0.2)|
+|NServiceBus.Persistence.AzureTable.TransactionalSession|7.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.AzureTable.TransactionalSession/7.0.2)|
+|NServiceBus.Persistence.CosmosDB|2.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/2.0.5)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|2.0.5|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/2.0.5)|
+|NServiceBus.Persistence.CosmosDB|3.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/3.2.2)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|3.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/3.2.2)|
+|NServiceBus.Persistence.CosmosDB|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB/4.0.1)|
+|NServiceBus.Persistence.CosmosDB.TransactionalSession|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.CosmosDB.TransactionalSession/4.0.1)|
+|NServiceBus.Persistence.DynamoDB|1.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/1.0.3)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|1.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/1.0.3)|
+|NServiceBus.Persistence.DynamoDB|2.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/2.2.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|2.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/2.2.2)|
+|NServiceBus.Persistence.DynamoDB|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/3.0.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/3.0.2)|
+|NServiceBus.Persistence.DynamoDB|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB/4.0.2)|
+|NServiceBus.Persistence.DynamoDB.TransactionalSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.DynamoDB.TransactionalSession/4.0.2)|
+|NServiceBus.Persistence.Sql|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/7.0.8)|
+|NServiceBus.Persistence.Sql.CommandLine|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/7.0.8) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 7.0.8`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/7.0.8)|
+|NServiceBus.Persistence.Sql.TransactionalSession|7.0.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/7.0.8)|
+|NServiceBus.Persistence.Sql|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/8.2.1)|
+|NServiceBus.Persistence.Sql.CommandLine|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/8.2.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 8.2.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/8.2.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|8.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/8.2.1)|
+|NServiceBus.Persistence.Sql|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/8.3.1)|
+|NServiceBus.Persistence.Sql.CommandLine|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/8.3.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 8.3.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/8.3.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|8.3.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/8.3.1)|
+|NServiceBus.Persistence.Sql|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql/9.0.1)|
+|NServiceBus.Persistence.Sql.CommandLine|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.CommandLine/9.0.1) or `dotnet tool update --g NServiceBus.Persistence.Sql.CommandLine --v 9.0.1`|
+|NServiceBus.Persistence.Sql.ScriptBuilder|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.ScriptBuilder/9.0.1)|
+|NServiceBus.Persistence.Sql.TransactionalSession|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.TransactionalSession/9.0.1)|
+|NServiceBus.RabbitMQ|10.1.8|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/10.1.8)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|10.1.8|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/10.1.8) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 10.1.8`|
+|NServiceBus.RabbitMQ|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.0.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.0.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.0.1`|
+|NServiceBus.RabbitMQ|11.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.1.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.1.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.1.1`|
+|NServiceBus.RabbitMQ|11.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/11.2.1)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|11.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/11.2.1) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 11.2.1`|
+|NServiceBus.RabbitMQ|8.0.10|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/8.0.10)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|8.0.10|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/8.0.10) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 8.0.10`|
+|NServiceBus.RabbitMQ|9.2.3|[NuGet](https://www.nuget.org/packages/NServiceBus.RabbitMQ/9.2.3)|
+|NServiceBus.Transport.RabbitMQ.CommandLine|9.2.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.RabbitMQ.CommandLine/9.2.3) or `dotnet tool update --g NServiceBus.Transport.RabbitMQ.CommandLine --v 9.2.3`|
+|NServiceBus.RavenDB|10.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/10.1.1)|
+|NServiceBus.RavenDB.TransactionalSession|10.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/10.1.1)|
+|NServiceBus.RavenDB|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/11.0.1)|
+|NServiceBus.RavenDB.TransactionalSession|11.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/11.0.1)|
+|NServiceBus.RavenDB|8.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/8.2.2)|
+|NServiceBus.RavenDB.TransactionalSession|8.2.2|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/8.2.2)|
+|NServiceBus.RavenDB|9.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB/9.1.1)|
+|NServiceBus.RavenDB.TransactionalSession|9.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.RavenDB.TransactionalSession/9.1.1)|
+|NServiceBus.SagaAudit|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/4.0.2)|
+|NServiceBus.SagaAudit|5.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/5.0.3)|
+|NServiceBus.SagaAudit|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.SagaAudit/6.0.1)|
+|NServiceBus.ServicePlatform.Connector|2.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/2.0.4)|
+|NServiceBus.ServicePlatform.Connector|3.0.3|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/3.0.3)|
+|NServiceBus.ServicePlatform.Connector|4.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.ServicePlatform.Connector/4.0.1)|
+|NServiceBus.Transport.PostgreSql|7.0.13|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/7.0.13)|
+|NServiceBus.Transport.SqlServer|7.0.13|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/7.0.13)|
+|NServiceBus.Transport.PostgreSql|8.1.12|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/8.1.12)|
+|NServiceBus.Transport.SqlServer|8.1.12|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/8.1.12)|
+|NServiceBus.Transport.PostgreSql|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.PostgreSql/9.0.1)|
+|NServiceBus.Transport.SqlServer|9.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.SqlServer/9.0.1)|
+|NServiceBus.Storage.MongoDB|3.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/3.0.6)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|3.0.6|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/3.0.6)|
+|NServiceBus.Storage.MongoDB|4.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/4.2.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|4.2.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/4.2.1)|
+|NServiceBus.Storage.MongoDB|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/5.0.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/5.0.1)|
+|NServiceBus.Storage.MongoDB|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/6.0.2)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|6.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/6.0.2)|
+|NServiceBus.Storage.MongoDB|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB/7.0.1)|
+|NServiceBus.Storage.MongoDB.TransactionalSession|7.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Storage.MongoDB.TransactionalSession/7.0.1)|
+|NServiceBus.Testing|10.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/10.0.2)|
+|NServiceBus.Testing|8.1.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/8.1.2)|
+|NServiceBus.Testing|9.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Testing/9.0.2)|
+|NServiceBus.TransactionalSession|2.0.4|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/2.0.4)|
+|NServiceBus.TransactionalSession|3.4.2|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/3.4.2)|
+|NServiceBus.TransactionalSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.TransactionalSession/4.0.2)|
+|NServiceBus.Transport.AzureServiceBus|3.2.9|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/3.2.9)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|3.2.9|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/3.2.9) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 3.2.9`|
+|NServiceBus.Transport.AzureServiceBus|5.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/5.1.3)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|5.1.3|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/5.1.3) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 5.1.3`|
+|NServiceBus.Transport.AzureServiceBus|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/6.0.1)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|6.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/6.0.1) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 6.0.1`|
+|NServiceBus.Transport.AzureServiceBus|6.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus/6.1.1)|
+|NServiceBus.Transport.AzureServiceBus.CommandLine|6.1.1|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.AzureServiceBus.CommandLine/6.1.1) or `dotnet tool update --g NServiceBus.Transport.AzureServiceBus.CommandLine --v 6.1.1`|
+|NServiceBus.Transport.Msmq|2.0.7|[NuGet](https://www.nuget.org/packages/NServiceBus.Transport.Msmq/2.0.7)|
+|NServiceBus.UniformSession|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/3.0.2)|
+|NServiceBus.UniformSession.Testing|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/3.0.2)|
+|NServiceBus.UniformSession|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/4.0.2)|
+|NServiceBus.UniformSession.Testing|4.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/4.0.2)|
+|NServiceBus.UniformSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/5.0.1)|
+|NServiceBus.UniformSession.Testing|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/5.0.1)|
+|NServiceBus.Wcf|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Wcf/3.0.2)|
+|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
+|servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
+|servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|
+|servicecontrol-monitoring|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-monitoring) or `docker pull particular/servicecontrol-monitoring:6.14.2`|
+|servicecontrol-ravendb|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-ravendb) or `docker pull particular/servicecontrol-ravendb:6.14.2`|
+
+### How to know if you are affected
+
+You are affected if you are using previous versions of any of these components, but this doesn't necessarily mean you are vulnerable.
+
+### Symptoms
+
+For NuGet packages your projects have the setting `NuGetAuditMode` set to `all` and see transitive dependency warnings at build time that mention Particular packages.
+
+Other components of the platform will not have any symptoms.
+
+### When to upgrade
+
+You should upgrade immediately if you are affected. Otherwise, you should upgrade during your next maintenance window.

--- a/security-advisories/ghsa-w3x6-4m5h-cxqf.md
+++ b/security-advisories/ghsa-w3x6-4m5h-cxqf.md
@@ -1,5 +1,5 @@
 ---
-title: "GHSA-w3x6-4m5h-cxqf: Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability"
+title: "GHSA-w3x6-4m5h-cxqf"
 summary: "Microsoft Security Advisory CVE-2026-26171 - .NET Denial of Service Vulnerability"
 reviewed: "2026-05-13"
 ---

--- a/security-advisories/ghsa-w3x6-4m5h-cxqf.md
+++ b/security-advisories/ghsa-w3x6-4m5h-cxqf.md
@@ -190,7 +190,7 @@ Patches for components to update their dependencies to avoid references that hav
 |NServiceBus.UniformSession|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession/5.0.1)|
 |NServiceBus.UniformSession.Testing|5.0.1|[NuGet](https://www.nuget.org/packages/NServiceBus.UniformSession.Testing/5.0.1)|
 |NServiceBus.Wcf|3.0.2|[NuGet](https://www.nuget.org/packages/NServiceBus.Wcf/3.0.2)|
-|ServiceControl|6.14.2|[Our website](https://particular.net/downloads)|
+|ServiceControl|6.14.2|[The downloads page](https://particular.net/downloads)|
 |Particular.ServiceControl.Management|6.14.2|Update-Module -Name Particular.ServiceControl.Management -RequiredVersion 6.14.2|
 |servicecontrol|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol) or `docker pull particular/servicecontrol:6.14.2`|
 |servicecontrol-audit|6.14.2|[Docker Hub](https://hub.docker.com/r/particular/servicecontrol-audit) or `docker pull particular/servicecontrol-audit:6.14.2`|


### PR DESCRIPTION
This PR adds the previously announced transitive vulnerabilities patches to the Security Advisories sections.