### PR TITLE
Pin MessagePack to 3.* to avoid CVEs

### DIFF
--- a/samples/aspire/platform-rabbitmq/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/aspire/platform-rabbitmq/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
@@ -20,5 +20,8 @@
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.*" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="13.*" />
   </ItemGroup>
-
+  
+  <ItemGroup Label="Pinned dependencies to avoid CVEs">
+    <PackageReference Include="MessagePack" Version="3.*" />
+  </ItemGroup>
 </Project>

--- a/samples/aspire/platform-rabbitmq/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
+++ b/samples/aspire/platform-rabbitmq/Core_9/AspireDemo.AppHost/AspireDemo.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>


### PR DESCRIPTION
One of the Aspire samples is broken because of MessagePack, this should fix it.