### PR TITLE
Remove Core 10to11 upgrade guide from menu until we release it

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -200,8 +200,6 @@
     Articles:
     - Url: nservicebus/upgrades
       Title: About upgrading NServiceBus
-    - Url: nservicebus/upgrades/10to11
-      Title: NServiceBus 10 to 11
     - Url: nservicebus/upgrades/9to10
       Title: NServiceBus 9 to 10
     - Url: nservicebus/upgrades/9to9.1

--- a/nservicebus/upgrades/10to11/index.md
+++ b/nservicebus/upgrades/10to11/index.md
@@ -9,6 +9,9 @@ upgradeGuideCoreVersions:
  - 11
 ---
 
+> [!TIP]
+> This is an upgrade guide for a version of NServiceBus that has not yet been released. It can currently be used to proactively adjust for changes introduced as warnings, but which will not be required until NServiceBus version 11 is released.
+
 include: upgrade-major
 
 ## Self-hosted endpoints


### PR DESCRIPTION
Removes the Core 10 to 11 upgrade guide from the navigation to avoid causing confusion, and places a TIP alert box at the top of the page to make clear the content is for an unreleased version.