### PR TITLE
Restore the Operations index to the menu and refresh its contents

### DIFF
--- a/menu/menu.yaml
+++ b/menu/menu.yaml
@@ -620,6 +620,8 @@
       Title: Dependency Vulnerabilities
   - Title: Operations
     Articles:
+    - Url: nservicebus/operations
+      Title: About operations
     - Url: nservicebus/hosting/startup-diagnostics
       Title: Startup diagnostics
     - Url: nservicebus/operations/opentelemetry

--- a/nservicebus/operations/index.md
+++ b/nservicebus/operations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Operations
 summary: Operations Table of Contents
-reviewed: 2025-10-13
+reviewed: 2026-08-28
 ---
 
 Operational tasks include the following categories:
@@ -12,57 +12,106 @@ Operational tasks include the following categories:
 * Diagnostics
 * Scripting activities (using the low level/native APIs to help perform any of the above tasks)
 
-Operational documentation is best reviewed from the perspective of the selected transport and persistence.
+Some of these tasks apply to every endpoint. The rest are best reviewed from the perspective of the selected transport and persistence, which are listed below when they have dedicated operational guidance.
+
+## Endpoints
+
+* [Installers](/nservicebus/operations/installers.md)
+* [Startup diagnostics](/nservicebus/hosting/startup-diagnostics.md)
+* [OpenTelemetry](/nservicebus/operations/opentelemetry.md)
+* [Tuning message throughput performance and concurrency](/nservicebus/operations/tuning.md)
+* [Decommissioning endpoints](/nservicebus/endpoints/decommissioning-endpoints.md)
+
+## Upgrades
+
+* [NServiceBus upgrade guides](/nservicebus/upgrades/)
+* [Transport upgrade guides](/transports/upgrades/)
+* [Persistence upgrade guides](/persistence/upgrades/)
 
 ## Transports
 
 ### [Azure Service Bus Transport](/transports/azure-service-bus)
 
 * [Scripting](/transports/azure-service-bus/operational-scripting.md)
+* [Queue-scoped permissions](/transports/azure-service-bus/queue-scoped-permissions.md)
 
 ### [Azure Storage Queues Transport](/transports/azure-storage-queues/)
 
 * [Performance Tuning](/transports/azure-storage-queues/performance-tuning.md)
 * [Use multiple accounts for scale out](/transports/azure-storage-queues/multi-storageaccount-support.md)
 * [Scripting](/transports/azure-storage-queues/operations-scripting.md)
+* [Troubleshooting](/transports/azure-storage-queues/troubleshooting.md)
 
-### [SQL Server Transport](/transports/sql/)
+### [Amazon SQS Transport](/transports/sqs/)
 
-* [Deployment options](/transports/sql/deployment-options.md)
-* [Scripting](/transports/sql/operations-scripting.md)
-
-### [MSMQ Transport](/transports/msmq/)
-
-* [Scripting](/transports/msmq/operations-scripting.md)
+* [Performance Tuning](/transports/sqs/performance-tuning.md)
+* [Scripting](/transports/sqs/operations-scripting.md)
+* [Troubleshooting](/transports/sqs/troubleshooting.md)
 
 ### [RabbitMQ Transport](/transports/rabbitmq/)
 
 * [Routing topology](/transports/rabbitmq/routing-topology.md)
 * [Scripting](/transports/rabbitmq/operations-scripting.md)
 
-### [Amazon SQS Transport](/transports/sqs/)
+### [SQL Server Transport](/transports/sql/)
 
-* [Scripting](/transports/sqs/operations-scripting.md)
+* [Deployment options](/transports/sql/deployment-options.md)
+* [Scripting](/transports/sql/operations-scripting.md)
+* [Azure SQL failover and connection pooling](/transports/sql/azure-sql-failover.md)
+* [Troubleshooting](/transports/sql/troubleshooting.md)
+
+### [PostgreSQL Transport](/transports/postgresql/)
+
+* [Deployment considerations](/transports/postgresql/#deployment-considerations)
+
+### [IBM MQ Transport](/transports/ibmmq/)
+
+* [Scripting](/transports/ibmmq/operations-scripting.md)
+* [Observability](/transports/ibmmq/observability.md)
+
+### [MSMQ Transport](/transports/msmq/)
+
+* [Scripting](/transports/msmq/operations-scripting.md)
+* [Management using PowerShell](/transports/msmq/management-using-powershell.md)
+* [Dead letter queues](/transports/msmq/dead-letter-queues.md)
+* [Viewing message content](/transports/msmq/viewing-message-content-in-msmq.md)
+* [Troubleshooting](/transports/msmq/troubleshooting.md)
 
 ## Persistences
 
 ### [SQL Persistence](/persistence/sql/)
 
 * [Installer workflow](/persistence/sql/installer-workflow.md)
+* [Scripting](/persistence/sql/operational-scripting.md)
+* [Controlling script generation](/persistence/sql/controlling-script-generation.md)
 * [MS SQL Server Scripts](/persistence/sql/sqlserver-scripts.md)
 * [MySql Scripts](/persistence/sql/mysql-scripts.md)
 * [Oracle Scripts](/persistence/sql/oracle-scripts.md)
+* [PostgreSQL Scripts](/persistence/sql/postgresql-scripts.md)
+* [Troubleshooting](/persistence/sql/troubleshooting.md)
+
+### [Cosmos DB Persistence](/persistence/cosmosdb/)
+
+* [Capacity planning using request units (RU)](/persistence/cosmosdb/#capacity-planning-using-request-units-ru)
+* [Provisioned throughput rate-limiting](/persistence/cosmosdb/#provisioned-throughput-rate-limiting)
+
+### [DynamoDB Persistence](/persistence/dynamodb/)
+
+* [Table creation](/persistence/dynamodb/table-creation.md)
+* [Capacity planning](/persistence/dynamodb/capacity-planning.md)
 
 ### [Azure Table Persistence](/persistence/azure-table/)
 
 * [Performance Tuning](/persistence/azure-table/performance-tuning.md)
+* [Capacity planning](/persistence/azure-table/capacity-planning.md)
 * [Scripting](/persistence/azure-table/scripting.md)
+
+### [NHibernate Persistence](/persistence/nhibernate/)
+
+* [Scripting](/persistence/nhibernate/scripting.md)
 
 ### [RavenDB Persistence](/persistence/ravendb/)
 
 * [Scripting](/persistence/ravendb/operations-scripting.md)
 * [Installing RavenDB](/persistence/ravendb/installation.md)
-
-### [NHibernate Persistence](/persistence/nhibernate/)
-
-* [Scripting](/persistence/nhibernate/scripting.md)
+* [Cluster configuration with multiple nodes](/persistence/ravendb/cluster-configuration.md)

--- a/transports/azure-storage-queues/troubleshooting.md
+++ b/transports/azure-storage-queues/troubleshooting.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queues Troubleshooting
-summary: Tips for troubleshooting the Azure Storage Queues persister
+summary: Tips for troubleshooting the Azure Storage Queues transport
 component: ASQ
-reviewed: 2026-02-25
+reviewed: 2026-08-28
 ---
 
 ## Message size too large


### PR DESCRIPTION
The Operations index has been unreachable from the navigation since the nav IA
re-org in be5bb8d6e1 (#5815, Aug 2022). That commit converted menu group nodes
from links into plain headers and re-added each group's index page as its first
article, but for Operations the URL was dropped and never re-added. The page's
only inbound link since then has been one sentence in
`nservicebus/operations/installers.md`.

Four years unindexed left the content stale:

- The PostgreSQL and IBM MQ transports were missing entirely, both having
  shipped after the re-org.
- PostgreSQL Scripts was absent from the SQL persistence dialect list, which had
  SQL Server, MySQL, and Oracle. That page has existed since 2017, so this
  predates the orphaning.
- Nothing addressed the diagnostics or upgrade categories the page's own intro
  promises.

Adds **Endpoints** and **Upgrades** sections for the transport- and
persistence-agnostic material, fills out the per-component lists with existing
but unlinked scripting, permissions, troubleshooting, and capacity planning
pages, and orders both sections to match `transports/index.md` and
`persistence/index.md`.

Also corrects the Azure Storage Queues troubleshooting summary, which described
ASQ as a persister rather than a transport.
