### PR TITLE
Update Azure Functions docs for flexible configure method naming

### DIFF
--- a/nservicebus/hosting/azure/functions/analyzers.md
+++ b/nservicebus/hosting/azure/functions/analyzers.md
@@ -14,9 +14,9 @@ The package includes [Roslyn analyzers](https://learn.microsoft.com/en-us/visual
 | `NSBFUNC001` | Error | A class containing a method with `[NServiceBusFunction]` must be `partial`. |
 | `NSBFUNC002` | Warning | A function class should not implement `IHandleMessages<T>`. Register handlers separately in endpoint configuration. |
 | `NSBFUNC003` | Error | A method with `[NServiceBusFunction]` must be `partial`. |
-| `NSBFUNC004` | Error | Only one `Configure{FunctionName}` method is allowed for a function. |
+| `NSBFUNC004` | Error | Multiple configure methods found that match the same function name. |
 | `NSBFUNC005` | Error | The Service Bus trigger must explicitly set `AutoCompleteMessages = false`. |
-| `NSBFUNC006` | Error | The function method is invalid, for example because required trigger parameters are missing or the matching `Configure{FunctionName}` method is missing or invalid. |
+| `NSBFUNC006` | Error | The function method is invalid, for example because required trigger parameters are missing or no matching configure method was found. |
 | `NSBFUNC007` | Error | Unsupported endpoint configuration API is used in a `Configure…` method for a receiving or send-only endpoint. |
 | `NSBFUNC008` | Error | Unsupported `SendOptions` or `ReplyOptions` API is used for Azure Functions endpoints. |
 | `NSBFUNC009` | Error | `EndpointConfiguration.UseTransport(…)` does not use `AzureServiceBusServerlessTransport`. |
@@ -60,7 +60,7 @@ For the supported transport configuration in this hosting model, see [Azure Func
 The method must:
 
 - be `static`
-- be named `Configure{EndpointName}` (case-insensitive)
+- follow the `Configure{EndpointName}` naming pattern, ignoring casing and non-alphanumeric characters
 - take `EndpointConfiguration` as the first parameter
 - only use `IServiceCollection`, `IConfigurationManager` (or any interface it implements, such as `IConfiguration` or `IConfigurationBuilder`), `IHostEnvironment`, and `IDictionary<object, object>` as additional optional parameters
 
@@ -74,4 +74,4 @@ The code fix can:
 
 - add missing trigger-related parameters such as `FunctionContext` and `CancellationToken`
 - add missing additional trigger parameters required by the function signature
-- generate a missing `Configure{FunctionName}` method stub
+- generate a missing configure method stub following the `Configure{FunctionName}` convention

--- a/nservicebus/hosting/azure/functions/configuration.md
+++ b/nservicebus/hosting/azure/functions/configuration.md
@@ -11,7 +11,9 @@ related:
 
 ## The configure method
 
-The static `Configure{FunctionName}` method is discovered by the source generator and called once per endpoint at host startup. Parameters are matched by type against the properties of [`IHostApplicationBuilder`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder). Any interface type implemented by those properties is accepted:
+The static configure method is discovered by the source generator and called once per endpoint at host startup. The method must be named following the `Configure{FunctionName}` pattern, where the suffix after `Configure` is compared to the function name after stripping non-alphanumeric characters. Casing and additional punctuation in the method name are ignored. For example, `ConfigureMy_Endpoint`, `Configuremyendpoint`, and `configure_my_endpoint` all match a function named `"my-endpoint"`.
+
+Parameters are matched by type against the properties of [`IHostApplicationBuilder`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder). Any interface type implemented by those properties is accepted:
 
 | Parameter | Source | Use |
 |---|---|---|

--- a/nservicebus/hosting/azure/functions/index.md
+++ b/nservicebus/hosting/azure/functions/index.md
@@ -26,7 +26,7 @@ NServiceBus enabled functions must be declared in a partial class and are compos
 - A partial method decorated with a `[NServiceBusFunction]` and a `[Function("MyFunction")]` attribute declaring an [Azure Service Bus trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger).
   - The trigger must set `AutoCompleteMessages = false` since the NServiceBus pipeline takes responsibility for completing or abandoning each message based on handler outcomes; the [`NSBFUNC005` analyzer](analyzers.md) enforces this requirement.
   - A source generator will emit the method body that forwards each incoming message to the NServiceBus pipeline.
-- A static `Configure{FunctionName}` method that configures the NServiceBus endpoint for the function.
+- A static method named `Configure{FunctionName}` (flexible casing and punctuation) that configures the NServiceBus endpoint for the function.
 
 For endpoint configuration, supported transport options, and explicit handler and saga registration, etc, see [Configuration](/nservicebus/hosting/azure/functions/configuration.md).
 
@@ -36,7 +36,7 @@ Multiple methods decorated with `[NServiceBusFunction]` can co-exist in one Func
 
 snippet: azure-functions-multiple-endpoints
 
-Each endpoint has its own `Configure{FunctionName}` method; the source generator routes each function to its matching configure method. Endpoints share the host's service provider but maintain independent message-handling pipelines.
+Each endpoint has its own configure method; the source generator matches methods whose name follows the `Configure{FunctionName}` pattern, where non-alphanumeric characters in the function name are ignored. For example, `ConfigureMy_Endpoint` matches the function name `"my-endpoint"`. Endpoints share the host's service provider but maintain independent message-handling pipelines.
 
 ## Send-only endpoints
 


### PR DESCRIPTION
The source generator [now uses pattern-based matching instead of exact name comparison](https://github.com/Particular/NServiceBus.AzureFunctions/pull/128). Updated index, configuration, and analyzers docs to reflect the new flexibility while maintaining the convention guidance.