### PR TITLE
ServiceControl audit log to a SIEM over OTLP

### DIFF
--- a/samples/servicecontrol/audit-log-otlp/ServiceControl_6/docker-compose.yml
+++ b/samples/servicecontrol/audit-log-otlp/ServiceControl_6/docker-compose.yml
@@ -1,0 +1,152 @@
+name: servicecontrol-audit-log-otlp
+
+services:
+
+  # Identity provider. The realm import creates the reader/admin/writer roles,
+  # three demo users, and the ServicePulse + ServiceControl API clients.
+  # start-dev + plain HTTP keep the sample small; production setups must use
+  # HTTPS - see https://docs.particular.net/servicecontrol/security/
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      # Pin the issuer to the host-visible URL; KC_HOSTNAME_BACKCHANNEL_DYNAMIC
+      # lets ServiceControl fetch discovery/JWKS via the in-network name
+      # (http://keycloak:8080) while tokens still validate against the pinned
+      # issuer (http://localhost:8088).
+      KC_HOSTNAME: http://localhost:8088
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8088:8080"
+    volumes:
+      - ./keycloak:/opt/keycloak/data/import:ro
+    healthcheck:
+      # No curl in the Keycloak image; a TCP connect is enough signal that
+      # Quarkus is up and serving the discovery document.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080"]
+      interval: 5s
+      timeout: 3s
+      retries: 40
+      start_period: 30s
+
+  rabbitmq:
+    image: rabbitmq:4-management
+    # Run as the rabbitmq uid throughout so the image entrypoint skips its
+    # root->rabbitmq privilege drop, which breaks under rootless Podman.
+    user: "999:999"
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  ravendb:
+    image: particular/servicecontrol-ravendb:6.18.0
+    volumes:
+      - ravendb-data:/var/lib/ravendb/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/setup/alive || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+
+  # startcode audit-otlp-compose-servicecontrol
+  servicecontrol:
+    image: particular/servicecontrol:6.18.0
+    command: ["--setup-and-run"]
+    env_file: [.env]                       # provides PARTICULARSOFTWARE_LICENSE
+    environment:
+      TRANSPORTTYPE: RabbitMQ.QuorumConventionalRouting
+      CONNECTIONSTRING: "host=rabbitmq"
+      RAVENDB_CONNECTIONSTRING: "http://ravendb:8080"
+
+      # --- Authentication (OIDC) + role-based access control ---
+      SERVICECONTROL_AUTHENTICATION_ENABLED: "true"
+      SERVICECONTROL_AUTHENTICATION_ROLEBASEDAUTHORIZATIONENABLED: "true"
+      SERVICECONTROL_AUTHENTICATION_AUTHORITY: "http://keycloak:8080/realms/particular"
+      SERVICECONTROL_AUTHENTICATION_AUDIENCE: "servicecontrol-api"
+      # Keycloak puts realm roles in a nested claim; a dotted path reaches them
+      SERVICECONTROL_AUTHENTICATION_ROLESCLAIM: "realm_access.roles"
+      SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_CLIENTID: "servicepulse"
+      SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_AUTHORITY: "http://localhost:8088/realms/particular"
+      SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_APISCOPES: '["servicecontrol"]'
+      # Sample runs the identity provider over plain HTTP; never do this in production
+      SERVICECONTROL_AUTHENTICATION_REQUIREHTTPSMETADATA: "false"
+
+      # --- Audit log over OTLP ---
+      # Keep NLog for the operational log/console and add the OTLP logging
+      # provider. The ECS audit documents become the OTLP log record body.
+      SERVICECONTROL_LOGGINGPROVIDERS: "NLog,Otlp"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+    ports:
+      - "33333:33333"
+    depends_on:
+      rabbitmq: { condition: service_healthy }
+      ravendb: { condition: service_healthy }
+      keycloak: { condition: service_healthy }
+      otel-collector: { condition: service_started }
+  # endcode
+
+  servicepulse:
+    image: particular/servicepulse:2.9.0
+    environment:
+      SERVICECONTROL_URL: "http://servicecontrol:33333"
+      # No monitoring instance in this sample; "!" disables the monitoring UI
+      MONITORING_URL: "!"
+    ports:
+      - "9090:9090"
+    depends_on:
+      - servicecontrol
+
+  # startcode audit-otlp-compose-collector
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.156.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector/otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
+    depends_on:
+      elasticsearch: { condition: service_healthy }
+  # endcode
+
+  # Single-node Elasticsearch as the SIEM backend. Security is disabled to
+  # keep the sample small; production clusters authenticate and use TLS.
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.4.3
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.4.3
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch: { condition: service_healthy }
+
+volumes:
+  ravendb-data:
+  rabbitmq-data:
+  elasticsearch-data:

--- a/samples/servicecontrol/audit-log-otlp/ServiceControl_6/keycloak/realm-particular.json
+++ b/samples/servicecontrol/audit-log-otlp/ServiceControl_6/keycloak/realm-particular.json
@@ -1,0 +1,202 @@
+{
+  "realm": "particular",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "accessTokenLifespan": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+
+  "roles": {
+    "realm": [
+      { "name": "reader", "description": "Read-only access to everything" },
+      { "name": "admin",  "description": "Reader access plus configuration/administration areas" },
+      { "name": "writer", "description": "Full access, including message actions such as retry, edit, archive, and restore" },
+      { "name": "offline_access", "description": "Re-seeded built-in role; required because the SPA requests the offline_access scope and Keycloak denies the token exchange without it" }
+    ]
+  },
+
+  "clientScopes": [
+    {
+      "name": "basic",
+      "description": "OIDC built-in basic scope (re-declared, see profile). Keycloak 24+ only emits the sub claim through this scope, and ServiceControl's Authentication.SubjectIdClaim requires it",
+      "protocol": "openid-connect",
+      "attributes": {"include.in.token.scope": "false", "display.on.consent.screen": "false"},
+      "protocolMappers": [
+        {
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "profile",
+      "description": "OIDC built-in profile scope (re-declared because providing clientScopes suppresses Keycloak's default seeding)",
+      "protocol": "openid-connect",
+      "attributes": {"include.in.token.scope": "true", "display.on.consent.screen": "false"}
+    },
+    {
+      "name": "email",
+      "description": "OIDC built-in email scope (re-declared, see profile)",
+      "protocol": "openid-connect",
+      "attributes": {"include.in.token.scope": "true", "display.on.consent.screen": "false"}
+    },
+    {
+      "name": "offline_access",
+      "description": "OIDC offline_access scope (re-declared, see profile)",
+      "protocol": "openid-connect",
+      "attributes": {"include.in.token.scope": "true", "display.on.consent.screen": "true", "consent.screen.text": "${offlineAccessScopeConsentText}"}
+    },
+    {
+      "name": "servicecontrol",
+      "description": "Grants an access token audience for the ServiceControl API",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "servicecontrol-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "servicecontrol-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+
+  "clients": [
+    {
+      "clientId": "servicecontrol-api",
+      "name": "ServiceControl API (resource server)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "secret": "servicecontrol-api-secret",
+      "fullScopeAllowed": true
+    },
+    {
+      "clientId": "servicepulse",
+      "name": "ServicePulse SPA",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "http://localhost:9090/*"
+      ],
+      "webOrigins": [
+        "http://localhost:9090"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:9090/*"
+      },
+      "defaultClientScopes": [
+        "basic",
+        "profile",
+        "email",
+        "servicecontrol"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "reader",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "reader@example.test",
+      "firstName": "Rita",
+      "lastName": "Reader",
+      "credentials": [ { "type": "password", "value": "reader", "temporary": false } ],
+      "realmRoles": [ "reader", "offline_access" ]
+    },
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "admin@example.test",
+      "firstName": "Ada",
+      "lastName": "Admin",
+      "credentials": [ { "type": "password", "value": "admin", "temporary": false } ],
+      "realmRoles": [ "admin", "offline_access" ]
+    },
+    {
+      "username": "writer",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "writer@example.test",
+      "firstName": "Walt",
+      "lastName": "Writer",
+      "credentials": [ { "type": "password", "value": "writer", "temporary": false } ],
+      "realmRoles": [ "writer", "offline_access" ]
+    }
+  ]
+}

--- a/samples/servicecontrol/audit-log-otlp/ServiceControl_6/otel-collector/otel-collector.yaml
+++ b/samples/servicecontrol/audit-log-otlp/ServiceControl_6/otel-collector/otel-collector.yaml
@@ -1,0 +1,81 @@
+# startcode audit-otlp-collector-config
+receivers:
+  # ServiceControl pushes its logs here (OTEL_EXPORTER_OTLP_ENDPOINT)
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+  # ServiceControl exports ALL its logs when the Otlp provider is enabled.
+  # The audit trail is identified by its logger category ("ServiceControl.Audit"
+  # and "ServiceControl.Audit.Messages"), which arrives as the OTLP
+  # instrumentation scope name. Drop everything else so only the audit
+  # trail reaches the SIEM pipeline.
+  filter/audit-only:
+    logs:
+      log_record:
+        - not IsMatch(instrumentation_scope.name, "^ServiceControl\\.Audit")
+
+  # The ECS document is the log record body (a JSON string). Parsing it into
+  # a structured body lets backends index the individual ECS fields - this is
+  # what the Elasticsearch exporter's bodymap mapping mode expects. The
+  # elastic.mapping.mode scope attribute selects that mode per record
+  # (since collector 0.156 the exporter's mapping::mode config is ignored).
+  transform/parse-ecs:
+    log_statements:
+      - context: log
+        statements:
+          - set(body, ParseJSON(body)) where IsMatch(body, "^\\{")
+      - context: scope
+        statements:
+          - set(attributes["elastic.mapping.mode"], "bodymap")
+
+exporters:
+  # Prints every audit entry to the collector's stdout so the sample is
+  # observable with "docker compose logs otel-collector".
+  debug:
+    verbosity: detailed
+
+  # Elasticsearch / Elastic Security. In "bodymap" mapping mode (selected via
+  # the elastic.mapping.mode scope attribute above) the parsed ECS document is
+  # indexed as-is, exactly as ServiceControl emitted it. Elasticsearch's
+  # built-in logs-*-* index template already maps ECS fields; no custom
+  # mapping is needed. Production clusters use https and an api_key.
+  elasticsearch:
+    endpoint: http://elasticsearch:9200
+    logs_index: logs-servicecontrol.audit-default
+
+  # --- Other SIEM delivery options (add to the pipeline as needed) ---
+  #
+  # Splunk (HTTP Event Collector):
+  #
+  # splunk_hec:
+  #   endpoint: https://splunk:8088/services/collector
+  #   token: ${env:SPLUNK_HEC_TOKEN}
+  #   index: servicecontrol_audit
+  #
+  # Grafana Loki natively ingests OTLP (Loki >= 3.0), no dedicated exporter needed:
+  #
+  # otlphttp/loki:
+  #   endpoint: https://loki:3100/otlp
+  #
+  # Plain files (rotated), e.g. for compliance archival:
+  #
+  # file:
+  #   path: /var/log/otel/servicecontrol-audit.json
+  #   rotation:
+  #     max_megabytes: 30
+  #     max_backups: 14
+
+service:
+  pipelines:
+    logs/audit:
+      receivers: [otlp]
+      processors: [filter/audit-only, transform/parse-ecs, batch]
+      exporters: [debug, elasticsearch]
+# endcode

--- a/samples/servicecontrol/audit-log-otlp/sample.md
+++ b/samples/servicecontrol/audit-log-otlp/sample.md
@@ -55,6 +55,8 @@ snippet: audit-otlp-compose-servicecontrol
 
 With `LoggingProviders=NLog,Otlp`, the operational log keeps flowing to the console/log files through NLog, while every log record — including the audit trail — is additionally exported as OTLP log records. The audit trail is emitted on the logger categories `ServiceControl.Audit` (authorization decisions and message operations) and `ServiceControl.Audit.Messages` (per-message entries of bulk operations), with the pre-rendered ECS JSON document as the OTLP log record *body*. Allowed decisions are logged at `Information` level; denied decisions at `Warning` level, so alerting on denials does not require parsing the payload.
 
+The `ServiceControl.Audit.Messages` category can be high volume on large bulk retries or archives. It can be filtered independently of the operation-level trail through standard `Microsoft.Extensions.Logging` configuration — see [filtering the per-message audit stream](/servicecontrol/logging.md#authorization-audit-trail-filtering-the-per-message-audit-stream).
+
 ## Configuring the collector
 
 The collector runs as a regular container next to ServiceControl:

--- a/samples/servicecontrol/audit-log-otlp/sample.md
+++ b/samples/servicecontrol/audit-log-otlp/sample.md
@@ -1,0 +1,176 @@
+---
+title: Shipping the ServiceControl audit log to a SIEM with OpenTelemetry
+summary: Export the ServiceControl authorization audit log over OTLP to an OpenTelemetry Collector and deliver it to a SIEM in Elastic Common Schema format
+component: ServiceControl
+reviewed: 2026-07-07
+related:
+- servicecontrol/security/configuration/authorization
+- servicecontrol/security/configuration/authentication
+- servicecontrol/logging
+---
+
+When [role-based access control](/servicecontrol/security/configuration/authorization.md) is enabled, ServiceControl writes every authorization decision — allowed and denied — to a dedicated audit log formatted as [Elastic Common Schema (ECS)](https://www.elastic.co/docs/reference/ecs) JSON. This sample shows how to ship that audit trail over OTLP (OpenTelemetry Protocol) to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), which can then deliver it to a SIEM (Security Information and Event Management system — a log aggregator such as Elastic Security, Splunk, or Microsoft Sentinel) for alerting and compliance retention.
+
+```mermaid
+flowchart LR
+    SP[ServicePulse] -->|user actions| SC[ServiceControl]
+    KC[Keycloak] -->|OIDC tokens with roles| SP
+    SC -->|"audit log (ECS JSON) over OTLP"| COL[OpenTelemetry Collector]
+    COL --> ES[Elasticsearch]
+    ES --> KB[Kibana]
+    COL -.-> SPL[Splunk HEC]
+    COL -.-> OTHER[Loki / syslog / files]
+```
+
+## Prerequisites
+
+- Docker (or Podman) with the compose plugin
+- A `.env` file next to `docker-compose.yml` containing a valid license:
+
+  ```
+  PARTICULARSOFTWARE_LICENSE=<license file contents>
+  ```
+
+## The stack
+
+The `docker-compose.yml` starts:
+
+| Service | Purpose |
+|---------|---------|
+| `keycloak` | Identity provider; the imported realm defines the `reader`, `admin`, and `writer` roles and one demo user per role (password equals the username) |
+| `rabbitmq`, `ravendb` | ServiceControl transport and storage |
+| `servicecontrol` | Primary instance with authentication + role-based access control enabled and the audit log exported over OTLP |
+| `servicepulse` | Web UI, to generate audit events interactively |
+| `otel-collector` | Receives the OTLP log stream and forwards the audit trail |
+| `elasticsearch`, `kibana` | The SIEM backend the audit trail is delivered to |
+
+> [!WARNING]
+> To stay focused on the logging pipeline, this sample runs the identity provider over plain HTTP and sets `Authentication.RequireHttpsMetadata` to `false`. Production deployments must use HTTPS end-to-end — see [securing ServiceControl](/servicecontrol/security/).
+
+## Configuring ServiceControl
+
+Two things happen in the ServiceControl service definition: role-based access control is switched on, and the OTLP logging provider is added alongside the default NLog provider via the `LoggingProviders` setting. The standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable points the exporter at the collector.
+
+snippet: audit-otlp-compose-servicecontrol
+
+With `LoggingProviders=NLog,Otlp`, the operational log keeps flowing to the console/log files through NLog, while every log record — including the audit trail — is additionally exported as OTLP log records. The audit trail is emitted on the logger categories `ServiceControl.Audit` (authorization decisions and message operations) and `ServiceControl.Audit.Messages` (per-message entries of bulk operations), with the pre-rendered ECS JSON document as the OTLP log record *body*. Allowed decisions are logged at `Information` level; denied decisions at `Warning` level, so alerting on denials does not require parsing the payload.
+
+## Configuring the collector
+
+The collector runs as a regular container next to ServiceControl:
+
+snippet: audit-otlp-compose-collector
+
+It receives all ServiceControl logs, keeps only the audit categories, parses the ECS document, and hands it to one or more exporters:
+
+snippet: audit-otlp-collector-config
+
+Four details worth calling out:
+
+- **Filtering by category.** The `Microsoft.Extensions.Logging` category name arrives as the OTLP *instrumentation scope name*, so the `filter` processor can isolate the audit trail (`ServiceControl.Audit*`) from operational logs without inspecting payloads.
+- **Parsing the body.** ServiceControl deliberately exports each audit entry as a self-contained ECS JSON string in the record body. The `transform` processor's `ParseJSON` turns it into a structured body so backends index the individual fields.
+- **Mapping mode.** The `elastic.mapping.mode` scope attribute selects the Elasticsearch exporter's `bodymap` mode, which indexes the parsed body verbatim — the Elasticsearch document is then exactly the ECS document ServiceControl emitted. (Since collector 0.156 the exporter's `mapping::mode` config option is deprecated and ignored; the scope attribute or the `X-Elastic-Mapping-Mode` client metadata key replaces it.)
+- **Fan-out.** A single collector pipeline can deliver the same stream to multiple destinations — a SIEM for alerting plus rotated files for long-term retention.
+
+## Running the sample
+
+```bash
+docker compose up -d
+```
+
+Once healthy, generate audit events. Either log into ServicePulse at `http://localhost:9090` (e.g. as `reader` / `reader`) and browse around, or use the API directly:
+
+```bash
+# An allowed request: 'reader' may view failed messages
+TOKEN=$(curl -s http://localhost:8088/realms/particular/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=servicepulse \
+  -d username=reader -d password=reader \
+  -d scope="openid profile servicecontrol" | jq -r .access_token)
+
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:33333/api/errors > /dev/null
+
+# A denied request: 'reader' may not retry messages
+curl -s -X POST -H "Authorization: Bearer $TOKEN" http://localhost:33333/api/errors/retry/all
+```
+
+Then watch the audit entries arrive at the collector:
+
+```bash
+docker compose logs otel-collector | grep "Body:"
+```
+
+Each OTLP record carries the ECS document as its body, together with the resource attributes `service.name`, `service.version`, and `service.instance.id` identifying which ServiceControl instance emitted it.
+
+### Querying the audit trail in Elasticsearch and Kibana
+
+The collector delivers the same entries to Elasticsearch, into the `logs-servicecontrol.audit-default` data stream. Elasticsearch's built-in `logs-*-*` index template recognizes the ECS field names and maps them correctly (`event.category`, `event.outcome`, and `user.name` become `keyword` fields; `@timestamp` becomes a `date`) — no custom mapping or index template needs to be installed. Query the denied decisions directly:
+
+```bash
+curl -s "http://localhost:9200/logs-servicecontrol.audit-default/_search?q=event.category:iam%20AND%20event.outcome:failure" | jq .hits.total.value
+```
+
+Or use Kibana at `http://localhost:5601`: create a data view for `logs-servicecontrol.audit-*` with `@timestamp` as the time field (**Stack management** → **Data views**), then in **Discover** run the KQL query:
+
+```
+event.category:iam and event.outcome:failure
+```
+
+Every denied authorization decision appears, with the full ECS document expandable per hit. Because `user.name` is a `keyword` field it is aggregatable, so visualizations and alert rules such as "failures per user over time" work immediately.
+
+## The ECS audit document
+
+ECS is Elastic's open specification for naming log fields consistently so that tooling — dashboards, correlation rules, detection content — works across data sources. It is the de-facto ingestion schema for SIEMs beyond Elastic's own: most systems either ingest ECS natively or ship converters for it. In 2023 Elastic [donated ECS to OpenTelemetry](https://opentelemetry.io/blog/2023/ecs-otel-semconv-convergence/), and the two schemas are converging namespace by namespace, though the security-relevant `event.*` classification fields remain ECS-only for now.
+
+An *allowed* decision looks like:
+
+```json
+{
+  "@timestamp": "2026-07-07T16:57:13.7857082+00:00",
+  "event": {
+    "kind": "event",
+    "category": ["iam"],
+    "type": ["allowed"],
+    "action": "error:messages:view",
+    "outcome": "success"
+  },
+  "user": {
+    "id": "38589380-f1ca-43da-9585-b9e94b2a49ad",
+    "name": "reader"
+  },
+  "servicecontrol": {
+    "permission": "error:messages:view",
+    "reason": "User holds 'error:messages:view' via role(s) [reader]"
+  }
+}
+```
+
+A *denied* decision differs in `event.type` (`["denied"]`), `event.outcome` (`"failure"`), the log level (`Warning`), and the reason. The fields follow ECS's [categorization model](https://www.elastic.co/docs/reference/ecs/ecs-category-field-values-reference):
+
+| Field | Meaning |
+|-------|---------|
+| `@timestamp` | When the decision was made (UTC, ISO 8601) |
+| `event.kind` | `event` — a regular occurrence, as opposed to an alert or a metric |
+| `event.category` | `iam` (Identity and Access Management) for authorization decisions; `configuration` for message operations such as retry or archive |
+| `event.type` | Sub-categorization: `allowed`/`denied` for decisions, `change`/`deletion` for operations |
+| `event.action` | The specific action attempted, expressed as the ServiceControl permission (`instance:resource:action`) |
+| `event.outcome` | `success` or `failure` — the field SIEM detection rules key on |
+| `user.id` / `user.name` | The caller, taken from the token claims configured by `Authentication.SubjectIdClaim` and `Authentication.SubjectNameClaim` |
+| `servicecontrol.*` | Application-specific detail (permission, resource, reason, message/operation ids) in a custom namespace, as ECS prescribes for non-standard fields |
+
+Because the documents are already ECS, they ingest into Elastic/Kibana with no custom mapping, and SIEM content such as "alert when `event.category:iam AND event.outcome:failure` spikes for one `user.name`" works out of the box — [querying the audit trail](#running-the-sample-querying-the-audit-trail-in-elasticsearch-and-kibana) demonstrates exactly this query against the included Elasticsearch container.
+
+## Delivering to a SIEM
+
+Is there something that can *output* the logs to the destination of choice? Yes — that is exactly the OpenTelemetry Collector's job. The `otel/opentelemetry-collector-contrib` distribution ships exporters for the common destinations; the sample delivers to Elasticsearch and its collector config contains ready-to-uncomment blocks for the others:
+
+| Destination | Exporter | Notes |
+|-------------|----------|-------|
+| Elasticsearch / Elastic Security | `elasticsearch` | The `bodymap` mapping mode indexes the parsed ECS document exactly as emitted; `ecs` mode instead maps OpenTelemetry semantic-convention attributes onto ECS names |
+| Splunk | `splunk_hec` | Sends to the HTTP Event Collector endpoint |
+| Grafana Loki | `otlphttp` | Loki 3.0+ ingests OTLP natively at `/otlp`; the dedicated Loki exporter was retired |
+| Generic / legacy SIEM | `syslog` | RFC 5424 over TCP/TLS as lowest common denominator |
+| Compliance archive | `file` | Rotated JSON files |
+
+Alternatives to the collector exist and speak OTLP too: [Elastic Agent embeds an OpenTelemetry Collector distribution](https://www.elastic.co/docs/reference/fleet/elastic-agent-as-otel-collector) (EDOT), [Vector](https://vector.dev/docs/reference/configuration/sources/opentelemetry/) has an OpenTelemetry source, and [Fluent Bit](https://docs.fluentbit.io/manual/data-pipeline/inputs/opentelemetry) ships OTLP input/output plugins. The collector remains the most direct fit here because the ECS documents need no re-mapping — any OTLP-capable pipeline can carry them.
+
+Deployments that cannot use OTLP can still collect the audit trail from its file/console destination: when running as a Windows service the audit trail is written to `audit.json` in the instance log directory, and in containers it goes to standard output — see [the authorization documentation](/servicecontrol/security/configuration/authorization.md#authorization-audit-log) for details.

--- a/servicecontrol/logging.md
+++ b/servicecontrol/logging.md
@@ -80,6 +80,50 @@ Log Level Options: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`, `Off`.
 <add key="ServiceControl/LogLevel" value="Info" />
 ```
 
+## Authorization audit trail
+
+When [role-based access control](/servicecontrol/security/configuration/authorization.md) is enabled (ServiceControl 6.18.0 and later), every authorization decision and message action is written to a dedicated audit trail, separate from the operational log, as [Elastic Common Schema (ECS)](https://www.elastic.co/docs/reference/ecs) JSON. See [the authorization documentation](/servicecontrol/security/configuration/authorization.md#authorization-audit-log) for the format and destinations, and the [audit-log-over-OTLP sample](/samples/servicecontrol/audit-log-otlp/) for an end-to-end pipeline into a SIEM.
+
+The audit trail uses two logger categories so they can be handled independently:
+
+| Category | Contents |
+|----------|----------|
+| `ServiceControl.Audit` | Authorization decisions (allow/deny) and operation-level message actions (e.g. "retry group X, 42 messages"). |
+| `ServiceControl.Audit.Messages` | One entry per individual message affected by a bulk action. High volume on large retry/archive operations. |
+
+### Filtering the per-message audit stream
+
+The `ServiceControl.Audit.Messages` category emits one entry per message, so a bulk retry or archive of thousands of messages produces thousands of entries. Because ServiceControl routes these categories through [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging), the per-message stream can be filtered independently using the standard [log-level configuration](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging#configure-logging), without affecting the operation-level trail on `ServiceControl.Audit`.
+
+Set the minimum level for the `ServiceControl.Audit.Messages` category to `Warning` to keep only failed per-message actions (successful ones are logged at `Information`), or to `None` to drop the per-message stream entirely. Either configuration source the host reads works:
+
+Environment variable (recommended for container deployments):
+
+```
+Logging__LogLevel__ServiceControl.Audit.Messages=Warning
+```
+
+Or an `appsettings.json` file in the instance folder:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "ServiceControl.Audit.Messages": "Warning"
+    }
+  }
+}
+```
+
+> [!NOTE]
+> This filters the category before it reaches any destination, so it applies to the `audit.json` file, the console, and the OTLP export alike. The operation-level `ServiceControl.Audit` trail — which still records that the bulk action occurred, who performed it, and the affected count — is unaffected. The same mechanism can raise or lower the level of any audit category; for example, setting `ServiceControl.Audit` to `Warning` keeps only denied decisions and failed actions.
+
+### Exporting the audit trail over OTLP
+
+ServiceControl can export its logs — including the audit trail — over OTLP (OpenTelemetry Protocol) in addition to, or instead of, the file/console output. Set the `LoggingProviders` setting to include `Otlp` (for example `NLog,Otlp`) and point the standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable at a collector. Each ECS audit document is exported as the OTLP log record body.
+
+When forwarding to Elasticsearch through the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)'s `elasticsearch` exporter, select the exporter's `bodymap` mapping mode so the ECS document is indexed exactly as ServiceControl emitted it. In collector-contrib 0.156.0 and later the exporter's `mapping::mode` configuration option is deprecated and ignored; set the mode with the `elastic.mapping.mode` scope attribute (or the `X-Elastic-Mapping-Mode` client-metadata key) instead. The [audit-log-over-OTLP sample](/samples/servicecontrol/audit-log-otlp/) shows the full collector configuration.
+
 ## RavenDB Logging
 
 ServiceControl stores data in an embedded RavenDB database which generates its own log messages into a different log file. This file is co-located with the ServiceControl logs. The default logging level for the RavenDB logs is `Warn`. The log level for the RavenDB logs can be set by adding the following to the `appSettings` section of the configuration file:


### PR DESCRIPTION
Demonstrates ServiceControl 6.18.0 RBAC with the authorization audit log (ECS JSON) exported via LoggingProviders=NLog,Otlp to an OpenTelemetry Collector, filtered by the ServiceControl.Audit scope and ready for Elasticsearch/Splunk/Loki delivery. Verified end-to-end with Keycloak.