### PR TITLE
Review /persistence/sql/dialect-mysql

### DIFF
--- a/persistence/sql/dialect-mysql.md
+++ b/persistence/sql/dialect-mysql.md
@@ -3,11 +3,11 @@ title: SQL Persistence - MySQL dialect
 summary: An SQL persister dialect that specifically targets MySQL, including AWS Aurora MySQL.
 component: SqlPersistence
 related:
-reviewed: 2024-10-09
+reviewed: 2026-06-15
 ---
 
 > [!WARNING]
-> This persistence will run on the free version of the above engines, i.e. [MySQL Community Edition](https://www.mysql.com/products/community/). However, it is strongly recommended to use commercial versions for any production system. It is also recommended to ensure that support agreements are in place. See [MySQL support](https://www.mysql.com/support/) for details.
+> This persistence will run on the free version of MySQL engines, i.e., [MySQL Community Edition](https://www.mysql.com/products/community/). However, it is strongly recommended to use commercial versions for any production system. It is also recommended to ensure that support agreements are in place. See [MySQL support](https://www.mysql.com/support/) for details.
 
 
 ## Supported database versions
@@ -21,7 +21,7 @@ Using the [MySql.Data NuGet Package](https://www.nuget.org/packages/MySql.Data/)
 snippet: SqlPersistenceUsageMySql
 
 > [!NOTE]
-> The following settings are required for [MySQL connections string](https://dev.mysql.com/doc/connector-net/en/connector-net-6-10-connection-options.html).
+> The following settings are required for [MySQL connection strings](https://dev.mysql.com/doc/connector-net/en/connector-net-8-0-connection-options.html).
 >
 > * `AllowUserVariables=True`: since the Persistence uses [user variables](https://dev.mysql.com/doc/refman/5.7/en/user-variables.html).
 > * `AutoEnlist=false`: To prevent auto enlistment in a [Distributed Transaction](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms681205(v=vs.85)) which the MySql .NET connector does not currently support.


### PR DESCRIPTION
Fixes typos and a broken link on 
- `/persistence/sql/dialect-mysql`