### PR TITLE
Review /transports/msmq/dead-letter-queues

### DIFF
--- a/Snippets/MsmqTransport/MsmqTransport_2/DLQOptInForTTBR.cs
+++ b/Snippets/MsmqTransport/MsmqTransport_2/DLQOptInForTTBR.cs
@@ -10,7 +10,7 @@
 
             var transport = new MsmqTransport
             {
-                UseDeadLetterQueueForMessagesWithTimeToBeReceived = false
+                UseDeadLetterQueueForMessagesWithTimeToBeReceived = true
             };
             endpointConfiguration.UseTransport(transport);
 

--- a/transports/msmq/dead-letter-queues.md
+++ b/transports/msmq/dead-letter-queues.md
@@ -1,18 +1,18 @@
 ---
 title: MSMQ Dead Letter Queues
 summary: Controlling MSMQ Dead Letter Queue behavior
-reviewed: 2024-10-09
+reviewed: 2026-06-15
 component: MsmqTransport
 redirects:
  - nservicebus/msmq/dead-letter-queues
 ---
 
-[Dead Letter Queues](https://msdn.microsoft.com/en-us/library/ms706227.aspx) is a feature of MSMQ that tracks messages that are undeliverable, deleted, expired etc. NServiceBus endpoints will by default enable DLQ for all outgoing messages except messages that have a [Time To Be Received(TTBR)](/nservicebus/messaging/discard-old-messages.md) set. This avoids expired messages ending up either in the TDLQ or DLQ (if [non-transactional queues are used](/transports/msmq/connection-strings.md)) wasting disk space on the machine when they time out.
+[Dead Letter Queues](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms706227(v=vs.85)) is a feature of MSMQ that tracks messages that are undeliverable, deleted, expired etc. NServiceBus endpoints will by default enable DLQ for all outgoing messages except messages that have a [Time To Be Received (TTBR)](/nservicebus/messaging/discard-old-messages.md) set. This avoids expired messages ending up either in the TDLQ or DLQ (if [non-transactional queues are used](/transports/msmq/connection-strings.md)) wasting disk space on the machine when they time out.
 
 DLQ can be disabled for the entire endpoint using the [MSMQ connection string](/transports/msmq/connection-strings.md).
 
 > [!NOTE]
-> If DLQ is enabled messages will remain in the senders outgoing queue until processed and count towards disk space quota on the senders machine.
+> If DLQ is enabled, messages will remain in the sender's outgoing queue until processed and count towards disk space quota on the sender's machine.
 
 
 partial: config
@@ -20,7 +20,7 @@ partial: config
 
 ### Monitoring DLQ
 
-MSMQ moves messages that cannot be delivered to their destination to the DLQ. This may be due to misconfiguration of [routing](/nservicebus/messaging/routing.md) or queues being purged. See [Dead-Letter Queues](https://msdn.microsoft.com/en-us/library/ms706227.aspx) for a comprehensive list of conditions under which messages may be moved to the DLQ.
+MSMQ moves messages that cannot be delivered to their destination to the DLQ. This may be due to misconfiguration of [routing](/nservicebus/messaging/routing.md) or queues being purged. See [Dead-Letter Queues](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms706227(v=vs.85)) for a comprehensive list of conditions under which messages may be moved to the DLQ.
 
 It is very important to monitor the DLQ in order to detect potential routing configuration errors or other situations that may lead to messages being moved to the dead-letter queue.
 
@@ -32,7 +32,7 @@ It is very important to monitor the DLQ in order to detect potential routing con
 
 The following addresses can be used to read messages from DLQ on a given machine:
 
-```
+```text
 DIRECT=OS:{MACHINE-NAME}\SYSTEM$;DEADLETTER
 DIRECT=OS:{MACHINE-NAME}\SYSTEM$;DEADXACT
 ```
@@ -40,4 +40,4 @@ DIRECT=OS:{MACHINE-NAME}\SYSTEM$;DEADXACT
 
 #### Performance counters
 
-The [**MSMQ Queue**](https://technet.microsoft.com/en-us/library/cc771098.aspx#Anchor_2) performance object contains counters that can be used to monitor the number of messages in various queues. Value of the **Messages in Queue** counter of the **Computer Queues** instance tracks the number of messages in the DLQ on a given machine.
+The [**MSMQ Queue**](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771098(v=ws.10)) performance object contains counters that can be used to monitor the number of messages in various queues. Value of the **Messages in Queue** counter of the **Computer Queues** instance tracks the number of messages in the DLQ on a given machine.

--- a/transports/msmq/dead-letter-queues_config_msmqtransport_[1,).partial.md
+++ b/transports/msmq/dead-letter-queues_config_msmqtransport_[1,).partial.md
@@ -2,7 +2,7 @@
 
 In Versions 6.1 and below, DLQ was enabled by default for TTBR messages.
 
-To opt-out of this behavior for Versions 6.2 and above, use:
+To opt-in to this behavior for Versions 6.2 and above, use:
 
 snippet: msmq-dlq-for-ttbr-optin
 

--- a/transports/msmq/dead-letter-queues_config_msmqtransport_[1,).partial.md
+++ b/transports/msmq/dead-letter-queues_config_msmqtransport_[1,).partial.md
@@ -1,8 +1,8 @@
 ### Enabling DLQ for messages with TTBR
 
-In Versions 6.1 and below DLQ is be enabled by default for TTBR messages.
+In Versions 6.1 and below, DLQ was enabled by default for TTBR messages.
 
-To opt-in to this behavior for Versions 6.2 and above, use:
+To opt-out of this behavior for Versions 6.2 and above, use:
 
 snippet: msmq-dlq-for-ttbr-optin
 


### PR DESCRIPTION
Fixes typos and redirected link urls for 
- `/transports/msmq/dead-letter-queues`