### PR TITLE
Document the ServiceControl QueryTimeoutInSeconds settings

### DIFF
--- a/servicecontrol/audit-instances/configuration.md
+++ b/servicecontrol/audit-instances/configuration.md
@@ -882,6 +882,23 @@ Configures the maximum duration, in seconds, for processing a batch of audited m
 | int | `60` (1 minute) |
 
 #end-if
+
+#if-version [6.20,)
+### ServiceControl.Audit/QueryTimeoutInSeconds
+
+Configures the maximum duration, in seconds, that an audit message query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the RavenDB server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default.
+
+| Context | Name |
+| --- | --- |
+| **Environment variable** | `SERVICECONTROL_AUDIT_QUERYTIMEOUTINSECONDS` |
+| **App config key** | `ServiceControl.Audit/QueryTimeoutInSeconds` |
+| **SCMU field** | N/A |
+
+| Type | Default value |
+| --- | --- |
+| int | `30` (30 seconds) |
+
+#end-if
 ## Transport
 
 ### ServiceControl.Audit/TransportType

--- a/servicecontrol/audit-instances/configuration.md
+++ b/servicecontrol/audit-instances/configuration.md
@@ -896,7 +896,7 @@ Configures the maximum duration, in seconds, that an audit message query (for ex
 
 | Type | Default value |
 | --- | --- |
-| int | `30` (30 seconds) |
+| int | `60` (1 minute) |
 
 #end-if
 ## Transport

--- a/servicecontrol/audit-instances/configuration.md
+++ b/servicecontrol/audit-instances/configuration.md
@@ -888,6 +888,8 @@ Configures the maximum duration, in seconds, for processing a batch of audited m
 
 Configures the maximum duration, in seconds, that an audit message query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the RavenDB server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default.
 
+A query that runs out of its allowed time is answered with HTTP status `504 Gateway Timeout` and a problem details body that names this setting. The error instance treats that answer as a missing instance rather than as an instance with no data, see [`ServiceControl/QueryTimeoutInSeconds`](/servicecontrol/servicecontrol-instances/configuration.md#performance-tuning-servicecontrol-querytimeoutinseconds), and should be configured with the same value.
+
 | Context | Name |
 | --- | --- |
 | **Environment variable** | `SERVICECONTROL_AUDIT_QUERYTIMEOUTINSECONDS` |

--- a/servicecontrol/audit-instances/configuration.md
+++ b/servicecontrol/audit-instances/configuration.md
@@ -888,7 +888,7 @@ Configures the maximum duration, in seconds, for processing a batch of audited m
 
 Configures the maximum duration, in seconds, that an audit message query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the RavenDB server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default.
 
-A query that runs out of its allowed time is answered with HTTP status `504 Gateway Timeout` and a problem details body that names this setting. The error instance treats that answer as a missing instance rather than as an instance with no data, see [`ServiceControl/QueryTimeoutInSeconds`](/servicecontrol/servicecontrol-instances/configuration.md#performance-tuning-servicecontrol-querytimeoutinseconds), and should be configured with the same value.
+A query that runs out of its allowed time is answered with HTTP status `504 Gateway Timeout` and a problem details body that names this setting. The error instance treats that answer as a missing instance rather than as an instance with no data. How long the error instance waits for an audit instance is bounded by its own [`ServiceControl/QueryTimeoutInSeconds`](/servicecontrol/servicecontrol-instances/configuration.md#performance-tuning-servicecontrol-querytimeoutinseconds), independently of this value.
 
 | Context | Name |
 | --- | --- |

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -976,6 +976,23 @@ Use this setting to configure whether the bodies of processed error messages sho
 > [!NOTE]
 > Changing the full-text search setting will cause indexes to be redeployed and rebuilt. Depending on the number of documents stored, this operation might take a long time and search results won't be available until completed.
 
+#if-version [6.20,)
+### ServiceControl/QueryTimeoutInSeconds
+
+Configures the maximum duration, in seconds, that a failed message view query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the RavenDB server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default. Applies to all persisters. On the SQL Server and PostgreSQL persisters the `Database/CommandTimeout` setting additionally bounds each individual database command.
+
+| Context | Name |
+| --- | --- |
+| **Environment variable** | `SERVICECONTROL_QUERYTIMEOUTINSECONDS` |
+| **App config key** | `ServiceControl/QueryTimeoutInSeconds` |
+| **SCMU field** | N/A |
+
+| Type | Default value |
+| --- | --- |
+| int | `30` (30 seconds) |
+
+#end-if
+
 ## Transport
 
 ### ServiceControl/TransportType

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -989,7 +989,7 @@ Configures the maximum duration, in seconds, that a failed message view query (f
 
 | Type | Default value |
 | --- | --- |
-| int | `30` (30 seconds) |
+| int | `60` (1 minute) |
 
 #end-if
 

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -985,7 +985,7 @@ A query that runs out of its allowed time is answered with HTTP status `504 Gate
 
 When the instance gathers a message view from its own database and the configured [audit instances](/servicecontrol/audit-instances/), a timed-out or unreachable instance does not fail the request. The response contains the data of the instances that did answer, carries no `ETag`, and lists the missing instances in the `X-Particular-Incomplete-Results` header as `instanceId:reason` entries, where the reason is `timeout`, `unavailable` or `error`. Only when no instance answered and at least one of them timed out is the request answered with `504 Gateway Timeout`.
 
-The instance waits for an audit instance's answer for this duration plus 30 seconds, so the same value should be configured on the audit instances through `ServiceControl.Audit/QueryTimeoutInSeconds`.
+The instance waits for an audit instance's answer for at most this duration, so it also bounds the whole query when an audit instance is slow, unresponsive, or configured with a larger `ServiceControl.Audit/QueryTimeoutInSeconds`. An audit instance that has not answered in time is reported as missing; its own limit still ends the query on its side.
 
 | Context | Name |
 | --- | --- |

--- a/servicecontrol/servicecontrol-instances/configuration.md
+++ b/servicecontrol/servicecontrol-instances/configuration.md
@@ -979,7 +979,13 @@ Use this setting to configure whether the bodies of processed error messages sho
 #if-version [6.20,)
 ### ServiceControl/QueryTimeoutInSeconds
 
-Configures the maximum duration, in seconds, that a failed message view query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the RavenDB server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default. Applies to all persisters. On the SQL Server and PostgreSQL persisters the `Database/CommandTimeout` setting additionally bounds each individual database command.
+Configures the maximum duration, in seconds, that a failed message view query (for example a message search or a conversation lookup issued by ServicePulse or ServiceInsight) is allowed to run before it is cancelled. This protects the database server from queries over very large data sets that would otherwise run for a long time and consume large amounts of temporary disk space. Values larger than one hour fall back to the default. Applies to all persisters. On the SQL Server and PostgreSQL persisters the database commands issued by these queries use this value as their command timeout, so `Database/CommandTimeout` does not apply to them.
+
+A query that runs out of its allowed time is answered with HTTP status `504 Gateway Timeout` and a problem details body that names this setting.
+
+When the instance gathers a message view from its own database and the configured [audit instances](/servicecontrol/audit-instances/), a timed-out or unreachable instance does not fail the request. The response contains the data of the instances that did answer, carries no `ETag`, and lists the missing instances in the `X-Particular-Incomplete-Results` header as `instanceId:reason` entries, where the reason is `timeout`, `unavailable` or `error`. Only when no instance answered and at least one of them timed out is the request answered with `504 Gateway Timeout`.
+
+The instance waits for an audit instance's answer for this duration plus 30 seconds, so the same value should be configured on the audit instances through `ServiceControl.Audit/QueryTimeoutInSeconds`.
 
 | Context | Name |
 | --- | --- |


### PR DESCRIPTION
Documents the new `QueryTimeoutInSeconds` setting on the audit and primary instance configuration pages (versioned `[6.20,)`, default 1 minute, applies to all persisters).

Documents:

- Particular/ServiceControl#5848