### PR TITLE
Use major versions for pub/sub deprecation guides

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1060,7 +1060,7 @@
       Articles:
       - Url: persistence/upgrades/nhibernate-10to11
         Title: Version 10 to 11
-      - Url: persistence/upgrades/nhibernate-8too9
+      - Url: persistence/upgrades/nhibernate-8to9
         Title: Version 8 to 9
       - Url: persistence/upgrades/nhibernate-8to8.1
         Title: Version 8 to 8.1

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1060,7 +1060,7 @@
       Articles:
       - Url: persistence/upgrades/nhibernate-10to11
         Title: Version 10 to 11
-      - Url: persistence/upgrades/nhibernate-8to9
+      - Url: persistence/upgrades/nhibernate-8too9
         Title: Version 8 to 9
       - Url: persistence/upgrades/nhibernate-8to8.1
         Title: Version 8 to 8.1

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -697,8 +697,8 @@
     Articles:
     - Title: Azure Storage Queues
       Articles:
-      - Url: transports/upgrades/asq-14to14.1
-        Title: Version 14 to 14.1
+      - Url: transports/upgrades/asq-14to15
+        Title: Version 14 to 15
       - Url: transports/upgrades/asq-11to12
         Title: Version 11 to 12
       - Url: transports/upgrades/asq-10to11
@@ -761,8 +761,8 @@
         Title: Version 3 to 4
     - Title: SQL Server
       Articles:
-      - Url: transports/upgrades/sqlserver-9to9.1
-        Title: Version 9 to 9.1
+      - Url: transports/upgrades/sqlserver-9to10
+        Title: Version 9 to 10
       - Url: transports/upgrades/sqlserver-7to8
         Title: Version 7 to 8
       - Url: transports/upgrades/sqlserver-client4
@@ -789,8 +789,8 @@
         Title: Version 1.x to 1.2.5
     - Title: Amazon SQS
       Articles:
-      - Url: transports/upgrades/amazonsqs-9to9.1
-        Title: Version 9 to 9.1
+      - Url: transports/upgrades/amazonsqs-9to10
+        Title: Version 9 to 10
       - Url: transports/upgrades/amazonsqs-7to8
         Title: Version 7 to 8
       - Url: transports/upgrades/amazonsqs-6to7

--- a/transports/sqs/configuration-options_message-driven-pubsub-compatibility-mode_sqs_[9,).partial.md
+++ b/transports/sqs/configuration-options_message-driven-pubsub-compatibility-mode_sqs_[9,).partial.md
@@ -7,7 +7,7 @@ Message-driven publish/subscribe compatibility mode must be enabled on publisher
 > [!WARNING]
 > Starting from version 9.1 of the transport, publish/subscribe compatibility mode is deprecated.
 >
-> See [the upgrade guide](/transports/upgrades/amazonsqs-9to9.1.md) for more details.
+> See [the upgrade guide](/transports/upgrades/amazonsqs-9to10.md) for more details.
 
 To enable message-driven publish/subscribe compatibility mode, configure the endpoint as follows:
 

--- a/transports/upgrades/amazonsqs-9to10.md
+++ b/transports/upgrades/amazonsqs-9to10.md
@@ -1,11 +1,8 @@
 ---
-title: SQL Server Transport Upgrade Version 9 to 9.1
-summary: Migration instructions on how to migrate the SQL Server transport from version 9 to version 9.1
-reviewed: 2026-06-04
-component: SqlTransport
-related:
-- transports/sql
-- transports/upgrades/sqlserver-4to5
+title: AmazonSQS Transport Upgrade Version 9 to 10
+summary: Instructions on how to upgrade the AmazonSQS transport from version 9 to 10
+component: SQS
+reviewed: 2026-06-17
 isUpgradeGuide: true
 ---
 
@@ -23,7 +20,7 @@ async Task Initialize()
     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
     // Rest of your transport configuration here
-    var transport = new SqlServerTransport("connectionString");
+    var transport = new SqsTransport();
     // ...
 
     // Enable message-driven publish/subscribe compatibility
@@ -55,7 +52,7 @@ async Task Initialize(bool migrateAwayFromMessageDrivenPubSub = false)
     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
     // Rest of your transport configuration here
-    var transport = new SqlServerTransport("connectionString");
+    var transport = new SqsTransport();
     // ...
 
     var routingConfig = config.UseTransport(transport);
@@ -70,10 +67,10 @@ async Task MigrateAwayFromMessageDrivenPubSub()
     autoSubscribe.DisableFor<MyEvent>();
 
     // Rest of your transport configuration here
-    var transport = new SqlServerTransport("connectionString");
+    var transport = new SqsTransport();
     // ...
 
-    // Enable message-driven publish/subscribe compatibility
+    // Enable message-driven pubsub compatibility
     transport.EnableMessageDrivenPubSubCompatibilityMode();
 
     var routing = endpointConfiguration.UseTransport(transport);

--- a/transports/upgrades/asq-14to15.md
+++ b/transports/upgrades/asq-14to15.md
@@ -1,7 +1,7 @@
 ---
-title: Azure Storage Queues Transport Upgrade Version 14 to 14.1
-summary: Instructions on how to upgrade the Azure Storage Queues transport from version 14 to 14.1.
-reviewed: 2026-06-04
+title: Azure Storage Queues Transport Upgrade Version 14 to 15
+summary: Instructions on how to upgrade the Azure Storage Queues transport from version 14 to 15.
+reviewed: 2026-06-17
 component: ASQ
 related:
 - transports/azure-storage-queues

--- a/transports/upgrades/sqlserver-9to10.md
+++ b/transports/upgrades/sqlserver-9to10.md
@@ -1,8 +1,11 @@
 ---
-title: AmazonSQS Transport Upgrade Version 9 to 9.1
-summary: Instructions on how to upgrade the AmazonSQS transport from version 9 to 9.1
-component: SQS
-reviewed: 2026-06-04
+title: SQL Server Transport Upgrade Version 9 to 10
+summary: Migration instructions on how to migrate the SQL Server transport from version 9 to version 10
+reviewed: 2026-06-17
+component: SqlTransport
+related:
+- transports/sql
+- transports/upgrades/sqlserver-4to5
 isUpgradeGuide: true
 ---
 
@@ -20,7 +23,7 @@ async Task Initialize()
     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
     // Rest of your transport configuration here
-    var transport = new SqsTransport();
+    var transport = new SqlServerTransport("connectionString");
     // ...
 
     // Enable message-driven publish/subscribe compatibility
@@ -52,7 +55,7 @@ async Task Initialize(bool migrateAwayFromMessageDrivenPubSub = false)
     var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
     // Rest of your transport configuration here
-    var transport = new SqsTransport();
+    var transport = new SqlServerTransport("connectionString");
     // ...
 
     var routingConfig = config.UseTransport(transport);
@@ -67,10 +70,10 @@ async Task MigrateAwayFromMessageDrivenPubSub()
     autoSubscribe.DisableFor<MyEvent>();
 
     // Rest of your transport configuration here
-    var transport = new SqsTransport();
+    var transport = new SqlServerTransport("connectionString");
     // ...
 
-    // Enable message-driven pubsub compatibility
+    // Enable message-driven publish/subscribe compatibility
     transport.EnableMessageDrivenPubSubCompatibilityMode();
 
     var routing = endpointConfiguration.UseTransport(transport);


### PR DESCRIPTION
Instead of targeting the next minor version release for pub/sub hybrid mode deprecation, they should target the next major version instead.

This updates the name, description, and link to each page in question.