### PR TITLE
legacy docs review /persistence/sql/controlling-script-generation

### DIFF
--- a/persistence/sql/controlling-script-generation.md
+++ b/persistence/sql/controlling-script-generation.md
@@ -4,7 +4,7 @@ summary: Control how SQL scripts are generated for the SQL persister
 component: SqlPersistence
 related:
  - persistence/sql/operational-scripting
-reviewed: 2024-10-09
+reviewed: 2026-06-15
 ---
 
 
@@ -19,16 +19,13 @@ For example, for a project named `ClassLibrary` built in Debug mode, the followi
  * `ClassLibrary\bin\Debug\NServiceBus.Persistence.Sql\Oracle`
  * `ClassLibrary\bin\Debug\NServiceBus.Persistence.Sql\PostgreSql`
 
-Scripts will also be included in the list of project output files. This means that those files produced will be copied to the output directory of any project that references it.
-
-> [!WARNING]
-> Projects using `project.json` are **not** supported. The `project.json` approach was an experiment by Microsoft for a new project system that was not based on MSBuild. Since `project.json` did not support running MSBuild files shipped inside a NuGet, the SQL Persistence script creation does not work. This experiment has since been abandoned. To fix this, either migrate back to the older Visual Studio 2015 project format (`.csproj` and `packages.config`) or migrate to the new [Visual Studio 2017 project format](https://learn.microsoft.com/en-us/dotnet/core/tools/project-json-to-csproj). [dotnet-migrate](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-migrate) can help migrating to the new `.csproj` format.
+Scripts will also be included in the list of project output files. This means that those files produced will be copied to the output directory of any project that references the assembly.
 
 partial: DisableGeneration
 
 ## SqlPersistenceSettings attribute
 
-Scripts creation is configured via `[SqlPersistenceSettings]` applied to the target assembly.
+Script creation is configured via `[SqlPersistenceSettings]` applied to the target assembly.
 
 
 ### To produce all scripts

--- a/persistence/sql/controlling-script-generation_disablegeneration_sqlpersistence_[4,).partial.md
+++ b/persistence/sql/controlling-script-generation_disablegeneration_sqlpersistence_[4,).partial.md
@@ -1,7 +1,5 @@
 ## Disabling script generation
 
-In version 4.2 and below, script generation can be disabled by removing the [NServiceBus.Persistence.Sql.MsBuild package](https://www.nuget.org/packages/NServiceBus.Persistence.Sql.MsBuild) from the project.
-
-In version 4.3 and above, the script generation capability isn't contained in a separate package. Execution of the script generation task can be completely disabled by including the following in the project file:
+Script generation can be completely disabled by including the following in the project file:
 
 snippet: DisableScriptGeneration

--- a/persistence/sql/controlling-script-generation_promote_sqlpersistence_[2,).partial.md
+++ b/persistence/sql/controlling-script-generation_promote_sqlpersistence_[2,).partial.md
@@ -6,7 +6,7 @@ As stated above, scripts are created in the target project output directory. Thi
 > [!WARNING]
 > The target directory will be deleted and recreated as part of each build. Be sure to choose a path that is for script promotion only.
 
-Some token replacement using [MSBuild variables](https://msdn.microsoft.com/en-us/library/c02as0cs.aspx) is supported.
+Some token replacement using [MSBuild variables](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties) is supported.
 
  * `$(SolutionDir)`: The directory of the solution.
  * `$(ProjectDir)`: The directory of the project


### PR DESCRIPTION
removing references to legacy versions