### PR TITLE
📝 Legacy docs review: Sharing message contracts

### DIFF
--- a/nservicebus/messaging/sharing-contracts.md
+++ b/nservicebus/messaging/sharing-contracts.md
@@ -2,7 +2,7 @@
 title: Sharing message contracts
 summary: How to define and share message contracts between endpoints.
 component: Core
-reviewed: 2024-10-31
+reviewed: 2026-06-29
 related:
  - nservicebus/messaging/messages-events-commands
  - nservicebus/messaging/unobtrusive-mode
@@ -19,13 +19,13 @@ A sender and receiver of a given message must use the same message contract. Mes
 
 * When all endpoints are located in a single solution, message contract assemblies may be directly referenced as project dependencies.
 * When endpoints are located in multiple solutions, message contracts may be shared as [NuGet packages](https://learn.microsoft.com/en-us/nuget/create-packages/creating-a-package-msbuild). NuGet packages may be published on the file system or a NuGet server. A [custom NuGet config file](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file) may be used to configure additional NuGet package sources.
-* Messages contracts may be shared as C# source files.
+* Message contracts may be shared as C# source files.
 
 ### NServiceBus dependency
 
 When [marker interfaces](/nservicebus/messaging/messages-events-commands.md#identifying-messages-marker-interfaces) are used to define messages, message contract projects have a dependency on the NServiceBus package. This may cause version conflicts when message contracts are updated in endpoints targeting older major versions of NServiceBus. This may be avoided by either:
 
-* Use the [`NServiceBus.MessageInterfaces` package](/samples/message-assembly-sharing/) available from Version 8.2 onwards.
+* Using the [`NServiceBus.MessageInterfaces` package](/samples/message-assembly-sharing/) available from Version 8.2 onwards.
 * Referencing the oldest used NServiceBus major version from message contracts projects. [NuGet dependency resolution](https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution) allows endpoints on newer major versions of NServiceBus to reference assemblies that target an older version of NServiceBus, but not vice versa.
 * Switching to [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md). Unobtrusive mode allows an assembly to define message contracts without a dependency on the NServiceBus package, making it easy to share message contracts with endpoints targeting multiple versions of NServiceBus and running on various frameworks and platforms.
 

--- a/nservicebus/messaging/sharing-contracts.md
+++ b/nservicebus/messaging/sharing-contracts.md
@@ -25,7 +25,7 @@ A sender and receiver of a given message must use the same message contract. Mes
 
 When [marker interfaces](/nservicebus/messaging/messages-events-commands.md#identifying-messages-marker-interfaces) are used to define messages, message contract projects have a dependency on the NServiceBus package. This may cause version conflicts when message contracts are updated in endpoints targeting older major versions of NServiceBus. This may be avoided by either:
 
-* Using the [`NServiceBus.MessageInterfaces` package](/samples/message-assembly-sharing/) available from Version 8.2 onwards.
+* Using the [`NServiceBus.MessageInterfaces` package](/samples/message-assembly-sharing/), available from Version 8.2 onwards. This package contains the marker interfaces (`IMessage`, `IEvent`, and `ICommand`), so message contract projects can reference them without taking a dependency on the full NServiceBus package.
 * Referencing the oldest used NServiceBus major version from message contracts projects. [NuGet dependency resolution](https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution) allows endpoints on newer major versions of NServiceBus to reference assemblies that target an older version of NServiceBus, but not vice versa.
 * Switching to [unobtrusive mode](/nservicebus/messaging/unobtrusive-mode.md). Unobtrusive mode allows an assembly to define message contracts without a dependency on the NServiceBus package, making it easy to share message contracts with endpoints targeting multiple versions of NServiceBus and running on various frameworks and platforms.
 


### PR DESCRIPTION
Legacy documentation review of [Sharing message contracts](https://docs.particular.net/nservicebus/messaging/sharing-contracts).

### Changes
- Updated `reviewed` date in frontmatter.
- Fixed grammar: "Messages contracts may be shared" → "Message contracts may be shared".
- Made the bullet list parallel: "Use the `NServiceBus.MessageInterfaces` package" → "Using the..." to match the sibling "Referencing..." and "Switching..." bullets.

### Verification
- `docstool test --no-version-check` passes.

Content reviewed for technical accuracy (contract assembly sharing, NServiceBus dependency handling, versioning), en-US spelling/grammar, and link validity; no further changes required.