### PR TITLE
Add  more callouts for persistence and transport limitations

### DIFF
--- a/persistence/azure-table/index.md
+++ b/persistence/azure-table/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Table Persistence
 summary: Using Azure Tables as persistence
-reviewed: 2026-04-10
+reviewed: 2026-07-27
 component: ASP
 related:
  - persistence/upgrades/asp-saga-deduplication
@@ -58,3 +58,6 @@ Saga correlation property values are subject to the underlying Azure Storage tab
 ### Storage format
 
 partial: outbox-storage-format
+
+> [!WARNING]
+> Serialized transport operations for a single Outbox record cannot exceed the Azure Table 64 KiB string-property limit. Exceeding the limit causes processing to fail. If this limit affects the workload, [add a thumbs-up or share the use case on issue #815](https://github.com/Particular/NServiceBus.Persistence.AzureTable/issues/815).

--- a/persistence/cosmosdb/saga-timeouts.md
+++ b/persistence/cosmosdb/saga-timeouts.md
@@ -2,9 +2,11 @@
 title: CosmosDB partition key and saga timeouts
 summary: How to resolve partition keys with saga timeouts when using Azure Cosmos DB
 component: CosmosDB
-reviewed: 2026-03-09
+reviewed: 2026-07-27
 ---
 
 When [sending saga timeouts](/nservicebus/sagas/timeouts.md/) the current partition information is not automatically added to the timeout message. When such a saga timeout message is processed, the partition to be used for the CosmosDB cannot be extracted from the incoming saga timeout message.
 
 Ensure that the timeout data state that is passed to `RequestTimeout` contains the partition key information. The [Cosmos DB Persistence Usage with non-default container sample](/samples/cosmosdb/container/) demonstrates this approach.
+
+Support for automatically resolving partition information for saga timeouts is being considered. If this workaround affects the application, [add a thumbs-up or share the use case on issue #720](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/720).

--- a/transports/azure-storage-queues/delayed-delivery.md
+++ b/transports/azure-storage-queues/delayed-delivery.md
@@ -6,7 +6,7 @@ related:
 - persistence
 - persistence/azure-table
 - persistence/azure-table/performance-tuning
-reviewed: 2026-06-16
+reviewed: 2026-07-27
 ---
 
 
@@ -19,6 +19,8 @@ When an endpoint is started, the transport creates a storage table to store the 
 
 By default, the storage table and blob container names are constructed using a naming scheme that starts with the word `delays` followed by SHA-1 hash of the endpoint's name. For example, `delays2fd4e1c67a2d28fced849ee1bb76e7391b93eb12` where `2fd4e1c67a2d28fced849ee1bb76e7391b93eb12` is a SHA-1 hash of an endpoint name.
 
+> [!WARNING]
+> A delayed message whose dispatched form exceeds the Azure Storage Queue size limit can fail repeatedly when it is forwarded to the destination queue. If this affects the workload, [add a thumbs-up or share the use case on issue #993](https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/993).
 
 ### Overriding table/container name
 


### PR DESCRIPTION
Introduce warning callouts in the Azure Table, CosmosDB, and Azure Storage Queues documentation. These highlight known limitations and direct users to relevant GitHub issues to provide feedback.