### PR TITLE
Add metric read permission for Microsoft.Insights

### DIFF
--- a/servicepulse/usage-config.md
+++ b/servicepulse/usage-config.md
@@ -114,7 +114,8 @@ To restrict permissions to the minimal required set, create a custom role with t
                     "Microsoft.ServiceBus/namespaces/providers/Microsoft.Insights/metricDefinitions/read",
                     "Microsoft.ServiceBus/namespaces/queues/read",
                     "Microsoft.Resources/subscriptions/read",
-                    "Microsoft.Resources/subscriptions/resources/read"
+                    "Microsoft.Resources/subscriptions/resources/read",
+                    "Microsoft.Insights/Metrics/Read"
                 ],
                 "notActions": [],
                 "dataActions": [],


### PR DESCRIPTION
Microsoft.Insights/Metrics/Read is needed to list available metrics.