### PR TITLE
Fix broken generic-host link in samples/about.md

### DIFF
--- a/samples/about.md
+++ b/samples/about.md
@@ -60,7 +60,7 @@ Samples are not meant to be production-ready code or to be used as-is with Parti
 
 ### Samples are not "endpoint drop in" projects
 
-Since the endpoint in samples have to choose specific technologies (transport, serializer, persistence, etc.), before using this code in production ensure the code conforms with any specific [technology choices](/nservicebus/hosting/generic-host/).
+Since the endpoint in samples have to choose specific technologies (transport, serializer, persistence, etc.), before using this code in production ensure the code conforms with any specific [technology choices](/samples/hosting/generic-host/).
 
 ### Samples are downloadable and runnable
 


### PR DESCRIPTION
The link conversion in 13e344e655 swapped the root: the relative `./hosting/generic-host/` in `samples/about.md` resolved to `/samples/hosting/generic-host/` (the sample), not `/nservicebus/hosting/generic-host/` (which doesn't exist as a page). Content verification has been failing on master and on every PR since.