### PR TITLE
removing ReadKey() from SqsSimple sample

### DIFF
--- a/samples/aws/sqs-simple/Sqs_7/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_7/Receiver/Program.cs
@@ -16,9 +16,6 @@ var transport = new SqsTransport
 };
 endpointConfiguration.UseTransport(transport);
 
-
-Console.WriteLine("Press any key, the application is starting");
-Console.ReadKey();
 Console.WriteLine("Starting...");
 
 builder.UseNServiceBus(endpointConfiguration);

--- a/samples/aws/sqs-simple/Sqs_8/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_8/Receiver/Program.cs
@@ -16,9 +16,6 @@ var transport = new SqsTransport
 };
 endpointConfiguration.UseTransport(transport);
 
-
-Console.WriteLine("Press any key, the application is starting");
-Console.ReadKey();
 Console.WriteLine("Starting...");
 
 builder.UseNServiceBus(endpointConfiguration);

--- a/samples/aws/sqs-simple/Sqs_9/Receiver/Program.cs
+++ b/samples/aws/sqs-simple/Sqs_9/Receiver/Program.cs
@@ -14,9 +14,6 @@ var transport = new SqsTransport
 };
 endpointConfiguration.UseTransport(transport);
 
-
-Console.WriteLine("Press any key, the application is starting");
-Console.ReadKey();
 Console.WriteLine("Starting...");
 
 builder.Services.AddNServiceBusEndpoint(endpointConfiguration);


### PR DESCRIPTION
Receiver is waiting on `ReadKey()`. If the user didn't press any key and started sending messages through the Sender, an error would occur.