### PR TITLE
Remove glyphicons references after BS5 upgrade

### DIFF
--- a/platform/masstransit.md
+++ b/platform/masstransit.md
@@ -14,7 +14,7 @@ The platform provides an aggregated view of the information necessary to detect,
 
 youtube: https://www.youtube.com/watch?v=h5gcHWizS7o
 
-<div class="text-center inline-download hidden-xs"><a id='masstransit-sample' target="_blank" href='https://github.com/particular/MassTransitShowcaseDemo/' class="btn btn-primary btn-lg"><span class="glyphicon" aria-hidden="true"></span>Check the GitHub Showcase</a>
+<div class="text-center inline-download hidden-xs"><a id='masstransit-sample' target="_blank" href='https://github.com/particular/MassTransitShowcaseDemo/' class="btn btn-primary btn-lg">Check the GitHub Showcase</a>
 </div>
 
 

--- a/tutorials/monitoring-demo/index.md
+++ b/tutorials/monitoring-demo/index.md
@@ -12,7 +12,7 @@ Experience the monitoring features of the Particular Service Platform by running
 
 <div class="text-center inline-download hidden-xs">
   <a id='download-demo' href='https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.zip' class="btn btn-primary btn-lg">
-    <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download demo
+    <span class="bi bi-download" aria-hidden="true"></span> Download demo
   </a>
 </div>
 

--- a/tutorials/monitoring-demo/index.md
+++ b/tutorials/monitoring-demo/index.md
@@ -12,7 +12,7 @@ Experience the monitoring features of the Particular Service Platform by running
 
 <div class="text-center inline-download hidden-xs">
   <a id='download-demo' href='https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.zip' class="btn btn-primary btn-lg">
-    <span class="bi bi-download" aria-hidden="true"></span> Download demo
+    <i class="bi bi-download" aria-hidden="true" /> Download demo
   </a>
 </div>
 


### PR DESCRIPTION
This pull request makes small updates to UI elements in documentation files, specifically improving icon usage and simplifying button markup.

- **UI Improvements:**
  * Updated the download button in `tutorials/monitoring-demo/index.md` to use the Bootstrap Icons `bi bi-download` class instead of the older `glyphicon glyphicon-download-alt` class for better consistency and modern icon support.
  * Simplified the showcase button in `platform/masstransit.md` by removing an unused `<span>` element, cleaning up the button markup.