### PR TITLE
Document SQL Server queue length monitoring interval options

### DIFF
--- a/servicecontrol/transports.md
+++ b/servicecontrol/transports.md
@@ -144,7 +144,7 @@ In addition to the [connection string options of the transport](/transports/sql/
 The following options tune queue length monitoring (the data behind the throughput graphs) and are available in versions <!-- TODO: confirm first shipping ServiceControl version --> and above:
 
 * `QueueLengthQueryDelayInterval=<value_in_milliseconds>` - The base interval between queue length refresh queries. The default value is 1000 ms, matching the finest monitoring resolution (one data point per second). This is the cadence used whenever any monitored queue has messages.
-* `QueueLengthQueryMaxDelayInterval=<value_in_milliseconds>` - The upper bound for the adaptive back-off. While *every* monitored queue is empty the interval ramps from `QueueLengthQueryDelayInterval` up to this value, reducing query load on an idle system; it returns to the base interval as soon as any queue has work. The default value is 10000 ms. Set it equal to `QueueLengthQueryDelayInterval` to disable back-off and poll at a constant cadence.
+* `QueueLengthQueryMaxDelayInterval=<value_in_milliseconds>` - The upper bound for the adaptive back-off. While *every* monitored queue is empty, the interval ramps from `QueueLengthQueryDelayInterval` up to this value, reducing query load on an idle system; it returns to the base interval as soon as any queue has messages. The default value is 10000 ms. Set it equal to `QueueLengthQueryDelayInterval` to disable back-off and poll at a constant cadence.
 
 ### Example connection string
 

--- a/servicecontrol/transports.md
+++ b/servicecontrol/transports.md
@@ -141,10 +141,15 @@ In addition to the [connection string options of the transport](/transports/sql/
   * *Optional* `Subscriptions Table=<subscription_table_name>@<schema>` - to specify the schema.
   * *Optional* `Subscriptions Table=<subscription_table_name>@<schema>@<catalog>` - to specify the schema and catalog.
 
+The following options tune queue length monitoring (the data behind the throughput graphs) and are available in versions <!-- TODO: confirm first shipping ServiceControl version --> and above:
+
+* `QueueLengthQueryDelayInterval=<value_in_milliseconds>` - The base interval between queue length refresh queries. The default value is 1000 ms, matching the finest monitoring resolution (one data point per second). This is the cadence used whenever any monitored queue has messages.
+* `QueueLengthQueryMaxDelayInterval=<value_in_milliseconds>` - The upper bound for the adaptive back-off. While *every* monitored queue is empty the interval ramps from `QueueLengthQueryDelayInterval` up to this value, reducing query load on an idle system; it returns to the base interval as soon as any queue has work. The default value is 10000 ms. Set it equal to `QueueLengthQueryDelayInterval` to disable back-off and poll at a constant cadence.
+
 ### Example connection string
 
 ```text
-Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True;Queue Schema=myschema;Subscriptions Table=tablename@schema@catalog
+Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True;Queue Schema=myschema;Subscriptions Table=tablename@schema@catalog;QueueLengthQueryDelayInterval=1000;QueueLengthQueryMaxDelayInterval=10000
 ```
 
 ## PostgreSQL


### PR DESCRIPTION
Draft. Documents the two new SQL Server transport connection-string options introduced in:

- Particular/ServiceControl#5555:

----


- `QueueLengthQueryDelayInterval` — base poll cadence for queue length monitoring (default 1000 ms).
- `QueueLengthQueryMaxDelayInterval` — ceiling for the adaptive back-off while every monitored queue is idle (default 10000 ms; set equal to the base to disable).

Added to the SQL section of `servicecontrol/transports.md`, mirroring how the Azure Service Bus transport already documents `QueueLengthQueryDelayInterval`.