### PR TITLE
ServiceControl: document RavenDB database licensing, connectivity, and air-gapped deployments

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1727,6 +1727,8 @@
       Url: servicecontrol/backup-sc-database
     - Title: Containers
       Url: servicecontrol/ravendb/containers
+    - Title: RavenDB licensing
+      Url: servicecontrol/ravendb/licensing
     - Title: Compacting the database
       Url: servicecontrol/db-compaction
     - Title: Move database location

--- a/servicecontrol/ravendb/containers.md
+++ b/servicecontrol/ravendb/containers.md
@@ -12,7 +12,7 @@ When ServiceControl is hosted in containers, the [`particular/servicecontrol-rav
 The database container extends the [official RavenDB container](https://hub.docker.com/r/ravendb/ravendb) and is provided to ensure compatibility with ServiceControl instances. In other words, for any version `x.y.z` version of ServiceControl, the same version `x.y.z` of the database container should be used to ensure data storage compatibility.
 
 > [!NOTE]
-The NServiceBus license covers the license for the embedded RavenDB that ships with ServiceControl. A separate RavenDB license is not required in this case.
+The NServiceBus license covers the license for the embedded RavenDB that ships with ServiceControl. A separate RavenDB license is not required in this case. See [Licensing the ServiceControl RavenDB database](/servicecontrol/ravendb/licensing.md) for how the license is kept valid, its connectivity requirements, and air-gapped deployments.
 
 > [!WARNING]
 > A single database container should not be shared between multiple ServiceControl instances in production scenarios.

--- a/servicecontrol/ravendb/licensing.md
+++ b/servicecontrol/ravendb/licensing.md
@@ -1,0 +1,67 @@
+---
+title: Licensing the ServiceControl RavenDB database
+summary: How the RavenDB database used by ServiceControl is licensed, the connectivity it uses, and how to run it in air-gapped deployments
+reviewed: 2026-07-09
+component: ServiceControl
+versions: '[5,)'
+related:
+- servicecontrol/license
+- servicecontrol/ravendb/containers
+---
+
+ServiceControl stores its data in [RavenDB](https://ravendb.net/). The RavenDB server is hosted in one of two ways:
+
+- as a **child process** started by ServiceControl, using the RavenDB server and license bundled with the ServiceControl installation — the default for Windows and other non-container installations; or
+- as a **container**, using the [`particular/servicecontrol-ravendb` image](/servicecontrol/ravendb/containers.md).
+
+In both cases the RavenDB license is the `RavenLicense.json` file bundled with ServiceControl and is covered by the [Particular Software license](/servicecontrol/license.md) — a separate RavenDB license is not required. This page describes how that license is kept valid, the connectivity RavenDB uses, and how to run ServiceControl in air-gapped or egress-restricted environments.
+
+## How the license is kept valid
+
+The RavenDB server validates its license against the RavenDB server **version** that is running: a license covers server builds released within its update window. The RavenDB server also refreshes its license from the RavenDB license server at `api.ravendb.net`.
+
+When the bundled license already covers the running server version — the normal case, because ServiceControl ships a matched RavenDB server and license — the license validates without contacting the license server. A refresh from `api.ravendb.net` is only needed when the running server version is **newer** than the locally available license covers.
+
+## Outbound connectivity
+
+To validate and refresh its license, the RavenDB server contacts the RavenDB license server, using outbound **HTTPS (port 443)** with name resolution, at:
+
+```
+api.ravendb.net
+```
+
+This is needed to obtain an updated license when the one held locally does not cover the running server version (see [Air-gapped and egress-restricted deployments](#air-gapped-and-egress-restricted-deployments)). ServiceControl itself does not require internet access — the [Particular Software license](/servicecontrol/license.md) is supplied directly to each instance.
+
+## Air-gapped and egress-restricted deployments
+
+If the RavenDB server cannot reach `api.ravendb.net` **and** the license available to it does not cover the RavenDB server version that is running, it cannot validate its license. When this happens:
+
+- The **RavenDB server keeps running**, but in a restricted, unlicensed mode.
+- The **ServiceControl instance connected to it fails to start**. In ServiceControl version 6.9 and later, the instance stops immediately with a fatal error rather than continuing in a degraded state:
+
+```
+Cannot validate the current RavenDB license
+```
+
+This requires the RavenDB server version and its license to have diverged, which is primarily a concern for the **container** deployment: the [`particular/servicecontrol-ravendb` image](/servicecontrol/ravendb/containers.md) is versioned and pulled independently of ServiceControl, so a database container can end up running a server version that its bundled license does not cover — most commonly after upgrading the database image without a matching license, or when different instances in a fleet run different image versions.
+
+Installations that use the **bundled** RavenDB server (the child process on Windows and other non-container hosts) install the RavenDB server and its license together, so they always match and validate offline. This failure does not arise from a normal installation or upgrade of such a host.
+
+## Remedies
+
+### Restore access to the license server
+
+The recommended remedy is to allow the RavenDB server outbound access to `api.ravendb.net`, as described in [Outbound connectivity](#outbound-connectivity). Once connectivity is available, restart the affected ServiceControl instance; the RavenDB server refreshes its license during startup. The license can also be refreshed from the **License** view in [RavenDB Studio](/servicecontrol/ravendb/accessing-database.md) using **Force Update**.
+
+### Air-gapped deployments
+
+When outbound access to `api.ravendb.net` cannot be granted, keep the RavenDB server and its license matched and current:
+
+- **Container** — run an up-to-date [`particular/servicecontrol-ravendb` image](/servicecontrol/ravendb/containers.md) matched to the ServiceControl version. Because the license is included in the image, a current, matched image already contains a license that covers its own server version, so no refresh from the license server is required.
+- **Bundled (child process)** — no separate action is required. Upgrading ServiceControl installs a matched RavenDB server and license together, so the license always covers the server version being run.
+
+## Version compatibility
+
+When the database runs in a container or as a separate server, the RavenDB database container should use the **same version** (`Major.Minor.Patch`) as the ServiceControl instances that connect to it. See the version map in [Managing ServiceControl RavenDB instances via Containers](/servicecontrol/ravendb/containers.md).
+
+A ServiceControl instance can connect to a RavenDB server of the **same or a higher** RavenDB version, because RavenDB clients are compatible with servers of an equal or higher version. An older ServiceControl instance can therefore operate against a newer RavenDB server, for example during a staged upgrade. A ServiceControl instance refuses to start only when it requires a **newer** RavenDB server version than the one that is running.

--- a/servicecontrol/troubleshooting.md
+++ b/servicecontrol/troubleshooting.md
@@ -107,6 +107,16 @@ When encryption is enabled, SQL Server uses a certificate to encrypt communicati
 
 To fix this error, [update the SQL Server installation with a valid certificate and update the ServiceControl machine to trust this certificate](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine) or add `Encrypt=False` to the connection string if encryption is truly not necessary.
 
+## Service fails to start: Cannot validate the current RavenDB license
+
+If a ServiceControl instance stops during startup with the following error, the RavenDB server it uses cannot validate its license:
+
+```
+Cannot validate the current RavenDB license
+```
+
+This occurs when the RavenDB server cannot reach the RavenDB license server at `api.ravendb.net` and the license it holds does not cover the running RavenDB server version, most commonly after an upgrade. See [Licensing the ServiceControl RavenDB database](/servicecontrol/ravendb/licensing.md) for the cause and remedies.
+
 ## Unable to connect to ServiceControl from ServicePulse
 
 Attempt to connect to the ServiceControl instance's URL using a web browser. A valid response with JSON data should be returned. If not, verify that network configuration and/or firewall settings do not block access to the ServiceControl port specified in the URL.


### PR DESCRIPTION
## What

New page **Licensing the ServiceControl RavenDB database** (`servicecontrol/ravendb/licensing.md`) documenting:

- how the embedded RavenDB is licensed (bundled in the `servicecontrol-ravendb` image, covered by the Particular license)
- that the RavenDB server validates and refreshes its license from `api.ravendb.net`, and the outbound connectivity that requires
- the air-gapped / egress-restricted startup failure (`Cannot validate the current RavenDB license`) and its remedies
- version-compatibility notes for the database container

Supporting changes:

- Cross-link the existing embedded-license note in `servicecontrol/ravendb/containers.md`
- Add a `servicecontrol/troubleshooting.md` entry that links to the new page
- Register the page in `menu/menu.yaml` (Data Management)

## Why

Derived from a support engagement: a containerized, egress-restricted ServiceControl deployment failed to start after an upgrade because its RavenDB nodes could not reach `api.ravendb.net` to refresh a license that no longer covered the upgraded RavenDB server build. This behavior and its remedies were not documented anywhere, so support had to work them out from scratch. This page captures them. (No customer or case identifiers are included.)
