### PR TITLE
Float image tags in the audit-log-otlp sample

### DIFF
--- a/samples/servicecontrol/audit-log-otlp/ServiceControl_6/docker-compose.yml
+++ b/samples/servicecontrol/audit-log-otlp/ServiceControl_6/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # start-dev + plain HTTP keep the sample small; production setups must use
   # HTTPS - see https://docs.particular.net/servicecontrol/security/
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: quay.io/keycloak/keycloak:latest
     command: ["start-dev", "--import-realm"]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
@@ -50,7 +50,7 @@ services:
       start_period: 20s
 
   ravendb:
-    image: particular/servicecontrol-ravendb:6.18.0
+    image: particular/servicecontrol-ravendb:latest
     volumes:
       - ravendb-data:/var/lib/ravendb/data
     healthcheck:
@@ -62,7 +62,7 @@ services:
 
   # startcode audit-otlp-compose-servicecontrol
   servicecontrol:
-    image: particular/servicecontrol:6.18.0
+    image: particular/servicecontrol:latest   # role-based access control + the audit log require 6.18.0 or later
     command: ["--setup-and-run"]
     env_file: [.env]                       # provides PARTICULARSOFTWARE_LICENSE
     environment:
@@ -98,7 +98,7 @@ services:
   # endcode
 
   servicepulse:
-    image: particular/servicepulse:2.9.0
+    image: particular/servicepulse:latest   # role-based access control requires 2.9.0 or later
     environment:
       SERVICECONTROL_URL: "http://servicecontrol:33333"
       # No monitoring instance in this sample; "!" disables the monitoring UI
@@ -110,6 +110,8 @@ services:
 
   # startcode audit-otlp-compose-collector
   otel-collector:
+    # Pinned deliberately: the collector is pre-1.0 and its configuration format
+    # still changes between releases, so a floating tag could break otel-collector.yaml.
     image: otel/opentelemetry-collector-contrib:0.156.0
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     volumes:
@@ -120,6 +122,7 @@ services:
 
   # Single-node Elasticsearch as the SIEM backend. Security is disabled to
   # keep the sample small; production clusters authenticate and use TLS.
+  # Elastic publishes only exact x.y.z tags (no floating major/minor/latest), so this stays pinned.
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.4.3
     environment:


### PR DESCRIPTION
Float image tags to `latest` where the registry supports it, to reduce the burden of keeping the sample current. The OpenTelemetry Collector and Elasticsearch/Kibana stay pinned (reasons in inline comments).