### PR TITLE
Add documentation for component limitations and unsupported features

### DIFF
--- a/nservicebus/sagas/saga-finding.md
+++ b/nservicebus/sagas/saga-finding.md
@@ -1,7 +1,7 @@
 ---
 title: Complex saga finding logic
 summary: Use IFindSaga to write custom code that resolves sagas.
-reviewed: 2026-06-29
+reviewed: 2026-07-27
 component: Core
 related:
 - samples/saga/nh-custom-sagafinder
@@ -17,6 +17,9 @@ Custom Saga Finders are created by implementing `IFindSagas`.
 snippet: saga-finder
 
 partial: mapping
+
+> [!NOTE]
+> Cosmos DB persistence does not support custom saga finders. Use [message-property correlation](/nservicebus/sagas/message-correlation.md#message-property-expression) with a partition-aware mapping. For more information, see [Cosmos DB saga finding limitations](/persistence/cosmosdb/#usage-saga-finding-limitations).
 
 Many finders may exist for a given saga or message type. If a saga can't be found and the saga specifies that it should be started for that message type, NServiceBus will know to create a new saga instance.
 

--- a/persistence/cosmosdb/index.md
+++ b/persistence/cosmosdb/index.md
@@ -2,7 +2,7 @@
 title: Azure Cosmos DB Persistence
 summary: How to use NServiceBus with Azure Cosmos DB
 component: CosmosDB
-reviewed: 2025-09-25
+reviewed: 2026-07-27
 related:
 - samples/cosmosdb/transactions
 - samples/cosmosdb/container
@@ -65,6 +65,10 @@ snippet: CosmosDBCustomClientProvider
 and registered on the container:
 
 snippet: CosmosDBCustomClientProviderRegistration
+
+### Saga finding limitations
+
+Custom saga finders are not supported by Cosmos DB persistence. Use [message-property correlation](/nservicebus/sagas/message-correlation.md#message-property-expression) with a partition-aware mapping. If custom saga finders are required, [add a thumbs-up or share the use case on issue #378](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/378).
 
 ## Capacity planning using request units (RU)
 
@@ -206,6 +210,8 @@ snippet: CosmosDBConfigureThrottlingWithBuilder
 ## Transactions
 
 The Cosmos DB persister supports using the [Cosmos DB transactional batch API](https://devblogs.microsoft.com/cosmosdb/introducing-transactionalbatch-in-the-net-sdk/). However, Cosmos DB only allows operations to be batched if all operations are performed within the [same logical partition key](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/transactional-batch?tabs=dotnet). This is due to the distributed nature of the Cosmos DB service, which does not support distributed transactions.
+
+Atomic commits are limited to operations in one logical partition of one container. Cross-partition and cross-container transactions are not supported. If this limitation affects the application, [add a thumbs-up or share the use case on issue #1049](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/1049).
 
 The [transactions](transactions.md) documentation provides additional details on how to configure NServiceBus to resolve the incoming message to a specific partition key to take advantage of this Cosmos DB feature.
 

--- a/transports/azure-service-bus/index.md
+++ b/transports/azure-service-bus/index.md
@@ -10,7 +10,7 @@ related:
  - samples/azure-service-bus-netstandard/topology-migration
  - samples/showcase/loan-broker-showcase
  - architecture/azure
-reviewed: 2026-05-05
+reviewed: 2026-07-27
 ---
 
 The Azure Service Bus transport leverages the [Azure.Messaging.ServiceBus](https://www.nuget.org/packages/Azure.Messaging.ServiceBus/) client library for .NET.
@@ -29,12 +29,15 @@ The Azure Service Bus transport leverages the [Azure.Messaging.ServiceBus](https
 |Scripted Deployment        |Supported using `NServiceBus.Transport.AzureServiceBus.CommandLine`
 |Installers                 |Optional
 |Native integration         |[Supported](native-integration.md)
+|Message sessions           |Not supported
 |Case Sensitive             |No
 |Aspire integration         |[Yes](/platform/aspire/#configuring-the-transport-azure-service-bus)
 
 > [!NOTE]
 > The Azure Service Bus transport only supports the Standard and Premium tiers of the Microsoft Azure Service Bus service. Premium tier is recommended for production environments.
 >
+
+Support for Azure Service Bus message sessions is being considered. If session-based ordered processing is required, [add a thumbs-up or share the use case on issue #535](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/535).
 
 ## Azure Service Bus Emulator
 

--- a/transports/azure-service-bus/native-integration.md
+++ b/transports/azure-service-bus/native-integration.md
@@ -4,7 +4,7 @@ summary: How to integrate NServiceBus endpoints with non-NServiceBus endpoints o
 component: ASBS
 related:
  - samples/azure-service-bus-netstandard/native-integration
-reviewed: 2025-10-14
+reviewed: 2026-07-27
 ---
 
 This document guides integrating NServiceBus endpoints with non-NServiceBus endpoints by sharing an Azure Service Bus (ASB) namespace as a mutual communication channel.
@@ -17,6 +17,7 @@ The following points must be taken into account when integrating
 1. The transport assumes a specific layout of ASB entities; any non-NServiceBus endpoint is expected to use the correct entities for each purpose. In general, the following rule applies: queues are for sending, and topics are for publishing. To learn more about the layouts of the built-in topology, refer to [Azure Service Bus Transport Topology](/transports/azure-service-bus/topology.md).
 1. By default, the transport creates its own entities when they don't exist in the namespace. However, non-NServiceBus endpoints may require manual creation of entities. Refer to the [Azure Service Bus documentation](https://learn.microsoft.com/en-us/azure/service-bus-messaging/) for more information on available ASB SDKs and tools to perform these tasks.
 1. The native message must allow NServiceBus to [detect the message type either via the headers or the message payload](/nservicebus/messaging/message-type-detection.md).
+1. The native Azure Service Bus `MessageId` is distinct from the `NServiceBus.MessageId` header. Native integrations must not assume they match. If matching identifiers are required, [add a thumbs-up or share the use case on issue #581](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/581).
 
 > [!NOTE]
 > Starting with versions 5.1.1, 5.0.3, 4.2.5, and 3.2.7, if the incoming Service Bus message specifies a value for the [`ContentType` property](https://learn.microsoft.com/en-us/rest/api/servicebus/message-headers-and-properties), the value is used to populate the `NServiceBus.ContentType` header.

--- a/transports/sqs/index.md
+++ b/transports/sqs/index.md
@@ -2,7 +2,7 @@
 title: Amazon SQS Transport
 summary: A transport for Amazon Web Services Simple Queue Service.
 component: SQS
-reviewed: 2026-03-24
+reviewed: 2026-07-27
 related:
  - samples/aws/sqs-simple
  - samples/showcase/loan-broker-showcase
@@ -25,9 +25,12 @@ redirects:
 |Scripted Deployment        |Built-in CLI, C#
 |Installers                 |Optional
 |Native integration         |[Supported](native-integration.md)
+|FIFO input queues          |Not supported
 |Case Sensitive             |Yes
 |Local development          |[Supported via LocalStack](/nservicebus/aws/local-development.md)
 |Aspire integration         |[Yes](/platform/aspire/#configuring-the-transport-amazon-sqs)
+
+The FIFO queue used for unrestricted delayed delivery does not provide FIFO semantics for an endpoint's input queue. Support for FIFO endpoint queues is being considered. If ordered message-group processing is required, [add a thumbs-up or share the use case on issue #240](https://github.com/Particular/NServiceBus.AmazonSQS/issues/240).
 
 ## Advantages
 


### PR DESCRIPTION
This change introduces callouts and dedicated sections to clarify current limitations and unsupported features across different NServiceBus components:
*   Cosmos DB Persistence: custom saga finding and transactional batching.
*   Azure Service Bus Transport: message sessions and native message ID correlation.
*   Amazon SQS Transport: FIFO input queues for endpoint input queues.

Each clarification includes a link to a relevant GitHub issue where users can provide feedback and share their use cases.