### PR TITLE
📝 Legacy docs review: Expired heartbeat messages

### DIFF
--- a/monitoring/heartbeats/expired-heartbeats.md
+++ b/monitoring/heartbeats/expired-heartbeats.md
@@ -6,14 +6,11 @@ component: Heartbeats
 versions: 'Heartbeats:*'
 ---
 
-Heartbeat messages have a [time to be received (TTBR)](/nservicebus/messaging/discard-old-messages.md) set based on the time to live (TTL) value. If ServiceControl does not consume the heartbeat messages before the TTBR expires then those messages may be discarded. Transports like MSMQ and Azure Service Bus support dead letter queues (DLQ) and the expired heartbeat messages can be explicitly configured to be forwarded to the DLQ instead of being discarded.
+Heartbeat messages have a [time to be received (TTBR)](/nservicebus/messaging/discard-old-messages.md) set based on the [time to live (TTL)](/monitoring/heartbeats/install-plugin.md#time-to-live-ttl) value, which defaults to four times the heartbeat interval. If ServiceControl does not consume the heartbeat messages before the TTBR expires then those messages may be discarded. Transports like MSMQ and Azure Service Bus support dead letter queues (DLQ) and the expired heartbeat messages can be explicitly configured to be forwarded to the DLQ instead of being discarded.
 
 ### MSMQ
 
 Although NServiceBus configures the use of DLQ by default, messages that are defined with TTBR will not be automatically forwarded to the DLQ and will be discarded. Configuration can be specified to [override this behavior](/transports/msmq/dead-letter-queues.md#enabling-dlq-for-messages-with-ttbr) so that these messages can be forwarded to the DLQ.
-
-> [!WARNING]
-> When using NServiceBus Versions 6.1 or below, messages will be forwarded to the DLQ even if TTBR is set on the messages. To avoid this behavior, DLQ can be disabled by configuring the [MSMQ connection strings](/transports/msmq/connection-strings.md). The heartbeat messages will be forwarded to the DLQ when ServiceControl is either stopped or very busy. In this case, the dead letter queue needs to be monitored and cleaned up.
 
 ### Azure Service Bus
 

--- a/monitoring/heartbeats/expired-heartbeats.md
+++ b/monitoring/heartbeats/expired-heartbeats.md
@@ -1,7 +1,7 @@
 ---
 title: Expired heartbeat messages
 summary: NServiceBus endpoints send heartbeat messages with TTBR; expired messages are discarded if unconsumed
-reviewed: 2024-10-28
+reviewed: 2026-06-29
 component: Heartbeats
 versions: 'Heartbeats:*'
 ---
@@ -13,8 +13,8 @@ Heartbeat messages have a [time to be received (TTBR)](/nservicebus/messaging/di
 Although NServiceBus configures the use of DLQ by default, messages that are defined with TTBR will not be automatically forwarded to the DLQ and will be discarded. Configuration can be specified to [override this behavior](/transports/msmq/dead-letter-queues.md#enabling-dlq-for-messages-with-ttbr) so that these messages can be forwarded to the DLQ.
 
 > [!WARNING]
-> When using NServiceBus Versions 6.1 or below, messages will be forwarded to the DLQ even if TTBR is set on the messages.  To avoid this behavior, DLQ can be disabled by configuring the [MSMQ connection strings](/transports/msmq/connection-strings.md). The heartbeat messages will be forwarded to the DLQ when ServiceControl is either stopped or very busy. In this case, the dead letter queue needs to be monitored and cleaned up.
+> When using NServiceBus Versions 6.1 or below, messages will be forwarded to the DLQ even if TTBR is set on the messages. To avoid this behavior, DLQ can be disabled by configuring the [MSMQ connection strings](/transports/msmq/connection-strings.md). The heartbeat messages will be forwarded to the DLQ when ServiceControl is either stopped or very busy. In this case, the dead letter queue needs to be monitored and cleaned up.
 
 ### Azure Service Bus
 
-Forwarding messages with expired TTL to DLQ is a configuration that needs to be set on the destination queue which is the ServiceControl queue for the heartbeat messages. In order to forward the heartbeat messages after the TTBR expiration to DLQ, ServiceControl needs to be explicitly configured by specifying `EnableDeadLetteringOnMessageExpiration`.
+Forwarding messages with expired TTL to DLQ is a configuration that needs to be set on the destination queue, which is the ServiceControl queue for the heartbeat messages. In order to forward the heartbeat messages after the TTBR expiration to DLQ, ServiceControl needs to be explicitly configured by specifying `EnableDeadLetteringOnMessageExpiration`.


### PR DESCRIPTION
Legacy documentation review of [Expired heartbeat messages](https://docs.particular.net/monitoring/heartbeats/expired-heartbeats).

### Changes
- Updated `reviewed` date in frontmatter.
- Removed a double space in the MSMQ warning callout.
- Added a comma before the non-restrictive clause: "destination queue, which is the ServiceControl queue".

### Verification
- `docstool test --no-version-check` passes.

Content reviewed for technical accuracy (TTBR/TTL/DLQ behavior for MSMQ and Azure Service Bus), en-US spelling/grammar, and link validity; no further changes required.