### PR TITLE
Add guide for remote access to integrated ServicePulse

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -1640,6 +1640,8 @@
       Url: servicecontrol/servicecontrol-instances
     - Title: Integrated ServicePulse
       Url: servicecontrol/servicecontrol-instances/integrated-servicepulse
+    - Title: Remote access to integrated ServicePulse
+      Url: servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access
     - Title: Deployment
       Url: servicecontrol/servicecontrol-instances/deployment
       Articles:

--- a/servicecontrol/configure-ravendb-location.md
+++ b/servicecontrol/configure-ravendb-location.md
@@ -1,7 +1,7 @@
 ---
 title: RavenDB Embedded Location
 summary: Increase space for monitored data by configuring ServiceControl to save data in a location other than the default
-reviewed: 2026-07-24
+reviewed: 2026-07-30
 ---
 
 Each ServiceControl instance deployed using PowerShell or the ServiceControl Management Utility stores its data in a RavenDB embedded database server. The location of the data is set at install time.
@@ -19,7 +19,7 @@ ServiceControl Management does not provide a means of moving the ServiceControl 
 * The current database path is listed in the utility. Copy the contents of this directory to the new location
 * The new database location should not be a subfolder of one of the existing locations (e.g. Installation path, Log Path, etc)
 * Ensure that the service account used for ServiceControl has read/write access to the new location
-* Manually edit the configuration and specify the new location by changing or adding the `ServiceControl/DbPath` setting. See [Configuration Settings](/servicecontrol/servicecontrol-instances/configuration.md)
+* Manually edit the configuration and specify the new location by changing or adding the [`ServiceControl/DbPath`](/servicecontrol/servicecontrol-instances/configuration.md#embedded-database-servicecontroldbpath) setting
 * Restart the ServiceControl service
 * Remove the old database directory and contents
 

--- a/servicecontrol/security/configuration/cors.md
+++ b/servicecontrol/security/configuration/cors.md
@@ -26,11 +26,12 @@ CORS configuration is required when:
 
 CORS configuration is *not* required when:
 
-- ServicePulse is [hosted by ServiceControl](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md), for calls to the Error instance that hosts it. Integrated ServicePulse calls that instance's API on its own origin using a relative URL.
-- ServicePulse is using the [internal reverse proxy](/servicepulse/containerization/#settings-enable-reverse-proxy).
+- ServicePulse is [hosted by ServiceControl](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md), for calls to the Error instance that hosts it. Integrated ServicePulse requests that instance's API on the same origin, using the root-relative URL `/api/`.
+- ServicePulse is using the [internal reverse proxy](/servicepulse/containerization/#settings-enable-reverse-proxy), which forwards both the Error instance API and the Monitoring instance API through the ServicePulse origin.
 
 > [!NOTE]
-> A ServiceControl Monitoring instance is always a separate origin, because it has its own host name and port. CORS must be configured on the Monitoring instance whenever ServicePulse connects to it from another machine, including when using integrated ServicePulse. See [Remote access to integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md#step-4-make-servicecontrol-monitoring-reachable).
+> Unless it is reached through one of the reverse proxies above, a [ServiceControl Monitoring instance](/servicecontrol/monitoring-instances/) listens on its own port, so it is a separate origin from ServicePulse even when both run on the same machine. This includes integrated ServicePulse, which shares an origin with the Error instance hosting it but not with the Monitoring instance. These cross-origin requests are allowed by default, because `Cors.AllowAnyOrigin` defaults to `true`. When origins are restricted, as recommended for production, the ServicePulse origin must be added to [`Monitoring/Cors.AllowedOrigins`](/servicecontrol/monitoring-instances/configuration.md#cors-monitoringcors-allowedorigins) as well as to the Error instance. For a worked example, see [making ServiceControl Monitoring reachable](/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md#step-4-make-servicecontrol-monitoring-reachable).
+
 
 ## Configuration examples
 

--- a/servicecontrol/security/configuration/cors.md
+++ b/servicecontrol/security/configuration/cors.md
@@ -1,7 +1,7 @@
 ---
 title: ServiceControl CORS Configuration
 summary: How to configure Cross-Origin Resource Sharing for ServiceControl instances
-reviewed: 2026-01-14
+reviewed: 2026-07-30
 component: ServiceControl
 related:
 - servicecontrol/security/hosting-guide
@@ -26,8 +26,11 @@ CORS configuration is required when:
 
 CORS configuration is *not* required when:
 
-- ServicePulse is [hosted by ServiceControl](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md)
+- ServicePulse is [hosted by ServiceControl](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md), for calls to the Error instance that hosts it. Integrated ServicePulse calls that instance's API on its own origin using a relative URL.
 - ServicePulse is using the [internal reverse proxy](/servicepulse/containerization/#settings-enable-reverse-proxy).
+
+> [!NOTE]
+> A ServiceControl Monitoring instance is always a separate origin, because it has its own host name and port. CORS must be configured on the Monitoring instance whenever ServicePulse connects to it from another machine, including when using integrated ServicePulse. See [Remote access to integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md#step-4-make-servicecontrol-monitoring-reachable).
 
 ## Configuration examples
 

--- a/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
+++ b/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
@@ -142,7 +142,7 @@ Monitoring data comes from a separate [ServiceControl Monitoring instance](/serv
 The default is `http://localhost:33633/`, and in a browser on someone else's machine `localhost` means *their* machine, not the ServiceControl machine. The Monitoring tab therefore fails to load until the following are configured.
 
 1. Set [`Monitoring/HttpHostname`](/servicecontrol/monitoring-instances/configuration.md#host-settings-monitoringhttphostname) on the Monitoring instance so it accepts connections from other machines, and allow its port (`33633` by default) through the firewall as in [Step 2](#step-2-allow-the-port-through-the-firewall).
-1. Allow the ServicePulse address on the Monitoring instance with [`Monitoring/Cors.AllowedOrigins`](/servicecontrol/monitoring-instances/configuration.md#cors-monitoringcors-allowedorigins). Because the Monitoring instance is at a different address from ServicePulse, browsers require it to opt in to these requests, even though this is not needed for the Error instance API:
+1. Decide which origins the Monitoring instance accepts requests from. Because it is at a different address from ServicePulse, its [CORS](/servicecontrol/security/configuration/cors.md) policy governs these requests, unlike calls to the Error instance API. [`Monitoring/Cors.AllowAnyOrigin`](/servicecontrol/monitoring-instances/configuration.md#cors-monitoringcors-allowanyorigin) defaults to `true`, so the Monitoring tab works without configuring anything here. For production, set it to `false` and list the ServicePulse address in [`Monitoring/Cors.AllowedOrigins`](/servicecontrol/monitoring-instances/configuration.md#cors-monitoringcors-allowedorigins) instead:
 
     ```xml
     <appSettings>

--- a/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
+++ b/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
@@ -58,7 +58,7 @@ Containers already accept connections addressed to any host name and need no cha
 
 Now that users type this address themselves, the default port `33333` is worth reconsidering. It can be changed with [`ServiceControl/Port`](configuration.md#host-settings-servicecontrolport).
 
-The port worth choosing is `443`, the standard port for HTTPS. Browsers hide it, so users get a clean address with no port number at all:
+The recommended port is `443`, the standard port for HTTPS. Browsers hide it, so users get a clean address with no port number.
 
 ```xml
 <appSettings>

--- a/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
+++ b/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
@@ -88,7 +88,7 @@ New-NetFirewallRule -DisplayName "ServiceControl (integrated ServicePulse)" -Dir
 
 Microsoft documents both approaches in [Windows Firewall rules](https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/rules) and the [`New-NetFirewallRule` reference](https://learn.microsoft.com/en-us/powershell/module/netsecurity/new-netfirewallrule).
 
-Network firewalls, proxies, or DNS between users and the machine may also need changes. If any of this is managed by another team, this is the point to involve whoever looks after the network and security in the organization: the request is to allow inbound TCP traffic to this port on this machine, from the users who need access.
+Network firewalls, proxies, or DNS between users and the machine may also need changes. If another team is responsible for the network or security infrastructure, involve them at this point. They should configure the network to allow inbound TCP traffic to this port on this machine from the users who require access.
 
 > [!NOTE]
 > No `netsh http add urlacl` command is needed. That step appears in the ServicePulse in IIS instructions because it applies to standalone ServicePulse, which uses a different web server. ServiceControl does not require it.

--- a/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
+++ b/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md
@@ -1,0 +1,202 @@
+---
+title: Remote access to integrated ServicePulse
+summary: How to make integrated ServicePulse reachable from other machines without installing IIS or a standalone ServicePulse
+reviewed: 2026-07-30
+component: ServiceControl
+related:
+- servicecontrol/servicecontrol-instances/integrated-servicepulse
+- servicecontrol/security
+- servicecontrol/setting-custom-hostname
+- servicepulse/install-servicepulse-in-iis
+---
+
+By default a ServiceControl Error instance only accepts connections from the machine it runs on, so [integrated ServicePulse](integrated-servicepulse.md) can only be opened in a browser on that machine. This guide describes how to make it available to other people on the network.
+
+> [!NOTE]
+> The instructions for [hosting ServicePulse in IIS](/servicepulse/install-servicepulse-in-iis.md) do **not** apply to integrated ServicePulse. Neither IIS nor a standalone ServicePulse installation is required.
+
+## Why integrated ServicePulse needs less configuration
+
+A standalone ServicePulse is a separate web application with its own address, and it has to be told where to find the ServiceControl API. Because the two sit at different addresses, they need URL rewriting or extra browser permissions to work together. This is why the IIS instructions are as long as they are.
+
+Integrated ServicePulse is served by the ServiceControl Error instance itself, at the same address that serves the API. It does not store an address for the API at all; it simply asks for `/api` on whatever address the browser used to reach it:
+
+| Address                       | Serves                                |
+|-------------------------------|---------------------------------------|
+| `http://<host>:33333/`        | Integrated ServicePulse               |
+| `http://<host>:33333/api`     | ServiceControl Error instance API     |
+
+Because ServicePulse and the API always share an address, making ServicePulse available to other machines needs no URL rewriting, no [CORS](/servicecontrol/security/configuration/cors.md) configuration, and no edits to `app.constants.js`. Changing the host name is enough.
+
+## Step 1: Accept connections from other machines
+
+> [!WARNING]
+> Anyone who can reach this address has full access to the message data stored in ServiceControl, including message bodies and headers, and can retry, edit, archive, and delete messages. Do not expose an instance without also completing [Step 3: Secure the deployment](#step-3-secure-the-deployment).
+
+Change [`ServiceControl/HostName`](configuration.md#host-settings-servicecontrolhostname) from `localhost` to either a specific host name (for example `sc.example.com`) or `*` to accept connections addressed to any host name.
+
+Using ServiceControl Management:
+
+1. Click the Configuration icon for the Error instance.
+1. Change the Host Name field.
+1. Click Save. ServiceControl Management validates the change and restarts the service.
+
+Or edit `ServiceControl.exe.config` directly and restart the service:
+
+```xml
+<appSettings>
+  <add key="ServiceControl/HostName" value="*" />
+</appSettings>
+```
+
+> [!WARNING]
+> Before changing the host name, confirm that `ServiceControl/DbPath` is present in `ServiceControl.exe.config`. When that setting is absent, the default database folder name is derived from the host name and port, so changing either one points ServiceControl at a different, empty database. Instances deployed with ServiceControl Management or PowerShell have `ServiceControl/DbPath` written explicitly and are unaffected. See [RavenDB embedded location](/servicecontrol/configure-ravendb-location.md).
+
+Containers already accept connections addressed to any host name and need no change; expose the container's port `33333` instead.
+
+### Choosing a port
+
+Now that users type this address themselves, the default port `33333` is worth reconsidering. It can be changed with [`ServiceControl/Port`](configuration.md#host-settings-servicecontrolport).
+
+The port worth choosing is `443`, the standard port for HTTPS. Browsers hide it, so users get a clean address with no port number at all:
+
+```xml
+<appSettings>
+  <add key="ServiceControl/HostName" value="servicepulse.example.com" />
+  <add key="ServiceControl/Port" value="443" />
+  <add key="ServiceControl/Https.Enabled" value="true" />
+</appSettings>
+```
+
+This gives `https://servicepulse.example.com` and combines with the TLS certificate from [Step 3](#step-3-secure-the-deployment).
+
+Before changing the port, check that:
+
+- nothing else on the machine already uses it, IIS in particular, which usually claims `443`
+- the [`ServiceControl/DbPath`](configuration.md#embedded-database-servicecontroldbpath) warning above is satisfied, because the default database folder name includes the port as well as the host name
+- any other tools or scripts calling the API directly are updated, along with the [`ServiceControl/RemoteInstances`](configuration.md#host-settings-servicecontrolremoteinstances) configuration of any *other* Error instance configured to read from this one, which only applies to federated setups
+
+Alternatively, leave ServiceControl's port alone and put a [reverse proxy](#using-a-reverse-proxy-instead) in front to publish it on `443`.
+
+## Step 2: Allow the port through the firewall
+
+Add an inbound firewall rule on the ServiceControl machine for the Error instance port (`33333` by default). On Windows this can be done through the Windows Defender Firewall console or with PowerShell:
+
+```powershell
+New-NetFirewallRule -DisplayName "ServiceControl (integrated ServicePulse)" -Direction Inbound -Protocol TCP -LocalPort 33333 -Action Allow
+```
+
+Microsoft documents both approaches in [Windows Firewall rules](https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/rules) and the [`New-NetFirewallRule` reference](https://learn.microsoft.com/en-us/powershell/module/netsecurity/new-netfirewallrule).
+
+Network firewalls, proxies, or DNS between users and the machine may also need changes. If any of this is managed by another team, this is the point to involve whoever looks after the network and security in the organization: the request is to allow inbound TCP traffic to this port on this machine, from the users who need access.
+
+> [!NOTE]
+> No `netsh http add urlacl` command is needed. That step appears in the ServicePulse in IIS instructions because it applies to standalone ServicePulse, which uses a different web server. ServiceControl does not require it.
+
+Users can now open `http://<host>:33333/`.
+
+## Step 3: Secure the deployment
+
+Once the instance accepts connections from other machines, the protection that came from only accepting local connections is gone, and access has to be controlled explicitly.
+
+### Encrypt traffic with TLS
+
+Without TLS, message data and sign-in credentials cross the network in plain text, readable by anyone able to capture that traffic. This applies on an internal network too. See [TLS configuration](/servicecontrol/security/configuration/tls.md) for the settings; integrated ServicePulse uses the TLS configuration of the Error instance that hosts it, so one certificate covers both.
+
+A certificate is required, in PFX (PKCS#12) format. Where to get one depends on the name users will type:
+
+- **An internal-only name**, such as `cm.corp.local` or a name that resolves only inside the network. Use the organization's own certificate authority, for example Active Directory Certificate Services. Certificates it issues are already trusted by domain-joined machines, so browsers show no warning. Public certificate authorities cannot issue certificates for names they are unable to verify.
+- **A name under a public domain the organization owns**, such as `servicepulse.example.com`, even if it only resolves internally. A public certificate authority can issue a certificate, including free ones from [Let's Encrypt](https://letsencrypt.org/). Use DNS-based validation (DNS-01), which proves ownership by adding a DNS record and does not require the server to be reachable from the internet. Note that these certificates are short-lived, so set up automatic renewal.
+- **Self-signed certificates** are not recommended here. Every user gets a browser security warning, and training a team to click through those warnings undermines the protection TLS provides. They are reasonable only for a quick test.
+
+### Require users to sign in
+
+Enable [authentication](/servicecontrol/security/) so users must sign in before they can see anything. Authentication is configured on ServiceControl only; integrated ServicePulse picks up the settings from the instance that hosts it and handles the sign-in automatically.
+
+This requires an identity provider that supports OpenID Connect. It does **not** have to be a cloud service:
+
+- Any OpenID Connect provider already in use will work, including on-premises ones. [Keycloak](https://www.keycloak.org/) is a common self-hosted, freely available choice, and the [authentication reference](/servicecontrol/security/configuration/authentication.md#identity-provider-setup-configuration-examples-keycloak) includes a configuration example for it. Other on-premises providers that implement OpenID Connect, such as Active Directory Federation Services, are configured with the same settings.
+- If no identity provider is available and standing one up is not realistic, use one of the alternatives in [If signing in is not an option](#step-3-secure-the-deployment-if-signing-in-is-not-an-option) below rather than exposing the instance unprotected.
+
+### Limit what each user can do
+
+With authentication alone, every signed-in user has full access. To give most of the team read-only access while a smaller group can retry or edit messages, enable [role-based access control](/servicecontrol/security/configuration/authorization.md). This requires ServiceControl 6.18.0 or later.
+
+> [!NOTE]
+> Role-based access control replaces the `SPReaders`, `SPFailedMessages`, and `SPMonitoring` roles used by the IIS URL Authorization approach in the [ServicePulse in IIS](/servicepulse/install-servicepulse-in-iis.md#advanced-configuration-role-based-security) instructions. The built-in roles are `reader`, `writer`, and `admin`.
+
+### If signing in is not an option
+
+Two alternatives, in order of preference:
+
+1. **Authenticate at a reverse proxy.** Put IIS or another web server in front and let it authenticate users, for example with Windows Integrated Authentication. This is the closest equivalent to the older ServicePulse in IIS setup. See [Using a reverse proxy instead](#using-a-reverse-proxy-instead), and note the warning there about leaving ServiceControl reachable only by the proxy.
+1. **Restrict access at the network layer.** Limit who can reach the port using a VPN or firewall rules scoped to specific subnets or addresses. This controls who can connect but not what they can do once connected: everyone who gets through has full access. See [Securing ServiceControl](/servicecontrol/securing-servicecontrol.md).
+
+## Step 4: Make ServiceControl Monitoring reachable
+
+> [!NOTE]
+> Skip this step if [monitoring](/monitoring/) is not in use. To hide the Monitoring tab, set the monitoring connection to `!` as described in [Configuring the monitoring URL](#step-4-make-servicecontrol-monitoring-reachable-configuring-the-monitoring-url).
+
+Monitoring data comes from a separate [ServiceControl Monitoring instance](/servicecontrol/monitoring-instances/) with its own host name and port. Unlike the Error instance API, it does not share an address with ServicePulse, so the browser has to be told where to find it.
+
+The default is `http://localhost:33633/`, and in a browser on someone else's machine `localhost` means *their* machine, not the ServiceControl machine. The Monitoring tab therefore fails to load until the following are configured.
+
+1. Set [`Monitoring/HttpHostname`](/servicecontrol/monitoring-instances/configuration.md#host-settings-monitoringhttphostname) on the Monitoring instance so it accepts connections from other machines, and allow its port (`33633` by default) through the firewall as in [Step 2](#step-2-allow-the-port-through-the-firewall).
+1. Allow the ServicePulse address on the Monitoring instance with [`Monitoring/Cors.AllowedOrigins`](/servicecontrol/monitoring-instances/configuration.md#cors-monitoringcors-allowedorigins). Because the Monitoring instance is at a different address from ServicePulse, browsers require it to opt in to these requests, even though this is not needed for the Error instance API:
+
+    ```xml
+    <appSettings>
+      <add key="Monitoring/HttpHostname" value="*" />
+      <add key="Monitoring/Cors.AllowAnyOrigin" value="false" />
+      <add key="Monitoring/Cors.AllowedOrigins" value="https://sc.example.com:33333" />
+    </appSettings>
+    ```
+
+1. If [authentication](/servicecontrol/security/) is enabled, configure it on the Monitoring instance too, using the same authority and audience as the Error instance.
+1. Tell ServicePulse the correct monitoring address, using one of the options below.
+
+### Configuring the monitoring URL
+
+- **A shared link.** Send users a link with the monitoring address included, for example `https://sc.example.com:33333/?mu=https://monitoring.example.com:33633/`. Opening it once is enough; the browser remembers the setting afterward.
+- **Per user, in the ServicePulse UI.** Each user sets the monitoring address once under Configuration > Connections. See [configuring connections](/servicepulse/host-config.md#configuring-connections-via-the-servicepulse-ui). The ServiceControl connection cannot be edited here, because integrated ServicePulse is always connected to the instance hosting it.
+- **For everyone, on the server.** Set a `MONITORING_URL` environment variable for the ServiceControl Error instance and restart the service, so every user gets the correct address without configuring anything:
+
+    ```shell
+    setx MONITORING_URL "https://monitoring.example.com:33633/" /M
+    ```
+
+    Unlike other Error instance settings, this is a plain environment variable with no `SERVICECONTROL_` prefix and cannot be set in `ServiceControl.exe.config`. Users who have already saved a monitoring address in their browser keep the one they saved.
+
+To hide the Monitoring tab, set the monitoring address to `!`.
+
+## Using a reverse proxy instead
+
+A reverse proxy is a web server that sits in front of ServiceControl and forwards requests to it. Adding one is optional. It is worth doing to present ServicePulse on a friendly address such as `https://servicepulse.example.com`, to manage TLS certificates centrally alongside other internal sites, or to apply an authentication method ServiceControl does not implement itself, such as Windows Integrated Authentication.
+
+> [!NOTE]
+> ServiceControl cannot run *inside* IIS. IIS can only sit in front of it and forward requests. See the [ServiceControl hosting guide](/servicecontrol/security/hosting-guide.md#hosting-model).
+
+Forwarding integrated ServicePulse is simpler than forwarding a standalone ServicePulse: one rule for the site root covers both the UI and the API, because they share an address. The separate `^api/(.*)` rewrite rule needed when ServicePulse and ServiceControl are separate applications does not apply.
+
+> [!WARNING]
+> When relying on the proxy to authenticate users, make sure ServiceControl itself cannot be reached directly, or users can bypass the proxy and the authentication with it. If the proxy runs on the same machine as ServiceControl, the simplest way is to leave `ServiceControl/HostName` set to `localhost` and skip [Step 1](#step-1-accept-connections-from-other-machines) entirely, so only the proxy can connect. If the proxy runs elsewhere, restrict the port to the proxy's address.
+
+When using a reverse proxy, configure [forwarded headers](/servicecontrol/security/configuration/forward-headers.md) on the Error instance so it knows the address users actually typed. Integrated ServicePulse uses the Error instance's forwarded header configuration; there is no separate ServicePulse setting. For worked examples, see the [ServiceControl hosting guide](/servicecontrol/security/hosting-guide.md).
+
+## Troubleshooting
+
+### ServicePulse does not load from another machine
+
+The Error instance is still only accepting local connections, or the port is blocked. Check the value of `ServiceControl/HostName`, that the service was restarted after the change, and that an inbound firewall rule exists. Opening `http://<host>:33333/api` from the other machine shows whether the problem is the network or ServicePulse.
+
+### ServicePulse loads but shows no data
+
+The browser reached ServicePulse but not the API. Check the browser developer tools Network tab (F12) for failing requests to `/api`. A leftover setting from a previous standalone ServicePulse is not the cause: integrated ServicePulse always uses the instance hosting it.
+
+### The Monitoring tab shows "unable to connect"
+
+The monitoring address still points at `localhost`, the Monitoring instance is not accepting connections from other machines, or the browser is blocking the request. Work through [Step 4](#step-4-make-servicecontrol-monitoring-reachable) and check the developer tools Console for CORS errors. See also [CORS troubleshooting](/servicecontrol/security/configuration/cors.md#troubleshooting).
+
+### ServiceControl starts with an empty database after changing the host name
+
+`ServiceControl/DbPath` was not set explicitly, so the default database location changed along with the host name. Stop the service, add `ServiceControl/DbPath` pointing at the original database folder, and restart. See [RavenDB embedded location](/servicecontrol/configure-ravendb-location.md).

--- a/servicecontrol/servicecontrol-instances/integrated-servicepulse.md
+++ b/servicecontrol/servicecontrol-instances/integrated-servicepulse.md
@@ -1,7 +1,7 @@
 ---
 title: Integrated ServicePulse
 summary: A guide to hosting ServicePulse and ServiceControl within the same host process.
-reviewed: 2026-02-16
+reviewed: 2026-07-30
 component: ServiceControl
 ---
 
@@ -11,9 +11,10 @@ Benefits:
 - No need for a standalone ServicePulse installation. Install and manage ServiceControl and ServicePulse in one place.
 - No need to configure ServicePulse with the ServiceControl Error instance url. Integrated ServicePulse is preconfigured to connect to the ServiceControl installation it runs in.
 - No need to upgrade ServicePulse. Each new version of ServiceControl includes the latest ServicePulse. Every time ServiceControl is upgraded, integrated ServicePulse is upgraded as well.
+- No need for a reverse proxy in front of ServicePulse, and fewer moving parts as a result. ServicePulse and the Error instance API are served from the same address, so there is nothing to route or rewrite and [CORS](/servicecontrol/security/configuration/cors.md) does not apply. Making ServicePulse [available to other machines](integrated-servicepulse-remote-access.md) is a matter of configuring the Error instance.
 
 Drawbacks:
-- Can not use built-in ServicePulse reverse proxy. Enable [security features of ServiceControl](/servicecontrol/security/) to secure access to ServiceControl data.
+- A ServiceControl Monitoring instance is not served through integrated ServicePulse. A standalone ServicePulse container can front both ServiceControl and Monitoring on a single address with its [built-in reverse proxy](/servicepulse/containerization/#reverse-proxy), whereas a Monitoring instance used with integrated ServicePulse must be [reachable by the browser directly](integrated-servicepulse-remote-access.md#step-4-make-servicecontrol-monitoring-reachable).
 - Can not use a single ServicePulse instance to control multiple ServiceControl installations. Each ServiceControl Error instance can be configured with a dedicated integrated ServicePulse.
 
 > [!NOTE]
@@ -36,8 +37,8 @@ When upgrading an existing ServiceControl Error instance via Powershell or docke
 
 Integrated ServicePulse shares settings with the ServiceControl Error instance it is hosted by (the hosting instance).
 
-- All host settings (such as [host name](/servicecontrol/servicecontrol-instances/configuration.md#host-settings-servicecontrolhostname) and [port number](/servicecontrol/servicecontrol-instances/configuration.md#host-settings-servicecontrolport)) are shared with the hosting instance. Integrated ServicePulse is available at the root url (`http://localhost:33333/` in a default installation).
-- Most security settings are shared with the hosting instance. There is no need to enable [header forwarding](/servicepulse/security/configuration/forward-headers.md) for ServicePulse specifically, and [CORS](/servicecontrol/security/configuration/cors.md) is no longer required
+- All host settings (such as [host name](/servicecontrol/servicecontrol-instances/configuration.md#host-settings-servicecontrolhostname) and [port number](/servicecontrol/servicecontrol-instances/configuration.md#host-settings-servicecontrolport)) are shared with the hosting instance. Integrated ServicePulse is available at the root url (`http://localhost:33333/` in a default installation). To make it reachable from other machines, see [Remote access to integrated ServicePulse](integrated-servicepulse-remote-access.md).
+- Most security settings are shared with the hosting instance. There is no need to enable [header forwarding](/servicepulse/security/configuration/forward-headers.md) for ServicePulse specifically, and [CORS](/servicecontrol/security/configuration/cors.md) is no longer required. Use the [security features of ServiceControl](/servicecontrol/security/) to control access to ServiceControl data.
 - [ServicePulse specific authorization configuration](/servicecontrol/servicecontrol-instances/configuration.md#authentication-servicecontrolauthentication-servicepulse-clientid) is still required.
 - Integrated ServicePulse is automatically configured to connect to the hosting instance. This configuration is read-only and cannot be changed.
 - Connection to a ServiceControl Monitoring instance can be [configured via the ServicePulse UI](/servicepulse/host-config.md#configuring-connections-via-the-servicepulse-ui).

--- a/servicecontrol/setting-custom-hostname.md
+++ b/servicecontrol/setting-custom-hostname.md
@@ -1,7 +1,7 @@
 ---
 title: Configure the ServiceControl URI
 summary: How to configure ServiceControl to be exposed through a custom hostname and IP port
-reviewed: 2026-03-09
+reviewed: 2026-07-30
 ---
 
 To set a custom hostname and IP port for an instance of the ServiceControl service:
@@ -26,4 +26,6 @@ ServiceControl Management will then validate the settings changes and restart th
 
 ## Updating ServicePulse Configuration to ServiceControl Custom Hostname
 
-Refer to the [ServicePulse documentation](/servicepulse/host-config.md#configuring-connections-via-the-servicepulse-ui) for guidance on how to configure ServicePulse to connect to ServiceControl.
+Refer to the [ServicePulse documentation](/servicepulse/host-config.md#configuring-connections-via-the-servicepulse-ui) for guidance on how to configure a standalone ServicePulse to connect to ServiceControl.
+
+When using [integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md), no such update is needed. It is preconfigured to connect to the Error instance that hosts it using a relative URL, so it follows the custom hostname automatically. See [Remote access to integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md).

--- a/servicepulse/install-servicepulse-in-iis.md
+++ b/servicepulse/install-servicepulse-in-iis.md
@@ -1,9 +1,12 @@
 ---
 title: Install ServicePulse in IIS
 summary: Describes how to manually install ServicePulse in IIS
-reviewed: 2026-02-27
+reviewed: 2026-07-30
 component: ServicePulse
 ---
+
+> [!NOTE]
+> This page applies to standalone ServicePulse installations only. When using [integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse.md), ServicePulse is served by the ServiceControl Error instance and neither IIS nor these steps are required. To make integrated ServicePulse reachable from other machines, see [Remote access to integrated ServicePulse](/servicecontrol/servicecontrol-instances/integrated-servicepulse-remote-access.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
This new guide details how to configure integrated ServicePulse for network access, including security, monitoring, and reverse proxy considerations. It also updates related documentation to clarify behavior differences between integrated and standalone ServicePulse.