### PR TITLE
Clarify API application ownership in Entra ID authentication guide

### DIFF
--- a/servicecontrol/security/entra-id-authentication.md
+++ b/servicecontrol/security/entra-id-authentication.md
@@ -51,6 +51,9 @@ Follow Microsoft's guide to [expose a web API](https://learn.microsoft.com/en-us
 | Admin consent display name | `Full access to ServiceControl API`          |
 | Admin consent description  | `Allows ServicePulse to call ServiceControl` |
 
+> [!NOTE]
+> Ensure that an owner is [assigned to the API application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#assign-application-owner), otherwise the API will not be listed when requesting API permissions.
+
 ## Step 2: Register ServicePulse
 
 Follow Microsoft's guide to [register an application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) with the following settings:

--- a/servicecontrol/security/entra-id-authentication.md
+++ b/servicecontrol/security/entra-id-authentication.md
@@ -52,7 +52,7 @@ Follow Microsoft's guide to [expose a web API](https://learn.microsoft.com/en-us
 | Admin consent description  | `Allows ServicePulse to call ServiceControl` |
 
 > [!NOTE]
-> Ensure that an owner is [assigned to the API application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#assign-application-owner), otherwise the API will not be listed when requesting API permissions.
+> Ensure that you are assigned as the [owner of the API application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis#assign-application-owner), otherwise the API will not be listed when requesting API permissions.
 
 ## Step 2: Register ServicePulse
 


### PR DESCRIPTION
## ServiceControl security

Add a note emphasizing the importance of assigning an owner to the API application to ensure it appears when requesting API permissions when setting up the ServicePulse app registration.