### PR TITLE
📝 Legacy docs review: SQL/PostgreSQL transport design + peek batch size deprecation

### DIFF
--- a/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/DelayConfig.cs
+++ b/Snippets/PostgreSqlTransport/PostgreSqlTransport_8/DelayConfig.cs
@@ -17,19 +17,4 @@ class DelayConfig
 
         #endregion
     }
-
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region postgresql-queue-peeker-config-batch-size
-
-        var transport = new PostgreSqlTransport("connectionString")
-        {
-            QueuePeeker =
-            {
-                MaxRecordsToPeek = 50
-            }
-        };
-
-        #endregion
-    }
 }

--- a/Snippets/PostgreSqlTransport/PostgreSqlTransport_9/DelayConfig.cs
+++ b/Snippets/PostgreSqlTransport/PostgreSqlTransport_9/DelayConfig.cs
@@ -17,19 +17,4 @@ class DelayConfig
 
         #endregion
     }
-
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region postgresql-queue-peeker-config-batch-size
-
-        var transport = new PostgreSqlTransport("connectionString")
-        {
-            QueuePeeker =
-            {
-                MaxRecordsToPeek = 50
-            }
-        };
-
-        #endregion
-    }
 }

--- a/Snippets/SqlTransport/SqlTransport_6/DelayConfig.cs
+++ b/Snippets/SqlTransport/SqlTransport_6/DelayConfig.cs
@@ -12,14 +12,4 @@ class DelayConfig
 
         #endregion
     }
-    
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region sqlserver-queue-peeker-config-batch-size
-
-        var transport = endpointConfiguration.UseTransport<SqlServerTransport>();
-        transport.QueuePeekerOptions(peekBatchSize: 50);
-
-        #endregion
-    }
 }

--- a/Snippets/SqlTransport/SqlTransport_7/DelayConfig.cs
+++ b/Snippets/SqlTransport/SqlTransport_7/DelayConfig.cs
@@ -17,19 +17,4 @@ class DelayConfig
 
         #endregion
     }
-
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region sqlserver-queue-peeker-config-batch-size
-
-        var transport = new SqlServerTransport("connectionString")
-        {
-            QueuePeeker =
-            {
-                MaxRecordsToPeek = 50
-            }
-        };
-
-        #endregion
-    }
 }

--- a/Snippets/SqlTransport/SqlTransport_8/DelayConfig.cs
+++ b/Snippets/SqlTransport/SqlTransport_8/DelayConfig.cs
@@ -17,19 +17,4 @@ class DelayConfig
 
         #endregion
     }
-
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region sqlserver-queue-peeker-config-batch-size
-
-        var transport = new SqlServerTransport("connectionString")
-        {
-            QueuePeeker =
-            {
-                MaxRecordsToPeek = 50
-            }
-        };
-
-        #endregion
-    }
 }

--- a/Snippets/SqlTransport/SqlTransport_9/DelayConfig.cs
+++ b/Snippets/SqlTransport/SqlTransport_9/DelayConfig.cs
@@ -17,19 +17,4 @@ class DelayConfig
 
         #endregion
     }
-
-    void ConfigurePeekBatchSize(EndpointConfiguration endpointConfiguration)
-    {
-        #region sqlserver-queue-peeker-config-batch-size
-
-        var transport = new SqlServerTransport("connectionString")
-        {
-            QueuePeeker =
-            {
-                MaxRecordsToPeek = 50
-            }
-        };
-
-        #endregion
-    }
 }

--- a/transports/postgresql/design.md
+++ b/transports/postgresql/design.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL Transport Design
 summary: The design and implementation details of PostgreSQL Transport
-reviewed: 2026-03-09
+reviewed: 2026-06-29
 component: PostgreSqlTransport
 ---
 
@@ -55,9 +55,9 @@ The maximum number of concurrent receive tasks never exceeds the value set by `L
 
 When all tasks are done the transport switches back to the *peek* mode.
 
-Under certain conditions, the initial estimate of the number of pending messages might be wrong e.g. when there is more than one instance of a scaled-out endpoint consuming messages from the same queue. In this case, one of the received tasks will fail (i.e. `delete` will return no results). When this happens, the transport immediately switches back to the *peek* mode.
+Under certain conditions, the initial estimate of the number of pending messages might be wrong e.g. when there is more than one instance of a scaled-out endpoint consuming messages from the same queue. In this case, one of the receive tasks will fail (i.e. `delete` will return no results). When this happens, the transport immediately switches back to the *peek* mode.
 
-The [default peek interval](#behavior-queue-peek-settings-peek-delay-configuration), if no peek has yet been run or the previous peek returned no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. While a value less than 100 milliseconds will put unnecessary stress on the database, a value larger than 10 seconds should also be used with caution as it may result in messages backing up in the queue.
+The [default peek interval](#behavior-queue-peek-settings-peek-delay-configuration), if no peek has yet been run or the previous peek returned no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. A value less than 100 milliseconds is rejected because it puts unnecessary stress on the database, while a value larger than 10 seconds should be used with caution as it may result in messages backing up in the queue.
 
 > [!WARNING]
 > If the queue peek interval is configured, it must not be set larger than the [Time-To-Be-Received](/nservicebus/messaging/discard-old-messages.md)(TTBR) to ensure that such messages are not discarded.
@@ -69,11 +69,5 @@ The [default peek interval](#behavior-queue-peek-settings-peek-delay-configurati
 Use the following code:
 
 snippet: postgresql-queue-peeker-config-delay
-
-#### Peek batch size configuration
-
-Use the following code:
-
-snippet: postgresql-queue-peeker-config-batch-size
 
 Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md).

--- a/transports/sql/design.md
+++ b/transports/sql/design.md
@@ -1,7 +1,7 @@
 ---
 title: SQL Transport Design
 summary: The design and implementation details of SQL Server Transport
-reviewed: 2024-10-24
+reviewed: 2026-06-29
 component: SqlTransport
 redirects:
  - nservicebus/sqlserver/design

--- a/transports/sql/design.md
+++ b/transports/sql/design.md
@@ -69,7 +69,7 @@ partial: messageBodyString-column
 
 The `RowVersion` column is used to define the FIFO order of the queue. It is auto-incremented by SQL Server (`identity(1,1)`). The receive message T-SQL query returns a message with the lowest value of `RowVersion` that is not locked by any other concurrent receive operation.
 
-The clustered index of the queue table is based on the `RowVersion` column to ensure that new messages are always added at the end of the table.
+A non-clustered index on the `RowVersion` column allows the receive query to efficiently locate the message with the lowest `RowVersion`. If this index is missing, the transport logs a warning recommending that it be created.
 
 
 ## Behavior

--- a/transports/sql/design.md
+++ b/transports/sql/design.md
@@ -69,7 +69,7 @@ partial: messageBodyString-column
 
 The `RowVersion` column is used to define the FIFO order of the queue. It is auto-incremented by SQL Server (`identity(1,1)`). The receive message T-SQL query returns a message with the lowest value of `RowVersion` that is not locked by any other concurrent receive operation.
 
-A non-clustered index on the `RowVersion` column allows the receive query to efficiently locate the message with the lowest `RowVersion`. If this index is missing, the transport logs a warning recommending that it be created.
+A non-clustered index on the `RowVersion` column allows the receive query to efficiently locate the message with the lowest `RowVersion`. If this index is missing, the transport logs a warning recommending that it be created. Systems created with earlier transport versions may still use a clustered index; see the [non-clustered index upgrade guide](/transports/upgrades/sqlserver-non-clustered-idx.md) for migration steps.
 
 
 ## Behavior

--- a/transports/sql/design_concurrency_sqltransport_[6,).partial.md
+++ b/transports/sql/design_concurrency_sqltransport_[6,).partial.md
@@ -1,12 +1,12 @@
-SQL Server transport operates in two modes: *peek* and *receive*. It starts in the *peek* mode and checks, using a `select count` query the number of pending messages. If the number is greater then zero, it switches to the *receive* mode and starts spawning receive tasks that use the `delete` command to receive messages.
+SQL Server transport operates in two modes: *peek* and *receive*. It starts in the *peek* mode and checks, using a `select count` query the number of pending messages. If the number is greater than zero, it switches to the *receive* mode and starts spawning receive tasks that use the `delete` command to receive messages.
 
 The maximum number of concurrent receive tasks never exceeds the value set by `LimitMessageProcessingConcurrencyTo` (the number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms).
 
 When all tasks are done the transport switches back to the *peek* mode. 
 
-In certain conditions, the initial estimate of a number of pending messages might be wrong e.g. when there is more than one instance of a scaled-out endpoint consuming messages from the same queue. In this case, one of the received tasks is going to fail (`delete` returns no results). When this happens, the transport immediately switches back to the *peek* mode.
+In certain conditions, the initial estimate of a number of pending messages might be wrong e.g. when there is more than one instance of a scaled-out endpoint consuming messages from the same queue. In this case, one of the receive tasks is going to fail (`delete` returns no results). When this happens, the transport immediately switches back to the *peek* mode.
 
-The default peek interval, if there is has been no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. While a value less than 100 milliseconds will put too much unnecessary stress on the database, a value larger than 10 seconds should also be used with caution as it may result in messages backing up in the queue. 
+The default peek interval, if there have been no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. While a value less than 100 milliseconds will put too much unnecessary stress on the database, a value larger than 10 seconds should also be used with caution as it may result in messages backing up in the queue. 
 
 ### Queue peek settings
 

--- a/transports/sql/design_concurrency_sqltransport_[6,).partial.md
+++ b/transports/sql/design_concurrency_sqltransport_[6,).partial.md
@@ -1,4 +1,4 @@
-SQL Server transport operates in two modes: *peek* and *receive*. It starts in the *peek* mode and checks, using a `select count` query the number of pending messages. If the number is greater than zero, it switches to the *receive* mode and starts spawning receive tasks that use the `delete` command to receive messages.
+SQL Server transport operates in two modes: *peek* and *receive*. It starts in the *peek* mode and estimates the number of pending messages from the difference between the highest and lowest `RowVersion` values in the queue table. If the estimate is greater than zero, it switches to the *receive* mode and starts spawning receive tasks that use the `delete` command to receive messages.
 
 The maximum number of concurrent receive tasks never exceeds the value set by `LimitMessageProcessingConcurrencyTo` (the number of tasks does not translate to the number of running threads which is controlled by the TPL scheduling mechanisms).
 
@@ -6,7 +6,7 @@ When all tasks are done the transport switches back to the *peek* mode.
 
 In certain conditions, the initial estimate of a number of pending messages might be wrong e.g. when there is more than one instance of a scaled-out endpoint consuming messages from the same queue. In this case, one of the receive tasks is going to fail (`delete` returns no results). When this happens, the transport immediately switches back to the *peek* mode.
 
-The default peek interval, if there have been no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. While a value less than 100 milliseconds will put too much unnecessary stress on the database, a value larger than 10 seconds should also be used with caution as it may result in messages backing up in the queue. 
+The default peek interval, if there have been no messages in the queue, is 1 second. The recommended range for this setting is between 100 milliseconds to 10 seconds. If a value higher than the maximum recommended settings is used, a warning message will be logged. A value less than 100 milliseconds is rejected because it puts too much unnecessary stress on the database, while a value larger than 10 seconds should be used with caution as it may result in messages backing up in the queue. 
 
 ### Queue peek settings
 
@@ -15,11 +15,5 @@ The default peek interval, if there have been no messages in the queue, is 1 sec
 Use the following code:
 
 snippet: sqlserver-queue-peeker-config-delay
-
-#### Peek batch size configuration
-
-Use the following code:
-
-snippet: sqlserver-queue-peeker-config-batch-size
 
 Read more information about [tuning endpoint message processing](/nservicebus/operations/tuning.md).

--- a/transports/upgrades/sqlserver-9to10.md
+++ b/transports/upgrades/sqlserver-9to10.md
@@ -94,4 +94,4 @@ async Task MigrateAwayFromMessageDrivenPubSub()
 
 The queue peek batch size configuration (`SqlServerTransport.QueuePeeker.MaxRecordsToPeek`, and the `peekBatchSize` parameter of the legacy `QueuePeekerOptions(delay, peekBatchSize)` overload) has no effect and is deprecated. It has had no effect since Version 6.2: the number of messages received per peek is bounded by the configured [message processing concurrency](/nservicebus/operations/tuning.md), and the receive loop stops as soon as the queue is drained.
 
-Configuring it now logs a warning. Remove it from the transport configuration; it will be removed in a future version.
+Configuring it logs a warning starting in the next Version 9 minor release. In Version 10, it is marked obsolete and produces a compilation error. Remove it from the transport configuration.

--- a/transports/upgrades/sqlserver-9to10.md
+++ b/transports/upgrades/sqlserver-9to10.md
@@ -94,4 +94,4 @@ async Task MigrateAwayFromMessageDrivenPubSub()
 
 The queue peek batch size configuration (`SqlServerTransport.QueuePeeker.MaxRecordsToPeek`, and the `peekBatchSize` parameter of the legacy `QueuePeekerOptions(delay, peekBatchSize)` overload) has no effect and is deprecated. It has had no effect since Version 6.2: the number of messages received per peek is bounded by the configured [message processing concurrency](/nservicebus/operations/tuning.md), and the receive loop stops as soon as the queue is drained.
 
-Configuring it logs a warning starting in the next Version 9 minor release. In Version 10, it is marked obsolete and produces a compilation error. Remove it from the transport configuration.
+Configuring it produces a compile-time warning and logs a runtime warning starting in the next Version 9 minor release. In Version 10, using it produces a compilation error. Remove it from the transport configuration.

--- a/transports/upgrades/sqlserver-9to10.md
+++ b/transports/upgrades/sqlserver-9to10.md
@@ -89,3 +89,9 @@ async Task MigrateAwayFromMessageDrivenPubSub()
     await endpointInstance.Stop();
 }
 ```
+
+## Queue peek batch size deprecation
+
+The queue peek batch size configuration (`SqlServerTransport.QueuePeeker.MaxRecordsToPeek`, and the `peekBatchSize` parameter of the legacy `QueuePeekerOptions(delay, peekBatchSize)` overload) has no effect and is deprecated. It has had no effect since Version 6.2: the number of messages received per peek is bounded by the configured [message processing concurrency](/nservicebus/operations/tuning.md), and the receive loop stops as soon as the queue is drained.
+
+Configuring it now logs a warning. Remove it from the transport configuration; it will be removed in a future version.


### PR DESCRIPTION
Legacy documentation review of [SQL Transport Design](https://docs.particular.net/transports/sql/design), extended to cover the PostgreSQL transport and the related upgrade guide as the docs side of the `MaxRecordsToPeek` / `peekBatchSize` deprecation (Particular/NServiceBus.SqlServer#1754).

### SQL design page
- `reviewed` date; grammar fixes in the concurrency partial.
- **Correctness:** RowVersion index is **non-clustered** on a heap, not clustered (since 6.0.1); peek estimates pending count via a **RowVersion range**, not a `select count` query (since 6.1.1).
- Removed the non-functional **peek batch size** config section + orphaned `SqlTransport_6/7/8/9` snippets (`MaxRecordsToPeek` is a no-op).
- Cross-linked the non-clustered index note to the existing [non-clustered index upgrade guide](https://docs.particular.net/transports/upgrades/sqlserver-non-clustered-idx).

### PostgreSQL design page (parity)
- Removed the identical no-op peek batch size config section + orphaned `PostgreSqlTransport_8/9` snippets; aligned the receive-tasks wording and the rejected sub-100ms delay; bumped `reviewed`.

### Upgrade guide
- `sqlserver-9to10`: documented that the queue peek batch size (`MaxRecordsToPeek` / `peekBatchSize`) has no effect, is deprecated, and should be removed.

### Verification
- `docstool test --no-version-check` passes; affected snippet projects compile.

Pairs with code deprecation:

- Particular/NServiceBus.SqlServer#1755.
