### PR TITLE
High availability improvements

### DIFF
--- a/architecture/azure/index.md
+++ b/architecture/azure/index.md
@@ -38,7 +38,7 @@ The Azure Architecture Center describes several [reference architectures](https:
 
 ### Design principles
 
-The Particular Service Platform makes systems follow the [ten design principles for Azure applications](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/).
+The Particular Service Platform makes systems follow the [design principles for Azure applications](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/).
 
 * [Self healing](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/self-healing) is provided by the rich set of [recoverability](/architecture/recoverability.md) features like automatic retries, load leveling, throttling and more, which make application services resilient to failures.
 * [Redundancy](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/redundancy) is provided by capabilities such as [scaling out](/nservicebus/scaling.md#scaling-out-to-multiple-nodes) and [high availability](/nservicebus/scaling.md#high-availability). Further guidance on achieving this for Azure Service Bus can be found here:

--- a/architecture/azure/index.md
+++ b/architecture/azure/index.md
@@ -41,7 +41,9 @@ The Azure Architecture Center describes several [reference architectures](https:
 The Particular Service Platform makes systems follow the [ten design principles for Azure applications](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/).
 
 * [Self healing](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/self-healing) is provided by the rich set of [recoverability](/architecture/recoverability.md) features like automatic retries, load leveling, throttling and more, which make application services resilient to failures.
-* [Redundancy](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/redundancy) is provided by capabilities such as [scaling out](/nservicebus/scaling.md#scaling-out-to-multiple-nodes) and [high availability](/nservicebus/scaling.md#high-availability).
+* [Redundancy](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/redundancy) is provided by capabilities such as [scaling out](/nservicebus/scaling.md#scaling-out-to-multiple-nodes) and [high availability](/nservicebus/scaling.md#high-availability). Further guidance on achieving this for Azure Service Bus can be found here:
+  * [Reliability in Azure Service Bus](https://learn.microsoft.com/en-us/azure/reliability/reliability-service-bus)
+  * [Azure Service Bus Geo-Disaster Recovery](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr)
 * [Coordination is minimized](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/minimize-coordination) between services by [messaging](/architecture/messaging.md). Watch [_Autonomous microservices don't share data. Period_ (video)](https://www.youtube.com/watch?v=0TYbHVc2yWI) for more recommendations.
 * [Scaling out](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/scale-out) is achieved by various methods such as [asynchronous message-based communication](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/architect-microservice-container-applications/asynchronous-message-based-communication) and [competing consumers](/nservicebus/scaling.md#scaling-out-to-multiple-nodes-competing-consumers).
 * [Partitioning](https://learn.microsoft.com/en-us/azure/architecture/guide/design-principles/partition) is achieved by making [suitable technology choices](/architecture/azure/#technology-choices). NServiceBus directly supports and integrates with a range of Azure services that provide partitioning for large-scale systems.
@@ -92,3 +94,4 @@ The Particular Service Platform helps achieve the five pillars of software quali
 
 * [Microsoft Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)
 * [Azure services available by region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/)
+* [Architecture best practices for Azure Service Bus](https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-service-bus)

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -67,7 +67,7 @@
       Url: architecture/observability
     - Title: Data distribution
       Url: architecture/data-distribution
-    - Title: Availability
+    - Title: Reliability
       Url: architecture/high-availability-and-disaster-recovery
   - Title: Azure
     Articles:

--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -67,6 +67,8 @@
       Url: architecture/observability
     - Title: Data distribution
       Url: architecture/data-distribution
+    - Title: Availability
+      Url: architecture/high-availability-and-disaster-recovery
   - Title: Azure
     Articles:
     - Title: Introduction

--- a/nservicebus/scaling.md
+++ b/nservicebus/scaling.md
@@ -37,7 +37,7 @@ Because of the [federated nature of queues with MSMQ](/transports/types.md#feder
 
 ## High availability
 
-Though not discussed here, there are many ways to achieve high availability for endpoints using infrastructure with either on-premise or cloud-based solutions. However, a different reason to try to achieve high availability is to make sure an endpoint continues to process messages while upgrading it to a newer version of either the endpoint itself or its messages. For more information on how to do message versioning, see [this sample](/samples/versioning/).
+Though not discussed here, there are many ways to achieve [high availability](/architecture/high-availability-and-disaster-recovery.md) for endpoints using infrastructure with either on-premise or cloud-based solutions. However, a different reason to try to achieve high availability is to make sure an endpoint continues to process messages while upgrading it to a newer version of either the endpoint itself or its messages. For more information on how to do message versioning, see [this sample](/samples/versioning/).
 
 Upgrading an endpoint without stopping message processing, can be accomplished by also using the *competing consumer pattern*, without necessarily deploying multiple endpoint instances to different nodes. In order words, this can even be achieved by deploying two endpoint instances on the same node.
 

--- a/transports/azure-service-bus/index.md
+++ b/transports/azure-service-bus/index.md
@@ -8,6 +8,7 @@ related:
  - samples/azure-service-bus-netstandard/options
  - samples/azure-service-bus-netstandard/send-receive-with-nservicebus
  - samples/azure-service-bus-netstandard/topology-migration
+ - architecture/azure
 reviewed: 2026-05-05
 ---
 

--- a/transports/selecting.md
+++ b/transports/selecting.md
@@ -82,7 +82,7 @@ Azure provides multiple messaging technologies. One of the most advanced and rel
 ### When to select this transport
 
 - When the application is running on Microsoft Azure
-- For enterprise messaging features, such as additional reliability
+- For enterprise messaging features, such as [additional reliability](https://learn.microsoft.com/en-us/azure/reliability/reliability-service-bus)
 - When messages are too large for Azure Storage Queues
 - When elastic scaling is required
 


### PR DESCRIPTION
Closes #6649 

This makes the `/architecture/high-availability-and-disaster-recovery` page visible in the nav and adds some relevant high availability links to:
- `/architecture/azure`
- `/transports/azure-service-bus`
- `/transports/selecting`
- `/nservicebus/scaling`